### PR TITLE
cylc poll-all: no options given then poll all

### DIFF
--- a/bin/cylc-poll
+++ b/bin/cylc-poll
@@ -29,10 +29,10 @@ from cylc.CylcOptionParsers import cop, multitask_usage
 from cylc.command_prep import prep_pyro
 import cylc.flags
 
-parser = cop( """cylc [control] poll [OPTIONS] ARGS
+parser = cop("""cylc [control] poll [OPTIONS] ARGS
 
-Poll a 'submitted' or 'running' task to verify its status. If a job was
-killed by external means this will update the suite accordingly.
+Poll a 'submitted' or 'running' or 'all' task(s) to verify the status(es).
+If a job was killed by external means this will update the suite accordingly.
 
 Note that automatic job polling can used to track task status on task
 hosts that do not allow any communication by RPC (pyro) or ssh back to
@@ -41,16 +41,20 @@ the suite host - see site/user config file documentation.
 Polling is also done automatically on restarting a suite, for any tasks
 that were recorded as submitted or running when the suite went down.
 """ + multitask_usage, pyro=True, multitask=True,
-        argdoc=[ ('REG', 'Suite name'),
-            ('MATCH', 'Task or family name matching regular expression'),
-            ('POINT', 'Task cycle point (e.g. date-time or integer)') ])
+        argdoc=[('REG', 'Suite name'),
+            ('[MATCH]', 'Task or family name matching regular expression'),
+            ('[POINT]', 'Task cycle point (e.g. date-time or integer)')])
 
 (options, args) = parser.parse_args()
 
-suite, pphrase = prep_pyro( args[0], options ).execute()
+suite, pphrase = prep_pyro(args[0], options).execute()
 
-name = args[1]
-point_string = args[2]
+if len(args) == 3:
+    name = args[1]
+    point_string = args[2]
+else:
+    name = str(None)
+    point_string = str(None)
 
 try:
     proxy = cylc_pyro_client.client( suite, pphrase, options.owner,

--- a/lib/cylc/gui/SuiteControl.py
+++ b/lib/cylc/gui/SuiteControl.py
@@ -2141,6 +2141,12 @@ shown here in the state they were in at the time of triggering.''' )
         if not result[0]:
             warning_dialog( result[1], self.window ).warn()
 
+    def poll_all(self, w):
+        command = "cylc poll " + self.cfg.suite + " --host=" + self.cfg.host
+        foo = gcapture_tmpfile(command, self.cfg.cylc_tmpdir, 600, 400)
+        self.gcapture_windows.append(foo)
+        foo.run()
+
     def reload_suite( self, w ):
         msg = """Reload the suite definition.
 This allows you change task runtime configuration and add
@@ -2467,6 +2473,12 @@ it tries to reconnect after increasingly long delays, to reduce network traffic.
         insert_item.set_image(img)
         start_menu.append( insert_item )
         insert_item.connect( 'activate', self.insert_task_popup )
+
+        poll_item = gtk.ImageMenuItem('Poll All ...')
+        img = gtk.image_new_from_stock(gtk.STOCK_REFRESH, gtk.ICON_SIZE_MENU)
+        poll_item.set_image(img)
+        start_menu.append(poll_item)
+        poll_item.connect('activate', self.poll_all)
 
         start_menu.append( gtk.SeparatorMenuItem() )
 

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -435,13 +435,17 @@ class scheduler(object):
         task_ids = [TaskID.get(i, point_string) for i in matches]
         self.pool.release_tasks( task_ids )
 
-    def command_poll_tasks( self, name, point_string, is_family ):
-        matches = self.get_matching_tasks( name, is_family )
-        if not matches:
-            raise TaskNotFoundError, "No matching tasks found: " + name
-        point_string = standardise_point_string(point_string)
-        task_ids = [TaskID.get(i, point_string) for i in matches]
-        self.pool.poll_tasks( task_ids )
+    def command_poll_tasks(self, name, point_string, is_family):
+        """Poll all tasks or a task/family if options are provided."""
+        if name == "None" and point_string == "None":
+            self.pool.poll_tasks()
+        else:
+            matches = self.get_matching_tasks(name, is_family)
+            if not matches:
+                raise TaskNotFoundError, "No matching tasks found: " + name
+            point_string = standardise_point_string(point_string)
+            task_ids = [TaskID.get(i, point_string) for i in matches]
+            self.pool.poll_tasks(task_ids)
 
     def command_kill_tasks( self, name, point_string, is_family ):
         matches = self.get_matching_tasks( name, is_family )

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -614,11 +614,13 @@ class TaskPool(object):
                 return False
         return True
 
-    def poll_tasks(self, ids):
+    def poll_tasks(self, ids=None):
         for itask in self.get_tasks(incl_runahead=False):
-            if itask.identity in ids:
-                # (state check done in task module)
-                itask.poll()
+            if itask.state.is_currently('running', 'submitted'):
+                if ids is None:
+                    itask.poll()
+                elif itask.identity in ids:
+                    itask.poll()
 
     def kill_active_tasks(self):
         for itask in self.get_tasks(incl_runahead=False):

--- a/tests/cylc-poll/03-poll-all.t
+++ b/tests/cylc-poll/03-poll-all.t
@@ -1,0 +1,31 @@
+#!/bin/bash
+#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+#C: Copyright (C) 2008-2014 NIWA
+#C:
+#C: This program is free software: you can redistribute it and/or modify
+#C: it under the terms of the GNU General Public License as published by
+#C: the Free Software Foundation, either version 3 of the License, or
+#C: (at your option) any later version.
+#C:
+#C: This program is distributed in the hope that it will be useful,
+#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
+#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#C: GNU General Public License for more details.
+#C:
+#C: You should have received a copy of the GNU General Public License
+#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test that when polling all a failed task sets the task state correctly
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 2
+#-------------------------------------------------------------------------------
+install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-validate
+run_ok $TEST_NAME cylc validate $SUITE_NAME
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-run
+suite_run_ok $TEST_NAME cylc run --reference-test --debug $SUITE_NAME
+#-------------------------------------------------------------------------------
+purge_suite $SUITE_NAME

--- a/tests/cylc-poll/03-poll-all/reference.log
+++ b/tests/cylc-poll/03-poll-all/reference.log
@@ -1,0 +1,80 @@
+2015-01-15T05:33:20Z INFO - Initial point: 20141207T0000Z
+2015-01-15T05:33:20Z INFO - Final point: 20141208T0000Z
+2015-01-15T05:33:20Z INFO - Cold Start 20141207T0000Z
+2015-01-15T05:33:20Z INFO - [run_kill.20141207T0000Z] -initiate job-submit
+2015-01-15T05:33:20Z INFO - [run_kill.20141207T0000Z] -triggered off []
+2015-01-15T05:33:21Z INFO - [run_kill.20141207T0000Z] -submission succeeded
+2015-01-15T05:33:22Z INFO - [run_kill.20141207T0000Z] -(current:submitted)> run_kill.20141207T0000Z started at 2015-01-15T05:33:21Z
+2015-01-15T05:33:23Z INFO - [submit_hold.20141207T0000Z] -initiate job-submit
+2015-01-15T05:33:23Z INFO - [submit_hold.20141207T0000Z] -triggered off ['run_kill.20141207T0000Z']
+2015-01-15T05:33:25Z INFO - [submit_hold.20141207T0000Z] -submission succeeded
+2015-01-15T05:33:25Z INFO - [poll_check_kill.20141207T0000Z] -initiate job-submit
+2015-01-15T05:33:25Z INFO - [poll_check_kill.20141207T0000Z] -triggered off ['submit_hold.20141207T0000Z']
+2015-01-15T05:33:26Z INFO - [poll_check_kill.20141207T0000Z] -submission succeeded
+2015-01-15T05:33:27Z INFO - [poll_check_kill.20141207T0000Z] -(current:submitted)> poll_check_kill.20141207T0000Z started at 2015-01-15T05:33:26Z
+2015-01-15T05:33:27Z INFO - [poll_check_kill.20141207T0000Z] -initiate job-poll
+2015-01-15T05:33:27Z INFO - [run_kill.20141207T0000Z] -initiate job-poll
+2015-01-15T05:33:27Z INFO - [submit_hold.20141207T0000Z] -initiate job-poll
+2015-01-15T05:33:27Z INFO - Command succeeded: poll tasks(None,None,False)
+2015-01-15T05:33:28Z INFO - polled poll_check_kill.20141207T0000Z started at 2015-01-15T05:33:25Z
+2015-01-15T05:33:28Z INFO - [poll_check_kill.20141207T0000Z] -(current:running)> polled poll_check_kill.20141207T0000Z started at 2015-01-15T05:33:25Z
+2015-01-15T05:33:28Z INFO - polled run_kill.20141207T0000Z failed at unknown-time
+2015-01-15T05:33:28Z INFO - [run_kill.20141207T0000Z] -(current:running)> polled run_kill.20141207T0000Z failed at unknown-time
+2015-01-15T05:33:28Z INFO - polled submit_hold.20141207T0000Z submitted
+2015-01-15T05:33:28Z INFO - [submit_hold.20141207T0000Z] -(current:submitted)> polled submit_hold.20141207T0000Z submitted
+2015-01-15T05:33:28Z INFO - [run_kill.20141208T0000Z] -initiate job-submit
+2015-01-15T05:33:28Z INFO - [run_kill.20141208T0000Z] -triggered off ['run_kill.20141207T0000Z']
+2015-01-15T05:33:28Z INFO - [run_kill.20141207T0000Z] -suiciding
+2015-01-15T05:33:29Z INFO - [run_kill.20141208T0000Z] -submission succeeded
+2015-01-15T05:33:29Z INFO - [run_kill.20141209T0000Z] -holding (beyond suite stop point) 20141208T0000Z
+2015-01-15T05:33:29Z INFO - [run_kill.20141209T0000Z] -waiting => held
+2015-01-15T05:33:29Z INFO - [poll_check_kill.20141207T0000Z] -(current:running)> poll_check_kill.20141207T0000Z succeeded at 2015-01-15T05:33:29Z
+2015-01-15T05:33:30Z INFO - [poll_now.20141207T0000Z] -initiate job-submit
+2015-01-15T05:33:30Z INFO - [poll_now.20141207T0000Z] -triggered off ['poll_check_kill.20141207T0000Z']
+2015-01-15T05:33:30Z INFO - [run_kill.20141208T0000Z] -(current:submitted)> run_kill.20141208T0000Z started at 2015-01-15T05:33:29Z
+2015-01-15T05:33:31Z INFO - [poll_now.20141207T0000Z] -submission succeeded
+2015-01-15T05:33:31Z INFO - [submit_hold.20141208T0000Z] -initiate job-submit
+2015-01-15T05:33:31Z INFO - [submit_hold.20141208T0000Z] -triggered off ['run_kill.20141208T0000Z']
+2015-01-15T05:33:32Z INFO - [submit_hold.20141208T0000Z] -submission succeeded
+2015-01-15T05:33:32Z INFO - [poll_check_kill.20141208T0000Z] -initiate job-submit
+2015-01-15T05:33:32Z INFO - [poll_check_kill.20141208T0000Z] -triggered off ['submit_hold.20141208T0000Z']
+2015-01-15T05:33:32Z INFO - [submit_hold.20141209T0000Z] -holding (beyond suite stop point) 20141208T0000Z
+2015-01-15T05:33:32Z INFO - [submit_hold.20141209T0000Z] -waiting => held
+2015-01-15T05:33:32Z INFO - [poll_now.20141207T0000Z] -(current:submitted)> poll_now.20141207T0000Z started at 2015-01-15T05:33:31Z
+2015-01-15T05:33:32Z INFO - [poll_now.20141207T0000Z] -(current:running)> poll_now.20141207T0000Z succeeded at 2015-01-15T05:33:32Z
+2015-01-15T05:33:32Z INFO - [run_kill.20141208T0000Z] -initiate job-poll
+2015-01-15T05:33:32Z INFO - [submit_hold.20141208T0000Z] -initiate job-poll
+2015-01-15T05:33:32Z INFO - [submit_hold.20141207T0000Z] -initiate job-poll
+2015-01-15T05:33:32Z INFO - Command succeeded: poll tasks(None,None,False)
+2015-01-15T05:33:33Z INFO - [poll_check_kill.20141208T0000Z] -submission succeeded
+2015-01-15T05:33:33Z INFO - polled run_kill.20141208T0000Z failed at unknown-time
+2015-01-15T05:33:33Z INFO - [run_kill.20141208T0000Z] -(current:running)> polled run_kill.20141208T0000Z failed at unknown-time
+2015-01-15T05:33:33Z INFO - polled submit_hold.20141208T0000Z submitted
+2015-01-15T05:33:33Z INFO - [submit_hold.20141208T0000Z] -(current:submitted)> polled submit_hold.20141208T0000Z submitted
+2015-01-15T05:33:33Z INFO - polled submit_hold.20141207T0000Z submission failed
+
+2015-01-15T05:33:33Z INFO - [submit_hold.20141207T0000Z] -(current:submitted)> polled submit_hold.20141207T0000Z submission failed
+2015-01-15T05:33:33Z ERROR - [submit_hold.20141207T0000Z] -submission failed
+2015-01-15T05:33:33Z INFO - [poll_check_kill.20141209T0000Z] -holding (beyond suite stop point) 20141208T0000Z
+2015-01-15T05:33:33Z INFO - [poll_check_kill.20141209T0000Z] -waiting => held
+2015-01-15T05:33:33Z INFO - [run_kill.20141208T0000Z] -suiciding
+2015-01-15T05:33:33Z INFO - [submit_hold.20141207T0000Z] -suiciding
+2015-01-15T05:33:34Z INFO - [poll_check_kill.20141208T0000Z] -(current:submitted)> poll_check_kill.20141208T0000Z started at 2015-01-15T05:33:33Z
+2015-01-15T05:33:34Z INFO - [poll_check_kill.20141208T0000Z] -(current:running)> poll_check_kill.20141208T0000Z succeeded at 2015-01-15T05:33:34Z
+2015-01-15T05:33:34Z INFO - [submit_hold.20141208T0000Z] -initiate job-poll
+2015-01-15T05:33:34Z INFO - Command succeeded: poll tasks(None,None,False)
+2015-01-15T05:33:35Z INFO - polled submit_hold.20141208T0000Z submission failed
+2015-01-15T05:33:35Z INFO - [submit_hold.20141208T0000Z] -(current:submitted)> polled submit_hold.20141208T0000Z submission failed
+2015-01-15T05:33:35Z ERROR - [submit_hold.20141208T0000Z] -submission failed
+2015-01-15T05:33:35Z INFO - [poll_now.20141208T0000Z] -initiate job-submit
+2015-01-15T05:33:35Z INFO - [poll_now.20141208T0000Z] -triggered off ['poll_check_kill.20141208T0000Z']
+2015-01-15T05:33:35Z INFO - [submit_hold.20141208T0000Z] -suiciding
+2015-01-15T05:33:36Z INFO - [poll_now.20141208T0000Z] -submission succeeded
+2015-01-15T05:33:36Z INFO - [poll_now.20141209T0000Z] -holding (beyond suite stop point) 20141208T0000Z
+2015-01-15T05:33:36Z INFO - [poll_now.20141209T0000Z] -waiting => held
+2015-01-15T05:33:37Z INFO - [poll_now.20141208T0000Z] -(current:submitted)> poll_now.20141208T0000Z started at 2015-01-15T05:33:36Z
+2015-01-15T05:33:37Z INFO - [poll_now.20141208T0000Z] -initiate job-poll
+2015-01-15T05:33:37Z INFO - Command succeeded: poll tasks(None,None,False)
+2015-01-15T05:33:38Z INFO - polled poll_now.20141208T0000Z succeeded at 2015-01-15T05:33:37Z
+2015-01-15T05:33:38Z INFO - [poll_now.20141208T0000Z] -(current:running)> polled poll_now.20141208T0000Z succeeded at 2015-01-15T05:33:37Z
+2015-01-15T05:33:39Z INFO - Suite shutting down at 2015-01-15T05:33:39Z

--- a/tests/cylc-poll/03-poll-all/suite.rc
+++ b/tests/cylc-poll/03-poll-all/suite.rc
@@ -1,0 +1,62 @@
+title = "Test suite for task state change on poll result."
+description = """Task run_kill fails silently - it will be stuck in 'running'
+unless polled. Task run_kill goes to Task submit_hold. Task poll_check_kill 
+then polls all to find if any tasks have failed, allowing run_kill to suicide
+via a :fail trigger. Task submit_hold is an idle task which is killed after
+Task poll_check_kill succeds by Task poll_now. Task poll_now then polls all
+to find if any tasks, allowing submit_hold to suicide via a :submit-fail
+trigger, and the suite to shut down successfully."""
+
+[cylc]
+   UTC mode = True
+   [[reference test]]
+       required run mode = live
+       live mode suite timeout = PT2M # minutes
+       expected task failures = run_kill.20141207T0000Z,\
+                                run_kill.20141208T0000Z,\
+                                submit_hold.20141207T0000Z,\
+                                submit_hold.20141208T0000Z
+       
+[scheduling]
+    initial cycle point = 20141207T0000Z
+    final cycle point   = 20141208T0000Z
+    [[dependencies]]
+        [[[T00]]]
+            graph = """
+        run_kill[-P1D]:fail => run_kill:start => submit_hold
+        run_kill:fail => !run_kill
+        submit_hold:submit => poll_check_kill => poll_now
+        submit_hold:submit-fail => !submit_hold
+        """
+
+[runtime]
+    [[run_kill]]
+        command scripting = """
+trap '' EXIT # die silently 
+exit 0"""
+    [[poll_check_kill]]
+        command scripting = """
+            cylc poll $CYLC_SUITE_NAME
+
+            while test $(grep "\[submit_hold.${CYLC_TASK_CYCLE_POINT}\] -submission succeeded
+\[run_kill.${CYLC_TASK_CYCLE_POINT}\] -suiciding" ${CYLC_SUITE_LOG_DIR%suite}suite/log -c) -ne 2 ; do
+                sleep 2
+            done
+
+            eval $(grep "^CYLC_BATCH_SYS_JOB_ID="\
+ ${CYLC_SUITE_LOG_DIR%suite}job/$CYLC_TASK_CYCLE_POINT/submit_hold/NN/job.status)
+            echo $CYLC_BATCH_SYS_JOB_ID
+            atrm  $CYLC_BATCH_SYS_JOB_ID
+
+        """
+    [[poll_now]]
+        command scripting = """ 
+            cylc poll $CYLC_SUITE_NAME
+       """
+        [[[job submission]]]
+            method           = at
+            
+    [[submit_hold]]
+        [[[job submission]]]
+            method           = at
+            command template = at now + 2 minutes


### PR DESCRIPTION
Closes #1177

Tests added.

Polls all tasks when no options are given at the command line.

Note that in my environment including on master tests/cylc-show/03-clock-triggered-non-utc-mode.t fails.