### PR TITLE
Task host select timeout

### DIFF
--- a/bin/cylc-submit
+++ b/bin/cylc-submit
@@ -182,4 +182,7 @@ if not options.dry_run:
         proc_pool.handle_results_async()
     proc_pool.close()
     proc_pool.join()
-    print 'Job ID:', task_proxy.submit_method_id
+    if task_proxy.submit_method_id is not None:
+        print 'Job ID:', task_proxy.submit_method_id
+
+sys.exit(task_proxy.state.get_status() == "submit-failed")

--- a/doc/siterc.tex
+++ b/doc/siterc.tex
@@ -128,6 +128,19 @@ value is probably sufficient for job submission polling.
 \item {\em example:} (see the execution polling example above)
 \end{myitemize}
 
+\subsubsection{task host select command timeout}
+
+When a task host in a suite is a shell command string, cylc calls the shell to
+determine the task host. This call is invoked by the main process, and may
+cause the suite to hang while waiting for the command to finish. This setting
+sets a timeout for such a command to ensure that the suite can continue.
+
+\begin{myitemize}
+\item {\em type:} ISO 8601 duration/interval representation (e.g.
+\lstinline=PT10S=, 10 seconds, or \lstinline=PT1M=, 1 minute).
+\item {\em default: PT10S}
+\end{myitemize}
+
 \subsection{[task messaging]}
 
 This section contains configuration items that affect task-to-suite

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -57,6 +57,7 @@ SPEC = {
     'submission polling intervals'        : vdr( vtype='interval_minutes_list', default=[]),
     'execution polling intervals'         : vdr( vtype='interval_minutes_list', default=[]),
 
+    'task host select command timeout'    : vdr( vtype='interval_seconds', default=10),
     'task messaging' : {
         'retry interval'                  : vdr( vtype='interval_seconds', default=5),
         'maximum number of tries'         : vdr( vtype='integer', vmin=1, default=7 ),

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -29,9 +29,6 @@ from parsec.validate import (
 from parsec.util import itemstr
 from parsec.upgrade import upgrader, converter
 from parsec.fileparse import parse
-from cylc.syntax_flags import (
-set_syntax_version, VERSION_PREV, VERSION_NEW, SyntaxVersionError
-)
 from isodatetime.data import Calendar
 from cylc.owner import user
 from cylc.envvar import expandvars
@@ -43,9 +40,11 @@ from cylc.cfgspec.suite import coerce_interval_list
 
 "Cylc site and user configuration file spec."
 
-coercers['interval_seconds'] = coerce_interval
-coercers['interval_minutes_list'] = lambda *a: coerce_interval_list(
-*a, back_comp_unit_factor=60)
+coercers['interval_seconds'] = (
+    lambda *args: coerce_interval(*args, check_syntax_version=False))
+coercers['interval_minutes_list'] = (
+    lambda *args: coerce_interval_list(*args, back_comp_unit_factor=60,
+                                       check_syntax_version=False))
 
 SPEC = {
     'process pool size'                   : vdr( vtype='integer', default=None ),

--- a/lib/cylc/version.py
+++ b/lib/cylc/version.py
@@ -31,10 +31,10 @@ def _get_cylc_version():
         # We're running in a cylc git repository, so dynamically determine
         # the cylc version string.  Enclose the path in quotes to handle
         # avoid failure when cylc_dir contains spaces.
-        res = run_get_stdout('"%s"' %
-            os.path.join(cylc_dir, "admin", "get-repo-version"))
-        if res[0]:
-            return res[1][0]
+        is_ok, outlines = run_get_stdout(
+            '"%s"' % os.path.join(cylc_dir, "admin", "get-repo-version"))
+        if is_ok and outlines:
+            return outlines[0]
         else:
             raise SystemExit("Failed to get version number!")
 

--- a/tests/cylc-submit/09-bad.t
+++ b/tests/cylc-submit/09-bad.t
@@ -1,0 +1,28 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "cylc submit" with "no-such-command".
+. "$(dirname "$0")/test_header"
+set_test_number 3
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+run_fail "${TEST_NAME_BASE}" cylc submit "${SUITE_NAME}" 'bar.1'
+run_fail "${TEST_NAME_BASE}" cylc submit "${SUITE_NAME}" 'foo.1'
+
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/cylc-submit/09-bad/suite.rc
+++ b/tests/cylc-submit/09-bad/suite.rc
@@ -1,0 +1,14 @@
+#!jinja2
+[scheduling]
+    [[dependencies]]
+        graph = foo & bar
+[runtime]
+    [[root]]
+        command scripting = true
+    [[bar]]
+        [[[remote]]]
+            host = $(no-such-command)
+    [[foo]]
+        [[[job submission]]]
+            method = at
+            command template = no-such-command

--- a/tests/host-select/01-timeout.t
+++ b/tests/host-select/01-timeout.t
@@ -1,0 +1,32 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test host selection, with a command that times out.
+. "$(dirname "$0")/test_header"
+
+set_test_number 2
+
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+echo 'task host select command timeout = 1' >'global.rc'
+export CYLC_CONF_PATH="${PWD}"
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+suite_run_ok "${TEST_NAME_BASE}" \
+    cylc run --reference-test --debug "${SUITE_NAME}"
+
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/host-select/01-timeout.t
+++ b/tests/host-select/01-timeout.t
@@ -18,7 +18,7 @@
 # Test host selection, with a command that times out.
 . "$(dirname "$0")/test_header"
 
-set_test_number 2
+set_test_number 3
 
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
@@ -27,6 +27,7 @@ export CYLC_CONF_PATH="${PWD}"
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
 suite_run_ok "${TEST_NAME_BASE}" \
     cylc run --reference-test --debug "${SUITE_NAME}"
-
+grep_ok 'ERROR: command timed out (>1s), terminated by signal 15' \
+    "$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/log/suite/err"
 purge_suite "${SUITE_NAME}"
 exit

--- a/tests/host-select/01-timeout/reference.log
+++ b/tests/host-select/01-timeout/reference.log
@@ -1,0 +1,6 @@
+2015-02-02T15:14:04Z INFO - Run mode: live
+2015-02-02T15:14:04Z INFO - Initial point: 1
+2015-02-02T15:14:04Z INFO - Final point: 1
+2015-02-02T15:14:04Z INFO - Cold Start 1
+2015-02-02T15:14:04Z ERROR - [foo.1] -submission failed
+2015-02-02T15:14:04Z INFO - [foo.1] -triggered off []

--- a/tests/host-select/01-timeout/suite.rc
+++ b/tests/host-select/01-timeout/suite.rc
@@ -1,0 +1,17 @@
+#!Jinja2
+
+title = Test task host selection with a bad command
+
+[cylc]
+    [[reference test]]
+        required run mode = live
+        live mode suite timeout = PT10S
+        expected task failures = foo.1
+[scheduling]
+    [[dependencies]]
+        graph = "foo:submit-fail => !foo"
+[runtime]
+    [[foo]]
+        command scripting = true
+        [[[remote]]]
+            host = $(sleep 2; echo 'localhost')

--- a/tests/validate/27-mixed-syntax-global-suite.t
+++ b/tests/validate/27-mixed-syntax-global-suite.t
@@ -1,0 +1,29 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test validate OK with old syntax in "global.rc" and new syntax in "suite.rc"
+
+. "$(dirname "$0")/test_header"
+set_test_number 1
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+echo 'submission polling intervals = 1, 5, 15' >'global.rc'
+CYLC_CONF_PATH="${PWD}" \
+    run_ok "${TEST_NAME_BASE}" cylc validate "${SUITE_NAME}"
+
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/validate/27-mixed-syntax-global-suite/suite.rc
+++ b/tests/validate/27-mixed-syntax-global-suite/suite.rc
@@ -1,0 +1,9 @@
+[scheduling]
+    initial cycle time = 20140303T00Z
+    final cycle time   = 20140303T06Z
+    [[dependencies]]
+        [[[P1D]]]
+            graph = t1
+[runtime]
+    [[t1]]
+        command scripting = true


### PR DESCRIPTION
This change allows the task host selection command to timeout. Consider something like this:

```cfg
[runtime]
    [[t1]]
        [[[remote]]]
            host = $(command-that-hangs-for-some-reason)
```

Something similar has caused our suites to hang. This change will allow the job submission to fail.

While testing the new functionality, I have discovered and fixed 2 bugs:
* `cylc submit` does not return non-zero if task host selection command fails.
* If `global.rc` has old date-time syntax, all suites in new date-time syntax will fail; and vice versa. (#1277).