### PR TITLE
Handle spaces in CYLC_DIR when checking the version number in a git repo

### DIFF
--- a/lib/cylc/version.py
+++ b/lib/cylc/version.py
@@ -29,8 +29,9 @@ def _get_cylc_version():
 
     if os.path.exists(os.path.join(cylc_dir, ".git")):
         # We're running in a cylc git repository, so dynamically determine
-        # the cylc version string.
-        res = run_get_stdout(
+        # the cylc version string.  Enclose the path in quotes to handle
+        # avoid failure when cylc_dir contains spaces.
+        res = run_get_stdout('"%s"' %
             os.path.join(cylc_dir, "admin", "get-repo-version"))
         if res[0]:
             return res[1][0]


### PR DESCRIPTION
The current method uses subprocess, which passes the strings unescaped into
a shell - when CYLC_DIR contains spaces, they are not properly escaped which
causes a "Failed to get version number" error because attempt to run the
get-repo-version script stops at the first space in the path.  Adding quotes around the path when passing the command to the shell solves the issue.

I'm not sure how to take the merge commits out of this PR - if there's an easy way please let me know and I can resubmit if it's going to muck up the history.