### PR TITLE
Fixed a reconnection bug in gcylc.

### DIFF
--- a/lib/cylc/gui/updater.py
+++ b/lib/cylc/gui/updater.py
@@ -143,7 +143,11 @@ class Updater(threading.Thread):
         self.all_families = self.sinfo.get('all families')
         self.triggering_families = self.sinfo.get('triggering families')
 
-    def _reconnect( self ):
+    def _reconnect(self):
+        """Connect to the suite daemon and get Pyro client proxies."""
+        self.god = None
+        self.sinfo = None
+        self.log = None
         try:
             client = cylc_pyro_client.client(
                     self.cfg.suite,


### PR DESCRIPTION
On current master, the following sequence of actions results in blank GUI views, although the suite summary icons update as normal in status bar:
 1. run a suite
 2. kill the suite so that the port file remains on disk
 3. start up gcylc for the suite
 4. remove the port file
 5. start the suite
 6. (observe the open gcylc instance)

The variable referencing the state summary Pyro proxy object needs to be set to ```None``` before attempting to reconnect. 