### PR TITLE
Fix test battery host-select ssh/scp to localhost

### DIFF
--- a/tests/host-select/simple/bin/cleanup.sh
+++ b/tests/host-select/simple/bin/cleanup.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 # remove installed remote passphrase
 set -e
+cylc check-triggering "$@"
+if [[ $CYLC_TEST_TASK_OWNER@$CYLC_TEST_TASK_HOST == $USER@localhost || \
+      $CYLC_TEST_TASK_OWNER@$CYLC_TEST_TASK_HOST == $USER@$(hostname) ]]; then
+    exit
+fi
 PPHRASE=.cylc/$CYLC_SUITE_REG_NAME/passphrase
 echo -n "Removing remote passphrase ${CYLC_TEST_TASK_OWNER}@${CYLC_TEST_TASK_HOST}:$PPHRASE ... "
 ssh -oBatchmode=yes ${CYLC_TEST_TASK_OWNER}@${CYLC_TEST_TASK_HOST} "rm $PPHRASE && rmdir $( dirname $PPHRASE )"

--- a/tests/host-select/simple/bin/startup.sh
+++ b/tests/host-select/simple/bin/startup.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 set -e
+if [[ $CYLC_TEST_TASK_OWNER@$CYLC_TEST_TASK_HOST == $USER@localhost || \
+      $CYLC_TEST_TASK_OWNER@$CYLC_TEST_TASK_HOST == $USER@$(hostname) ]]; then
+    exit
+fi
 PPHRASE=$CYLC_SUITE_DEF_PATH/passphrase
 # copy the passphrase over in case this host does not use ssh messaging
 echo "Copying suite passphrase to ${CYLC_TEST_TASK_OWNER}@$CYLC_TEST_TASK_HOST"

--- a/tests/host-select/simple/reference.log
+++ b/tests/host-select/simple/reference.log
@@ -1,10 +1,21 @@
-2012/08/30 16:10:03 INFO - Suite starting at 2012-08-30 16:10:03.350069
-2012/08/30 16:10:03 INFO - Log event clock: real time
-2012/08/30 16:10:03 INFO - Run mode: live
-2012/08/30 16:10:03 INFO - Initial point: 1
-2012/08/30 16:10:03 INFO - Final point: 1
-2012/08/30 16:10:03 INFO - [foo.1] -job submitted
-2012/08/30 16:10:03 INFO - [foo.1] -triggered off []
-2012/08/30 16:10:03 INFO - [foo.1] -foo.1 started
-2012/08/30 16:10:12 INFO - [foo.1] -foo.1 succeeded
-2012/08/30 16:10:12 INFO - Suite shutting down at 2012-08-30 16:10:12.254146
+2015-02-03T15:14:21Z INFO - Suite starting at 2015-02-03T15:14:21Z
+2015-02-03T15:14:21Z INFO - Run mode: live
+2015-02-03T15:14:21Z INFO - Initial point: 1
+2015-02-03T15:14:21Z INFO - Final point: 1
+2015-02-03T15:14:21Z INFO - Cold Start 1
+2015-02-03T15:14:21Z INFO - Calling startup handler in the foreground
+2015-02-03T15:14:21Z INFO - [bar.1] -initiate job-submit
+2015-02-03T15:14:21Z INFO - [foo.1] -initiate job-submit
+2015-02-03T15:14:21Z INFO - [bar.1] -triggered off []
+2015-02-03T15:14:21Z INFO - [foo.1] -triggered off []
+
+2015-02-03T15:14:22Z INFO - [bar.1] -submit_method_id=12577
+2015-02-03T15:14:22Z INFO - [bar.1] -submission succeeded
+
+2015-02-03T15:14:22Z INFO - [foo.1] -submit_method_id=12578
+2015-02-03T15:14:22Z INFO - [foo.1] -submission succeeded
+2015-02-03T15:14:22Z INFO - [bar.1] -(current:submitted)> bar.1 started at 2015-02-03T15:14:22Z
+2015-02-03T15:14:22Z INFO - [foo.1] -(current:submitted)> foo.1 started at 2015-02-03T15:14:22Z
+2015-02-03T15:14:23Z INFO - [bar.1] -(current:running)> bar.1 succeeded at 2015-02-03T15:14:23Z
+2015-02-03T15:14:23Z INFO - [foo.1] -(current:running)> foo.1 succeeded at 2015-02-03T15:14:23Z
+2015-02-03T15:14:24Z INFO - Suite shutting down at 2015-02-03T15:14:24Z

--- a/tests/remote/00-basic.t
+++ b/tests/remote/00-basic.t
@@ -26,7 +26,7 @@ TEST_NAME=$TEST_NAME_BASE-validate
 run_ok $TEST_NAME cylc validate $SUITE_NAME
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-run
-suite_run_ok $TEST_NAME cylc run --debug $SUITE_NAME
+suite_run_ok $TEST_NAME cylc run --reference-test --debug $SUITE_NAME
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-userathost
 SUITE_RUN_DIR=$(cylc get-global-config --print-run-dir)/$SUITE_NAME

--- a/tests/remote/basic/bin/cleanup.sh
+++ b/tests/remote/basic/bin/cleanup.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 # remove installed remote passphrase
 set -e
+cylc check-triggering "$@"
+if [[ $CYLC_TEST_TASK_OWNER@$CYLC_TEST_TASK_HOST == $USER@localhost || \
+      $CYLC_TEST_TASK_OWNER@$CYLC_TEST_TASK_HOST == $USER@$(hostname) ]]; then
+    exit
+fi
 PPHRASE=.cylc/$CYLC_SUITE_REG_NAME/passphrase
 echo -n "Removing remote passphrase ${CYLC_TEST_TASK_OWNER}@${CYLC_TEST_TASK_HOST}:$PPHRASE ... "
 ssh -oBatchmode=yes ${CYLC_TEST_TASK_OWNER}@${CYLC_TEST_TASK_HOST} "rm $PPHRASE && rmdir $( dirname $PPHRASE )"

--- a/tests/remote/basic/bin/startup.sh
+++ b/tests/remote/basic/bin/startup.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -e
 PPHRASE=$CYLC_SUITE_DEF_PATH/passphrase
-if [[ $CYLC_TEST_TASK_OWNER@$CYLC_TEST_TASK_HOST == $USER@localhost || $CYLC_TEST_TASK_OWNER@$CYLC_TEST_TASK_HOST == $USER@$(hostname) ]]; then
+if [[ $CYLC_TEST_TASK_OWNER@$CYLC_TEST_TASK_HOST == $USER@localhost || \
+      $CYLC_TEST_TASK_OWNER@$CYLC_TEST_TASK_HOST == $USER@$(hostname) ]]; then
     exit
 fi
 # copy the passphrase over in case this host does not use ssh messaging

--- a/tests/remote/basic/reference.log
+++ b/tests/remote/basic/reference.log
@@ -1,11 +1,21 @@
-2012/08/24 13:40:20 INFO - Suite starting at 2012-08-24 13:40:20.373348
-2012/08/24 13:40:20 INFO - Log event clock: real time
-2012/08/24 13:40:20 INFO - Run mode: live
-2012/08/24 13:40:20 INFO - Initial point: None
-2012/08/24 13:40:20 INFO - Final point: None
-2012/08/24 13:40:20 WARNING - Calling startup event handler in the foreground
-2012/08/24 13:40:20 INFO - [foo.1] -job submitted
-2012/08/24 13:40:20 INFO - [foo.1] -triggered off []
-2012/08/24 13:40:21 INFO - [foo.1] -foo.1 started
-2012/08/24 13:40:31 INFO - [foo.1] -foo.1 succeeded
-2012/08/24 13:40:31 INFO - Suite shutting down at 2012-08-24 13:40:31.387626
+2015-02-03T15:12:56Z INFO - Suite starting at 2015-02-03T15:12:56Z
+2015-02-03T15:12:56Z INFO - Run mode: live
+2015-02-03T15:12:56Z INFO - Initial point: 1
+2015-02-03T15:12:56Z INFO - Final point: 1
+2015-02-03T15:12:56Z INFO - Cold Start 1
+2015-02-03T15:12:56Z INFO - Calling startup handler in the foreground
+2015-02-03T15:12:56Z INFO - [foo.1] -initiate job-submit
+2015-02-03T15:12:56Z INFO - [foo.1] -triggered off []
+
+2015-02-03T15:12:57Z INFO - [foo.1] -submit_method_id=12290
+2015-02-03T15:12:57Z INFO - [foo.1] -submission succeeded
+2015-02-03T15:12:58Z INFO - [foo.1] -(current:submitted)> foo.1 started at 2015-02-03T15:12:57Z
+2015-02-03T15:12:58Z INFO - [foo.1] -(current:running)> foo.1 succeeded at 2015-02-03T15:12:57Z
+2015-02-03T15:12:59Z INFO - [bar.1] -initiate job-submit
+2015-02-03T15:12:59Z INFO - [bar.1] -triggered off ['foo.1']
+
+2015-02-03T15:13:00Z INFO - [bar.1] -submit_method_id=12403
+2015-02-03T15:13:00Z INFO - [bar.1] -submission succeeded
+2015-02-03T15:13:00Z INFO - [bar.1] -(current:submitted)> bar.1 started at 2015-02-03T15:13:00Z
+2015-02-03T15:13:01Z INFO - [bar.1] -(current:running)> bar.1 succeeded at 2015-02-03T15:13:00Z
+2015-02-03T15:13:02Z INFO - Suite shutting down at 2015-02-03T15:13:02Z


### PR DESCRIPTION
This prevents an ssh/scp to `localhost` in the `tests/host-select/00-simple.t` test.

It also provides some proper reference log checking for it and another similar
test, `tests/remote/00-basic.t`.

@matthewrmshin, please review.