### PR TITLE
Update xdot.py

### DIFF
--- a/lib/xdot.py
+++ b/lib/xdot.py
@@ -1568,11 +1568,12 @@ class DotWidget(gtk.DrawingArea):
             dialog.destroy()
             return False
         else:
-            if filename is None:
+            if filename is None or filename == "<stdin>":
                 self.last_mtime = None
+                self.openfilename = None
             else:
                 self.last_mtime = os.stat(filename).st_mtime
-            self.openfilename = filename
+                self.openfilename = filename
             return True
 
     def set_xdotcode(self, xdotcode):


### PR DESCRIPTION
This updates xdot.py from 0.5 to 0.6 and fixes #902, allowing `cylc gui`'s Graph View
and `cylc graph` to work with later versions of graphviz.

See https://github.com/jrfonseca/xdot.py/compare/0.5...0.6.

@hjoliver, please review.