### PR TITLE
Handle spaces in CYLC_DIR for git repo version.

### DIFF
--- a/admin/get-repo-version
+++ b/admin/get-repo-version
@@ -26,7 +26,7 @@ LF='
 '
 
 # move to the repository
-cd $( dirname $0 )/..
+cd $( dirname "$0" )/..
 VN=$(git describe --abbrev=4 --tags HEAD 2>/dev/null)
 case "$VN" in
     *$LF*) (exit 1) ;;

--- a/lib/cylc/version.py
+++ b/lib/cylc/version.py
@@ -29,8 +29,9 @@ def _get_cylc_version():
 
     if os.path.exists(os.path.join(cylc_dir, ".git")):
         # We're running in a cylc git repository, so dynamically determine
-        # the cylc version string.
-        res = run_get_stdout(
+        # the cylc version string.  Enclose the path in quotes to handle
+        # avoid failure when cylc_dir contains spaces.
+        res = run_get_stdout('"%s"' %
             os.path.join(cylc_dir, "admin", "get-repo-version"))
         if res[0]:
             return res[1][0]


### PR DESCRIPTION
Replaces #1275 (as per https://github.com/cylc/cylc/pull/1275#issuecomment-70774708).

I cherry-picked @trwhitcomb's commit.  My testing showed that it fixed the explicit error but returned nothing for the repo version - the directory had to be quoted in ```admin/get-repo-version``` too.

I have not checked for other dire consequences of having spaces in CYLC_DIR ... presumably Tim would have mentioned if there were any.

@matthewrmshin - please review.