### PR TITLE
Test for #958

### DIFF
--- a/tests/hold-release/13-ready-restart.t
+++ b/tests/hold-release/13-ready-restart.t
@@ -1,0 +1,36 @@
+#!/bin/bash
+#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+#C: Copyright (C) 2008-2014 NIWA
+#C:
+#C: This program is free software: you can redistribute it and/or modify
+#C: it under the terms of the GNU General Public License as published by
+#C: the Free Software Foundation, either version 3 of the License, or
+#C: (at your option) any later version.
+#C:
+#C: This program is distributed in the hope that it will be useful,
+#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
+#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#C: GNU General Public License for more details.
+#C:
+#C: You should have received a copy of the GNU General Public License
+#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test #958: task in ready state, stop now, restart hold, release
+. "$(dirname "$0")/test_header"
+
+set_test_number 4
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+run_ok "${TEST_NAME_BASE}-run" cylc run "${SUITE_NAME}"
+SUITE_DIR="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}"
+export CYLC_SUITE_LOG_DIR="${SUITE_DIR}/log/suite"
+export PATH="${TEST_DIR}/${SUITE_NAME}/bin:$PATH"
+run_ok "${TEST_NAME_BASE}-restart" \
+    timeout 1m my-file-poll "${CYLC_SUITE_LOG_DIR}/log.1"
+# foo-1 should run when the suite is released
+run_ok "${TEST_NAME_BASE}-foo-1" \
+    timeout 1m my-log-grepper 'foo-1.1 succeeded'
+timeout 1m my-log-grepper 'Suite shutting down'
+purge_suite "${TEST_NAME_BASE}"
+exit

--- a/tests/hold-release/13-ready-restart/bin/my-file-poll
+++ b/tests/hold-release/13-ready-restart/bin/my-file-poll
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -eu
+while [[ ! -e "$1" ]]; do
+    sleep 1
+done
+test -e "$1"

--- a/tests/hold-release/13-ready-restart/bin/my-log-grepper
+++ b/tests/hold-release/13-ready-restart/bin/my-log-grepper
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -eu
+while ! grep -q -F "$@" "${CYLC_SUITE_LOG_DIR}/log"; do
+    sleep 1
+done
+exit

--- a/tests/hold-release/13-ready-restart/suite.rc
+++ b/tests/hold-release/13-ready-restart/suite.rc
@@ -1,0 +1,38 @@
+title = Restart with hold, with a task in ready state
+
+[cylc]
+    [[reference test]]
+        live mode suite timeout = PT1M
+        dummy mode suite timeout = PT1M
+        simulation mode suite timeout = PT1M
+
+[scheduling]
+    [[dependencies]]
+        graph = """
+foo => foo-1
+bar
+"""
+
+[runtime]
+    [[foo]]
+        command scripting = true
+    [[foo-1]]
+        command scripting = true
+        [[[job submission]]]
+            method = at
+            # A fake submission on 1st attempt
+            command template = sleep 10
+    [[bar]]
+        command scripting = """
+# Stop the suite as soon as job file of "foo-1" is in the ready state
+timeout 1m my-file-poll "${CYLC_SUITE_RUN_DIR}/log/job/1/foo-1/NN/job"
+cylc stop --now --max-polls=10 --interval=1 "${CYLC_SUITE_NAME}"
+# Restart the suite on hold
+cylc restart --hold "${CYLC_SUITE_NAME}"
+timeout 1m my-log-grepper 'Held on start-up (no tasks will be submitted)'
+# Modify the job submission command template for "foo-1"
+cylc broadcast "${CYLC_SUITE_NAME}" \
+    -p '1' -n 'foo-1' -s '[job submission]command template=at now'
+# Release the suite to run to completion
+cylc release "${CYLC_SUITE_NAME}"
+"""


### PR DESCRIPTION
This test proves that we can close #958.

Stop suite `--now` while a task is in ready state. Restart with `--hold` and
then release. The ready task should continue instead of being set to
waiting.