### PR TITLE
Tests.niwa fixes

### DIFF
--- a/tests/hold-release/11-retrying/suite.rc
+++ b/tests/hold-release/11-retrying/suite.rc
@@ -15,7 +15,9 @@ t-retry-able => t-analyse
 
 [runtime]
     [[t-retry-able]]
-        command scripting = ((CYLC_TASK_TRY_NUMBER >= 3))
+        # Note under bash 4.2 failed bare arithmetic tests such as
+        # "(( VAR >= 3 ))" do not cause an abort under 'set -e'.
+        command scripting = (( CYLC_TASK_TRY_NUMBER < 3 )) && exit 1
         retry delays = PT15S, 2*PT1S
     [[t-hold-release]]
         command scripting = """
@@ -27,5 +29,8 @@ timeout 30s my-log-grepper '[t-retry-able.1] -held => retrying'
 """
     [[t-analyse]]
         command scripting = """
-test "$(readlink "$(dirname "$0")/../../t-retry-able/NN")" = '03'
+set -x
+readlink "$(dirname "$0")/../../t-retry-able/NN"
+test "$(readlink "$(dirname "$0")/../../t-retry-able/NN")" == '03'
+set +x
 """

--- a/tests/hold-release/11-retrying/suite.rc
+++ b/tests/hold-release/11-retrying/suite.rc
@@ -29,8 +29,5 @@ timeout 30s my-log-grepper '[t-retry-able.1] -held => retrying'
 """
     [[t-analyse]]
         command scripting = """
-set -x
-readlink "$(dirname "$0")/../../t-retry-able/NN"
-test "$(readlink "$(dirname "$0")/../../t-retry-able/NN")" == '03'
-set +x
+test "$(readlink "$(dirname "$0")/../../t-retry-able/NN")" = '03'
 """

--- a/tests/hold-release/hold-after/suite.rc
+++ b/tests/hold-release/hold-after/suite.rc
@@ -4,6 +4,7 @@ title = "cylc hold --after"
 description = """One task that holds future cycles after a given cycle."""
 
 [cylc]
+    UTC mode = True
     [[reference test]]
         live mode suite timeout = PT1M
 

--- a/tests/hold-release/run-hold-after/suite.rc
+++ b/tests/hold-release/run-hold-after/suite.rc
@@ -4,6 +4,7 @@ title = "cylc run --hold-after"
 description = """Test running with a hold-after cycle point."""
 
 [cylc]
+    UTC mode = True
     [[reference test]]
         live mode suite timeout = PT1M
 


### PR DESCRIPTION
Three tests under ```tests/hold-release/``` are failing on my desktop box at work.
 
* ```11-retrying.t``` - the problem reported in https://github.com/cylc/cylc/pull/1324#issuecomment-74208499 was caused by this bash 4.2 behaviour: https://github.com/cylc/cylc/pull/1108#discussion_r16582794
* ```15-hold-after.t``` and ```16-run-hold-after.t``` need to run in UTC mode, for compatibility with the UTC start and stop times extracted from the reference logs.

@arjclark - please review.
