### PR TITLE
Copyright.2015

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,18 @@
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 all: version docs ordereddict
 

--- a/README
+++ b/README
@@ -1,5 +1,5 @@
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/README
+++ b/README
@@ -1,18 +1,18 @@
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 This is the Cylc Suite Engine, version: cylc -v
 

--- a/admin/get-repo-version
+++ b/admin/get-repo-version
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/admin/get-repo-version
+++ b/admin/get-repo-version
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # This script determines the cylc version string in a repository clone
 # and echoes it to stdout. It is executed by lib/cylc/version.py when

--- a/bin/cycl
+++ b/bin/cycl
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Catch a common command line typo: 'cycl'. This could be done by shell
 # alias, but we're relieving the user of the burden.

--- a/bin/cycl
+++ b/bin/cycl
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc
+++ b/bin/cylc
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, re, sys
 import subprocess

--- a/bin/cylc
+++ b/bin/cylc
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-5to6
+++ b/bin/cylc-5to6
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Transform a cylc 5 suite rc file into a cylc 6 suite rc file where possible.
 

--- a/bin/cylc-5to6
+++ b/bin/cylc-5to6
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-broadcast
+++ b/bin/cylc-broadcast
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 if '--use-ssh' in sys.argv[1:]:

--- a/bin/cylc-broadcast
+++ b/bin/cylc-broadcast
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 from cylc.remote import remrun

--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-cat-state
+++ b/bin/cylc-cat-state
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 from cylc.remote import remrun

--- a/bin/cylc-cat-state
+++ b/bin/cylc-cat-state
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-check-software
+++ b/bin/cylc-check-software
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Check for cylc software dependencies
 

--- a/bin/cylc-check-software
+++ b/bin/cylc-check-software
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-check-versions
+++ b/bin/cylc-check-versions
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys, os, re
 from subprocess import Popen, PIPE

--- a/bin/cylc-check-versions
+++ b/bin/cylc-check-versions
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-conditions
+++ b/bin/cylc-conditions
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 usage() {
     echo "USAGE: cylc [license] warranty [--help]"

--- a/bin/cylc-conditions
+++ b/bin/cylc-conditions
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-copy
+++ b/bin/cylc-copy
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 from cylc.remote import remrun

--- a/bin/cylc-copy
+++ b/bin/cylc-copy
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-cycle-point
+++ b/bin/cylc-cycle-point
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-cycle-point
+++ b/bin/cylc-cycle-point
@@ -1,21 +1,21 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, sys, re
 import cylc.cycling.iso8601

--- a/bin/cylc-depend
+++ b/bin/cylc-depend
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 if '--use-ssh' in sys.argv[1:]:

--- a/bin/cylc-depend
+++ b/bin/cylc-depend
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-diff
+++ b/bin/cylc-diff
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 from cylc.remote import remrun

--- a/bin/cylc-diff
+++ b/bin/cylc-diff
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-documentation
+++ b/bin/cylc-documentation
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys, os, re
 import subprocess

--- a/bin/cylc-documentation
+++ b/bin/cylc-documentation
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-dump
+++ b/bin/cylc-dump
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 if '--use-ssh' in sys.argv[1:]:

--- a/bin/cylc-dump
+++ b/bin/cylc-dump
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-edit
+++ b/bin/cylc-edit
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 from cylc.remote import remrun

--- a/bin/cylc-edit
+++ b/bin/cylc-edit
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-email-suite
+++ b/bin/cylc-email-suite
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 usage() {
     echo "USAGE: cylc [hook] email-suite EVENT SUITE MESSAGE"

--- a/bin/cylc-email-suite
+++ b/bin/cylc-email-suite
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-email-task
+++ b/bin/cylc-email-task
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 usage() {
     echo "USAGE: cylc [hook] email-task EVENT SUITE TASKID MESSAGE"

--- a/bin/cylc-email-task
+++ b/bin/cylc-email-task
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-failed
+++ b/bin/cylc-failed
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-failed
+++ b/bin/cylc-failed
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, sys
 from optparse import OptionParser

--- a/bin/cylc-get-cylc-version
+++ b/bin/cylc-get-cylc-version
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 if '--use-ssh' in sys.argv[1:]:

--- a/bin/cylc-get-cylc-version
+++ b/bin/cylc-get-cylc-version
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-get-directory
+++ b/bin/cylc-get-directory
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-get-directory
+++ b/bin/cylc-get-directory
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 from cylc.CylcOptionParsers import cop

--- a/bin/cylc-get-gui-config
+++ b/bin/cylc-get-gui-config
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 from optparse import OptionParser

--- a/bin/cylc-get-gui-config
+++ b/bin/cylc-get-gui-config
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-get-site-config
+++ b/bin/cylc-get-site-config
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 from optparse import OptionParser

--- a/bin/cylc-get-site-config
+++ b/bin/cylc-get-site-config
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-get-suite-config
+++ b/bin/cylc-get-suite-config
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 from cylc.remote import remrun

--- a/bin/cylc-get-suite-config
+++ b/bin/cylc-get-suite-config
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-gpanel
+++ b/bin/cylc-gpanel
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from optparse import OptionParser
 import os

--- a/bin/cylc-gpanel
+++ b/bin/cylc-gpanel
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-graph
+++ b/bin/cylc-graph
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 from cylc.remote import remrun

--- a/bin/cylc-graph
+++ b/bin/cylc-graph
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-gsummary
+++ b/bin/cylc-gsummary
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-gsummary
+++ b/bin/cylc-gsummary
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from optparse import OptionParser
 

--- a/bin/cylc-gui
+++ b/bin/cylc-gui
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 if '--use-ssh' in sys.argv[1:]:

--- a/bin/cylc-gui
+++ b/bin/cylc-gui
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-hold
+++ b/bin/cylc-hold
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 if '--use-ssh' in sys.argv[1:]:

--- a/bin/cylc-hold
+++ b/bin/cylc-hold
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-import-examples
+++ b/bin/cylc-import-examples
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 set -e
 

--- a/bin/cylc-import-examples
+++ b/bin/cylc-import-examples
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-insert
+++ b/bin/cylc-insert
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 if '--use-ssh' in sys.argv[1:]:

--- a/bin/cylc-insert
+++ b/bin/cylc-insert
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-job-kill
+++ b/bin/cylc-job-kill
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-job-kill
+++ b/bin/cylc-job-kill
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """cylc [control] job-kill ST-FILE
 
 (This command is for internal use. Users should use "cylc kill".) Read the job

--- a/bin/cylc-job-poll
+++ b/bin/cylc-job-poll
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """cylc [control] job-poll ST-FILE
 
 (This command is for internal use. Users should use "cylc poll".) Poll a

--- a/bin/cylc-job-poll
+++ b/bin/cylc-job-poll
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-job-submit
+++ b/bin/cylc-job-submit
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """cylc [task] job-submit [--remote-mode] JOB-FILE-PATH
 

--- a/bin/cylc-job-submit
+++ b/bin/cylc-job-submit
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-jobscript
+++ b/bin/cylc-jobscript
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 set -e
 

--- a/bin/cylc-jobscript
+++ b/bin/cylc-jobscript
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-kill
+++ b/bin/cylc-kill
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 if '--use-ssh' in sys.argv[1:]:

--- a/bin/cylc-kill
+++ b/bin/cylc-kill
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-list
+++ b/bin/cylc-list
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-list
+++ b/bin/cylc-list
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, sys
 from cylc.remote import remrun

--- a/bin/cylc-message
+++ b/bin/cylc-message
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-message
+++ b/bin/cylc-message
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, sys
 from optparse import OptionParser

--- a/bin/cylc-monitor
+++ b/bin/cylc-monitor
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """
 Display the state of all existing task proxy objects.

--- a/bin/cylc-monitor
+++ b/bin/cylc-monitor
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-nudge
+++ b/bin/cylc-nudge
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 if '--use-ssh' in sys.argv[1:]:

--- a/bin/cylc-nudge
+++ b/bin/cylc-nudge
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-ping
+++ b/bin/cylc-ping
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 if '--use-ssh' in sys.argv[1:]:

--- a/bin/cylc-ping
+++ b/bin/cylc-ping
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-poll
+++ b/bin/cylc-poll
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 if '--use-ssh' in sys.argv[1:]:

--- a/bin/cylc-poll
+++ b/bin/cylc-poll
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-print
+++ b/bin/cylc-print
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 from cylc.remote import remrun

--- a/bin/cylc-print
+++ b/bin/cylc-print
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-purge
+++ b/bin/cylc-purge
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 if '--use-ssh' in sys.argv[1:]:

--- a/bin/cylc-purge
+++ b/bin/cylc-purge
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-random
+++ b/bin/cylc-random
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, sys
 import random

--- a/bin/cylc-random
+++ b/bin/cylc-random
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-refresh
+++ b/bin/cylc-refresh
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 from cylc.remote import remrun

--- a/bin/cylc-refresh
+++ b/bin/cylc-refresh
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-register
+++ b/bin/cylc-register
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 from cylc.remote import remrun

--- a/bin/cylc-register
+++ b/bin/cylc-register
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-release
+++ b/bin/cylc-release
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 if '--use-ssh' in sys.argv[1:]:

--- a/bin/cylc-release
+++ b/bin/cylc-release
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-reload
+++ b/bin/cylc-reload
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 if '--use-ssh' in sys.argv[1:]:

--- a/bin/cylc-reload
+++ b/bin/cylc-reload
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-remove
+++ b/bin/cylc-remove
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 if '--use-ssh' in sys.argv[1:]:

--- a/bin/cylc-remove
+++ b/bin/cylc-remove
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-reregister
+++ b/bin/cylc-reregister
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 from cylc.remote import remrun

--- a/bin/cylc-reregister
+++ b/bin/cylc-reregister
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-reset
+++ b/bin/cylc-reset
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 if '--use-ssh' in sys.argv[1:]:

--- a/bin/cylc-reset
+++ b/bin/cylc-reset
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-restart
+++ b/bin/cylc-restart
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 from cylc.remote import remrun

--- a/bin/cylc-restart
+++ b/bin/cylc-restart
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-run
+++ b/bin/cylc-run
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 from cylc.remote import remrun

--- a/bin/cylc-run
+++ b/bin/cylc-run
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-scan
+++ b/bin/cylc-scan
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-scan
+++ b/bin/cylc-scan
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """cylc [discovery] scan [OPTIONS] [HOSTS ...]
 
 Detect running suites by port scanning.  Use --verbose to see (with "connection

--- a/bin/cylc-scp-transfer
+++ b/bin/cylc-scp-transfer
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 set -eu
 

--- a/bin/cylc-scp-transfer
+++ b/bin/cylc-scp-transfer
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-search
+++ b/bin/cylc-search
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 from cylc.remote import remrun

--- a/bin/cylc-search
+++ b/bin/cylc-search
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-set-runahead
+++ b/bin/cylc-set-runahead
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 if '--use-ssh' in sys.argv[1:]:

--- a/bin/cylc-set-runahead
+++ b/bin/cylc-set-runahead
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-set-verbosity
+++ b/bin/cylc-set-verbosity
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 

--- a/bin/cylc-set-verbosity
+++ b/bin/cylc-set-verbosity
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-show
+++ b/bin/cylc-show
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 if '--use-ssh' in sys.argv[1:]:

--- a/bin/cylc-show
+++ b/bin/cylc-show
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-started
+++ b/bin/cylc-started
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-started
+++ b/bin/cylc-started
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, sys
 from optparse import OptionParser

--- a/bin/cylc-stop
+++ b/bin/cylc-stop
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 if '--use-ssh' in sys.argv[1:]:

--- a/bin/cylc-stop
+++ b/bin/cylc-stop
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-submit
+++ b/bin/cylc-submit
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 from cylc.remote import remrun

--- a/bin/cylc-submit
+++ b/bin/cylc-submit
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-succeeded
+++ b/bin/cylc-succeeded
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-succeeded
+++ b/bin/cylc-succeeded
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, sys
 from optparse import OptionParser

--- a/bin/cylc-suite-state
+++ b/bin/cylc-suite-state
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, sys
 from time import sleep, time

--- a/bin/cylc-suite-state
+++ b/bin/cylc-suite-state
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-test-battery
+++ b/bin/cylc-test-battery
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 usage() {
   cat <<eof

--- a/bin/cylc-test-battery
+++ b/bin/cylc-test-battery
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-test-db
+++ b/bin/cylc-test-db
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 set -e
 

--- a/bin/cylc-test-db
+++ b/bin/cylc-test-db
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-trigger
+++ b/bin/cylc-trigger
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 if '--use-ssh' in sys.argv[1:]:

--- a/bin/cylc-trigger
+++ b/bin/cylc-trigger
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-unregister
+++ b/bin/cylc-unregister
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 from cylc.remote import remrun

--- a/bin/cylc-unregister
+++ b/bin/cylc-unregister
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-upgrade-db
+++ b/bin/cylc-upgrade-db
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys, os
 from optparse import OptionParser

--- a/bin/cylc-upgrade-db
+++ b/bin/cylc-upgrade-db
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-upgrade-run-dir
+++ b/bin/cylc-upgrade-run-dir
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
 import os

--- a/bin/cylc-upgrade-run-dir
+++ b/bin/cylc-upgrade-run-dir
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-validate
+++ b/bin/cylc-validate
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 from cylc.remote import remrun

--- a/bin/cylc-validate
+++ b/bin/cylc-validate
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-view
+++ b/bin/cylc-view
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 from cylc.remote import remrun

--- a/bin/cylc-view
+++ b/bin/cylc-view
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-warranty
+++ b/bin/cylc-warranty
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/cylc-warranty
+++ b/bin/cylc-warranty
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 import sys

--- a/bin/gcapture
+++ b/bin/gcapture
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/gcapture
+++ b/bin/gcapture
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, sys
 from optparse import OptionParser

--- a/bin/gcontrol
+++ b/bin/gcontrol
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 echo "WARNING: \"gcontrol\" is deprecated - it is now called \"gcylc\""
 echo "WARNING: This command alias will eventually be deleted."

--- a/bin/gcontrol
+++ b/bin/gcontrol
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/gcycl
+++ b/bin/gcycl
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Catch a common command line typo: 'gcycl':
 echo >&2

--- a/bin/gcycl
+++ b/bin/gcycl
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/bin/gcylc
+++ b/bin/gcylc
@@ -1,19 +1,19 @@
 #!/bin/bash
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 exec $(dirname $0)/cylc gui "$@"

--- a/bin/gcylc
+++ b/bin/gcylc
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/conf/5to6/5to6.sedfile
+++ b/conf/5to6/5to6.sedfile
@@ -1,5 +1,5 @@
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/conf/5to6/5to6.sedfile
+++ b/conf/5to6/5to6.sedfile
@@ -1,18 +1,18 @@
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Sed command file for the 5 to 6 cylc suite.rc syntax transformer tool.
 #

--- a/dev/bin/addcopyright.pl
+++ b/dev/bin/addcopyright.pl
@@ -16,21 +16,21 @@ while (<>) {
     if ( $skip and $count == 1 or ! $skip and $count == 0 ) {
         print <<eof
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 eof
     }
     $count += 1;

--- a/dev/bin/addcopyright.pl
+++ b/dev/bin/addcopyright.pl
@@ -17,7 +17,7 @@ while (<>) {
         print <<eof
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/dev/bin/updatecopyright.sh
+++ b/dev/bin/updatecopyright.sh
@@ -6,11 +6,11 @@ set -e
 # USAGE:
 # cd $CYLC_DIR
 # find . -type f -not -path "./.*" | xargs dev/bin/updatecopyright.sh
-# (find path exclusion avoids .git directory!)
+# (find path exclusion avoids .git directory)
 
 YY=$(date +%y)
 
-OLD="Copyright \(C\) 2008-20\d\d Hilary Oliver, NIWA"
+OLD="Copyright \(C\) 2008-20\d\d NIWA"
 NEW="Copyright (C) 2008-20$YY NIWA"
 
 FILES=$@

--- a/dev/registration.py.dict
+++ b/dev/registration.py.dict
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import pickle
 import datetime, time

--- a/dev/registration.py.dict
+++ b/dev/registration.py.dict
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,20 +1,20 @@
 #!/usr/bin/make -f
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 CYLC=$(dir $(abspath $(lastword $(MAKEFILE_LIST))))../bin/cylc
 

--- a/doc/cug-html.tex
+++ b/doc/cug-html.tex
@@ -25,7 +25,7 @@
 \renewcommand{\headsep}{10pt}
 \lhead{\leftmark}
 \rhead{\rightmark}
-\lfoot{Copyright Hilary Oliver, NIWA, 2008-2014}
+\lfoot{Copyright (C) 2008-2015 NIWA}
 \rfoot{\thepage}
 
 \usepackage{titlepic}  % off CTAN, held locally in cylc doc dir.

--- a/doc/cug-html.tex
+++ b/doc/cug-html.tex
@@ -203,7 +203,7 @@ basicstyle=\color{basic}\ttfamily,
 User Guide \\
 \protect \input{cylc-version.txt} \\
 GNU GPL v3.0 Software License \\
-Copyright (C) 2008-2014 NIWA}
+Copyright (C) 2008-2015 NIWA}
 
 \author{Hilary Oliver}
 

--- a/doc/cug-pdf.tex
+++ b/doc/cug-pdf.tex
@@ -24,7 +24,7 @@
 \renewcommand{\headsep}{10pt}
 \lhead{\leftmark}
 \rhead{\rightmark}
-\lfoot{Copyright (C) 2008-2014 NIWA}
+\lfoot{Copyright (C) 2008-2015 NIWA}
 \rfoot{\thepage}
 
 \usepackage{lmodern}

--- a/doc/cug-pdf.tex
+++ b/doc/cug-pdf.tex
@@ -154,7 +154,7 @@ User Guide \linebreak
 \input{cylc-version.txt} % generated each time by doc/process
 } \linebreak
 {\em \small Released Under the GNU GPL v3.0 Software License} \linebreak
-{\small Copyright Hilary Oliver, NIWA, 2008-2013}}
+{\small Copyright (C) 2008-2015 NIWA}}
 
 \author{Hilary Oliver}
 

--- a/doc/cug.tex
+++ b/doc/cug.tex
@@ -1041,7 +1041,7 @@ you can exit the terminal or even log out without killing the suite:
 shell$ cylc run tut.oneoff.basic
 ************************************************************************
 *                     The Cylc Suite Engine [6.0.0]                    *
-*             Copyright (C) 2008-2014 NIWA              *
+*             Copyright (C) 2008-2015 NIWA              *
 *                                                                      *
 * This program comes with ABSOLUTELY NO WARRANTY.  It is free software;*
 * you are welcome to redistribute it under certain conditions. Details:*
@@ -1085,7 +1085,7 @@ submission commands to to be printed stdout:
 shell$ cylc run --debug tut.oneoff.basic
 ************************************************************************
 *                     The Cylc Suite Engine [6.0.0]                    *
-*             Copyright (C) 2008-2014 NIWA              *
+*             Copyright (C) 2008-2015 NIWA              *
 *                                                                      *
 * This program comes with ABSOLUTELY NO WARRANTY.  It is free software;*
 * you are welcome to redistribute it under certain conditions. Details:*
@@ -1201,7 +1201,7 @@ job submission command printed to stdout:
  cylc run --debug tut.oneoff.jobsub
 ************************************************************************
 *        The Cylc Suite Engine [6.0.0alpha1-294-ge08560-dirty]         *
-*             Copyright (C) 2008-2014 NIWA              *
+*             Copyright (C) 2008-2015 NIWA              *
 *                                                                      *
 * This program comes with ABSOLUTELY NO WARRANTY.  It is free software;*
 * you are welcome to redistribute it under certain conditions. Details:*

--- a/doc/graphics/scale-images.sh
+++ b/doc/graphics/scale-images.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/doc/graphics/scale-images.sh
+++ b/doc/graphics/scale-images.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Scale png images down *if they are wider than 600px* for use in the
 # HTML User Guide.

--- a/doc/scripts/make-commands.sh
+++ b/doc/scripts/make-commands.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/doc/scripts/make-commands.sh
+++ b/doc/scripts/make-commands.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 CYLC=../bin/cylc
 

--- a/doc/scripts/make-html.sh
+++ b/doc/scripts/make-html.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/doc/scripts/make-html.sh
+++ b/doc/scripts/make-html.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 set -e
 

--- a/doc/scripts/make-index.sh
+++ b/doc/scripts/make-index.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # This script generates an HTML index page linking to cylc
 # documentation. It is intended to be executed automatically 

--- a/doc/scripts/make-index.sh
+++ b/doc/scripts/make-index.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/doc/scripts/make-pdf.sh
+++ b/doc/scripts/make-pdf.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/doc/scripts/make-pdf.sh
+++ b/doc/scripts/make-pdf.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 set -e
 

--- a/lib/cylc/CylcError.py
+++ b/lib/cylc/CylcError.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Here lies the unfinished early beginnings of more consistent
 cylc-wide exception handling ..."""

--- a/lib/cylc/CylcError.py
+++ b/lib/cylc/CylcError.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/CylcOptionParsers.py
+++ b/lib/cylc/CylcOptionParsers.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, re
 from optparse import OptionParser

--- a/lib/cylc/CylcOptionParsers.py
+++ b/lib/cylc/CylcOptionParsers.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/RunEventHandler.py
+++ b/lib/cylc/RunEventHandler.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import subprocess
 import logging

--- a/lib/cylc/RunEventHandler.py
+++ b/lib/cylc/RunEventHandler.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/__init__.py
+++ b/lib/cylc/__init__.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Set up the cylc environment.
 

--- a/lib/cylc/__init__.py
+++ b/lib/cylc/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/batch_sys_handlers/at.py
+++ b/lib/cylc/batch_sys_handlers/at.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Logic to submit jobs to the "at" batch system."""
 
 import re

--- a/lib/cylc/batch_sys_handlers/at.py
+++ b/lib/cylc/batch_sys_handlers/at.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/batch_sys_handlers/background.py
+++ b/lib/cylc/batch_sys_handlers/background.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/batch_sys_handlers/background.py
+++ b/lib/cylc/batch_sys_handlers/background.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Background job submission and manipulation."""
 
 import os

--- a/lib/cylc/batch_sys_handlers/loadleveler.py
+++ b/lib/cylc/batch_sys_handlers/loadleveler.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 "Loadleveler job submission"
 
 import re

--- a/lib/cylc/batch_sys_handlers/loadleveler.py
+++ b/lib/cylc/batch_sys_handlers/loadleveler.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/batch_sys_handlers/pbs.py
+++ b/lib/cylc/batch_sys_handlers/pbs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/batch_sys_handlers/pbs.py
+++ b/lib/cylc/batch_sys_handlers/pbs.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 "PBS batch system job submission and manipulation."
 
 import re

--- a/lib/cylc/batch_sys_handlers/sge.py
+++ b/lib/cylc/batch_sys_handlers/sge.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 "SGE qsub job submission"
 
 import re

--- a/lib/cylc/batch_sys_handlers/sge.py
+++ b/lib/cylc/batch_sys_handlers/sge.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/batch_sys_handlers/slurm.py
+++ b/lib/cylc/batch_sys_handlers/slurm.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """SLURM job submission and manipulation."""
 
 import re

--- a/lib/cylc/batch_sys_handlers/slurm.py
+++ b/lib/cylc/batch_sys_handlers/slurm.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/batch_sys_manager.py
+++ b/lib/cylc/batch_sys_manager.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/batch_sys_manager.py
+++ b/lib/cylc/batch_sys_manager.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Manage submission, poll and kill of a job to the batch systems.
 

--- a/lib/cylc/batchproc.py
+++ b/lib/cylc/batchproc.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/batchproc.py
+++ b/lib/cylc/batchproc.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys, re
 import subprocess

--- a/lib/cylc/broadcast.py
+++ b/lib/cylc/broadcast.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import Pyro.core
 from copy import deepcopy

--- a/lib/cylc/broadcast.py
+++ b/lib/cylc/broadcast.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/broker.py
+++ b/lib/cylc/broker.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/broker.py
+++ b/lib/cylc/broker.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
 

--- a/lib/cylc/cfgspec/gcylc.py
+++ b/lib/cylc/cfgspec/gcylc.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/cfgspec/gcylc.py
+++ b/lib/cylc/cfgspec/gcylc.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, sys, gtk
 from copy import deepcopy, copy

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, sys, re
 import atexit

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/cfgspec/suite.py
+++ b/lib/cylc/cfgspec/suite.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
 

--- a/lib/cylc/cfgspec/suite.py
+++ b/lib/cylc/cfgspec/suite.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/command_polling.py
+++ b/lib/cylc/command_polling.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 from time import sleep, time

--- a/lib/cylc/command_polling.py
+++ b/lib/cylc/command_polling.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/command_prep.py
+++ b/lib/cylc/command_prep.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
 from cylc.passphrase import passphrase

--- a/lib/cylc/command_prep.py
+++ b/lib/cylc/command_prep.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re, os, sys
 import traceback

--- a/lib/cylc/cycling/__init__.py
+++ b/lib/cylc/cycling/__init__.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """This module provides base classes for cycling data objects."""
 

--- a/lib/cylc/cycling/__init__.py
+++ b/lib/cylc/cycling/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/cycling/integer.py
+++ b/lib/cylc/cycling/integer.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 Integer cycling by point, interval, and sequence classes.
 """

--- a/lib/cylc/cycling/integer.py
+++ b/lib/cylc/cycling/integer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/cycling/iso8601.py
+++ b/lib/cylc/cycling/iso8601.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/cycling/iso8601.py
+++ b/lib/cylc/cycling/iso8601.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Date-time cycling by point, interval, and sequence classes."""
 

--- a/lib/cylc/cycling/loader.py
+++ b/lib/cylc/cycling/loader.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """
 Tasks spawn a sequence of POINTS (P) separated by INTERVALS (I).

--- a/lib/cylc/cycling/loader.py
+++ b/lib/cylc/cycling/loader.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/cylc_mode.py
+++ b/lib/cylc/cylc_mode.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
 

--- a/lib/cylc/cylc_mode.py
+++ b/lib/cylc/cylc_mode.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/cylc_pyro_client.py
+++ b/lib/cylc/cylc_pyro_client.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 try:
     import Pyro.core

--- a/lib/cylc/cylc_pyro_client.py
+++ b/lib/cylc/cylc_pyro_client.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/cylc_pyro_server.py
+++ b/lib/cylc/cylc_pyro_server.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 import socket

--- a/lib/cylc/cylc_pyro_server.py
+++ b/lib/cylc/cylc_pyro_server.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/cylc_xdot.py
+++ b/lib/cylc/cylc_xdot.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import xdot
 from gui import util

--- a/lib/cylc/cylc_xdot.py
+++ b/lib/cylc/cylc_xdot.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/dbstatecheck.py
+++ b/lib/cylc/dbstatecheck.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
 import sqlite3

--- a/lib/cylc/dbstatecheck.py
+++ b/lib/cylc/dbstatecheck.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/dump.py
+++ b/lib/cylc/dump.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
 import sys

--- a/lib/cylc/dump.py
+++ b/lib/cylc/dump.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/envvar.py
+++ b/lib/cylc/envvar.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/envvar.py
+++ b/lib/cylc/envvar.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """ environment variable utility functions """
 

--- a/lib/cylc/exceptions.py
+++ b/lib/cylc/exceptions.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 class SchedulerStop( Exception ):
     def __init__( self, msg ):

--- a/lib/cylc/exceptions.py
+++ b/lib/cylc/exceptions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/execute.py
+++ b/lib/cylc/execute.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys, subprocess
 

--- a/lib/cylc/execute.py
+++ b/lib/cylc/execute.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/flags.py
+++ b/lib/cylc/flags.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Some global flags used in cylc"""
 

--- a/lib/cylc/flags.py
+++ b/lib/cylc/flags.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/graphing.py
+++ b/lib/cylc/graphing.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/graphing.py
+++ b/lib/cylc/graphing.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Cylc suite graphing module. Modules relying on this should test for
 ImportError due to pygraphviz/graphviz not being installed."""

--- a/lib/cylc/graphnode.py
+++ b/lib/cylc/graphnode.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from cylc.cycling.loader import get_interval, get_interval_cls
 from cylc.syntax_flags import set_syntax_version, VERSION_PREV, VERSION_NEW

--- a/lib/cylc/graphnode.py
+++ b/lib/cylc/graphnode.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/gui/DotMaker.py
+++ b/lib/cylc/gui/DotMaker.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/gui/DotMaker.py
+++ b/lib/cylc/gui/DotMaker.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import gtk
 from copy import deepcopy

--- a/lib/cylc/gui/DotUpdater.py
+++ b/lib/cylc/gui/DotUpdater.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import gobject
 import gtk

--- a/lib/cylc/gui/DotUpdater.py
+++ b/lib/cylc/gui/DotUpdater.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/gui/GraphUpdater.py
+++ b/lib/cylc/gui/GraphUpdater.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from cylc import cylc_pyro_client, dump, graphing
 from cylc.mkdir_p import mkdir_p

--- a/lib/cylc/gui/GraphUpdater.py
+++ b/lib/cylc/gui/GraphUpdater.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/gui/SuiteControl.py
+++ b/lib/cylc/gui/SuiteControl.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import gtk
 #import pygtk

--- a/lib/cylc/gui/SuiteControl.py
+++ b/lib/cylc/gui/SuiteControl.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by
@@ -1039,7 +1039,7 @@ been defined for this suite""").inform()
                 # set_program_name() was added in PyGTK 2.12
                 about.set_program_name( "cylc" )
         about.set_version( CYLC_VERSION )
-        about.set_copyright( "Copyright (C) 2008-2014 NIWA" )
+        about.set_copyright( "Copyright (C) 2008-2015 NIWA" )
 
         about.set_comments(
 """

--- a/lib/cylc/gui/SuiteControlGraph.py
+++ b/lib/cylc/gui/SuiteControlGraph.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import gtk
 import os, re

--- a/lib/cylc/gui/SuiteControlGraph.py
+++ b/lib/cylc/gui/SuiteControlGraph.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/gui/SuiteControlLED.py
+++ b/lib/cylc/gui/SuiteControlLED.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import gtk
 import os, re

--- a/lib/cylc/gui/SuiteControlLED.py
+++ b/lib/cylc/gui/SuiteControlLED.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/gui/SuiteControlTree.py
+++ b/lib/cylc/gui/SuiteControlTree.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import gtk
 import os, re

--- a/lib/cylc/gui/SuiteControlTree.py
+++ b/lib/cylc/gui/SuiteControlTree.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/gui/TreeUpdater.py
+++ b/lib/cylc/gui/TreeUpdater.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/gui/TreeUpdater.py
+++ b/lib/cylc/gui/TreeUpdater.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from copy import deepcopy
 import datetime

--- a/lib/cylc/gui/color_rotator.py
+++ b/lib/cylc/gui/color_rotator.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 class rotator(object):
     def __init__( self, colors=[ '#fcc', '#cfc', '#bbf', '#ffb' ] ):

--- a/lib/cylc/gui/color_rotator.py
+++ b/lib/cylc/gui/color_rotator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/gui/combo_logviewer.py
+++ b/lib/cylc/gui/combo_logviewer.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/gui/combo_logviewer.py
+++ b/lib/cylc/gui/combo_logviewer.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Cylc gui log viewer, with a combo box for log file selection."""
 
 import gtk

--- a/lib/cylc/gui/cylc_logviewer.py
+++ b/lib/cylc/gui/cylc_logviewer.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from filtered_tailer import filtered_tailer
 from tailer import tailer

--- a/lib/cylc/gui/cylc_logviewer.py
+++ b/lib/cylc/gui/cylc_logviewer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/gui/dbchooser.py
+++ b/lib/cylc/gui/dbchooser.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import gobject
 #import pygtk

--- a/lib/cylc/gui/dbchooser.py
+++ b/lib/cylc/gui/dbchooser.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/gui/filtered_tailer.py
+++ b/lib/cylc/gui/filtered_tailer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/gui/filtered_tailer.py
+++ b/lib/cylc/gui/filtered_tailer.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import gobject
 from tailer import tailer

--- a/lib/cylc/gui/gcapture.py
+++ b/lib/cylc/gui/gcapture.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/gui/gcapture.py
+++ b/lib/cylc/gui/gcapture.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from tailer import tailer
 import gtk

--- a/lib/cylc/gui/gpanel.py
+++ b/lib/cylc/gui/gpanel.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import copy
 import datetime

--- a/lib/cylc/gui/gpanel.py
+++ b/lib/cylc/gui/gpanel.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/gui/graph.py
+++ b/lib/cylc/gui/graph.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import gobject
 #import pygtk

--- a/lib/cylc/gui/graph.py
+++ b/lib/cylc/gui/graph.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/gui/gsummary.py
+++ b/lib/cylc/gui/gsummary.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import copy
 import datetime

--- a/lib/cylc/gui/gsummary.py
+++ b/lib/cylc/gui/gsummary.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by
@@ -263,7 +263,7 @@ def launch_about_dialog(program_name, hosts):
         comments_text = program_name + "\n" + hosts_text
 
     about.set_version(CYLC_VERSION)
-    about.set_copyright("Copyright (C) 2008-2014 NIWA")
+    about.set_copyright("Copyright (C) 2008-2015 NIWA")
     about.set_comments(comments_text)
     about.set_icon(get_icon())
     about.run()

--- a/lib/cylc/gui/legend.py
+++ b/lib/cylc/gui/legend.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import gtk
 #import pygtk

--- a/lib/cylc/gui/legend.py
+++ b/lib/cylc/gui/legend.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/gui/logviewer.py
+++ b/lib/cylc/gui/logviewer.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import gtk
 import pygtk

--- a/lib/cylc/gui/logviewer.py
+++ b/lib/cylc/gui/logviewer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/gui/option_group.py
+++ b/lib/cylc/gui/option_group.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/gui/option_group.py
+++ b/lib/cylc/gui/option_group.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import gtk
 

--- a/lib/cylc/gui/tailer.py
+++ b/lib/cylc/gui/tailer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/gui/tailer.py
+++ b/lib/cylc/gui/tailer.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import gobject
 import threading, subprocess

--- a/lib/cylc/gui/textload.py
+++ b/lib/cylc/gui/textload.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import gtk
 import pygtk

--- a/lib/cylc/gui/textload.py
+++ b/lib/cylc/gui/textload.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/gui/updater.py
+++ b/lib/cylc/gui/updater.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/gui/updater.py
+++ b/lib/cylc/gui/updater.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from cylc import cylc_pyro_client, dump
 from cylc.task_state import task_state

--- a/lib/cylc/gui/util.py
+++ b/lib/cylc/gui/util.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/gui/util.py
+++ b/lib/cylc/gui/util.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
 import sys

--- a/lib/cylc/gui/warning_dialog.py
+++ b/lib/cylc/gui/warning_dialog.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import gtk
 import pygtk

--- a/lib/cylc/gui/warning_dialog.py
+++ b/lib/cylc/gui/warning_dialog.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/host_select.py
+++ b/lib/cylc/host_select.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, re
 from cylc.run_get_stdout import run_get_stdout

--- a/lib/cylc/host_select.py
+++ b/lib/cylc/host_select.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/job_file.py
+++ b/lib/cylc/job_file.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Write task job files."""
 
 import os

--- a/lib/cylc/job_file.py
+++ b/lib/cylc/job_file.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/job_host.py
+++ b/lib/cylc/job_host.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Manage a remote job host."""
 
 import os

--- a/lib/cylc/job_host.py
+++ b/lib/cylc/job_host.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/job_logs.py
+++ b/lib/cylc/job_logs.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Logging of output from job activities."""
 
 import os

--- a/lib/cylc/job_logs.py
+++ b/lib/cylc/job_logs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/mkdir_p.py
+++ b/lib/cylc/mkdir_p.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # A function that emulates the shell's 'mkdir -p', i.e. it creates
 # intermediate directories if necessary AND does not throw an exception

--- a/lib/cylc/mkdir_p.py
+++ b/lib/cylc/mkdir_p.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/mp_pool.py
+++ b/lib/cylc/mp_pool.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Process pool to execute shell commands for the suite daemon.
 
 In debug mode, commands are printed to stdout before execution.

--- a/lib/cylc/mp_pool.py
+++ b/lib/cylc/mp_pool.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/multisubprocess.py
+++ b/lib/cylc/multisubprocess.py
@@ -1,20 +1,20 @@
 #!/usr/bin/python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import subprocess
 from cylc.wallclock import get_current_time_string

--- a/lib/cylc/multisubprocess.py
+++ b/lib/cylc/multisubprocess.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/output.py
+++ b/lib/cylc/output.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
 from cycling.loader import get_interval, get_interval_cls

--- a/lib/cylc/output.py
+++ b/lib/cylc/output.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/outputs.py
+++ b/lib/cylc/outputs.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re, sys
 

--- a/lib/cylc/outputs.py
+++ b/lib/cylc/outputs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/owner.py
+++ b/lib/cylc/owner.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """In analogy with cylc.hostname.is_remote_host(), determine if a
 username is "remote"."""

--- a/lib/cylc/owner.py
+++ b/lib/cylc/owner.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/passphrase.py
+++ b/lib/cylc/passphrase.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/passphrase.py
+++ b/lib/cylc/passphrase.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, re
 from stat import *

--- a/lib/cylc/poll_timer.py
+++ b/lib/cylc/poll_timer.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Timer for polling task job submission and execution."""
 
 import time

--- a/lib/cylc/poll_timer.py
+++ b/lib/cylc/poll_timer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/port_file.py
+++ b/lib/cylc/port_file.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, sys
 from suite_host import is_remote_host

--- a/lib/cylc/port_file.py
+++ b/lib/cylc/port_file.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/port_scan.py
+++ b/lib/cylc/port_scan.py
@@ -1,20 +1,20 @@
 #!/usr/bin/pyro
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, sys
 from suite_host import get_hostname

--- a/lib/cylc/port_scan.py
+++ b/lib/cylc/port_scan.py
@@ -1,7 +1,7 @@
 #!/usr/bin/pyro
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/prerequisites/conditionals.py
+++ b/lib/cylc/prerequisites/conditionals.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/prerequisites/conditionals.py
+++ b/lib/cylc/prerequisites/conditionals.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re, sys
 from simplify import conditional_simplifier

--- a/lib/cylc/prerequisites/plain_prerequisites.py
+++ b/lib/cylc/prerequisites/plain_prerequisites.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/prerequisites/plain_prerequisites.py
+++ b/lib/cylc/prerequisites/plain_prerequisites.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re, sys
 from cylc.cycling.loader import get_point

--- a/lib/cylc/prerequisites/prerequisites.py
+++ b/lib/cylc/prerequisites/prerequisites.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
 

--- a/lib/cylc/prerequisites/prerequisites.py
+++ b/lib/cylc/prerequisites/prerequisites.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/prerequisites/simplify.py
+++ b/lib/cylc/prerequisites/simplify.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
 import ast

--- a/lib/cylc/prerequisites/simplify.py
+++ b/lib/cylc/prerequisites/simplify.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/print_tree.py
+++ b/lib/cylc/print_tree.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
 

--- a/lib/cylc/print_tree.py
+++ b/lib/cylc/print_tree.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/prompt.py
+++ b/lib/cylc/prompt.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 

--- a/lib/cylc/prompt.py
+++ b/lib/cylc/prompt.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/registration.py
+++ b/lib/cylc/registration.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/registration.py
+++ b/lib/cylc/registration.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
 import sys

--- a/lib/cylc/regpath.py
+++ b/lib/cylc/regpath.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
 

--- a/lib/cylc/regpath.py
+++ b/lib/cylc/regpath.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/regprompt.py
+++ b/lib/cylc/regprompt.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/regprompt.py
+++ b/lib/cylc/regprompt.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 def prompt( question, default ):
     def explain():

--- a/lib/cylc/remote.py
+++ b/lib/cylc/remote.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Run command on a remote host."""
 
 import os

--- a/lib/cylc/remote.py
+++ b/lib/cylc/remote.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/rolling_archive.py
+++ b/lib/cylc/rolling_archive.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # Implements a simple rolling archive based on a given base filename.
 # Used for cylc state dump files.

--- a/lib/cylc/rolling_archive.py
+++ b/lib/cylc/rolling_archive.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/run.py
+++ b/lib/cylc/run.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Provide the main function for "cylc run" and "cylc restart"."""
 

--- a/lib/cylc/run.py
+++ b/lib/cylc/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by
@@ -28,7 +28,7 @@ from exceptions import SchedulerStop, SchedulerError
 def print_blurb():
     lines = []
     lines.append( " The Cylc Suite Engine [" + CYLC_VERSION + "] " )
-    lines.append( " Copyright (C) 2008-2014 NIWA " )
+    lines.append( " Copyright (C) 2008-2015 NIWA " )
 
     lic = """
  This program comes with ABSOLUTELY NO WARRANTY.  It is free software;

--- a/lib/cylc/run_get_stdout.py
+++ b/lib/cylc/run_get_stdout.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/run_get_stdout.py
+++ b/lib/cylc/run_get_stdout.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 import subprocess

--- a/lib/cylc/rundb.py
+++ b/lib/cylc/rundb.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
 import errno

--- a/lib/cylc/rundb.py
+++ b/lib/cylc/rundb.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from cylc_pyro_server import pyro_server
 from cylc.job_host import RemoteJobHostManager

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/state_summary.py
+++ b/lib/cylc/state_summary.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/state_summary.py
+++ b/lib/cylc/state_summary.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import Pyro.core
 import logging

--- a/lib/cylc/strftime.py
+++ b/lib/cylc/strftime.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import datetime
 

--- a/lib/cylc/strftime.py
+++ b/lib/cylc/strftime.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/suite_cmd_interface.py
+++ b/lib/cylc/suite_cmd_interface.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/suite_cmd_interface.py
+++ b/lib/cylc/suite_cmd_interface.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import Pyro.core
 from Queue import Queue

--- a/lib/cylc/suite_host.py
+++ b/lib/cylc/suite_host.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re, sys, socket
 

--- a/lib/cylc/suite_host.py
+++ b/lib/cylc/suite_host.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/suite_id.py
+++ b/lib/cylc/suite_id.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # A minimal Pyro-connected object to allow client programs to identify
 # what suite is running at a given cylc port - by suite name and owner.

--- a/lib/cylc/suite_id.py
+++ b/lib/cylc/suite_id.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/suite_info_interface.py
+++ b/lib/cylc/suite_info_interface.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import Pyro.core
 

--- a/lib/cylc/suite_info_interface.py
+++ b/lib/cylc/suite_info_interface.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/suite_log_interface.py
+++ b/lib/cylc/suite_log_interface.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/suite_log_interface.py
+++ b/lib/cylc/suite_log_interface.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import Pyro.core
 import os

--- a/lib/cylc/suite_logging.py
+++ b/lib/cylc/suite_logging.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, sys, re
 import logging, logging.handlers

--- a/lib/cylc/suite_logging.py
+++ b/lib/cylc/suite_logging.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/suite_output.py
+++ b/lib/cylc/suite_output.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, sys
 import logging, logging.handlers

--- a/lib/cylc/suite_output.py
+++ b/lib/cylc/suite_output.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/suite_state_dumping.py
+++ b/lib/cylc/suite_state_dumping.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/suite_state_dumping.py
+++ b/lib/cylc/suite_state_dumping.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """State dump generator."""
 
 import errno

--- a/lib/cylc/syntax_flags.py
+++ b/lib/cylc/syntax_flags.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Global syntax flags used in cylc"""
 

--- a/lib/cylc/syntax_flags.py
+++ b/lib/cylc/syntax_flags.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/tail.py
+++ b/lib/cylc/tail.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/tail.py
+++ b/lib/cylc/tail.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import time
 

--- a/lib/cylc/task_id.py
+++ b/lib/cylc/task_id.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/task_id.py
+++ b/lib/cylc/task_id.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Task ID utilities."""
 
 

--- a/lib/cylc/task_message.py
+++ b/lib/cylc/task_message.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/task_message.py
+++ b/lib/cylc/task_message.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Task to cylc progress messaging."""
 

--- a/lib/cylc/task_output_logs.py
+++ b/lib/cylc/task_output_logs.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
 

--- a/lib/cylc/task_output_logs.py
+++ b/lib/cylc/task_output_logs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Manage the task pool of a suite.
 
 All new task proxies (including spawned ones) are added first to the runahead

--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Task Proxy."""
 
 import Queue

--- a/lib/cylc/task_receiver.py
+++ b/lib/cylc/task_receiver.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/task_receiver.py
+++ b/lib/cylc/task_receiver.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import Pyro.core
 from Queue import Queue

--- a/lib/cylc/task_state.py
+++ b/lib/cylc/task_state.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
 import sys

--- a/lib/cylc/task_state.py
+++ b/lib/cylc/task_state.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/taskdef.py
+++ b/lib/cylc/taskdef.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Task definition.
 
 NOTE on conditional and non-conditional triggers: all plain triggers

--- a/lib/cylc/taskdef.py
+++ b/lib/cylc/taskdef.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/time_parser.py
+++ b/lib/cylc/time_parser.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """This module is for parsing date/time representations.
 
 Expressions can be formatted in either the full ISO 8601:2004 date/time

--- a/lib/cylc/time_parser.py
+++ b/lib/cylc/time_parser.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/trigger.py
+++ b/lib/cylc/trigger.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
 

--- a/lib/cylc/trigger.py
+++ b/lib/cylc/trigger.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/version.py
+++ b/lib/cylc/version.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/version.py
+++ b/lib/cylc/version.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Determine the cylc version string; repository or raw source distribution."""
 

--- a/lib/cylc/wallclock.py
+++ b/lib/cylc/wallclock.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import flags
 from datetime import datetime, timedelta

--- a/lib/cylc/wallclock.py
+++ b/lib/cylc/wallclock.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/which.py
+++ b/lib/cylc/which.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/cylc/which.py
+++ b/lib/cylc/which.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # python implementation of the unix 'which' command
 

--- a/lib/parsec/Jinja2Support.py
+++ b/lib/parsec/Jinja2Support.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, sys, re
 import glob

--- a/lib/parsec/Jinja2Support.py
+++ b/lib/parsec/Jinja2Support.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/parsec/OrderedDict.py
+++ b/lib/parsec/OrderedDict.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Ordered Dictionary data structure used extensively in cylc."""
 

--- a/lib/parsec/OrderedDict.py
+++ b/lib/parsec/OrderedDict.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/parsec/config.py
+++ b/lib/parsec/config.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, sys, re
 from fileparse import parse, FileNotFoundError

--- a/lib/parsec/config.py
+++ b/lib/parsec/config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/parsec/example/cfgspec.py
+++ b/lib/parsec/example/cfgspec.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from validate import validator as vdr
 

--- a/lib/parsec/example/cfgspec.py
+++ b/lib/parsec/example/cfgspec.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/parsec/example/test.py
+++ b/lib/parsec/example/test.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 import os, sys

--- a/lib/parsec/example/test.py
+++ b/lib/parsec/example/test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/parsec/fileparse.py
+++ b/lib/parsec/fileparse.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/parsec/fileparse.py
+++ b/lib/parsec/fileparse.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
 import sys

--- a/lib/parsec/include.py
+++ b/lib/parsec/include.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/parsec/include.py
+++ b/lib/parsec/include.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re, os, sys
 import datetime

--- a/lib/parsec/tests/getcfg/00-one-line.t
+++ b/lib/parsec/tests/getcfg/00-one-line.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/parsec/tests/getcfg/00-one-line.t
+++ b/lib/parsec/tests/getcfg/00-one-line.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test that one-line config print works
 . $(dirname $0)/test_header

--- a/lib/parsec/tests/lib/bash/test_header
+++ b/lib/parsec/tests/lib/bash/test_header
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # NAME
 #     test_header

--- a/lib/parsec/tests/lib/bash/test_header
+++ b/lib/parsec/tests/lib/bash/test_header
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/parsec/tests/nullcfg/00-missing-file.t
+++ b/lib/parsec/tests/nullcfg/00-missing-file.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test that missing config files yield empty config dicts
 . $(dirname $0)/test_header

--- a/lib/parsec/tests/nullcfg/00-missing-file.t
+++ b/lib/parsec/tests/nullcfg/00-missing-file.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/parsec/tests/nullcfg/01-empty-file.t
+++ b/lib/parsec/tests/nullcfg/01-empty-file.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test that empty config files yield empty config dicts
 . $(dirname $0)/test_header

--- a/lib/parsec/tests/nullcfg/01-empty-file.t
+++ b/lib/parsec/tests/nullcfg/01-empty-file.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/parsec/tests/synonyms/00-boolean.t
+++ b/lib/parsec/tests/synonyms/00-boolean.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test parsing of boolean items
 . $(dirname $0)/test_header

--- a/lib/parsec/tests/synonyms/00-boolean.t
+++ b/lib/parsec/tests/synonyms/00-boolean.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/parsec/tests/synonyms/01-integer.t
+++ b/lib/parsec/tests/synonyms/01-integer.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test parsing of integer items
 . $(dirname $0)/test_header

--- a/lib/parsec/tests/synonyms/01-integer.t
+++ b/lib/parsec/tests/synonyms/01-integer.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/parsec/tests/synonyms/02-float.t
+++ b/lib/parsec/tests/synonyms/02-float.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test parsing of float items
 . $(dirname $0)/test_header

--- a/lib/parsec/tests/synonyms/02-float.t
+++ b/lib/parsec/tests/synonyms/02-float.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/parsec/tests/synonyms/03-string.t
+++ b/lib/parsec/tests/synonyms/03-string.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/parsec/tests/synonyms/03-string.t
+++ b/lib/parsec/tests/synonyms/03-string.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test parsing of string items
 . $(dirname $0)/test_header

--- a/lib/parsec/tests/synonyms/04-integer_list.t
+++ b/lib/parsec/tests/synonyms/04-integer_list.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test parsing of integer list items
 . $(dirname $0)/test_header

--- a/lib/parsec/tests/synonyms/04-integer_list.t
+++ b/lib/parsec/tests/synonyms/04-integer_list.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/parsec/tests/synonyms/05-float_list.t
+++ b/lib/parsec/tests/synonyms/05-float_list.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test parsing of float list items
 . $(dirname $0)/test_header

--- a/lib/parsec/tests/synonyms/05-float_list.t
+++ b/lib/parsec/tests/synonyms/05-float_list.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/parsec/tests/synonyms/06-string_list.t
+++ b/lib/parsec/tests/synonyms/06-string_list.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test parsing of string list items
 . $(dirname $0)/test_header

--- a/lib/parsec/tests/synonyms/06-string_list.t
+++ b/lib/parsec/tests/synonyms/06-string_list.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/parsec/tests/synonyms/lib/python/cfgspec.py
+++ b/lib/parsec/tests/synonyms/lib/python/cfgspec.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from validate import validator as vdr
 

--- a/lib/parsec/tests/synonyms/lib/python/cfgspec.py
+++ b/lib/parsec/tests/synonyms/lib/python/cfgspec.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/parsec/upgrade.py
+++ b/lib/parsec/upgrade.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
 if __name__ == '__main__':

--- a/lib/parsec/upgrade.py
+++ b/lib/parsec/upgrade.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/parsec/util.py
+++ b/lib/parsec/util.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/parsec/util.py
+++ b/lib/parsec/util.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
 import sys

--- a/lib/parsec/validate.py
+++ b/lib/parsec/validate.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/lib/parsec/validate.py
+++ b/lib/parsec/validate.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys, re
 from OrderedDict import OrderedDict

--- a/tests/broadcast/00-simple.t
+++ b/tests/broadcast/00-simple.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test broadcasts
 . $(dirname $0)/test_header

--- a/tests/broadcast/00-simple.t
+++ b/tests/broadcast/00-simple.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/broadcast/01-dependencies.t
+++ b/tests/broadcast/01-dependencies.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test broadcasts
 . $(dirname $0)/test_header

--- a/tests/broadcast/01-dependencies.t
+++ b/tests/broadcast/01-dependencies.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/broadcast/02-inherit.t
+++ b/tests/broadcast/02-inherit.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/broadcast/02-inherit.t
+++ b/tests/broadcast/02-inherit.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test broadcasts, with overriding inheritance.
 . $(dirname $0)/test_header

--- a/tests/cat-log/00-local.t
+++ b/tests/cat-log/00-local.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cat-log/00-local.t
+++ b/tests/cat-log/00-local.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cat-log, localhost
 . $(dirname $0)/test_header

--- a/tests/cat-log/01-remote.t
+++ b/tests/cat-log/01-remote.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cat-log, remote host
 . $(dirname $0)/test_header

--- a/tests/cat-log/01-remote.t
+++ b/tests/cat-log/01-remote.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/combined/00-simple.t
+++ b/tests/combined/00-simple.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test triggering of asynchronous one-off, synchronous one-off
 # (start-up), and cycling tasks in one suite.

--- a/tests/combined/00-simple.t
+++ b/tests/combined/00-simple.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/config-log/00-basic.t
+++ b/tests/config-log/00-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/config-log/00-basic.t
+++ b/tests/config-log/00-basic.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test suite config logging.
 . $(dirname $0)/test_header

--- a/tests/cyclers/00-daily.t
+++ b/tests/cyclers/00-daily.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test intercycle dependencies.
 . $(dirname $0)/test_header

--- a/tests/cyclers/00-daily.t
+++ b/tests/cyclers/00-daily.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cyclers/23-multidaily_local.t
+++ b/tests/cyclers/23-multidaily_local.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test intercycle dependencies, local time.
 . $(dirname $0)/test_header

--- a/tests/cyclers/23-multidaily_local.t
+++ b/tests/cyclers/23-multidaily_local.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cyclers/24-360_calendar.t
+++ b/tests/cyclers/24-360_calendar.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test intercycle dependencies.
 . $(dirname $0)/test_header

--- a/tests/cyclers/24-360_calendar.t
+++ b/tests/cyclers/24-360_calendar.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cyclers/25-no_initial_cycle_point.t
+++ b/tests/cyclers/25-no_initial_cycle_point.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test intercycle dependencies.
 . $(dirname $0)/test_header

--- a/tests/cyclers/25-no_initial_cycle_point.t
+++ b/tests/cyclers/25-no_initial_cycle_point.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cyclers/26-no_final_cycle_point.t
+++ b/tests/cyclers/26-no_final_cycle_point.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test intercycle dependencies.
 . $(dirname $0)/test_header

--- a/tests/cyclers/26-no_final_cycle_point.t
+++ b/tests/cyclers/26-no_final_cycle_point.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cyclers/27-no_initial_but_final_cycle_point.t
+++ b/tests/cyclers/27-no_initial_but_final_cycle_point.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test intercycle dependencies.
 . $(dirname $0)/test_header

--- a/tests/cyclers/27-no_initial_but_final_cycle_point.t
+++ b/tests/cyclers/27-no_initial_but_final_cycle_point.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cyclers/29-0000_rollunder.t
+++ b/tests/cyclers/29-0000_rollunder.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test intercycle dependencies.
 . $(dirname $0)/test_header

--- a/tests/cyclers/29-0000_rollunder.t
+++ b/tests/cyclers/29-0000_rollunder.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cyclers/30-9999_rollover.t
+++ b/tests/cyclers/30-9999_rollover.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test intercycle dependencies.
 . $(dirname $0)/test_header

--- a/tests/cyclers/30-9999_rollover.t
+++ b/tests/cyclers/30-9999_rollover.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cyclers/34-implicit-back-compat.t
+++ b/tests/cyclers/34-implicit-back-compat.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Check that implicit cycling is ok in cylc-5 back compat mode.
 . $(dirname $0)/test_header

--- a/tests/cyclers/34-implicit-back-compat.t
+++ b/tests/cyclers/34-implicit-back-compat.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cyclers/35-implicit-disallowed.t
+++ b/tests/cyclers/35-implicit-disallowed.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Check that missing explicit cycling fails validation.
 . $(dirname $0)/test_header

--- a/tests/cyclers/35-implicit-disallowed.t
+++ b/tests/cyclers/35-implicit-disallowed.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cycletime/00-time.t
+++ b/tests/cycletime/00-time.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cycletime/00-time.t
+++ b/tests/cycletime/00-time.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # basic jinja2 expansion test
 . $(dirname $0)/test_header

--- a/tests/cycletime/01-iso_timeparser.t
+++ b/tests/cycletime/01-iso_timeparser.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cycletime/01-iso_timeparser.t
+++ b/tests/cycletime/01-iso_timeparser.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Run the time_parser.py tests
 . $(dirname $0)/test_header

--- a/tests/cylc-5to6/00-simple-start-up.t
+++ b/tests/cylc-5to6/00-simple-start-up.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cat-view with a Jinja2 variable defined in a single cylc include-file
 # TODO - another test for nested file inclusion

--- a/tests/cylc-5to6/00-simple-start-up.t
+++ b/tests/cylc-5to6/00-simple-start-up.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-5to6/01-single-cycler.t
+++ b/tests/cylc-5to6/01-single-cycler.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cat-view with a Jinja2 variable defined in a single cylc include-file
 # TODO - another test for nested file inclusion

--- a/tests/cylc-5to6/01-single-cycler.t
+++ b/tests/cylc-5to6/01-single-cycler.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-cat-state/00-basic.t
+++ b/tests/cylc-cat-state/00-basic.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cat-check against suite database
 . $(dirname $0)/test_header

--- a/tests/cylc-cat-state/00-basic.t
+++ b/tests/cylc-cat-state/00-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-cat-state/basic/state-check.py
+++ b/tests/cylc-cat-state/basic/state-check.py
@@ -1,5 +1,5 @@
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-cat-state/basic/state-check.py
+++ b/tests/cylc-cat-state/basic/state-check.py
@@ -1,18 +1,18 @@
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 
 import os

--- a/tests/cylc-edit/00-basic.t
+++ b/tests/cylc-edit/00-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-edit/00-basic.t
+++ b/tests/cylc-edit/00-basic.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test "cylc edit" basic usage.
 . $(dirname $0)/test_header

--- a/tests/cylc-get-config/00-simple.t
+++ b/tests/cylc-get-config/00-simple.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cylc get-config
 . $(dirname $0)/test_header

--- a/tests/cylc-get-config/00-simple.t
+++ b/tests/cylc-get-config/00-simple.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-get-config/01-no-final.t
+++ b/tests/cylc-get-config/01-no-final.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cylc get-config with a suite with an explicitly empty final cycle point
 . $(dirname $0)/test_header

--- a/tests/cylc-get-config/01-no-final.t
+++ b/tests/cylc-get-config/01-no-final.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-get-cylc-version/00-basic.t
+++ b/tests/cylc-get-cylc-version/00-basic.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Basic get-cylc-version test.
 

--- a/tests/cylc-get-cylc-version/00-basic.t
+++ b/tests/cylc-get-cylc-version/00-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-get-site-config/00-basic.t
+++ b/tests/cylc-get-site-config/00-basic.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cylc-get-site-config
 . $(dirname $0)/test_header

--- a/tests/cylc-get-site-config/00-basic.t
+++ b/tests/cylc-get-site-config/00-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-insert/00-insert.t
+++ b/tests/cylc-insert/00-insert.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cylc insert command
 . $(dirname $0)/test_header

--- a/tests/cylc-insert/00-insert.t
+++ b/tests/cylc-insert/00-insert.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-insert/01-insert-bad-cycle-point.t
+++ b/tests/cylc-insert/01-insert-bad-cycle-point.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cylc insert command with an invalid cycle point
 . $(dirname $0)/test_header

--- a/tests/cylc-insert/01-insert-bad-cycle-point.t
+++ b/tests/cylc-insert/01-insert-bad-cycle-point.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-insert/02-insert-bad-stop-cycle-point.t
+++ b/tests/cylc-insert/02-insert-bad-stop-cycle-point.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-insert/02-insert-bad-stop-cycle-point.t
+++ b/tests/cylc-insert/02-insert-bad-stop-cycle-point.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cylc insert command with an invalid stop cycle point
 . $(dirname $0)/test_header

--- a/tests/cylc-job-poll/00-background.t
+++ b/tests/cylc-job-poll/00-background.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cylc job-poll, background jobs
 . $(dirname $0)/test_header

--- a/tests/cylc-job-poll/00-background.t
+++ b/tests/cylc-job-poll/00-background.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-job-poll/01-at.t
+++ b/tests/cylc-job-poll/01-at.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-job-poll/01-at.t
+++ b/tests/cylc-job-poll/01-at.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cylc job-poll, "at" jobs
 . $(dirname $0)/test_header

--- a/tests/cylc-job-poll/02-loadleveler.t
+++ b/tests/cylc-job-poll/02-loadleveler.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cylc job-poll, "loadleveler" jobs
 . $(dirname $0)/test_header

--- a/tests/cylc-job-poll/02-loadleveler.t
+++ b/tests/cylc-job-poll/02-loadleveler.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-job-poll/03-slurm.t
+++ b/tests/cylc-job-poll/03-slurm.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cylc job-poll, "slurm" jobs
 . $(dirname $0)/test_header

--- a/tests/cylc-job-poll/03-slurm.t
+++ b/tests/cylc-job-poll/03-slurm.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-job-poll/04-pbs.t
+++ b/tests/cylc-job-poll/04-pbs.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cylc job-poll, "pbs" jobs
 . $(dirname $0)/test_header

--- a/tests/cylc-job-poll/04-pbs.t
+++ b/tests/cylc-job-poll/04-pbs.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-list/00-options.t
+++ b/tests/cylc-list/00-options.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #------------------------------------------------------------------------------
 # Test various uses of the cylc list command
 . $(dirname $0)/test_header

--- a/tests/cylc-list/00-options.t
+++ b/tests/cylc-list/00-options.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-ping/00-simple.t
+++ b/tests/cylc-ping/00-simple.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-ping/00-simple.t
+++ b/tests/cylc-ping/00-simple.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cylc ping behaviour
 . $(dirname $0)/test_header

--- a/tests/cylc-poll/00-basic.t
+++ b/tests/cylc-poll/00-basic.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cat-check against suite database
 . $(dirname $0)/test_header

--- a/tests/cylc-poll/00-basic.t
+++ b/tests/cylc-poll/00-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-poll/01-task-failed.t
+++ b/tests/cylc-poll/01-task-failed.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test that polling a failed task sets the task state correctly
 . $(dirname $0)/test_header

--- a/tests/cylc-poll/01-task-failed.t
+++ b/tests/cylc-poll/01-task-failed.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-poll/02-task-submit-failed.t
+++ b/tests/cylc-poll/02-task-submit-failed.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-poll/02-task-submit-failed.t
+++ b/tests/cylc-poll/02-task-submit-failed.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test that polling a submit-failed task sets the task state correctly
 . $(dirname $0)/test_header

--- a/tests/cylc-poll/03-poll-all.t
+++ b/tests/cylc-poll/03-poll-all.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test that when polling all a failed task sets the task state correctly
 . $(dirname $0)/test_header

--- a/tests/cylc-poll/03-poll-all.t
+++ b/tests/cylc-poll/03-poll-all.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-remove/00-simple.t
+++ b/tests/cylc-remove/00-simple.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-remove/00-simple.t
+++ b/tests/cylc-remove/00-simple.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cylc remove
 . $(dirname $0)/test_header

--- a/tests/cylc-scan/00-simple.t
+++ b/tests/cylc-scan/00-simple.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-scan/00-simple.t
+++ b/tests/cylc-scan/00-simple.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cylc scan is picking up running suite
 . $(dirname $0)/test_header

--- a/tests/cylc-scan/01-hosts.t
+++ b/tests/cylc-scan/01-hosts.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cylc scan with multiple hosts
 . "$(dirname "$0")/test_header"

--- a/tests/cylc-scan/01-hosts.t
+++ b/tests/cylc-scan/01-hosts.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-search/00-basic.t
+++ b/tests/cylc-search/00-basic.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test "cylc search" basic usage.
 . $(dirname $0)/test_header

--- a/tests/cylc-search/00-basic.t
+++ b/tests/cylc-search/00-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-show/00-simple.t
+++ b/tests/cylc-show/00-simple.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cylc show for a basic task.
 . $(dirname $0)/test_header

--- a/tests/cylc-show/00-simple.t
+++ b/tests/cylc-show/00-simple.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-show/01-clock-triggered.t
+++ b/tests/cylc-show/01-clock-triggered.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-show/01-clock-triggered.t
+++ b/tests/cylc-show/01-clock-triggered.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cylc show for a clock triggered task
 . $(dirname $0)/test_header

--- a/tests/cylc-show/02-clock-triggered-alt-tz.t
+++ b/tests/cylc-show/02-clock-triggered-alt-tz.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-show/02-clock-triggered-alt-tz.t
+++ b/tests/cylc-show/02-clock-triggered-alt-tz.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cylc show for a clock triggered task
 . $(dirname $0)/test_header

--- a/tests/cylc-show/03-clock-triggered-non-utc-mode.t
+++ b/tests/cylc-show/03-clock-triggered-non-utc-mode.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-show/03-clock-triggered-non-utc-mode.t
+++ b/tests/cylc-show/03-clock-triggered-non-utc-mode.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cylc show for a clock triggered task
 . $(dirname $0)/test_header

--- a/tests/cylc-submit/00-bg.t
+++ b/tests/cylc-submit/00-bg.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test "cylc submit" a background task.
 . $(dirname $0)/test_header

--- a/tests/cylc-submit/00-bg.t
+++ b/tests/cylc-submit/00-bg.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-trigger/00-basic.t
+++ b/tests/cylc-trigger/00-basic.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test intercycle dependencies.
 . $(dirname $0)/test_header

--- a/tests/cylc-trigger/00-basic.t
+++ b/tests/cylc-trigger/00-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/cylc-view/00-single-inc.t
+++ b/tests/cylc-view/00-single-inc.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cat-view with a Jinja2 variable defined in a single cylc include-file
 # TODO - another test for nested file inclusion

--- a/tests/cylc-view/00-single-inc.t
+++ b/tests/cylc-view/00-single-inc.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/database/00-simple.t
+++ b/tests/database/00-simple.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # basic tests for suite database contents
 . $(dirname $0)/test_header

--- a/tests/database/00-simple.t
+++ b/tests/database/00-simple.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/directives/00-loadleveler.t
+++ b/tests/directives/00-loadleveler.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/directives/00-loadleveler.t
+++ b/tests/directives/00-loadleveler.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test loadleveler directives
 #     This test requires an e.g. [test battery][directives]loadleveler host

--- a/tests/directives/01-at.t
+++ b/tests/directives/01-at.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test at submission
 . $(dirname $0)/test_header

--- a/tests/directives/01-at.t
+++ b/tests/directives/01-at.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/documentation/00-make.t
+++ b/tests/documentation/00-make.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test documentation can be made
 . $(dirname $0)/test_header

--- a/tests/documentation/00-make.t
+++ b/tests/documentation/00-make.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/env-filter/00-filter.t
+++ b/tests/env-filter/00-filter.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/env-filter/00-filter.t
+++ b/tests/env-filter/00-filter.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test environment filtering
 . $(dirname $0)/test_header

--- a/tests/events/00-suite.t
+++ b/tests/events/00-suite.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/events/00-suite.t
+++ b/tests/events/00-suite.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Validate and run the events/suite test suite
 . $(dirname $0)/test_header

--- a/tests/events/01-task.t
+++ b/tests/events/01-task.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Validate and run the task events suite.
 . $(dirname $0)/test_header

--- a/tests/events/01-task.t
+++ b/tests/events/01-task.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/events/02-multi.t
+++ b/tests/events/02-multi.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # test list of multiple event handlers
 . $(dirname $0)/test_header

--- a/tests/events/02-multi.t
+++ b/tests/events/02-multi.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/events/03-timeout.t
+++ b/tests/events/03-timeout.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/events/03-timeout.t
+++ b/tests/events/03-timeout.t
@@ -1,21 +1,21 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-#C: Validate and run the suite timeout suite
+# Validate and run the suite timeout suite
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 set_test_number 3

--- a/tests/events/04-timeout-ref-live.t
+++ b/tests/events/04-timeout-ref-live.t
@@ -1,21 +1,21 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-#C: Validate and run the suite reference test live timeout suite
+# Validate and run the suite reference test live timeout suite
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 set_test_number 3

--- a/tests/events/04-timeout-ref-live.t
+++ b/tests/events/04-timeout-ref-live.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/events/05-timeout-ref-dummy.t
+++ b/tests/events/05-timeout-ref-dummy.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/events/05-timeout-ref-dummy.t
+++ b/tests/events/05-timeout-ref-dummy.t
@@ -1,21 +1,21 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-#C: Validate and run the suite reference test dummy timeout suite
+# Validate and run the suite reference test dummy timeout suite
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 set_test_number 3

--- a/tests/events/06-timeout-ref-simulation.t
+++ b/tests/events/06-timeout-ref-simulation.t
@@ -1,21 +1,21 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-#C: Validate and run the suite reference test simulation timeout suite
+# Validate and run the suite reference test simulation timeout suite
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 set_test_number 3

--- a/tests/events/06-timeout-ref-simulation.t
+++ b/tests/events/06-timeout-ref-simulation.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/events/07-task-iso.t
+++ b/tests/events/07-task-iso.t
@@ -1,21 +1,21 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-#C: Validate and run the task events suite (iso mode).
+# Validate and run the task events suite (iso mode).
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 set_test_number 2

--- a/tests/events/07-task-iso.t
+++ b/tests/events/07-task-iso.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/graph-equivalence/00-oneline.t
+++ b/tests/graph-equivalence/00-oneline.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test graph="a=>b=>c" gives the same result as
 #      graph = """a => b\

--- a/tests/graph-equivalence/00-oneline.t
+++ b/tests/graph-equivalence/00-oneline.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/graph-equivalence/01-twolines.t
+++ b/tests/graph-equivalence/01-twolines.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test graph = """a => b
 #                 b => c""" gives the same result as

--- a/tests/graph-equivalence/01-twolines.t
+++ b/tests/graph-equivalence/01-twolines.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/graph-equivalence/02-splitline.t
+++ b/tests/graph-equivalence/02-splitline.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/graph-equivalence/02-splitline.t
+++ b/tests/graph-equivalence/02-splitline.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test graph = """a => b\
 #                   => c""" gives the same result as

--- a/tests/graph-equivalence/03-multiline_and1.t
+++ b/tests/graph-equivalence/03-multiline_and1.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test graph = "a & b => c"
 # gives the same result as

--- a/tests/graph-equivalence/03-multiline_and1.t
+++ b/tests/graph-equivalence/03-multiline_and1.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/graph-equivalence/04-multiline_and2.t
+++ b/tests/graph-equivalence/04-multiline_and2.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test graph = """a => c
 #                 b => c"""

--- a/tests/graph-equivalence/04-multiline_and2.t
+++ b/tests/graph-equivalence/04-multiline_and2.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/graphing/00-boundaries.t
+++ b/tests/graphing/00-boundaries.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test "[visualization]number of cycles" for a suite with two different cycling
 # intervals.

--- a/tests/graphing/00-boundaries.t
+++ b/tests/graphing/00-boundaries.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/graphing/01-namespace.t
+++ b/tests/graphing/01-namespace.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/graphing/01-namespace.t
+++ b/tests/graphing/01-namespace.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test namespace graphing. 
 . $(dirname $0)/test_header

--- a/tests/hold-release/00-suite.t
+++ b/tests/hold-release/00-suite.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/hold-release/00-suite.t
+++ b/tests/hold-release/00-suite.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test suite hold and release, with cycling and async tasks present.
 . $(dirname $0)/test_header

--- a/tests/hold-release/01-beyond-stop.t
+++ b/tests/hold-release/01-beyond-stop.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test suite hold and release, with tasks present held beyond stop point.
 . $(dirname $0)/test_header

--- a/tests/hold-release/01-beyond-stop.t
+++ b/tests/hold-release/01-beyond-stop.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/hold-release/02-hold-on-spawn.t
+++ b/tests/hold-release/02-hold-on-spawn.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test suite hold and limited task release, making sure spawned tasks are held
 . $(dirname $0)/test_header

--- a/tests/hold-release/02-hold-on-spawn.t
+++ b/tests/hold-release/02-hold-on-spawn.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/hold-release/03-release-family-exact.t
+++ b/tests/hold-release/03-release-family-exact.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/hold-release/03-release-family-exact.t
+++ b/tests/hold-release/03-release-family-exact.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test suite hold and family release, using an exact match for the family.
 . $(dirname $0)/test_header

--- a/tests/hold-release/04-release-family-inexact.t
+++ b/tests/hold-release/04-release-family-inexact.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test suite hold and family release, using a regular expression.
 . $(dirname $0)/test_header

--- a/tests/hold-release/04-release-family-inexact.t
+++ b/tests/hold-release/04-release-family-inexact.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/hold-release/05-release-task-exact.t
+++ b/tests/hold-release/05-release-task-exact.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test suite hold and task release, using an exact match for the task name.
 . $(dirname $0)/test_header

--- a/tests/hold-release/05-release-task-exact.t
+++ b/tests/hold-release/05-release-task-exact.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/hold-release/06-release-task-inexact.t
+++ b/tests/hold-release/06-release-task-inexact.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/hold-release/06-release-task-inexact.t
+++ b/tests/hold-release/06-release-task-inexact.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test suite hold and task release, using a regular expression for the task.
 . $(dirname $0)/test_header

--- a/tests/hold-release/07-hold-family-exact.t
+++ b/tests/hold-release/07-hold-family-exact.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/hold-release/07-hold-family-exact.t
+++ b/tests/hold-release/07-hold-family-exact.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test suite hold and family release, using an exact match for the family.
 . $(dirname $0)/test_header

--- a/tests/hold-release/08-hold-family-inexact.t
+++ b/tests/hold-release/08-hold-family-inexact.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/hold-release/08-hold-family-inexact.t
+++ b/tests/hold-release/08-hold-family-inexact.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test suite hold and family release, using an exact match for the family.
 . $(dirname $0)/test_header

--- a/tests/hold-release/09-hold-task-exact.t
+++ b/tests/hold-release/09-hold-task-exact.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/hold-release/09-hold-task-exact.t
+++ b/tests/hold-release/09-hold-task-exact.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test suite hold and family release, using an exact match for the family.
 . $(dirname $0)/test_header

--- a/tests/hold-release/10-hold-task-inexact.t
+++ b/tests/hold-release/10-hold-task-inexact.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/hold-release/10-hold-task-inexact.t
+++ b/tests/hold-release/10-hold-task-inexact.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test suite hold and family release, using an exact match for the family.
 . $(dirname $0)/test_header

--- a/tests/hold-release/11-retrying.t
+++ b/tests/hold-release/11-retrying.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test hold and release of a retrying task.
 . "$(dirname "$0")/test_header"

--- a/tests/hold-release/11-retrying.t
+++ b/tests/hold-release/11-retrying.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/hold-release/12-hold-then-retry.t
+++ b/tests/hold-release/12-hold-then-retry.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test suite hold => retry and submit-retry => suite release
 . "$(dirname "$0")/test_header"

--- a/tests/hold-release/12-hold-then-retry.t
+++ b/tests/hold-release/12-hold-then-retry.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/hold-release/13-ready-restart.t
+++ b/tests/hold-release/13-ready-restart.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test #958: task in ready state, stop now, restart hold, release
 . "$(dirname "$0")/test_header"

--- a/tests/hold-release/13-ready-restart.t
+++ b/tests/hold-release/13-ready-restart.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/host-select/00-simple.t
+++ b/tests/host-select/00-simple.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/host-select/00-simple.t
+++ b/tests/host-select/00-simple.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test host selection
 . $(dirname $0)/test_header

--- a/tests/include-files/00-basic.t
+++ b/tests/include-files/00-basic.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test include-file inlining
 . $(dirname $0)/test_header

--- a/tests/include-files/00-basic.t
+++ b/tests/include-files/00-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/inheritance/00-namespace-list.t
+++ b/tests/inheritance/00-namespace-list.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test that members of namespace lists [[n1,n2,...]] are inserted into the
 # [runtime] ordered dict in the correct order. If just appended, they break

--- a/tests/inheritance/00-namespace-list.t
+++ b/tests/inheritance/00-namespace-list.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/inheritance/01-circular.t
+++ b/tests/inheritance/01-circular.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/inheritance/01-circular.t
+++ b/tests/inheritance/01-circular.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Check circular inheritance fails validation with the correct error message.
 . $(dirname $0)/test_header

--- a/tests/integer-cycling/00-satellite.t
+++ b/tests/integer-cycling/00-satellite.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/integer-cycling/00-satellite.t
+++ b/tests/integer-cycling/00-satellite.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Run the integer cycling satellite example suite.
 # Non-specific, tests a bunch of stuff.

--- a/tests/intercycle/00-past.t
+++ b/tests/intercycle/00-past.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test intercycle dependencies.
 . $(dirname $0)/test_header

--- a/tests/intercycle/00-past.t
+++ b/tests/intercycle/00-past.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/intercycle/01-future.t
+++ b/tests/intercycle/01-future.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/intercycle/01-future.t
+++ b/tests/intercycle/01-future.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test future cycle dependencies.
 . $(dirname $0)/test_header

--- a/tests/intercycle/02-asynch.t
+++ b/tests/intercycle/02-asynch.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/intercycle/02-asynch.t
+++ b/tests/intercycle/02-asynch.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test dependencies on an asynch task from cycling tasks.
 . $(dirname $0)/test_header

--- a/tests/intercycle/03-complex-implicit.t
+++ b/tests/intercycle/03-complex-implicit.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/intercycle/03-complex-implicit.t
+++ b/tests/intercycle/03-complex-implicit.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test future cycle dependencies.
 . $(dirname $0)/test_header

--- a/tests/jinja2/00-simple.t
+++ b/tests/jinja2/00-simple.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/jinja2/00-simple.t
+++ b/tests/jinja2/00-simple.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # basic jinja2 expansion test
 . $(dirname $0)/test_header

--- a/tests/jinja2/01-include.t
+++ b/tests/jinja2/01-include.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/jinja2/01-include.t
+++ b/tests/jinja2/01-include.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # basic jinja2 include and expand test
 . $(dirname $0)/test_header

--- a/tests/jinja2/02-incomplete.t
+++ b/tests/jinja2/02-incomplete.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/jinja2/02-incomplete.t
+++ b/tests/jinja2/02-incomplete.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # jinja2 test for fail to validate when including a file with incomplete loop
 . $(dirname $0)/test_header

--- a/tests/jinja2/03-bad.t
+++ b/tests/jinja2/03-bad.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # jinja2 test for fail to validate an included file with missing quotes in array
 . $(dirname $0)/test_header

--- a/tests/jinja2/03-bad.t
+++ b/tests/jinja2/03-bad.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/jinja2/04-missing.t
+++ b/tests/jinja2/04-missing.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/jinja2/04-missing.t
+++ b/tests/jinja2/04-missing.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # jinja2 test for fail to validate when including a missing file
 . $(dirname $0)/test_header

--- a/tests/jinja2/05-commandline.t
+++ b/tests/jinja2/05-commandline.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # jinja2 command line variables test
 . $(dirname $0)/test_header

--- a/tests/jinja2/05-commandline.t
+++ b/tests/jinja2/05-commandline.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/jinja2/06-do-extension.t
+++ b/tests/jinja2/06-do-extension.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # test that the jinja2 do extension is loaded.
 . $(dirname $0)/test_header

--- a/tests/jinja2/06-do-extension.t
+++ b/tests/jinja2/06-do-extension.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/job-kill/00-local.t
+++ b/tests/job-kill/00-local.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test kill local jobs.
 . $(dirname $0)/test_header

--- a/tests/job-kill/00-local.t
+++ b/tests/job-kill/00-local.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/job-kill/01-remote.t
+++ b/tests/job-kill/01-remote.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test killing of jobs on a remote host.
 . $(dirname $0)/test_header

--- a/tests/job-kill/01-remote.t
+++ b/tests/job-kill/01-remote.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/job-kill/02-loadleveler.t
+++ b/tests/job-kill/02-loadleveler.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/job-kill/02-loadleveler.t
+++ b/tests/job-kill/02-loadleveler.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test killing of jobs submitted to loadleveler, slurm, pbs...
 . $(dirname $0)/test_header

--- a/tests/job-poll/00-late.t
+++ b/tests/job-poll/00-late.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test that a late polling result (after task finished) does not alter task state.
 . $(dirname $0)/test_header

--- a/tests/job-poll/00-late.t
+++ b/tests/job-poll/00-late.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/job-submission/00-user.t
+++ b/tests/job-submission/00-user.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test user-defined job submission methods can be used.
 . $(dirname $0)/test_header

--- a/tests/job-submission/00-user.t
+++ b/tests/job-submission/00-user.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/job-submission/00-user/python/my_background.py
+++ b/tests/job-submission/00-user/python/my_background.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from cylc.batch_sys_handlers.background import BgCommandHandler
 

--- a/tests/job-submission/00-user/python/my_background.py
+++ b/tests/job-submission/00-user/python/my_background.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/job-submission/01-job-nn-localhost.t
+++ b/tests/job-submission/01-job-nn-localhost.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test localhost job log NN link correctness.
 . $(dirname $0)/test_header

--- a/tests/job-submission/01-job-nn-localhost.t
+++ b/tests/job-submission/01-job-nn-localhost.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/job-submission/02-job-nn-remote-host.t
+++ b/tests/job-submission/02-job-nn-remote-host.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test remote host job log NN link correctness.
 . $(dirname $0)/test_header

--- a/tests/job-submission/02-job-nn-remote-host.t
+++ b/tests/job-submission/02-job-nn-remote-host.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/job-submission/03-job-nn-remote-host-with-shared-fs.t
+++ b/tests/job-submission/03-job-nn-remote-host-with-shared-fs.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test remote host (with shared fs) job log NN link correctness.
 . $(dirname $0)/test_header

--- a/tests/job-submission/03-job-nn-remote-host-with-shared-fs.t
+++ b/tests/job-submission/03-job-nn-remote-host-with-shared-fs.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/job-submission/04-submit-num.t
+++ b/tests/job-submission/04-submit-num.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test usage of CYLC_TASK_SUBMIT_NUMBER.
 . $(dirname $0)/test_header

--- a/tests/job-submission/04-submit-num.t
+++ b/tests/job-submission/04-submit-num.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/job-submission/05-activity-log.t
+++ b/tests/job-submission/05-activity-log.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test writing various messages to the job activity log.
 . $(dirname $0)/test_header

--- a/tests/job-submission/05-activity-log.t
+++ b/tests/job-submission/05-activity-log.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/jobscript/00-torture.t
+++ b/tests/jobscript/00-torture.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # job script torture test and check jobscript is generated correctly
 . $(dirname $0)/test_header

--- a/tests/jobscript/00-torture.t
+++ b/tests/jobscript/00-torture.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/jobscript/01-multi.t
+++ b/tests/jobscript/01-multi.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/jobscript/01-multi.t
+++ b/tests/jobscript/01-multi.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test jobscipt is being generated right for mult-inheritance cases
 . $(dirname $0)/test_header

--- a/tests/jobscript/02-cycling.t
+++ b/tests/jobscript/02-cycling.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # job script torture test and check jobscript is generated correctly
 . $(dirname $0)/test_header

--- a/tests/jobscript/02-cycling.t
+++ b/tests/jobscript/02-cycling.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/jobscript/03-copyable-environment-variables.t
+++ b/tests/jobscript/03-copyable-environment-variables.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test that copyable environment variables is written
 . "$(dirname "${0}")/test_header"

--- a/tests/jobscript/03-copyable-environment-variables.t
+++ b/tests/jobscript/03-copyable-environment-variables.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/jobscript/04-global-initial-scripting.t
+++ b/tests/jobscript/04-global-initial-scripting.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test that global initial scripting is written
 . "$(dirname "${0}")/test_header"

--- a/tests/jobscript/04-global-initial-scripting.t
+++ b/tests/jobscript/04-global-initial-scripting.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/jobscript/05-global-config.t
+++ b/tests/jobscript/05-global-config.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/jobscript/05-global-config.t
+++ b/tests/jobscript/05-global-config.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test that global config is used search for poll
 . "$(dirname "${0}")/test_header"

--- a/tests/jobscript/06-slurm-no-directives.t
+++ b/tests/jobscript/06-slurm-no-directives.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test that directives are written correctly when no extra ones are supplied.
 . "$(dirname "${0}")/test_header"

--- a/tests/jobscript/06-slurm-no-directives.t
+++ b/tests/jobscript/06-slurm-no-directives.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/jobscript/07-traps-failure.t
+++ b/tests/jobscript/07-traps-failure.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/jobscript/07-traps-failure.t
+++ b/tests/jobscript/07-traps-failure.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test that trap signals are correctly output for at, background, pbs, etc.
 . "$(dirname "${0}")/test_header"

--- a/tests/lib/bash/test_header
+++ b/tests/lib/bash/test_header
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # NAME
 #     test_header

--- a/tests/lib/bash/test_header
+++ b/tests/lib/bash/test_header
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/manual/00-reset-with-deps.t
+++ b/tests/manual/00-reset-with-deps.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/manual/00-reset-with-deps.t
+++ b/tests/manual/00-reset-with-deps.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test reset to waiting for 2 tasks with dependencies t1=>t2
 # See https://github.com/cylc/cylc/pull/947

--- a/tests/message-triggers/00-old.t
+++ b/tests/message-triggers/00-old.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test pre cylc-6 message triggers.
 . $(dirname $0)/test_header

--- a/tests/message-triggers/00-old.t
+++ b/tests/message-triggers/00-old.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/message-triggers/01-new.t
+++ b/tests/message-triggers/01-new.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/message-triggers/01-new.t
+++ b/tests/message-triggers/01-new.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cylc-6 message triggers.
 . $(dirname $0)/test_header

--- a/tests/modes/00-simulation.t
+++ b/tests/modes/00-simulation.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test simulation mode
 . $(dirname $0)/test_header

--- a/tests/modes/00-simulation.t
+++ b/tests/modes/00-simulation.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/modes/01-dummy.t
+++ b/tests/modes/01-dummy.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test dummy mode
 . $(dirname $0)/test_header

--- a/tests/modes/01-dummy.t
+++ b/tests/modes/01-dummy.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/offset/00-final-simple.t
+++ b/tests/offset/00-final-simple.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test specifying final cycle as an offset
 . $(dirname $0)/test_header

--- a/tests/offset/00-final-simple.t
+++ b/tests/offset/00-final-simple.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/offset/01-final-next.t
+++ b/tests/offset/01-final-next.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test specifying final cycle as the next instance of T06
 . $(dirname $0)/test_header

--- a/tests/offset/01-final-next.t
+++ b/tests/offset/01-final-next.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/offset/02-final-chain.t
+++ b/tests/offset/02-final-chain.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test specifying final cycle as an offset chain
 . $(dirname $0)/test_header

--- a/tests/offset/02-final-chain.t
+++ b/tests/offset/02-final-chain.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/offset/03-final-next-chain.t
+++ b/tests/offset/03-final-next-chain.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/offset/03-final-next-chain.t
+++ b/tests/offset/03-final-next-chain.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test specifying final cycle as an offset to the next occurance of T06
 . $(dirname $0)/test_header

--- a/tests/offset/04-cycle-offset-chain.t
+++ b/tests/offset/04-cycle-offset-chain.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/offset/04-cycle-offset-chain.t
+++ b/tests/offset/04-cycle-offset-chain.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test specifying an offset as a chain of periods
 . $(dirname $0)/test_header

--- a/tests/offset/05-long-final-chain.t
+++ b/tests/offset/05-long-final-chain.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/offset/05-long-final-chain.t
+++ b/tests/offset/05-long-final-chain.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test a 3 item offset
 . $(dirname $0)/test_header

--- a/tests/periodicals/00-daily.t
+++ b/tests/periodicals/00-daily.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test Daily cycling
 . $(dirname $0)/test_header

--- a/tests/periodicals/00-daily.t
+++ b/tests/periodicals/00-daily.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/periodicals/01-daily.t
+++ b/tests/periodicals/01-daily.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test Daily cycling
 . $(dirname $0)/test_header

--- a/tests/periodicals/01-daily.t
+++ b/tests/periodicals/01-daily.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/periodicals/02-daily.t
+++ b/tests/periodicals/02-daily.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test Daily cycling
 . $(dirname $0)/test_header

--- a/tests/periodicals/02-daily.t
+++ b/tests/periodicals/02-daily.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/periodicals/03-monthly.t
+++ b/tests/periodicals/03-monthly.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/periodicals/03-monthly.t
+++ b/tests/periodicals/03-monthly.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test Monthly cycling
 . $(dirname $0)/test_header

--- a/tests/periodicals/04-monthly.t
+++ b/tests/periodicals/04-monthly.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/periodicals/04-monthly.t
+++ b/tests/periodicals/04-monthly.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test Monthly cycling
 . $(dirname $0)/test_header

--- a/tests/periodicals/05-monthly.t
+++ b/tests/periodicals/05-monthly.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/periodicals/05-monthly.t
+++ b/tests/periodicals/05-monthly.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test Monthly cycling
 . $(dirname $0)/test_header

--- a/tests/periodicals/06-yearly.t
+++ b/tests/periodicals/06-yearly.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test Yearly cycling
 . $(dirname $0)/test_header

--- a/tests/periodicals/06-yearly.t
+++ b/tests/periodicals/06-yearly.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/periodicals/07-yearly.t
+++ b/tests/periodicals/07-yearly.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test Yearly cycling
 . $(dirname $0)/test_header

--- a/tests/periodicals/07-yearly.t
+++ b/tests/periodicals/07-yearly.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/periodicals/08-yearly.t
+++ b/tests/periodicals/08-yearly.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test Yearly cycling
 . $(dirname $0)/test_header

--- a/tests/periodicals/08-yearly.t
+++ b/tests/periodicals/08-yearly.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/periodicals/09-monthly-reorder.t
+++ b/tests/periodicals/09-monthly-reorder.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/periodicals/09-monthly-reorder.t
+++ b/tests/periodicals/09-monthly-reorder.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test Monthly cycling
 . $(dirname $0)/test_header

--- a/tests/pre-initial/00-simple.t
+++ b/tests/pre-initial/00-simple.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test simple pre initial cycling dependencies removal
 . $(dirname $0)/test_header

--- a/tests/pre-initial/00-simple.t
+++ b/tests/pre-initial/00-simple.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/pre-initial/01-basic.t
+++ b/tests/pre-initial/01-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/pre-initial/01-basic.t
+++ b/tests/pre-initial/01-basic.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test simplification of basic conditionals in pre-initial cycling
 . $(dirname $0)/test_header

--- a/tests/pre-initial/02-advanced.t
+++ b/tests/pre-initial/02-advanced.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test nested conditional simplification for pre-initial cycling.
 . $(dirname $0)/test_header

--- a/tests/pre-initial/02-advanced.t
+++ b/tests/pre-initial/02-advanced.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/pre-initial/03-drop.t
+++ b/tests/pre-initial/03-drop.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test the case of dropping a conditional based on pre-initial cycling
 . $(dirname $0)/test_header

--- a/tests/pre-initial/03-drop.t
+++ b/tests/pre-initial/03-drop.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/pre-initial/04-warm.t
+++ b/tests/pre-initial/04-warm.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/pre-initial/04-warm.t
+++ b/tests/pre-initial/04-warm.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test pre-initial cycling works under warm starts
 . $(dirname $0)/test_header

--- a/tests/pre-initial/05-warm-new-ict.t
+++ b/tests/pre-initial/05-warm-new-ict.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test pre-initial cycling works under warm starts with a new initial cycle 
 # time that is later than the suite.rc initial cycle time.

--- a/tests/pre-initial/05-warm-new-ict.t
+++ b/tests/pre-initial/05-warm-new-ict.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/pre-initial/06-over-bracketed.t
+++ b/tests/pre-initial/06-over-bracketed.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test nested conditional simplification for pre-initial cycling.
 . $(dirname $0)/test_header

--- a/tests/pre-initial/06-over-bracketed.t
+++ b/tests/pre-initial/06-over-bracketed.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/pre-initial/07-simple-messaging.t
+++ b/tests/pre-initial/07-simple-messaging.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test removal of pre-initial cycle message dependencies.
 . $(dirname $0)/test_header

--- a/tests/pre-initial/07-simple-messaging.t
+++ b/tests/pre-initial/07-simple-messaging.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/pre-initial/08-conditional-messaging.t
+++ b/tests/pre-initial/08-conditional-messaging.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test removal of pre-initial cycle messages from conditionals.
 . $(dirname $0)/test_header

--- a/tests/pre-initial/08-conditional-messaging.t
+++ b/tests/pre-initial/08-conditional-messaging.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/pre-initial/09-warm-iso.t
+++ b/tests/pre-initial/09-warm-iso.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/pre-initial/09-warm-iso.t
+++ b/tests/pre-initial/09-warm-iso.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test pre-initial cycling works under warm starts
 . $(dirname $0)/test_header

--- a/tests/purge/00-purge.t
+++ b/tests/purge/00-purge.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/purge/00-purge.t
+++ b/tests/purge/00-purge.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cylc purge from a suite
 . $(dirname $0)/test_header

--- a/tests/queues/00-queuesize-3.t
+++ b/tests/queues/00-queuesize-3.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test running with a queue with limit=3
 . $(dirname $0)/test_header

--- a/tests/queues/00-queuesize-3.t
+++ b/tests/queues/00-queuesize-3.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/queues/01-queuesize-5.t
+++ b/tests/queues/01-queuesize-5.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test running with a queue with limit=5
 . $(dirname $0)/test_header

--- a/tests/queues/01-queuesize-5.t
+++ b/tests/queues/01-queuesize-5.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/registration/00-simple.t
+++ b/tests/registration/00-simple.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cylc suite registration
 . $(dirname $0)/test_header

--- a/tests/registration/00-simple.t
+++ b/tests/registration/00-simple.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/registration/01-reregister-passphrase.t
+++ b/tests/registration/01-reregister-passphrase.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test "cylc reregister" and passphrase creation.
 # See https://github.com/cylc/cylc/pull/1009

--- a/tests/registration/01-reregister-passphrase.t
+++ b/tests/registration/01-reregister-passphrase.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/reload/00-simple.t
+++ b/tests/reload/00-simple.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test reloading a simple suite
 . $(dirname $0)/test_header

--- a/tests/reload/00-simple.t
+++ b/tests/reload/00-simple.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/reload/01-asynch.t
+++ b/tests/reload/01-asynch.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/reload/01-asynch.t
+++ b/tests/reload/01-asynch.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test reloading a suite containing an asynchronous task
 . $(dirname $0)/test_header

--- a/tests/reload/02-cold.t
+++ b/tests/reload/02-cold.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test reloading a suite containing a cold-start task
 . $(dirname $0)/test_header

--- a/tests/reload/02-cold.t
+++ b/tests/reload/02-cold.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/reload/03-startup.t
+++ b/tests/reload/03-startup.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test reloading a suite containing a startup task.
 . $(dirname $0)/test_header

--- a/tests/reload/03-startup.t
+++ b/tests/reload/03-startup.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/reload/04-content.t
+++ b/tests/reload/04-content.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/reload/04-content.t
+++ b/tests/reload/04-content.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test reloads have actually updated environment variables
 . $(dirname $0)/test_header

--- a/tests/reload/05-queues.t
+++ b/tests/reload/05-queues.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/reload/05-queues.t
+++ b/tests/reload/05-queues.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test changing queue size via reload doesn't break anything
 . $(dirname $0)/test_header

--- a/tests/reload/06-inheritance.t
+++ b/tests/reload/06-inheritance.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/reload/06-inheritance.t
+++ b/tests/reload/06-inheritance.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test changing inheritance via a reload
 . $(dirname $0)/test_header

--- a/tests/reload/07-graphing-simple.t
+++ b/tests/reload/07-graphing-simple.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/reload/07-graphing-simple.t
+++ b/tests/reload/07-graphing-simple.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test changing basic graphing via a reload
 . $(dirname $0)/test_header

--- a/tests/reload/08-graphing-fam.t
+++ b/tests/reload/08-graphing-fam.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test changing family triggering via a reload
 . $(dirname $0)/test_header

--- a/tests/reload/08-graphing-fam.t
+++ b/tests/reload/08-graphing-fam.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/reload/09-final-cycle.t
+++ b/tests/reload/09-final-cycle.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test changing final cycle time
 . $(dirname $0)/test_header

--- a/tests/reload/09-final-cycle.t
+++ b/tests/reload/09-final-cycle.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/reload/10-cycle.t
+++ b/tests/reload/10-cycle.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/reload/10-cycle.t
+++ b/tests/reload/10-cycle.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test changing cycle times (and dependencies)
 . $(dirname $0)/test_header

--- a/tests/reload/11-garbage.t
+++ b/tests/reload/11-garbage.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test trying to reload a file with invalid dependencies section header
 . $(dirname $0)/test_header

--- a/tests/reload/11-garbage.t
+++ b/tests/reload/11-garbage.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/reload/12-runahead.t
+++ b/tests/reload/12-runahead.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/reload/12-runahead.t
+++ b/tests/reload/12-runahead.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test runahead limit is being correctly reloaded
 . $(dirname $0)/test_header

--- a/tests/reload/13-retrying.t
+++ b/tests/reload/13-retrying.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test that a reloaded retrying does does retry; ref github #945
 . $(dirname $0)/test_header

--- a/tests/reload/13-retrying.t
+++ b/tests/reload/13-retrying.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/reload/14-remove-task.t
+++ b/tests/reload/14-remove-task.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test that removing a task from the graph works OK.
 . $(dirname $0)/test_header

--- a/tests/reload/14-remove-task.t
+++ b/tests/reload/14-remove-task.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/reload/15-add-task.t
+++ b/tests/reload/15-add-task.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/reload/15-add-task.t
+++ b/tests/reload/15-add-task.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test that adding a task to the graph works OK.
 . $(dirname $0)/test_header

--- a/tests/reload/16-waiting.t
+++ b/tests/reload/16-waiting.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/reload/16-waiting.t
+++ b/tests/reload/16-waiting.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test reload a waiting task does not cause DB integrity error. cylc/cylc#1221
 . $(dirname $0)/test_header

--- a/tests/remote/00-basic.t
+++ b/tests/remote/00-basic.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test remote host settings.
 . $(dirname $0)/test_header

--- a/tests/remote/00-basic.t
+++ b/tests/remote/00-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/repeated-items/00-one.t
+++ b/tests/repeated-items/00-one.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test repeated item override and repeated graph string merge 
 . $(dirname $0)/test_header

--- a/tests/repeated-items/00-one.t
+++ b/tests/repeated-items/00-one.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/restart/00-pre-initial.t
+++ b/tests/restart/00-pre-initial.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test restarting a suite with pre-initial cycle dependencies
 . $(dirname $0)/test_header

--- a/tests/restart/00-pre-initial.t
+++ b/tests/restart/00-pre-initial.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/restart/01-broadcast.t
+++ b/tests/restart/01-broadcast.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test restarting a simple suite with a broadcast
 if [[ -z ${TEST_DIR:-} ]]; then

--- a/tests/restart/01-broadcast.t
+++ b/tests/restart/01-broadcast.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/restart/02-failed.t
+++ b/tests/restart/02-failed.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/restart/02-failed.t
+++ b/tests/restart/02-failed.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test restarting a simple suite with a failed task
 if [[ -z ${TEST_DIR:-} ]]; then

--- a/tests/restart/03-retrying.t
+++ b/tests/restart/03-retrying.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/restart/03-retrying.t
+++ b/tests/restart/03-retrying.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test restarting a simple suite with a retrying task
 if [[ -z ${TEST_DIR:-} ]]; then

--- a/tests/restart/04-running.t
+++ b/tests/restart/04-running.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test restarting a simple suite with a running task
 if [[ -z ${TEST_DIR:-} ]]; then

--- a/tests/restart/04-running.t
+++ b/tests/restart/04-running.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/restart/05-submit-failed.t
+++ b/tests/restart/05-submit-failed.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/restart/05-submit-failed.t
+++ b/tests/restart/05-submit-failed.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test restarting a simple suite with a submit-failed task
 if [[ -z ${TEST_DIR:-} ]]; then

--- a/tests/restart/06-succeeded.t
+++ b/tests/restart/06-succeeded.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test restarting a simple suite with a succeeded task
 if [[ -z ${TEST_DIR:-} ]]; then

--- a/tests/restart/06-succeeded.t
+++ b/tests/restart/06-succeeded.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/restart/07-waiting.t
+++ b/tests/restart/07-waiting.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test restarting a simple suite with a waiting task
 if [[ -z ${TEST_DIR:-} ]]; then

--- a/tests/restart/07-waiting.t
+++ b/tests/restart/07-waiting.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/restart/08-retrying-loadleveler.t
+++ b/tests/restart/08-retrying-loadleveler.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test restarting a simple suite using loadleveler with a retrying task
 #     This test requires a specific host [test battery] entry in 

--- a/tests/restart/08-retrying-loadleveler.t
+++ b/tests/restart/08-retrying-loadleveler.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/restart/09-running-loadleveler.t
+++ b/tests/restart/09-running-loadleveler.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/restart/09-running-loadleveler.t
+++ b/tests/restart/09-running-loadleveler.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test restarting a simple suite using loadleveler with a running task
 #     This test requires a specific host [test battery] entry in 

--- a/tests/restart/10-submit-failed-loadleveler.t
+++ b/tests/restart/10-submit-failed-loadleveler.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/restart/10-submit-failed-loadleveler.t
+++ b/tests/restart/10-submit-failed-loadleveler.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test restarting a simple suite using loadleveler with a submit-failed task
 #     This test requires a specific host [test battery] entry in 

--- a/tests/restart/11-bad-state-dump.t
+++ b/tests/restart/11-bad-state-dump.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/restart/11-bad-state-dump.t
+++ b/tests/restart/11-bad-state-dump.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test restarting for suites that have bad state dump files.
 . $(dirname $0)/test_header

--- a/tests/restart/12-reload.t
+++ b/tests/restart/12-reload.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/restart/12-reload.t
+++ b/tests/restart/12-reload.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test restarting after a reload has been done (ref bug fix 64e3b040).
 . $(dirname $0)/test_header

--- a/tests/restart/13-pre-initial-2.t
+++ b/tests/restart/13-pre-initial-2.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/restart/13-pre-initial-2.t
+++ b/tests/restart/13-pre-initial-2.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test restarting a suite with pre-initial cycle dependencies and no
 # initial cycle time in suite definition, ref. github #957.

--- a/tests/restart/14-back-comp-restart.t
+++ b/tests/restart/14-back-comp-restart.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test restarting a pre-Cylc-6 suite.
 . $(dirname $0)/test_header

--- a/tests/restart/14-back-comp-restart.t
+++ b/tests/restart/14-back-comp-restart.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/retries/00-execution-retry.t
+++ b/tests/retries/00-execution-retry.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/retries/00-execution-retry.t
+++ b/tests/retries/00-execution-retry.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test execution retries are working
 . $(dirname $0)/test_header

--- a/tests/retries/01-execution-retry-iso.t
+++ b/tests/retries/01-execution-retry-iso.t
@@ -1,21 +1,21 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-#C: Test execution retries are working
+# Test execution retries are working
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 set_test_number 3

--- a/tests/retries/01-execution-retry-iso.t
+++ b/tests/retries/01-execution-retry-iso.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/retries/02-submission-retry.t
+++ b/tests/retries/02-submission-retry.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/retries/02-submission-retry.t
+++ b/tests/retries/02-submission-retry.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test execution retries are working
 . $(dirname $0)/test_header

--- a/tests/retries/03-submission-retry-iso.t
+++ b/tests/retries/03-submission-retry-iso.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/retries/03-submission-retry-iso.t
+++ b/tests/retries/03-submission-retry-iso.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test execution retries are working
 . $(dirname $0)/test_header

--- a/tests/runahead/00-runahead.t
+++ b/tests/runahead/00-runahead.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/runahead/00-runahead.t
+++ b/tests/runahead/00-runahead.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test runahead limit is being enforced
 . $(dirname $0)/test_header

--- a/tests/runahead/01-check-default-simple.t
+++ b/tests/runahead/01-check-default-simple.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test default runahead limit behaviour is still the same
 . $(dirname $0)/test_header

--- a/tests/runahead/01-check-default-simple.t
+++ b/tests/runahead/01-check-default-simple.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/runahead/02-check-default-complex.t
+++ b/tests/runahead/02-check-default-complex.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/runahead/02-check-default-complex.t
+++ b/tests/runahead/02-check-default-complex.t
@@ -1,21 +1,21 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-#C: Test default runahead limit behaviour is still the same
+# Test default runahead limit behaviour is still the same
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 set_test_number 5

--- a/tests/runahead/03-check-default-future.t
+++ b/tests/runahead/03-check-default-future.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test default runahead limit behaviour is still the same
 . $(dirname $0)/test_header

--- a/tests/runahead/03-check-default-future.t
+++ b/tests/runahead/03-check-default-future.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/runahead/04-no-final-cycle.t
+++ b/tests/runahead/04-no-final-cycle.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/runahead/04-no-final-cycle.t
+++ b/tests/runahead/04-no-final-cycle.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test runahead limit is being enforced and doesn't break with no final cycle
 . $(dirname $0)/test_header

--- a/tests/runahead/05-check-default-future-2.t
+++ b/tests/runahead/05-check-default-future-2.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test default runahead limit behaviour is still the same
 . $(dirname $0)/test_header

--- a/tests/runahead/05-check-default-future-2.t
+++ b/tests/runahead/05-check-default-future-2.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/shutdown/00-cycle.t
+++ b/tests/shutdown/00-cycle.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test shutdown after a particular cycle.
 . $(dirname $0)/test_header

--- a/tests/shutdown/00-cycle.t
+++ b/tests/shutdown/00-cycle.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/shutdown/01-task.t
+++ b/tests/shutdown/01-task.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/shutdown/01-task.t
+++ b/tests/shutdown/01-task.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test shutdown after a specific task.
 . $(dirname $0)/test_header

--- a/tests/shutdown/02-no_dir.t
+++ b/tests/shutdown/02-no_dir.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test suite can shutdown successfully if its run dir is deleted
 . $(dirname $0)/test_header

--- a/tests/shutdown/02-no_dir.t
+++ b/tests/shutdown/02-no_dir.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/shutdown/03-bad-cycle.t
+++ b/tests/shutdown/03-bad-cycle.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test clean up of port file, on bad start with invalid initial cycle time.
 . $(dirname $0)/test_header

--- a/tests/shutdown/03-bad-cycle.t
+++ b/tests/shutdown/03-bad-cycle.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/shutdown/04-kill.t
+++ b/tests/shutdown/04-kill.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/shutdown/04-kill.t
+++ b/tests/shutdown/04-kill.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test kill OK after shutdown. Suite will timeout if kill not OK.
 . $(dirname $0)/test_header

--- a/tests/special/00-sequential.t
+++ b/tests/special/00-sequential.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/special/00-sequential.t
+++ b/tests/special/00-sequential.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test sequential tasks
 . $(dirname $0)/test_header

--- a/tests/special/01-one-off.t
+++ b/tests/special/01-one-off.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/special/01-one-off.t
+++ b/tests/special/01-one-off.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test one-off tasks
 . $(dirname $0)/test_header

--- a/tests/special/02-exclude.t
+++ b/tests/special/02-exclude.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test exclude at start-up is working
 . $(dirname $0)/test_header

--- a/tests/special/02-exclude.t
+++ b/tests/special/02-exclude.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/special/03-include.t
+++ b/tests/special/03-include.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/special/03-include.t
+++ b/tests/special/03-include.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test include at start-up is working
 . $(dirname $0)/test_header

--- a/tests/special/04-clock-triggered.t
+++ b/tests/special/04-clock-triggered.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test clock triggering is working
 . $(dirname $0)/test_header

--- a/tests/special/04-clock-triggered.t
+++ b/tests/special/04-clock-triggered.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/special/05-clock-triggered-utc.t
+++ b/tests/special/05-clock-triggered-utc.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test clock triggering is working
 . $(dirname $0)/test_header

--- a/tests/special/05-clock-triggered-utc.t
+++ b/tests/special/05-clock-triggered-utc.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/special/06-clock-triggered-iso.t
+++ b/tests/special/06-clock-triggered-iso.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test clock triggering is working
 . $(dirname $0)/test_header

--- a/tests/special/06-clock-triggered-iso.t
+++ b/tests/special/06-clock-triggered-iso.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/special/07-clock-triggered-360.t
+++ b/tests/special/07-clock-triggered-360.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test clock triggering is working
 . $(dirname $0)/test_header

--- a/tests/special/07-clock-triggered-360.t
+++ b/tests/special/07-clock-triggered-360.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/startup/00-cold.t
+++ b/tests/startup/00-cold.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/startup/00-cold.t
+++ b/tests/startup/00-cold.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cold starting, including that the cold start task has actually run
 . $(dirname $0)/test_header

--- a/tests/startup/01-warm.t
+++ b/tests/startup/01-warm.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test warm starting setting cold-start tasks to succeeded & not running them
 . $(dirname $0)/test_header

--- a/tests/startup/01-warm.t
+++ b/tests/startup/01-warm.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/state-dump/00-basic.t
+++ b/tests/state-dump/00-basic.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Basic test for state dumps.
 run_restart() {

--- a/tests/state-dump/00-basic.t
+++ b/tests/state-dump/00-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/state-dump/01-restart-file.t
+++ b/tests/state-dump/01-restart-file.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/state-dump/01-restart-file.t
+++ b/tests/state-dump/01-restart-file.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Basic test for state dumps, specify the dump on restart command line.
 run_restart() {

--- a/tests/state-dump/02-bad-pwd-state.t
+++ b/tests/state-dump/02-bad-pwd-state.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/state-dump/02-bad-pwd-state.t
+++ b/tests/state-dump/02-bad-pwd-state.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Basic test for state dumps restart, bogus state file in $PWD.
 run_restart() {

--- a/tests/state-dump/test_impl
+++ b/tests/state-dump/test_impl
@@ -1,21 +1,21 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-#C: Implements state dumps tests, caller should implement "run_restart".
+# Implements state dumps tests, caller should implement "run_restart".
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 set_test_number 8

--- a/tests/state-dump/test_impl
+++ b/tests/state-dump/test_impl
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/suite-host-self-id/00-address.t
+++ b/tests/suite-host-self-id/00-address.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/suite-host-self-id/00-address.t
+++ b/tests/suite-host-self-id/00-address.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Ensure that suite contact env host IP address is defined
 

--- a/tests/suite-state/00-polling.t
+++ b/tests/suite-state/00-polling.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/suite-state/00-polling.t
+++ b/tests/suite-state/00-polling.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Validate and run the suite-state/polling test suite
 # The test suite is in polling/; it depends on another suite in upstream/

--- a/tests/suite-state/01-polling.t
+++ b/tests/suite-state/01-polling.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/suite-state/01-polling.t
+++ b/tests/suite-state/01-polling.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Validate and run the suite-state/polling test suite
 # The test suite is in polling/; it depends on another suite in upstream/

--- a/tests/suite-state/02-validate-blank-command-scripting.t
+++ b/tests/suite-state/02-validate-blank-command-scripting.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Validate blank command scripting in automatic suite polling task.
 . $(dirname $0)/test_header

--- a/tests/suite-state/02-validate-blank-command-scripting.t
+++ b/tests/suite-state/02-validate-blank-command-scripting.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/task-name/00-basic.t
+++ b/tests/task-name/00-basic.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Basic task names tests.
 

--- a/tests/task-name/00-basic.t
+++ b/tests/task-name/00-basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/triggering/00-recovery.t
+++ b/tests/triggering/00-recovery.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/triggering/00-recovery.t
+++ b/tests/triggering/00-recovery.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test automated failure recovery example
 . $(dirname $0)/test_header

--- a/tests/triggering/01-or-conditional.t
+++ b/tests/triggering/01-or-conditional.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/triggering/01-or-conditional.t
+++ b/tests/triggering/01-or-conditional.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test "or" conditionals
 . $(dirname $0)/test_header

--- a/tests/triggering/02-fam-start-all.t
+++ b/tests/triggering/02-fam-start-all.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/triggering/02-fam-start-all.t
+++ b/tests/triggering/02-fam-start-all.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test correct expansion of FAM:start-all
 . $(dirname $0)/test_header

--- a/tests/triggering/03-fam-succeed-all.t
+++ b/tests/triggering/03-fam-succeed-all.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test correct expansion of FAM:succeed-all
 . $(dirname $0)/test_header

--- a/tests/triggering/03-fam-succeed-all.t
+++ b/tests/triggering/03-fam-succeed-all.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/triggering/04-fam-fail-all.t
+++ b/tests/triggering/04-fam-fail-all.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/triggering/04-fam-fail-all.t
+++ b/tests/triggering/04-fam-fail-all.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test correct expansion of FAM:fail-all
 . $(dirname $0)/test_header

--- a/tests/triggering/05-fam-finish-all.t
+++ b/tests/triggering/05-fam-finish-all.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/triggering/05-fam-finish-all.t
+++ b/tests/triggering/05-fam-finish-all.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test correct expansion of FAM:finish-all
 . $(dirname $0)/test_header

--- a/tests/triggering/06-fam-succeed-any.t
+++ b/tests/triggering/06-fam-succeed-any.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/triggering/06-fam-succeed-any.t
+++ b/tests/triggering/06-fam-succeed-any.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test correct expansion of FAM:succeed-any
 . $(dirname $0)/test_header

--- a/tests/triggering/07-fam-fail-any.t
+++ b/tests/triggering/07-fam-fail-any.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/triggering/07-fam-fail-any.t
+++ b/tests/triggering/07-fam-fail-any.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test correct expansion of FAM:fail-any
 . $(dirname $0)/test_header

--- a/tests/triggering/08-fam-finish-any.t
+++ b/tests/triggering/08-fam-finish-any.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test correct expansion of FAM:finish-any
 . $(dirname $0)/test_header

--- a/tests/triggering/08-fam-finish-any.t
+++ b/tests/triggering/08-fam-finish-any.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/triggering/09-fail.t
+++ b/tests/triggering/09-fail.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test fail triggering
 . $(dirname $0)/test_header

--- a/tests/triggering/09-fail.t
+++ b/tests/triggering/09-fail.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/triggering/10-finish.t
+++ b/tests/triggering/10-finish.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test finish triggering
 . $(dirname $0)/test_header

--- a/tests/triggering/10-finish.t
+++ b/tests/triggering/10-finish.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/triggering/11-start.t
+++ b/tests/triggering/11-start.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test start triggering
 . $(dirname $0)/test_header

--- a/tests/triggering/11-start.t
+++ b/tests/triggering/11-start.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/triggering/12-succeed.t
+++ b/tests/triggering/12-succeed.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/triggering/12-succeed.t
+++ b/tests/triggering/12-succeed.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test succeed triggering
 . $(dirname $0)/test_header

--- a/tests/triggering/13-submit.t
+++ b/tests/triggering/13-submit.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test submit triggering
 . $(dirname $0)/test_header

--- a/tests/triggering/13-submit.t
+++ b/tests/triggering/13-submit.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/triggering/14-submit-fail.t
+++ b/tests/triggering/14-submit-fail.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test submit-fail triggering
 . $(dirname $0)/test_header

--- a/tests/triggering/14-submit-fail.t
+++ b/tests/triggering/14-submit-fail.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/triggering/15-suicide.t
+++ b/tests/triggering/15-suicide.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test suicide triggering
 # (this is currently just a copy of the tutorial suicide example, but I

--- a/tests/triggering/15-suicide.t
+++ b/tests/triggering/15-suicide.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/tutorial/cycling/00-tut.five.t
+++ b/tests/tutorial/cycling/00-tut.five.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test CUG tutorial suites
 

--- a/tests/tutorial/cycling/00-tut.five.t
+++ b/tests/tutorial/cycling/00-tut.five.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/tutorial/cycling/01-tut.four.t
+++ b/tests/tutorial/cycling/01-tut.four.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test CUG tutorial suites
 

--- a/tests/tutorial/cycling/01-tut.four.t
+++ b/tests/tutorial/cycling/01-tut.four.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/tutorial/cycling/02-tut.one.t
+++ b/tests/tutorial/cycling/02-tut.one.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test CUG tutorial suites
 

--- a/tests/tutorial/cycling/02-tut.one.t
+++ b/tests/tutorial/cycling/02-tut.one.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/tutorial/cycling/03-tut.three.t
+++ b/tests/tutorial/cycling/03-tut.three.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test CUG tutorial suites
 

--- a/tests/tutorial/cycling/03-tut.three.t
+++ b/tests/tutorial/cycling/03-tut.three.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/tutorial/cycling/04-tut.two.t
+++ b/tests/tutorial/cycling/04-tut.two.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test CUG tutorial suites
 

--- a/tests/tutorial/cycling/04-tut.two.t
+++ b/tests/tutorial/cycling/04-tut.two.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/tutorial/oneoff/00-tut.basic.t
+++ b/tests/tutorial/oneoff/00-tut.basic.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test CUG tutorial suites
 

--- a/tests/tutorial/oneoff/00-tut.basic.t
+++ b/tests/tutorial/oneoff/00-tut.basic.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/tutorial/oneoff/01-tut.external.t
+++ b/tests/tutorial/oneoff/01-tut.external.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test CUG tutorial suites
 

--- a/tests/tutorial/oneoff/01-tut.external.t
+++ b/tests/tutorial/oneoff/01-tut.external.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/tutorial/oneoff/02-tut.ftrigger1.t
+++ b/tests/tutorial/oneoff/02-tut.ftrigger1.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test CUG tutorial suites
 

--- a/tests/tutorial/oneoff/02-tut.ftrigger1.t
+++ b/tests/tutorial/oneoff/02-tut.ftrigger1.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/tutorial/oneoff/03-tut.ftrigger2.t
+++ b/tests/tutorial/oneoff/03-tut.ftrigger2.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test CUG tutorial suites
 

--- a/tests/tutorial/oneoff/03-tut.ftrigger2.t
+++ b/tests/tutorial/oneoff/03-tut.ftrigger2.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/tutorial/oneoff/04-tut.goodbye.t
+++ b/tests/tutorial/oneoff/04-tut.goodbye.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test CUG tutorial suites
 

--- a/tests/tutorial/oneoff/04-tut.goodbye.t
+++ b/tests/tutorial/oneoff/04-tut.goodbye.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/tutorial/oneoff/05-tut.inherit.t
+++ b/tests/tutorial/oneoff/05-tut.inherit.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test CUG tutorial suites
 

--- a/tests/tutorial/oneoff/05-tut.inherit.t
+++ b/tests/tutorial/oneoff/05-tut.inherit.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/tutorial/oneoff/06-tut.jinja2.t
+++ b/tests/tutorial/oneoff/06-tut.jinja2.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test CUG tutorial suites
 

--- a/tests/tutorial/oneoff/06-tut.jinja2.t
+++ b/tests/tutorial/oneoff/06-tut.jinja2.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/tutorial/oneoff/07-tut.jobsub.t
+++ b/tests/tutorial/oneoff/07-tut.jobsub.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test CUG tutorial suites
 

--- a/tests/tutorial/oneoff/07-tut.jobsub.t
+++ b/tests/tutorial/oneoff/07-tut.jobsub.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/tutorial/oneoff/08-tut.minimal.t
+++ b/tests/tutorial/oneoff/08-tut.minimal.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test CUG tutorial suites
 

--- a/tests/tutorial/oneoff/08-tut.minimal.t
+++ b/tests/tutorial/oneoff/08-tut.minimal.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/tutorial/oneoff/09-tut.remote.t
+++ b/tests/tutorial/oneoff/09-tut.remote.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test CUG tutorial suites
 

--- a/tests/tutorial/oneoff/09-tut.remote.t
+++ b/tests/tutorial/oneoff/09-tut.remote.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/tutorial/oneoff/10-tut.retry.t
+++ b/tests/tutorial/oneoff/10-tut.retry.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test CUG tutorial suites
 

--- a/tests/tutorial/oneoff/10-tut.retry.t
+++ b/tests/tutorial/oneoff/10-tut.retry.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/tutorial/oneoff/11-tut.suicide.t
+++ b/tests/tutorial/oneoff/11-tut.suicide.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test CUG tutorial suites
 

--- a/tests/tutorial/oneoff/11-tut.suicide.t
+++ b/tests/tutorial/oneoff/11-tut.suicide.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/tutorial/update-tutorial-tests.sh
+++ b/tests/tutorial/update-tutorial-tests.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 set -e
 
@@ -61,21 +61,21 @@ for GROUP in oneoff cycling; do
         I=$( printf "%02d" $COUNT )
         cat > ${I}-${NAME}.t <<EOF
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test CUG tutorial suites
 

--- a/tests/tutorial/update-tutorial-tests.sh
+++ b/tests/tutorial/update-tutorial-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by
@@ -62,7 +62,7 @@ for GROUP in oneoff cycling; do
         cat > ${I}-${NAME}.t <<EOF
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/vacation/00-sigusr1.t
+++ b/tests/vacation/00-sigusr1.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/vacation/00-sigusr1.t
+++ b/tests/vacation/00-sigusr1.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test handle of SIGUSR1. (Handle a mock job vacation.)
 # Obviously, job vacation does not happen with background job, and the job

--- a/tests/vacation/00-sigusr1/python/background_vacation.py
+++ b/tests/vacation/00-sigusr1/python/background_vacation.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 from cylc.batch_sys_handlers.background import BgCommandHandler

--- a/tests/vacation/00-sigusr1/python/background_vacation.py
+++ b/tests/vacation/00-sigusr1/python/background_vacation.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/vacation/01-loadleveler.t
+++ b/tests/vacation/01-loadleveler.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test whether job vacation trap is included in a loadleveler job or not.
 # A job for a task with the restart=yes directive will have the trap.

--- a/tests/vacation/01-loadleveler.t
+++ b/tests/vacation/01-loadleveler.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/validate/00-multi.t
+++ b/tests/validate/00-multi.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test validating simple multi-inheritance suites.
 . $(dirname $0)/test_header

--- a/tests/validate/00-multi.t
+++ b/tests/validate/00-multi.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/validate/01-periodical.t
+++ b/tests/validate/01-periodical.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/validate/01-periodical.t
+++ b/tests/validate/01-periodical.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test validating Daily, Monthly and Yearly type tasks.
 . $(dirname $0)/test_header

--- a/tests/validate/02-scripting-quotes.t
+++ b/tests/validate/02-scripting-quotes.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/validate/02-scripting-quotes.t
+++ b/tests/validate/02-scripting-quotes.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test that validating: command scripting = "foo"bar"baz" fails
 . $(dirname $0)/test_header

--- a/tests/validate/03-incomplete-quotes.t
+++ b/tests/validate/03-incomplete-quotes.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/validate/03-incomplete-quotes.t
+++ b/tests/validate/03-incomplete-quotes.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test validating: command scripting = "foo  fails
 . $(dirname $0)/test_header

--- a/tests/validate/04-check-examples.t
+++ b/tests/validate/04-check-examples.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/validate/04-check-examples.t
+++ b/tests/validate/04-check-examples.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test validation of example suites
 . $(dirname $0)/test_header

--- a/tests/validate/05-strict-case.t
+++ b/tests/validate/05-strict-case.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test strict validation of suite with case mismatches in task names
 . $(dirname $0)/test_header

--- a/tests/validate/05-strict-case.t
+++ b/tests/validate/05-strict-case.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/validate/06-strict-missing.t
+++ b/tests/validate/06-strict-missing.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test strict validation of suite for tasks without runtime entries
 . $(dirname $0)/test_header

--- a/tests/validate/06-strict-missing.t
+++ b/tests/validate/06-strict-missing.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/validate/07-null-parentage.t
+++ b/tests/validate/07-null-parentage.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test strict validation of suite for tasks with inherit = None
 . $(dirname $0)/test_header

--- a/tests/validate/07-null-parentage.t
+++ b/tests/validate/07-null-parentage.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/validate/08-whitespace.t
+++ b/tests/validate/08-whitespace.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test validation with a lot of whitespace added - trailing, around
 # section headings, around list item delimiters, in include-files, and

--- a/tests/validate/08-whitespace.t
+++ b/tests/validate/08-whitespace.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/validate/09-include-missing.t
+++ b/tests/validate/09-include-missing.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/validate/09-include-missing.t
+++ b/tests/validate/09-include-missing.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test validation missing include-file.
 . $(dirname $0)/test_header

--- a/tests/validate/10-bad-sequence-interval.t
+++ b/tests/validate/10-bad-sequence-interval.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test validation for a bad sequence interval.
 . $(dirname $0)/test_header

--- a/tests/validate/10-bad-sequence-interval.t
+++ b/tests/validate/10-bad-sequence-interval.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/validate/11-bad-sequence-2-digit-century.t
+++ b/tests/validate/11-bad-sequence-2-digit-century.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test validation for a bad sequence interval.
 . $(dirname $0)/test_header

--- a/tests/validate/11-bad-sequence-2-digit-century.t
+++ b/tests/validate/11-bad-sequence-2-digit-century.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/validate/11-fail-mixed-syntax-formats-1.t
+++ b/tests/validate/11-fail-mixed-syntax-formats-1.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test validation with a new-style cycle time and an prev-style cycling section
 . $(dirname $0)/test_header

--- a/tests/validate/11-fail-mixed-syntax-formats-1.t
+++ b/tests/validate/11-fail-mixed-syntax-formats-1.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/validate/12-fail-mixed-syntax-formats-2.t
+++ b/tests/validate/12-fail-mixed-syntax-formats-2.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/validate/12-fail-mixed-syntax-formats-2.t
+++ b/tests/validate/12-fail-mixed-syntax-formats-2.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test validation with a new-style cycle point and a prev-style offset.
 . $(dirname $0)/test_header

--- a/tests/validate/13-fail-mixed-syntax-formats-3.t
+++ b/tests/validate/13-fail-mixed-syntax-formats-3.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/validate/13-fail-mixed-syntax-formats-3.t
+++ b/tests/validate/13-fail-mixed-syntax-formats-3.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test validation with a new-style cycle point and a prev-style limit.
 . $(dirname $0)/test_header

--- a/tests/validate/14-fail-mixed-syntax-formats-4.t
+++ b/tests/validate/14-fail-mixed-syntax-formats-4.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test validation with a prev-style cycle point and a new-style cycling section
 . $(dirname $0)/test_header

--- a/tests/validate/14-fail-mixed-syntax-formats-4.t
+++ b/tests/validate/14-fail-mixed-syntax-formats-4.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/validate/15-fail-mixed-syntax-formats-5.t
+++ b/tests/validate/15-fail-mixed-syntax-formats-5.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test validation with a prev-style cycle point and a new-style offset.
 . $(dirname $0)/test_header

--- a/tests/validate/15-fail-mixed-syntax-formats-5.t
+++ b/tests/validate/15-fail-mixed-syntax-formats-5.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/validate/16-fail-mixed-syntax-formats-6.t
+++ b/tests/validate/16-fail-mixed-syntax-formats-6.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/validate/16-fail-mixed-syntax-formats-6.t
+++ b/tests/validate/16-fail-mixed-syntax-formats-6.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test validation with a prev-style cycle point and a new-style limit.
 . $(dirname $0)/test_header

--- a/tests/validate/17-fail-mixed-syntax-formats-7.t
+++ b/tests/validate/17-fail-mixed-syntax-formats-7.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/validate/17-fail-mixed-syntax-formats-7.t
+++ b/tests/validate/17-fail-mixed-syntax-formats-7.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test validation with a prev-style cycle point and a new-style ^ offset.
 . $(dirname $0)/test_header

--- a/tests/validate/18-fail-mixed-syntax-formats-8.t
+++ b/tests/validate/18-fail-mixed-syntax-formats-8.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test validation with a new-style cycle point and start-up tasks.
 . $(dirname $0)/test_header

--- a/tests/validate/18-fail-mixed-syntax-formats-8.t
+++ b/tests/validate/18-fail-mixed-syntax-formats-8.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/validate/19-fail-mixed-syntax-formats-9.t
+++ b/tests/validate/19-fail-mixed-syntax-formats-9.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/validate/19-fail-mixed-syntax-formats-9.t
+++ b/tests/validate/19-fail-mixed-syntax-formats-9.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test validation with a new-style cycle point and an async graph.
 . $(dirname $0)/test_header

--- a/tests/validate/20-fail-no-scheduling.t
+++ b/tests/validate/20-fail-no-scheduling.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/validate/20-fail-no-scheduling.t
+++ b/tests/validate/20-fail-no-scheduling.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test validation with a new-style cycle point and an async graph.
 . $(dirname $0)/test_header

--- a/tests/validate/21-fail-no-dependencies.t
+++ b/tests/validate/21-fail-no-dependencies.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/validate/21-fail-no-dependencies.t
+++ b/tests/validate/21-fail-no-dependencies.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test validation with a new-style cycle point and an async graph.
 . $(dirname $0)/test_header

--- a/tests/validate/22-fail-no-graph-async.t
+++ b/tests/validate/22-fail-no-graph-async.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/validate/22-fail-no-graph-async.t
+++ b/tests/validate/22-fail-no-graph-async.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test validation with a new-style cycle point and an async graph.
 . $(dirname $0)/test_header

--- a/tests/validate/23-fail-no-graph-sequence.t
+++ b/tests/validate/23-fail-no-graph-sequence.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/validate/23-fail-no-graph-sequence.t
+++ b/tests/validate/23-fail-no-graph-sequence.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test validation with a new-style cycle point and an async graph.
 . $(dirname $0)/test_header

--- a/tests/validate/24-fail-year-bounds.t
+++ b/tests/validate/24-fail-year-bounds.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C: 
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/validate/24-fail-year-bounds.t
+++ b/tests/validate/24-fail-year-bounds.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C: 
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test validation with a new-style cycle point and an async graph.
 . $(dirname $0)/test_header

--- a/tests/validate/25-fail-mixed-syntax-formats-10.t
+++ b/tests/validate/25-fail-mixed-syntax-formats-10.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test validation with a  prev-style cycle synax and post-style retry syntax
 . $(dirname $0)/test_header

--- a/tests/validate/25-fail-mixed-syntax-formats-10.t
+++ b/tests/validate/25-fail-mixed-syntax-formats-10.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by

--- a/tests/validate/26-fail-initial-greater-final.t
+++ b/tests/validate/26-fail-initial-greater-final.t
@@ -1,19 +1,19 @@
 #!/bin/bash
-#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2015 NIWA
-#C:
-#C: This program is free software: you can redistribute it and/or modify
-#C: it under the terms of the GNU General Public License as published by
-#C: the Free Software Foundation, either version 3 of the License, or
-#C: (at your option) any later version.
-#C:
-#C: This program is distributed in the hope that it will be useful,
-#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
-#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#C: GNU General Public License for more details.
-#C:
-#C: You should have received a copy of the GNU General Public License
-#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test validation fails for initial cycle point greater than the final.
 . $(dirname $0)/test_header

--- a/tests/validate/26-fail-initial-greater-final.t
+++ b/tests/validate/26-fail-initial-greater-final.t
@@ -1,6 +1,6 @@
 #!/bin/bash
 #C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-#C: Copyright (C) 2008-2014 NIWA
+#C: Copyright (C) 2008-2015 NIWA
 #C:
 #C: This program is free software: you can redistribute it and/or modify
 #C: it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
This updates the copyright statements for 2015.

It also standardizes the the license/copyright header comment prefixes from "#C: " to "# ", because pep8 doesn't like the former (which were originally to uniquely identify the license headers in case they needed changing or removing).