### PR TITLE
Fix cylc gui blank graph for new runs with existing gui

### DIFF
--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -134,6 +134,7 @@ class config( object ):
 
         self.sequences = []
         self.actual_first_point = None
+        self._start_point_for_actual_first_point = None
 
         self.custom_runahead_limit = None
         self.max_num_active_cycle_points = None
@@ -1465,23 +1466,21 @@ class config( object ):
     def get_actual_first_point( self, start_point ):
         # Get actual first cycle point for the suite (get all
         # sequences to adjust the putative start time upward)
-        if self.actual_first_point:
-            # already computed
+        if (self._start_point_for_actual_first_point is not None and
+                self._start_point_for_actual_first_point == start_point and
+                self.actual_first_point is not None):
             return self.actual_first_point
-        if isinstance(start_point, basestring):
-            point = get_point(start_point)
-        else:
-            point = start_point
+        self._start_point_for_actual_first_point = start_point
         adjusted = []
         for seq in self.sequences:
-            foo = seq.get_first_point( point )
+            foo = seq.get_first_point( start_point )
             if foo:
                 adjusted.append( foo )
         if len( adjusted ) > 0:
             adjusted.sort()
             self.actual_first_point = adjusted[0]
         else:
-            self.actual_first_point = point
+            self.actual_first_point = start_point
         return self.actual_first_point
 
     def get_graph_raw( self, start_point_string, stop_point_string,

--- a/lib/cylc/gui/updater_graph.py
+++ b/lib/cylc/gui/updater_graph.py
@@ -444,7 +444,16 @@ class GraphUpdater(threading.Thread):
 
     def get_graph_id(self, edges):
         """If any of these quantities change, the graph should be redrawn."""
-        return (set(edges), self.crop,
+        node_ids = set()
+        for edge in edges:
+            node_ids.add(edge[0])
+            node_ids.add(edge[1])
+        # Get a set of ids that are actually present in the state summaries.
+        # We need this in case of no-longer-purely-base-node cycle points.
+        node_ids_in_state = set(node_ids).intersection(
+            set(self.state_summary).union(set(self.fam_state_summary)))
+        # Return a key that maps to the essential structure of the graph.
+        return (set(edges), self.crop, node_ids_in_state,
                 set(self.updater.filter_states_excl),
                 self.updater.filter_name_string,
                 self.orientation, self.ignore_suicide, self.subgraphs_on)


### PR DESCRIPTION
This fixes a blank cylc gui Graph View when a suite is re-run
while the cylc gui is still around from the previous run. The
root cause is the initial request for the last run's oldest and
newest cycle times, which gets stored in the 'actual_first_point'
variable (indirectly). This means that the subsequent requests
for the correct cycle point range do not give valid graphs,
because they appear to be well before the actual first point.

I've also fixed a bug in the purely-base-node-cycle-point cropping,
which would not have redrawn and uncropped the graph if e.g. a node
was re-inserted.

This addresses part of #1240, if not all of it.

@hjoliver, please review.