### PR TITLE
SMS-style edit-run functionality

### DIFF
--- a/bin/cylc-submit
+++ b/bin/cylc-submit
@@ -65,9 +65,8 @@ def commandline_parser():
     parser.set_defaults( sched=False, dry_run=False )
 
     parser.add_option( "-d", "--dry-run",
-            help="Generate the cylc task execution file for the "
-            "task and report how it would be submitted to run.",
-            action="store_true", dest="dry_run" )
+        help="Generate the job script for the task, but don't submit it."
+        action="store_true", dest="dry_run" )
 
     return parser
 
@@ -175,9 +174,11 @@ except TaskNotDefinedError, x:
 if not options.dry_run:
     proc_pool = SuiteProcPool.get_inst(pool_size=1)
 
-task_proxy.submit(dry_run=options.dry_run)
-
-if not options.dry_run:
+if options.dry_run:
+    # The edit-run flag prevents the job script from submitting.
+    task_proxy.edit_run = True
+    print "JOB SCRIPT: %s" % task_proxy.submit()
+else:
     while proc_pool.unhandled_results:
         proc_pool.handle_results_async()
     proc_pool.close()

--- a/bin/cylc-submit
+++ b/bin/cylc-submit
@@ -182,6 +182,7 @@ if not options.dry_run:
 if options.dry_run:
     print "JOB SCRIPT=%s" % task_proxy.submit(dry_run=True)
 else:
+    task_proxy.submit()
     while proc_pool.unhandled_results:
         proc_pool.handle_results_async()
     proc_pool.close()

--- a/bin/cylc-submit
+++ b/bin/cylc-submit
@@ -53,6 +53,7 @@ not present in the graph, the given cycle point is assumed to be valid.
 WARNING: do not 'cylc submit' a task that is running in its suite at the
 same time - both instances will attempt to write to the same job logs."""
 
+
 def commandline_parser():
     parser = cop(
         usage, jset=True,
@@ -62,19 +63,20 @@ def commandline_parser():
         ]
     )
 
-    parser.set_defaults( sched=False, dry_run=False )
+    parser.set_defaults(sched=False, dry_run=False)
 
-    parser.add_option( "-d", "--dry-run",
-        help="Generate the job script for the task, but don't submit it."
-        action="store_true", dest="dry_run" )
+    parser.add_option(
+        "-d", "--dry-run",
+        help="Generate the job script for the task, but don't submit it.",
+        action="store_true", dest="dry_run")
 
     return parser
 
 # parse command line options and arguments-----------------------------
 parser = commandline_parser()
-( options, args ) = parser.parse_args()
+(options, args) = parser.parse_args()
 
-suite, suiterc = prep_file( args[0], options ).execute()
+suite, suiterc = prep_file(args[0], options).execute()
 
 owner = options.owner
 host = options.host
@@ -86,7 +88,7 @@ task_id = args[1]
 
 suite_dir = os.path.dirname(suiterc)
 # For user-defined job submission methods:
-sys.path.append( os.path.join( suite_dir, 'python' ))
+sys.path.append(os.path.join(suite_dir, 'python'))
 
 # check task
 if not TaskID.is_valid_id(task_id):
@@ -96,13 +98,13 @@ task_name, point_string = TaskID.split(task_id)
 
 # load suite config
 try:
-    config = config( suite, suiterc,
-            template_vars=options.templatevars,
-            template_vars_file=options.templatevars_file )
-except Exception,x:
+    config = config(
+        suite, suiterc, template_vars=options.templatevars,
+        template_vars_file=options.templatevars_file)
+except Exception as exc:
     if cylc.flags.debug:
         raise
-    raise SystemExit(x)
+    raise SystemExit(exc)
 
 # No TASK EVENT HOOKS are set for the submit command because there is
 # no scheduler instance watching for task failure etc.
@@ -113,7 +115,7 @@ utc = config.cfg['cylc']['UTC mode']
 # create log (after CYLC_MODE is exported)
 os.environ['CYLC_MODE'] = 'submit'
 
-GLOBAL_CFG.create_cylc_run_tree( suite )
+GLOBAL_CFG.create_cylc_run_tree(suite)
 slog = suite_log(suite)
 suite_log_dir = slog.get_dir()
 slog.pimp()
@@ -121,28 +123,28 @@ slog.pimp()
 RemoteJobHostManager.get_inst().single_task_mode = True
 
 ict = config.cfg['scheduling']['initial cycle point']
-fct = config.cfg['scheduling']['final cycle point'  ]
+fct = config.cfg['scheduling']['final cycle point']
 
 # static cylc and suite-specific variables:
 suite_env = {
-        'CYLC_UTC'               : str(utc),
-        'CYLC_MODE'              : 'submit',
-        'CYLC_DEBUG'             : str( cylc.flags.debug ),
-        'CYLC_VERBOSE'           : str( cylc.flags.verbose),
-        'CYLC_DIR_ON_SUITE_HOST' : os.environ[ 'CYLC_DIR' ],
-        'CYLC_SUITE_NAME'        : suite,
-        'CYLC_SUITE_REG_NAME'    : suite, # DEPRECATED
-        'CYLC_SUITE_HOST'        : str( get_suite_host() ),
-        'CYLC_SUITE_OWNER'       : owner,
-        'CYLC_SUITE_PORT'        : 'None',
-        'CYLC_SUITE_REG_PATH'    : RegPath( suite ).get_fpath(), # DEPRECATED
-        'CYLC_SUITE_DEF_PATH_ON_SUITE_HOST' : suite_dir,
-        'CYLC_SUITE_INITIAL_CYCLE_POINT' : str( ict ), # may be "None"
-        'CYLC_SUITE_FINAL_CYCLE_POINT'   : str( fct ), # may be "None"
-        'CYLC_SUITE_INITIAL_CYCLE_TIME' : str( ict ), # may be "None"
-        'CYLC_SUITE_FINAL_CYCLE_TIME'   : str( fct ), # may be "None"
-        'CYLC_SUITE_LOG_DIR'     : suite_log_dir # needed by the test battery
-        }
+    'CYLC_UTC': str(utc),
+    'CYLC_MODE': 'submit',
+    'CYLC_DEBUG': str(cylc.flags.debug),
+    'CYLC_VERBOSE': str(cylc.flags.verbose),
+    'CYLC_DIR_ON_SUITE_HOST': os.environ['CYLC_DIR'],
+    'CYLC_SUITE_NAME': suite,
+    'CYLC_SUITE_REG_NAME': suite,  # DEPRECATED
+    'CYLC_SUITE_HOST': str(get_suite_host()),
+    'CYLC_SUITE_OWNER': owner,
+    'CYLC_SUITE_PORT': 'None',
+    'CYLC_SUITE_REG_PATH': RegPath(suite).get_fpath(),  # DEPRECATED
+    'CYLC_SUITE_DEF_PATH_ON_SUITE_HOST': suite_dir,
+    'CYLC_SUITE_INITIAL_CYCLE_POINT': str(ict),  # may be "None"
+    'CYLC_SUITE_FINAL_CYCLE_POINT': str(fct),  # may be "None"
+    'CYLC_SUITE_INITIAL_CYCLE_TIME': str(ict),  # may be "None"
+    'CYLC_SUITE_FINAL_CYCLE_TIME': str(fct),  # may be "None"
+    'CYLC_SUITE_LOG_DIR': suite_log_dir  # needed by the test battery
+    }
 
 # Note: a suite contact env file is not written by this command (it
 # would overwrite the real one if the suite is running).
@@ -152,12 +154,15 @@ suite_env = {
 # are overridden by tasks prior to job submission, but in
 # principle they could be needed locally by event handlers:
 suite_task_env = {
-        'CYLC_SUITE_RUN_DIR'    : GLOBAL_CFG.get_derived_host_item( suite, 'suite run directory' ),
-        'CYLC_SUITE_WORK_DIR'   : GLOBAL_CFG.get_derived_host_item( suite, 'suite work directory' ),
-        'CYLC_SUITE_SHARE_DIR'  : GLOBAL_CFG.get_derived_host_item( suite, 'suite share directory' ),
-        'CYLC_SUITE_SHARE_PATH' : '$CYLC_SUITE_SHARE_DIR', # DEPRECATED
-        'CYLC_SUITE_DEF_PATH'   : suite_dir
-        }
+    'CYLC_SUITE_RUN_DIR': GLOBAL_CFG.get_derived_host_item(
+        suite, 'suite run directory'),
+    'CYLC_SUITE_WORK_DIR': GLOBAL_CFG.get_derived_host_item(
+        suite, 'suite work directory'),
+    'CYLC_SUITE_SHARE_DIR': GLOBAL_CFG.get_derived_host_item(
+        suite, 'suite share directory'),
+    'CYLC_SUITE_SHARE_PATH': '$CYLC_SUITE_SHARE_DIR',  # DEPRECATED
+    'CYLC_SUITE_DEF_PATH': suite_dir
+    }
 # (note GLOBAL_CFG automatically expands environment variables in local paths)
 
 JOB_FILE.set_suite_env(suite_env)

--- a/bin/cylc-submit
+++ b/bin/cylc-submit
@@ -180,9 +180,7 @@ if not options.dry_run:
     proc_pool = SuiteProcPool.get_inst(pool_size=1)
 
 if options.dry_run:
-    # The edit-run flag prevents the job script from submitting.
-    task_proxy.edit_run = True
-    print "JOB SCRIPT: %s" % task_proxy.submit(dry_run=True)
+    print "JOB SCRIPT=%s" % task_proxy.submit(dry_run=True)
 else:
     while proc_pool.unhandled_results:
         proc_pool.handle_results_async()

--- a/bin/cylc-submit
+++ b/bin/cylc-submit
@@ -182,7 +182,7 @@ if not options.dry_run:
 if options.dry_run:
     # The edit-run flag prevents the job script from submitting.
     task_proxy.edit_run = True
-    print "JOB SCRIPT: %s" % task_proxy.submit()
+    print "JOB SCRIPT: %s" % task_proxy.submit(dry_run=True)
 else:
     while proc_pool.unhandled_results:
         proc_pool.handle_results_async()

--- a/bin/cylc-trigger
+++ b/bin/cylc-trigger
@@ -19,13 +19,14 @@
 import sys
 
 if '--host' in sys.argv[1:] and '--edit' in sys.argv[1:]:
+    # Edit runs must always be re-invoked on the suite host.
     if '--use-ssh' not in sys.argv[1:]:
         sys.argv[1:].append('--use-ssh')
 
 if '--use-ssh' in sys.argv[1:]:
-    sys.argv.remove( '--use-ssh' )
+    sys.argv.remove('--use-ssh')
     from cylc.remote import remrun
-    if remrun().execute( force_required=True ):
+    if remrun().execute(force_required=True):
         sys.exit(0)
 
 import re
@@ -41,7 +42,7 @@ from cylc.cfgspec.globalcfg import GLOBAL_CFG
 from cylc.job_logs import CommandLogger
 
 
-parser = cop( """cylc [control] trigger [OPTIONS] ARGS
+parser = cop("""cylc [control] trigger [OPTIONS] ARGS
 
 Manually trigger a task or tasks. For single tasks you can choose to edit the
 generated job script first, to apply one-off changes (--edit).  Triggering a
@@ -49,18 +50,22 @@ waiting task queues it for execution. If its queue is not limited it will
 submit immediately, otherwise it will submit when released by its queue.
 Triggering a queued task causes it to submit immediately even if that violates
 the queue limit.
-""" + multitask_usage, pyro=True, multitask=True,
-    argdoc=[ ('REG', 'Suite name'),
-        ('MATCH', 'Task or family name matching regular expression'),
-        ('POINT', 'Task cycle point (e.g. date-time or integer)') ])
+""" + multitask_usage, pyro=True, multitask=True, argdoc=[
+    ('REG', 'Suite name'),
+    ('MATCH', 'Task or family name matching regular expression'),
+    ('POINT', 'Task cycle point (e.g. date-time or integer)')
+    ]
+)
 
-parser.add_option( "-e", "--edit",
-                help="Manually edit the job script before running it.",
-                action="store_true", default=False, dest="edit_run" )
+parser.add_option(
+    "-e", "--edit",
+    help="Manually edit the job script before running it.",
+    action="store_true", default=False, dest="edit_run")
 
-parser.add_option( "-g", "--geditor",
-        help="(with --edit-run) force use of the configured GUI editor.",
-        action="store_true", default=False, dest="geditor" )
+parser.add_option(
+    "-g", "--geditor",
+    help="(with --edit-run) force use of the configured GUI editor.",
+    action="store_true", default=False, dest="geditor")
 
 (options, args) = parser.parse_args()
 suite, pphrase = prep_pyro(args[0], options).execute()
@@ -77,15 +82,17 @@ if options.edit_run:
         jobfile_mtime = None
 
 try:
-    proxy = cylc_pyro_client.client( suite, pphrase, options.owner,
-            options.host, options.pyro_timeout,
-            options.port ).get_proxy( 'command-interface' )
+    proxy = cylc_pyro_client.client(
+        suite, pphrase, options.owner,
+        options.host, options.pyro_timeout, options.port
+        ).get_proxy('command-interface')
     prompt(
         'Trigger task(s) ' + name + ' at ' + point_string + ' in ' + suite,
         options.force
     )
     result = proxy.put(
-        'trigger task', name, point_string, options.is_family, options.edit_run)
+        'trigger task', name, point_string, options.is_family,
+        options.edit_run)
 except Exception as exc:
     if cylc.flags.debug:
         raise
@@ -121,9 +128,10 @@ if options.edit_run:
     command = ' '.join(command_list)
     try:
         # Edit the job file (this blocks until editor exit).
-        retcode = subprocess.call( command_list )
+        retcode = subprocess.call(command_list)
         if retcode != 0:
-            sys.exit('ERROR, command failed with %d:\n %s' % (retcode, command))
+            sys.exit(
+                'ERROR, command failed with %d:\n %s' % (retcode, command))
     except OSError:
         sys.exit('ERROR, unable to execute:\n %s' % command)
 

--- a/bin/cylc-trigger
+++ b/bin/cylc-trigger
@@ -17,38 +17,64 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
+
+if '--host' in sys.argv[1:] and '--edit' in sys.argv[1:]:
+    if '--use-ssh' not in sys.argv[1:]:
+        sys.argv[1:].append('--use-ssh')
+
 if '--use-ssh' in sys.argv[1:]:
     sys.argv.remove( '--use-ssh' )
     from cylc.remote import remrun
     if remrun().execute( force_required=True ):
         sys.exit(0)
 
+import re
+import os
+import time
+import subprocess
 from cylc.prompt import prompt
 from cylc import cylc_pyro_client
 from cylc.CylcOptionParsers import cop, multitask_usage
 from cylc.command_prep import prep_pyro
 import cylc.flags
+from cylc.cfgspec.globalcfg import GLOBAL_CFG
+from cylc.job_logs import CommandLogger
+
 
 parser = cop( """cylc [control] trigger [OPTIONS] ARGS
 
-Manually trigger tasks. Triggering an unqueued task sets it "ready to
-run" and queues it for job submission (cylc internal queues). If the
-queue is not limited the task will submit immediately, otherwise it will
-submit when released by its queue. Triggering a queued task overrides the
-queue limiting mechanism and causes the task to submit immediately (be
-aware that this results in a greater number of active tasks than the
-queue limit specifies).
+Manually trigger a task or tasks. For single tasks you can choose to edit the
+generated job script first, to apply one-off changes (--edit).  Triggering a
+waiting task queues it for execution. If its queue is not limited it will
+submit immediately, otherwise it will submit when released by its queue.
+Triggering a queued task causes it to submit immediately even if that violates
+the queue limit.
 """ + multitask_usage, pyro=True, multitask=True,
     argdoc=[ ('REG', 'Suite name'),
         ('MATCH', 'Task or family name matching regular expression'),
         ('POINT', 'Task cycle point (e.g. date-time or integer)') ])
 
+parser.add_option( "-e", "--edit",
+                help="Manually edit the job script before running it.",
+                action="store_true", default=False, dest="edit_run" )
+
+parser.add_option( "-g", "--geditor",
+        help="(with --edit-run) force use of the configured GUI editor.",
+        action="store_true", default=False, dest="geditor" )
+
 (options, args) = parser.parse_args()
-
-suite, pphrase = prep_pyro( args[0], options ).execute()
-
+suite, pphrase = prep_pyro(args[0], options).execute()
 name = args[1]
 point_string = args[2]
+
+if options.edit_run:
+    jobfile_path = CommandLogger.get_latest_job_log(
+        suite, name, point_string)
+    try:
+        jobfile_mtime = os.stat(jobfile_path).st_mtime
+    except OSError:
+        # No job script yet.
+        jobfile_mtime = None
 
 try:
     proxy = cylc_pyro_client.client( suite, pphrase, options.owner,
@@ -59,13 +85,48 @@ try:
         options.force
     )
     result = proxy.put(
-        'trigger task', name, point_string, options.is_family)
-except Exception, x:
+        'trigger task', name, point_string, options.is_family, options.edit_run)
+except Exception as exc:
     if cylc.flags.debug:
         raise
-    sys.exit(x)
+    sys.exit(exc)
 
-if result[0]:
-    print result[1]
-else:
-    sys.exit( result[1] )
+if not result[0]:
+    sys.exit(result[1])
+
+if options.edit_run:
+    if options.geditor:
+        editor = GLOBAL_CFG.get(['editors', 'gui'])
+    else:
+        editor = GLOBAL_CFG.get(['editors', 'terminal'])
+
+    count = 0
+    MAX_TRIES = 10
+    while True:
+        count += 1
+        # Wait for the new jobfile to be written.
+        try:
+            if os.stat(jobfile_path).st_mtime > jobfile_mtime:
+                break
+        except:
+            # No job script yet.
+            pass
+        if count > MAX_TRIES:
+            sys.exit('ERROR: no job file after %s seconds' % MAX_TRIES)
+        time.sleep(1)
+
+    # The editor command may have options, e.g. 'emacs -nw'.
+    command_list = re.split(' ', editor)
+    command_list.append(jobfile_path)
+    command = ' '.join(command_list)
+    try:
+        # Edit the job file (this blocks until editor exit).
+        retcode = subprocess.call( command_list )
+        if retcode != 0:
+            sys.exit('ERROR, command failed with %d:\n %s' % (retcode, command))
+    except OSError:
+        sys.exit('ERROR, unable to execute:\n %s' % command)
+
+    # Release the task proxy to run.
+    result = proxy.put(
+        'release task', name, point_string, options.is_family)

--- a/bin/cylc-trigger
+++ b/bin/cylc-trigger
@@ -40,7 +40,7 @@ from cylc.command_prep import prep_pyro
 import cylc.flags
 from cylc.cfgspec.globalcfg import GLOBAL_CFG
 from cylc.job_logs import CommandLogger
-
+from cylc.task_id import TaskID
 
 parser = cop("""cylc [control] trigger [OPTIONS] ARGS
 
@@ -72,62 +72,78 @@ suite, pphrase = prep_pyro(args[0], options).execute()
 name = args[1]
 point_string = args[2]
 
-if options.edit_run:
-    jobfile_path = CommandLogger.get_latest_job_log(
-        suite, name, point_string)
-    try:
-        jobfile_mtime = os.stat(jobfile_path).st_mtime
-    except OSError:
-        # No job script yet.
-        jobfile_mtime = None
+msg = 'Trigger task(s) %s  at %s in %s' % (name, point_string, suite)
+prompt(msg, options.force)
 
+# Get the suite daemon command interface.
 try:
-    proxy = cylc_pyro_client.client(
-        suite, pphrase, options.owner,
-        options.host, options.pyro_timeout, options.port
-        ).get_proxy('command-interface')
-    prompt(
-        'Trigger task(s) ' + name + ' at ' + point_string + ' in ' + suite,
-        options.force
-    )
-    result = proxy.put(
-        'trigger task', name, point_string, options.is_family,
-        options.edit_run)
+    cmd_proxy = cylc_pyro_client.client(
+        suite, pphrase, options.owner, options.host, options.pyro_timeout,
+        options.port).get_proxy('command-interface')
 except Exception as exc:
     if cylc.flags.debug:
         raise
     sys.exit(exc)
 
-if not result[0]:
-    sys.exit(result[1])
-
 if options.edit_run:
-    if options.geditor:
-        editor = GLOBAL_CFG.get(['editors', 'gui'])
-    else:
-        editor = GLOBAL_CFG.get(['editors', 'terminal'])
+    # Check that TASK is a unique task.
+    task_id = TaskID.get(name, point_string)
+    try:
+        info_proxy = cylc_pyro_client.client( suite, pphrase, options.owner,
+                options.host, options.pyro_timeout,
+                options.port ).get_proxy( 'suite-info' )
+        res, msg = info_proxy.get('ping task', task_id, True)
+    except Exception as exc:
+        if cylc.flags.debug:
+            raise
+        sys.exit(exc)
+    if not res:
+        sys.exit('ERROR: %s' % msg)
 
+    # Get the current job file mtime, if the file exists.
+    jobfile_path = CommandLogger.get_latest_job_log(
+        suite, name, point_string)
+    try:
+        jobfile_mtime = os.stat(jobfile_path).st_mtime
+    except OSError:
+        # Does not exist.
+        jobfile_mtime = None
+
+    try:
+        # Tell the suite daemon to generate the job file.
+        result = cmd_proxy.put('dry run task', name, point_string)
+    except Exception as exc:
+        if cylc.flags.debug:
+            raise
+        sys.exit(exc)
+    if not result[0]:
+        sys.exit(result[1])
+
+    # Wait for the new job file to be written.
     count = 0
     MAX_TRIES = 10
     while True:
         count += 1
-        # Wait for the new jobfile to be written.
         try:
             if os.stat(jobfile_path).st_mtime > jobfile_mtime:
                 break
         except:
-            # No job script yet.
             pass
         if count > MAX_TRIES:
             sys.exit('ERROR: no job file after %s seconds' % MAX_TRIES)
         time.sleep(1)
 
+    # Edit the new job file.
+    if options.geditor:
+        editor = GLOBAL_CFG.get(['editors', 'gui'])
+    else:
+        editor = GLOBAL_CFG.get(['editors', 'terminal'])
     # The editor command may have options, e.g. 'emacs -nw'.
     command_list = re.split(' ', editor)
     command_list.append(jobfile_path)
     command = ' '.join(command_list)
     try:
-        # Edit the job file (this blocks until editor exit).
+        # Block until the editor exits.
         retcode = subprocess.call(command_list)
         if retcode != 0:
             sys.exit(
@@ -135,6 +151,12 @@ if options.edit_run:
     except OSError:
         sys.exit('ERROR, unable to execute:\n %s' % command)
 
-    # Release the task proxy to run.
-    result = proxy.put(
-        'release task', name, point_string, options.is_family)
+# Trigger the task proxy(s).
+try:
+    result = cmd_proxy.put('trigger task', name, point_string, options.is_family)
+except Exception as exc:
+    if cylc.flags.debug:
+        raise
+    sys.exit(exc)
+if not result[0]:
+    sys.exit(result[1])

--- a/lib/cylc/CylcOptionParsers.py
+++ b/lib/cylc/CylcOptionParsers.py
@@ -26,8 +26,11 @@ import cylc.flags
 """Common options for all cylc commands."""
 
 multitask_usage = """
-For matching multiple tasks or families at once note that MATCH is
-interpreted as a full regular expression, not a simple shell glob."""
+To match multiple tasks or families at once, MATCH is interpreted as a
+Python-style regular expression, not a simple shell glob.
+
+To match family rather than task names, use the -m/--family option.
+"""
 
 class db_optparse( object ):
     def __init__( self, dbopt ):

--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -1174,14 +1174,6 @@ The Cylc Suite Engine.
 
             items.append(gtk.SeparatorMenuItem())
 
-            trigger_edit_item = gtk.ImageMenuItem('Trigger (edit run)')
-            img = gtk.image_new_from_stock(
-                gtk.STOCK_MEDIA_PLAY, gtk.ICON_SIZE_MENU)
-            trigger_edit_item.set_image(img)
-            items.append(trigger_edit_item)
-            trigger_edit_item.connect(
-                'activate', self.trigger_task_edit_run, task_id)
-
         trigger_now_item = gtk.ImageMenuItem('Trigger (run now)')
         img = gtk.image_new_from_stock(
             gtk.STOCK_MEDIA_PLAY, gtk.ICON_SIZE_MENU)
@@ -1190,10 +1182,18 @@ The Cylc Suite Engine.
         trigger_now_item.connect(
             'activate', self.trigger_task_now, task_id, task_is_family)
 
+        if not task_is_family:
+            trigger_edit_item = gtk.ImageMenuItem('Trigger (edit run)')
+            img = gtk.image_new_from_stock(
+                gtk.STOCK_MEDIA_PLAY, gtk.ICON_SIZE_MENU)
+            trigger_edit_item.set_image(img)
+            items.append(trigger_edit_item)
+            trigger_edit_item.connect(
+                'activate', self.trigger_task_edit_run, task_id)
+
         items.append(gtk.SeparatorMenuItem())
 
-        # TODO - grey out poll and kill if the task is not 'submitted' or
-        # 'running' (requires the task state from the underlying data model...)
+        # TODO - grey out poll and kill if the task is not active.
         poll_item = gtk.ImageMenuItem('Poll')
         img = gtk.image_new_from_stock(gtk.STOCK_REFRESH, gtk.ICON_SIZE_MENU)
         poll_item.set_image(img)

--- a/lib/cylc/job_logs.py
+++ b/lib/cylc/job_logs.py
@@ -44,6 +44,15 @@ class CommandLogger(object):
     JOB_LOG_FMT_M = "%(timestamp)s %(mesg_type)s:\n\n%(mesg)s\n"
 
     @classmethod
+    def get_latest_job_log(cls, suite, task_name, task_point):
+        """Return the latest job log path on the suite host."""
+
+        suite_job_log_dir = GLOBAL_CFG.get_derived_host_item(
+            suite, "suite job log directory")
+        the_rest = os.path.join(str(task_point), task_name, "NN", "job")
+        return os.path.join(suite_job_log_dir, the_rest)
+ 
+    @classmethod
     def get_create_job_log_path(
             cls, suite, task_name, task_point, submit_num, new_mode=False):
         """Return a new job log path on the suite host, in two parts.

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -887,10 +887,11 @@ class TaskPool(object):
                     self.force_spawn(itask)
                 self.remove(itask, 'by request')
 
-    def trigger_tasks(self, ids):
+    def trigger_tasks(self, ids, edit_run):
         for itask in self.get_tasks(incl_runahead=False):
             if itask.identity in ids:
                 itask.manual_trigger = True
+                itask.edit_run = edit_run
                 if not itask.state.is_currently('queued'):
                     itask.reset_state_ready()
 
@@ -980,6 +981,19 @@ class TaskPool(object):
             return False, "task not running"
         else:
             return True, " running"
+
+    def get_task_jobfile_path(self, id_):
+        found = False
+        running = False
+        for itask in self.get_tasks(incl_runahead=False):
+            if itask.identity == id_:
+                found = True
+                jobfile_path = itask.job_conf['local job file path']
+                break
+        if not found:
+            return False, "task not found"
+        else:
+            return True, jobfile_path
 
     def get_task_requisites(self, ids):
         info = {}

--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -861,7 +861,7 @@ class TaskProxy(object):
         self.record_db_event(event="incrementing submit number")
         self.record_db_update("task_states", submit_num=self.submit_num)
 
-    def submit(self, overrides=None, dry_run=False):
+    def submit(self, dry_run=False, overrides=None):
         """Submit a job for this task."""
 
         if self.tdef.run_mode == 'simulation':
@@ -1518,7 +1518,6 @@ class TaskProxy(object):
         Run a job command with the multiprocess pool.
 
         """
-        self.job_prepped = False # (reset)
         if self.user_at_host in [user + '@localhost', 'localhost']:
             cmd = ["cylc", cmd_key] + list(args)
         else:  # if it is a remote job

--- a/tests/cylc-trigger/03-edit-run.t
+++ b/tests/cylc-trigger/03-edit-run.t
@@ -1,0 +1,34 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test an edit-run (cylc trigger --edit).
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 2
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+#-------------------------------------------------------------------------------
+TEST_NAME="${TEST_NAME_BASE}-validate"
+run_ok "${TEST_NAME}" cylc validate "${SUITE_NAME}"
+#-------------------------------------------------------------------------------
+# Configure a fake editor $PWD/bin/my-edit via $PWD/conf and run a suite
+# containing a task that does an edit run.
+TEST_NAME="${TEST_NAME_BASE}-run"
+CYLC_CONF_PATH=$PWD/conf \
+    run_ok "${TEST_NAME}" cylc run --no-detach "${SUITE_NAME}"
+#-------------------------------------------------------------------------------
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/cylc-trigger/03-edit-run/bin/my-edit
+++ b/tests/cylc-trigger/03-edit-run/bin/my-edit
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sed -i 's@/bin/false@/bin/true@' "$@"

--- a/tests/cylc-trigger/03-edit-run/conf/global.rc
+++ b/tests/cylc-trigger/03-edit-run/conf/global.rc
@@ -1,0 +1,2 @@
+[editors]
+    terminal=my-edit

--- a/tests/cylc-trigger/03-edit-run/suite.rc
+++ b/tests/cylc-trigger/03-edit-run/suite.rc
@@ -1,0 +1,17 @@
+title = A suite to test 'cylc trigger --edit'.
+description = """
+A broken task will fail and cause the suite to abort on timeout, unless a
+second task fixes and retriggers it with an edit-run."""
+[cylc]
+    [[event hooks]]
+        abort on timeout = True
+        timeout = PT20S
+[scheduling]
+    [[dependencies]]
+        graph = broken-task:fail => fixer-task
+[runtime]
+    [[broken-task]]
+        command scripting = /bin/false
+    [[fixer-task]]
+        command scripting = """
+cylc trigger --edit $CYLC_SUITE_NAME broken-task 1"""


### PR DESCRIPTION
This should allow us to finally close #91.

It works now, but is not quite ready for review yet - I still need to:
 * tidy the affected task proxy code,
 * make the new functionality available via the GUI,
 * restrict use to single tasks (not families or matched groups of tasks)
 * (consider use of this via gcylc running on another host)

*Implementation* [update: this has changed, see below]
The ```cylc trigger``` command gets a new option ```--edit``` that causes the suite daemon to get the target task to write its job script, set itself to ```held```, and then return without actually submitting the job.  Then ```cylc trigger``` fires up the user's editor on the new job script (waiting for it to be written if necessary). When the editor is exited, it tells the daemon to release the task, resulting in the edited job script being submitted.