### PR TITLE
Fix gcylc open with no suite specified.

### DIFF
--- a/bin/cylc-gui
+++ b/bin/cylc-gui
@@ -18,7 +18,7 @@
 
 import sys
 if '--use-ssh' in sys.argv[1:]:
-    sys.argv.remove( '--use-ssh' )
+    sys.argv.remove('--use-ssh')
     from cylc.remote import remrun
     if remrun().execute():
         sys.exit(0)
@@ -27,38 +27,42 @@ import os
 from cylc.CylcOptionParsers import cop
 import cylc.flags
 
-sys.path.append(os.path.dirname(os.path.realpath(os.path.abspath(__file__))) + '/../lib')
-sys.path.append(os.path.dirname(os.path.realpath(os.path.abspath(__file__))) + '/../')
+sys.path.append(
+    os.path.dirname(os.path.realpath(os.path.abspath(__file__))) + '/../lib')
+sys.path.append(
+    os.path.dirname(os.path.realpath(os.path.abspath(__file__))) + '/../')
 
-parser = cop( """cylc gui [OPTIONS] [REG]
+parser = cop(
+    """cylc gui [OPTIONS] [REG]
 gcylc [OPTIONS] [REG]
 
 This is the cylc Graphical User Interface.
 
-Local suites can be opened and switched between from within gcylc. To
-connect to running remote suites (whose passphrase you have installed)
-you must currently use --host and/or --user on the gcylc command line.
+Local suites can be opened and switched between from within gcylc. To connect
+to running remote suites (whose passphrase you have installed) you must
+currently use --host and/or --user on the gcylc command line.
 
-Available task state color themes are shown under the View menu. To
-customize themes copy $CYLC_DIR/conf/gcylcrc/gcylc.rc.eg to
-$HOME/.cylc/gcylc.rc and follow the instructions in the file.
+Available task state color themes are shown under the View menu. To customize
+themes copy $CYLC_DIR/conf/gcylcrc/gcylc.rc.eg to $HOME/.cylc/gcylc.rc and
+follow the instructions in the file.
 
 To see current configuration settings use "cylc get-gui-config".
 
 In the graph view, View -> Options -> "Write Graph Frames" writes .dot graph
-files to the suite share directory (locally, for a remote suite). These can be
-post-processed into a movie by \$CYLC_DIR/dev/bin/live-graph-movie.sh=.""",
-pyro=True, noforce=True, jset=True, argdoc=[('[REG]', 'Suite name' )])
+files to the suite share directory (locally, for a remote suite). These can
+be processed into a movie by \$CYLC_DIR/dev/bin/live-graph-movie.sh=.""",
+    pyro=True, noforce=True, jset=True, argdoc=[('[REG]', 'Suite name')])
 
-parser.add_option("-r", "--restricted",
-        help="Restrict display to 'active' task states: submitted, "
-        "submit-failed, submit-retrying, running, failed, retrying; "
-        "and disable the graph view.  This may be needed for very large "
-        "suites. The state summary icons in the status bar still "
-        "represent all task proxies.",
-        action="store_true", default=False, dest="restricted")
+parser.add_option(
+    "-r", "--restricted",
+    help="Restrict display to 'active' task states: submitted, "
+    "submit-failed, submit-retrying, running, failed, retrying; "
+    "and disable the graph view.  This may be needed for very large "
+    "suites. The state summary icons in the status bar still "
+    "represent all task proxies.",
+    action="store_true", default=False, dest="restricted")
 
-( options, args ) = parser.parse_args()
+(options, args) = parser.parse_args()
 
 # import modules that require gtk now, so that a display is not needed
 # just to get command help (e.g. when running make on a post-commit hook
@@ -76,9 +80,12 @@ from cylc.gui.SuiteControl import ControlApp
 # attempt to determine their CWD.
 os.chdir(os.environ['HOME'])
 
-gtk.settings_get_default().set_long_property("gtk-toolbar-icon-size", gtk.ICON_SIZE_SMALL_TOOLBAR, "main")
-gtk.settings_get_default().set_long_property("gtk-button-images", True, "main")
-gtk.settings_get_default().set_long_property("gtk-menu-images", True, "main")
+gtk.settings_get_default().set_long_property(
+    "gtk-toolbar-icon-size", gtk.ICON_SIZE_SMALL_TOOLBAR, "main")
+gtk.settings_get_default().set_long_property(
+    "gtk-button-images", True, "main")
+gtk.settings_get_default().set_long_property(
+    "gtk-menu-images", True, "main")
 
 if len(args) == 1:
     suite = args[0]
@@ -86,10 +93,9 @@ else:
     suite = None
 
 try:
-    app = ControlApp(suite, options.db, options.owner,
-            options.host, options.port, options.pyro_timeout,
-            options.templatevars, options.templatevars_file,
-            options.restricted)
+    app = ControlApp(suite, options.db, options.owner, options.host,
+                     options.port, options.pyro_timeout, options.templatevars,
+                     options.templatevars_file, options.restricted)
 except Exception, x:
     if cylc.flags.debug:
         raise

--- a/bin/cylc-gui
+++ b/bin/cylc-gui
@@ -25,7 +25,6 @@ if '--use-ssh' in sys.argv[1:]:
 
 import os
 from cylc.CylcOptionParsers import cop
-from cylc.cfgspec.globalcfg import GLOBAL_CFG
 import cylc.flags
 
 sys.path.append(os.path.dirname(os.path.realpath(os.path.abspath(__file__))) + '/../lib')
@@ -46,10 +45,9 @@ $HOME/.cylc/gcylc.rc and follow the instructions in the file.
 
 To see current configuration settings use "cylc get-gui-config".
 
-The graph view option, View -> Options -> "Write Graph Frames" writes a
-dot-language file to the suite share directory on every state change.
-These can be post-processed into a movie by
-\lstinline=$CYLC_DIR/dev/bin/live-graph-movie.sh=.""",
+In the graph view, View -> Options -> "Write Graph Frames" writes .dot graph
+files to the suite share directory (locally, for a remote suite). These can be
+post-processed into a movie by \$CYLC_DIR/dev/bin/live-graph-movie.sh=.""",
 pyro=True, noforce=True, jset=True, argdoc=[('[REG]', 'Suite name' )])
 
 parser.add_option("-r", "--restricted",
@@ -87,12 +85,11 @@ if len(args) == 1:
 else:
     suite = None
 
-share_dir = GLOBAL_CFG.get_derived_host_item(suite, 'suite share directory')
 try:
     app = ControlApp(suite, options.db, options.owner,
             options.host, options.port, options.pyro_timeout,
             options.templatevars, options.templatevars_file,
-            options.restricted, share_dir=share_dir)
+            options.restricted)
 except Exception, x:
     if cylc.flags.debug:
         raise

--- a/lib/cylc/gui/SuiteControl.py
+++ b/lib/cylc/gui/SuiteControl.py
@@ -106,13 +106,12 @@ Class to hold initialisation data.
     """
     def __init__(self, suite, owner, host, port, db,
             pyro_timeout, template_vars, template_vars_file,
-            ungrouped_views, use_defn_order, share_dir):
+            ungrouped_views, use_defn_order):
         self.suite = suite
         self.owner = owner
         self.host = host
         self.port = port
         self.db = db
-        self.share_dir = share_dir
         if pyro_timeout:
             self.pyro_timeout = float(pyro_timeout)
         else:
@@ -387,8 +386,7 @@ Main Control GUI that displays one or more views or interfaces to the suite.
         VIEWS_ORDERED.append( "graph" )
 
     def __init__(self, suite, db, owner, host, port, pyro_timeout,
-            template_vars, template_vars_file, restricted_display,
-            share_dir):
+            template_vars, template_vars_file, restricted_display):
 
         gobject.threads_init()
 
@@ -403,8 +401,7 @@ Main Control GUI that displays one or more views or interfaces to the suite.
         self.cfg = InitData( suite, owner, host, port, db,
                 pyro_timeout, template_vars, template_vars_file,
                 gcfg.get(["ungrouped views"]),
-                gcfg.get(["sort by definition order"]),
-                share_dir)
+                gcfg.get(["sort by definition order"]))
 
         self.theme_name = gcfg.get( ['use theme'] )
         self.theme = gcfg.get( ['themes', self.theme_name ] )

--- a/lib/cylc/gui/SuiteControlGraph.py
+++ b/lib/cylc/gui/SuiteControlGraph.py
@@ -402,7 +402,7 @@ Dependency graph suite control interface.
         self.t.action_required = True
 
     def toggle_write_dot_frames(self, w):
-        self.t.write_dot_frames = not self.t.write_dot_frames
+        self.t.toggle_write_dot_frames()
 
     def toggle_cycle_point_subgraphs( self, toggle_item ):
         subgraphs_on = toggle_item.get_active()


### PR DESCRIPTION
In #1260 (since last release) I broke gcylc's ability to open without targetting a specific suite.  This fixes the problem by moving the suite share directory code into the graph updater class, which is the only place it's used.

@benfitzpatrick - please review.