### PR TITLE
gcylc run suite dialog options

### DIFF
--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -2012,9 +2012,13 @@ shown here in the state they were in at the time of triggering.''')
         debug_group = controlled_option_group("Debug", "--debug")
         debug_group.pack(hbox)
 
+        nodetach_group = controlled_option_group("No-detach", "--no-detach")
+        nodetach_group.pack(hbox)
+
+
         vbox.pack_start(hbox)
 
-        optgroups = [debug_group]
+        optgroups = [nodetach_group, debug_group]
 
         cancel_button = gtk.Button("_Cancel")
         cancel_button.connect("clicked", lambda x: window.destroy())


### PR DESCRIPTION
@matthewrmshin - in response to https://github.com/cylc/cylc/pull/1322#issuecomment-73863233, this adds the missing ```--no-detach``` option to the gcylc run suite dialog, thereby making the "options" label less silly.  (better overall layout could done too, later...)