### PR TITLE
cylc graph-diff: new utility to compare suite graphs.

### DIFF
--- a/bin/cylc
+++ b/bin/cylc
@@ -80,6 +80,7 @@ def match_dict(abbrev, categories, title):
 def match_command(abbrev):
     # allow any unique abbreviation to commands when no category is specified
     matches = []
+    finished_matching = False
     for dct in [
         admin_commands,
         license_commands,
@@ -92,10 +93,16 @@ def match_command(abbrev):
         hook_commands,
         task_commands]:
         for com in dct.keys():
+            if com == abbrev:
+                matches = [com]
+                finished_matching = True
+                break
             for alias in dct[com]:
                 if re.match('^' + abbrev + '.*', alias):
                     if com not in matches:
                         matches.append(com)
+            if finished_matching:
+                break
     if len(matches) == 0:
         raise CommandNotFoundError, 'COMMAND not found: ' + abbrev
     elif len(matches) > 1:
@@ -245,6 +252,7 @@ preparation_commands['5to6'] = ['5to6']
 preparation_commands['list'] = ['list', 'ls']
 preparation_commands['search'] = ['search', 'grep']
 preparation_commands['graph'] = ['graph']
+preparation_commands['graph-diff'] = ['graph-diff']
 preparation_commands['diff'] = ['diff', 'compare']
 preparation_commands['jobscript'] = ['jobscript']
 
@@ -376,6 +384,7 @@ comsum['validate'] = 'Parse and validate suite definitions'
 comsum['5to6'] = 'Improve the cylc 6 compatibility of a cylc 5 suite file'
 comsum['search'] = 'Search in suite definitions'
 comsum['graph'] = 'Plot suite dependency graphs and runtime hierarchies'
+comsum['graph-diff'] = 'Compare two suite dependencies or runtime hierarchies'
 comsum['diff'] = 'Compare two suite definitions and print differences'
 # information
 comsum['list'] = 'List suite tasks and family namespaces'

--- a/bin/cylc-graph
+++ b/bin/cylc-graph
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import StringIO
 import sys
 from cylc.remote import remrun
 from cylc.task_id import TaskID
@@ -86,6 +87,11 @@ parser = cop( """1/ cylc [prep] graph [OPTIONS] SUITE [START[STOP]]
      Plot the suite.rc dependency graph for SUITE.
        2/ cylc [prep] graph [OPTIONS] -f,--file FILE
      Plot the specified dot-language graph file.
+       3/ cylc [prep] graph [OPTIONS] --reference SUITE [START[STOP]]
+     Print out a reference format for the dependencies in SUITE.
+       4/ cylc [prep] graph [OPTIONS] --output-file FILE SUITE
+     Plot SUITE dependencies to a file FILE with a extension-derived format.
+     If FILE endswith ".png", output in PNG format, etc.
 
 Plot suite dependency graphs in an interactive graph viewer.
 
@@ -137,13 +143,20 @@ parser.add_option( "-f", "--file",
 
 parser.add_option( "-O", "--output-file",
     help="Output to a specific file, with a format given by --output-format" +
-         " or extrapolated from the extension.",
+         " or extrapolated from the extension. " +
+         "'-' implies stdout in plain format.",
     metavar="FILE", action="store", default=None, dest="output_filename" )
 
 parser.add_option( "--output-format",
     help="Specify a format for writing out the graph to --output-file " +
-         "e.g. png, svg, jpg, eps, dot.",
+         "e.g. png, svg, jpg, eps, dot. 'ref' is a special sorted plain " +
+         "text format for comparison and reference purposes.",
     metavar="FORMAT", action="store", default=None, dest="output_format" )
+
+parser.add_option( "-r", "--reference",
+    help="Output in a sorted plain text format for comparison purposes." +
+         " If not given, assume --output-file=-.",
+    action="store_true", default=False, dest="reference")
 
 (options, args) = parser.parse_args()
 
@@ -153,7 +166,8 @@ parser.add_option( "--output-format",
 import gtk, gobject
 from xdot import DotWindow
 try:
-    from cylc.cylc_xdot import MyDotWindow, MyDotWindow2
+    from cylc.cylc_xdot import (
+        MyDotWindow, MyDotWindow2, get_reference_from_plain_format)
 except ImportError, x:
     # this imports pygraphviz via cylc.graphing
     print >> sys.stderr, str(x)
@@ -206,11 +220,29 @@ else:
 window.widget.connect('clicked', on_url_clicked, window)
 window.get_graph()
 
+if options.reference and options.output_filename is None:
+    options.output_filename = "-"
+
 if options.output_filename:
-    if options.output_filename == "-":
-        window.graph.draw(sys.stdout, format="plain", prog="dot")
+    if (options.reference or options.output_filename.endswith(".ref") or
+            options.output_format == "ref"):
+        dest = StringIO.StringIO()
+        window.graph.draw(dest, format="plain", prog="dot")
+        output_text = get_reference_from_plain_format(dest.getvalue())
+        if options.output_filename == "-":
+            sys.stdout.write(output_text)
+        else:
+            open(options.output_filename).write(output_text)
     else:
-        window.graph.draw(options.output_filename, prog="dot")
+        if options.output_filename == "-":
+            window.graph.draw(sys.stdout, format="plain", prog="dot")
+        elif options.output_format:
+            window.graph.draw(
+                options.output_filename, format=options.output_format,
+                prog="dot"
+            )
+        else:
+            window.graph.draw(options.output_filename, prog="dot")
     sys.exit(0)
 
 window.connect('destroy', gtk.main_quit)

--- a/bin/cylc-graph-diff
+++ b/bin/cylc-graph-diff
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+set -eu
+
+usage() {
+  cat <<'__USAGE__'
+USAGE: cylc graph-diff [OPTIONS] SUITE1 SUITE2 -- [GRAPH_OPTIONS_ARGS]
+
+Difference 'cylc graph --reference' output for SUITE1 and SUITE2.
+
+OPTIONS: Use '-g' to launch a graphical diff utility.
+         Use '--diff-cmd=MY_DIFF_CMD' to use a custom diff tool.
+
+SUITE1, SUITE2: Suite names to compare.
+GRAPH_OPTIONS_ARGS: Options and arguments passed directly to cylc graph.
+__USAGE__
+}
+
+DIFF_CMD="diff -u"
+GRAPHICAL_DIFF=false
+SUITES=""
+NUM_SUITES=0
+for ARG in "$@"; do
+    shift
+    if [[ "$ARG" == '--' ]]; then
+        break
+    elif [[ "$ARG" == '--help' ]]; then
+        usage
+        exit 0
+    elif [[ "$ARG" == "-g" ]]; then
+        GRAPHICAL_DIFF=true
+    elif [[ "$ARG" == --diff-cmd=* ]]; then
+        DIFF_CMD=${ARG#*=}
+    else
+        # A suite - check it's registered.
+        if ! cylc db print --fail "$ARG$" >/dev/null 2>&1; then
+            echo "Suite not found: "$ARG >&2
+            exit 1
+        fi
+        SUITES="$SUITES $ARG"
+        NUM_SUITES=$((NUM_SUITES+1))
+    fi
+done
+if (( NUM_SUITES != 2 )); then
+    usage >&2
+    exit 1
+fi
+
+DIFF_FILES=""
+for SUITE in $SUITES; do
+    FILE=$(mktemp -t $SUITE.graph.ref.XXXX)
+    cylc graph --reference "$@" $SUITE >$FILE
+    DIFF_FILES="$DIFF_FILES $FILE"
+done
+
+if $GRAPHICAL_DIFF; then
+    for DIFFTOOL in xxdiff diffuse kdiff3 kompare gvimdiff2 meld tkdiff; do
+        if type -P $DIFFTOOL >/dev/null; then
+            "$DIFFTOOL" $DIFF_FILES
+            exit 0
+        fi
+    done
+    echo "Error: no graphical diff tool found." >&2
+    exit 1
+fi
+
+$DIFF_CMD $DIFF_FILES

--- a/lib/cylc/cylc_xdot.py
+++ b/lib/cylc/cylc_xdot.py
@@ -24,6 +24,7 @@ import time
 import gobject
 import config
 import os, sys
+import re
 from graphing import CGraphPlain
 from cylc.task_id import TaskID
 
@@ -515,3 +516,28 @@ class xdot_widgets(object):
 
     def on_reload(self, action):
         self.widget.reload()
+
+
+def get_reference_from_plain_format(plain_text):
+    """Return a stripped text format for 'plain' graphviz output.
+
+    Strip graph coordinates, extra spaces, and sort based on numeric
+    content.
+
+    """
+    indexed_lines = []
+    for line in plain_text.splitlines(True):
+        # Remove spaces followed by numbers.
+        line = re.sub(r"\s+[+-]?\d+(?:\.\d+)?(?:e[+-][.\d]+)?\b", "", line)
+        # Get rid of extra spaces.
+        line = re.sub("^((?:node|edge).*)\s+\w+", r"\1", line)
+        # Create a numeric content index.
+        line_items = re.split("(\d+)", line)
+        for i, item in enumerate(line_items):
+            try:
+                line_items[i] = int(item)
+            except (TypeError, ValueError):
+                pass
+        indexed_lines.append((line_items, line))
+    indexed_lines.sort()
+    return "".join([l[1] for l in indexed_lines])

--- a/tests/cylc-graph-diff/00-simple-control/suite.rc
+++ b/tests/cylc-graph-diff/00-simple-control/suite.rc
@@ -1,0 +1,13 @@
+[cylc]
+    UTC mode = True
+[scheduling]
+    initial cycle point = 20140808T00
+    [[dependencies]]
+        [[[R1]]]
+            graph = cold_foo => foo
+        [[[T00]]]
+            graph = foo => bar & baz
+[runtime]
+    [[FOO]]
+    [[foo]]
+        inherit = None, FOO

--- a/tests/cylc-graph-diff/00-simple-diffs/suite.rc
+++ b/tests/cylc-graph-diff/00-simple-diffs/suite.rc
@@ -1,0 +1,13 @@
+[cylc]
+    UTC mode = True
+[scheduling]
+    initial cycle point = 20140808T00
+    [[dependencies]]
+        [[[R1]]]
+            graph = cold_foo => foo
+        [[[T00]]]
+            graph = foo => bar => baz
+[runtime]
+    [[FOO]]
+    [[foo,bar,baz]]
+        inherit = None, FOO

--- a/tests/cylc-graph-diff/00-simple-same
+++ b/tests/cylc-graph-diff/00-simple-same
@@ -1,0 +1,1 @@
+00-simple-control

--- a/tests/cylc-graph-diff/00-simple.t
+++ b/tests/cylc-graph-diff/00-simple.t
@@ -1,0 +1,166 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test cylc graph-diff for two suites.
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 24
+#-------------------------------------------------------------------------------
+install_suite $TEST_NAME_BASE-control $TEST_NAME_BASE-control
+CONTROL_SUITE_NAME=$SUITE_NAME
+install_suite $TEST_NAME_BASE-diffs $TEST_NAME_BASE-diffs
+DIFF_SUITE_NAME=$SUITE_NAME
+install_suite $TEST_NAME_BASE-same $TEST_NAME_BASE-same
+SAME_SUITE_NAME=$SUITE_NAME
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-validate-diffs
+run_ok $TEST_NAME cylc validate "$DIFF_SUITE_NAME"
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-validate-same
+run_ok $TEST_NAME cylc validate "$SAME_SUITE_NAME"
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-validate-new
+run_ok $TEST_NAME cylc validate "$CONTROL_SUITE_NAME"
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-bad-suites-number-1
+run_fail $TEST_NAME cylc graph-diff "$DIFF_SUITE_NAME"
+cmp_ok "$TEST_NAME.stdout" </dev/null
+cmp_ok "$TEST_NAME.stderr" <<'__ERR__'
+USAGE: cylc graph-diff [OPTIONS] SUITE1 SUITE2 -- [GRAPH_OPTIONS_ARGS]
+
+Difference 'cylc graph --reference' output for SUITE1 and SUITE2.
+
+OPTIONS: Use '-g' to launch a graphical diff utility.
+         Use '--diff-cmd=MY_DIFF_CMD' to use a custom diff tool.
+
+SUITE1, SUITE2: Suite names to compare.
+GRAPH_OPTIONS_ARGS: Options and arguments passed directly to cylc graph.
+__ERR__
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-bad-suites-number-3
+run_fail $TEST_NAME cylc graph-diff "$DIFF_SUITE_NAME" "$CONTROL_SUITE_NAME" \
+    "$SAME_SUITE_NAME"
+cmp_ok "$TEST_NAME.stdout" </dev/null
+cmp_ok "$TEST_NAME.stderr" <<'__ERR__'
+USAGE: cylc graph-diff [OPTIONS] SUITE1 SUITE2 -- [GRAPH_OPTIONS_ARGS]
+
+Difference 'cylc graph --reference' output for SUITE1 and SUITE2.
+
+OPTIONS: Use '-g' to launch a graphical diff utility.
+         Use '--diff-cmd=MY_DIFF_CMD' to use a custom diff tool.
+
+SUITE1, SUITE2: Suite names to compare.
+GRAPH_OPTIONS_ARGS: Options and arguments passed directly to cylc graph.
+__ERR__
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-bad-suite-name
+run_fail $TEST_NAME cylc graph-diff "$DIFF_SUITE_NAME" "$CONTROL_SUITE_NAME.bad"
+cmp_ok "$TEST_NAME.stdout" </dev/null
+cmp_ok "$TEST_NAME.stderr" <<__ERR__
+Suite not found: $CONTROL_SUITE_NAME.bad
+__ERR__
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-deps-fail
+run_fail $TEST_NAME cylc graph-diff "$DIFF_SUITE_NAME" "$CONTROL_SUITE_NAME"
+sed -i "/\.graph\.ref\./d" "$TEST_NAME.stdout"
+cmp_ok "$TEST_NAME.stdout" <<'__OUT__'
+@@ -1,10 +1,10 @@
+-edge "bar.20140808T0000Z" "baz.20140808T0000Z" solid
+-edge "bar.20140809T0000Z" "baz.20140809T0000Z" solid
+-edge "bar.20140810T0000Z" "baz.20140810T0000Z" solid
+ edge "cold_foo.20140808T0000Z" "foo.20140808T0000Z" solid
+ edge "foo.20140808T0000Z" "bar.20140808T0000Z" solid
++edge "foo.20140808T0000Z" "baz.20140808T0000Z" solid
+ edge "foo.20140809T0000Z" "bar.20140809T0000Z" solid
++edge "foo.20140809T0000Z" "baz.20140809T0000Z" solid
+ edge "foo.20140810T0000Z" "bar.20140810T0000Z" solid
++edge "foo.20140810T0000Z" "baz.20140810T0000Z" solid
+ graph
+ node "bar.20140808T0000Z" "bar\n20140808T0000Z" unfilled box black
+ node "bar.20140809T0000Z" "bar\n20140809T0000Z" unfilled box black
+__OUT__
+cmp_ok "$TEST_NAME.stderr" </dev/null
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-deps-ok
+run_ok $TEST_NAME cylc graph-diff "$SAME_SUITE_NAME" "$CONTROL_SUITE_NAME"
+cmp_ok "$TEST_NAME.stdout" </dev/null
+cmp_ok "$TEST_NAME.stderr" </dev/null
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-ns
+run_fail $TEST_NAME cylc graph-diff "$DIFF_SUITE_NAME" "$CONTROL_SUITE_NAME" -- --namespaces
+sed -i "/\.graph\.ref\./d" "$TEST_NAME.stdout"
+cmp_ok "$TEST_NAME.stdout" <<'__OUT__'
+@@ -1,7 +1,7 @@
+-edge FOO bar solid
+-edge FOO baz solid
+ edge FOO foo solid
+ edge root FOO solid
++edge root bar solid
++edge root baz solid
+ edge root cold_foo solid
+ graph
+ node FOO FOO filled box royalblue
+__OUT__
+cmp_ok "$TEST_NAME.stderr" </dev/null
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-custom-diff
+run_ok $TEST_NAME cylc graph-diff --diff-cmd=cat "$DIFF_SUITE_NAME" "$CONTROL_SUITE_NAME"
+cmp_ok "$TEST_NAME.stdout" <<'__OUT__'
+edge "bar.20140808T0000Z" "baz.20140808T0000Z" solid
+edge "bar.20140809T0000Z" "baz.20140809T0000Z" solid
+edge "bar.20140810T0000Z" "baz.20140810T0000Z" solid
+edge "cold_foo.20140808T0000Z" "foo.20140808T0000Z" solid
+edge "foo.20140808T0000Z" "bar.20140808T0000Z" solid
+edge "foo.20140809T0000Z" "bar.20140809T0000Z" solid
+edge "foo.20140810T0000Z" "bar.20140810T0000Z" solid
+graph
+node "bar.20140808T0000Z" "bar\n20140808T0000Z" unfilled box black
+node "bar.20140809T0000Z" "bar\n20140809T0000Z" unfilled box black
+node "bar.20140810T0000Z" "bar\n20140810T0000Z" unfilled box black
+node "baz.20140808T0000Z" "baz\n20140808T0000Z" unfilled box black
+node "baz.20140809T0000Z" "baz\n20140809T0000Z" unfilled box black
+node "baz.20140810T0000Z" "baz\n20140810T0000Z" unfilled box black
+node "cold_foo.20140808T0000Z" "cold_foo\n20140808T0000Z" unfilled box black
+node "foo.20140808T0000Z" "foo\n20140808T0000Z" unfilled box black
+node "foo.20140809T0000Z" "foo\n20140809T0000Z" unfilled box black
+node "foo.20140810T0000Z" "foo\n20140810T0000Z" unfilled box black
+stop
+edge "cold_foo.20140808T0000Z" "foo.20140808T0000Z" solid
+edge "foo.20140808T0000Z" "bar.20140808T0000Z" solid
+edge "foo.20140808T0000Z" "baz.20140808T0000Z" solid
+edge "foo.20140809T0000Z" "bar.20140809T0000Z" solid
+edge "foo.20140809T0000Z" "baz.20140809T0000Z" solid
+edge "foo.20140810T0000Z" "bar.20140810T0000Z" solid
+edge "foo.20140810T0000Z" "baz.20140810T0000Z" solid
+graph
+node "bar.20140808T0000Z" "bar\n20140808T0000Z" unfilled box black
+node "bar.20140809T0000Z" "bar\n20140809T0000Z" unfilled box black
+node "bar.20140810T0000Z" "bar\n20140810T0000Z" unfilled box black
+node "baz.20140808T0000Z" "baz\n20140808T0000Z" unfilled box black
+node "baz.20140809T0000Z" "baz\n20140809T0000Z" unfilled box black
+node "baz.20140810T0000Z" "baz\n20140810T0000Z" unfilled box black
+node "cold_foo.20140808T0000Z" "cold_foo\n20140808T0000Z" unfilled box black
+node "foo.20140808T0000Z" "foo\n20140808T0000Z" unfilled box black
+node "foo.20140809T0000Z" "foo\n20140809T0000Z" unfilled box black
+node "foo.20140810T0000Z" "foo\n20140810T0000Z" unfilled box black
+stop
+__OUT__
+cmp_ok "$TEST_NAME.stderr" </dev/null
+#-------------------------------------------------------------------------------
+purge_suite $DIFF_SUITE_NAME
+purge_suite $SAME_SUITE_NAME
+purge_suite $CONTROL_SUITE_NAME

--- a/tests/cylc-graph-diff/test_header
+++ b/tests/cylc-graph-diff/test_header
@@ -1,0 +1,1 @@
+../lib/bash/test_header

--- a/tests/lib/bash/test_header
+++ b/tests/lib/bash/test_header
@@ -251,17 +251,7 @@ function graph_suite() {
     local SUITE_NAME="${1}"
     local OUTPUT_FILE="${2}"
     shift 2
-    # Strip graph coordinates.
-    # Some (older?) graphviz versions (e.g. 2.20.2) put two spaces before node
-    # coordinates instead of one.
-    # Different graphviz versions use "lightgrey" or "black" as the final word
-    # on node and edge lines.
-    # Sort the result to "natural order".
-    cylc graph '--output-file=-' "${SUITE_NAME}" "$@" \
-        | perl -p -e '
-            s/\s+[+\-]?[0-9]+(?:\.[0-9]+)?(?:e[+\-][.0-9]+)?\b//gmsx;
-            s/^((?:node|edge).*)\s+\w+/$1/msx;' \
-        | sort -V  >"${OUTPUT_FILE}"
+    cylc graph --reference "${SUITE_NAME}" "$@" >"${OUTPUT_FILE}"
 }
 
 function init_suite() {


### PR DESCRIPTION
This adds a new command called `cylc graph-diff` which is intended
to help the user compare dependencies (or runtime hierarchies)
across suites. This should help the upgrade process from cylc 5
syntax.

This closes #1296 and is also related to #1068.

This introduces a `cylc graph --reference` option, which is used to
provide sorted structural output describing the suite graph. This
improves the test battery, which used to do this after the fact.

cylc graph-diff is a thin wrapper on top of two calls to `cylc
graph --reference`.

Note that `bin/cylc` needed a change to allow one cylc command
to be a subset of another (`graph` vs `graph-diff`). This also means
that e.g. typing `cylc gr` will bring up an error announcing more than
one command for that abbreviation.

@hjoliver, please test on your site (graphviz checking?) and review.