### PR TITLE
1335.cylc version

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -11,30 +11,33 @@ Cylc is typically installed into a designated "cylc admin" user account
     % make      # (see below to understand what 'make' does here)
 
 _______________________________________________________________________
-ARRANGING ACCESS TO CYLC ONCE INSTALLED
+ARRANGING ACCESS TO CYLC
 
-To use cylc you just need the cylc bin directory in your $PATH (on task
-host accounts as well as on the suite host). Instead of arranging access
-to a specific cylc bin directory, however, you should consider
-installing successive versions in parallel like this:
+Users need access to the the "cylc" command from suite and task host user
+accounts.  Do not simply put the bin directory of a specific cylc release in
+$PATH for users, however. Instead install admin/cylc-wrapper as "cylc" in a
+central location and ensure that location is in $PATH. The wrapper must be
+modified slightly, as described in the file, to point to the location under
+which multiple cycle versions will be intalled. For example:
 
-    /home/admin/cylc/cylc-5.2.0/
-    /home/admin/cylc/cylc-5.4.0/
-        # etc.
-    /home/admin/cylc/cylc-5.4.5/
-    /home/admin/cylc/cylc -> cylc-5.4.5   # symlink to default version
-
-Now install admin/cylc-wrapper to a convenient location as "cylc", e.g.:
-
-    % cp admin/cylc-wrapper /home/admin/bin/cylc
-        # OR:
+    # Install the central wrapper:
     % cp admin/cylc-wrapper /usr/local/bin/cylc
-    
-Modify the wrapper for your environment as per instructions in the file
-and ensure that it is in $PATH for users. The wrapper selects from the
-installed versions via an environment variable $CYLC_VERSION that users
-can set if they don't want the default version. Running suites also use
-this to ensure that their tasks access the right version of cylc.
+
+Then (a) ensure that /usr/local/bin is in $PATH for users, and (b) modify
+/usr/local/bin/cylc to point to /home/admin/cylc, where successive releases can
+be installed like this:
+
+    # Install cylc releases side by side:
+    /home/admin/cylc/cylc-6.0.0/
+    /home/admin/cylc/cylc-6.1.0/
+    /home/admin/cylc/cylc-6.1.2/
+        # etc.
+    /home/admin/cylc/cylc -> cylc-6.3.0  # SYMLINK TO DEFAULT VERSION
+   
+The central wrapper selects from the available versions of cylc according to
+the value of an environment variable, $CYLC_VERSION.  This allows running
+suites to continue to function correctly even if they have not been upgraded
+to the latest release.
 
 _______________________________________________________________________
 CYLC DEVELOPMENT - CLONING THE GIT REPOSITORY

--- a/README
+++ b/README
@@ -14,12 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-This is the Cylc Suite Engine, version: cylc -v
-
-Access to cylc:
-  % export PATH=/path/to/cylc/bin:$PATH
-  % cylc help
-  % gcylc &
+This is the Cylc Suite Engine, a workflow engine and metascheduler.
 
 Documentation:
   * Installation: /path/to/cylc/INSTALL

--- a/bin/cylc
+++ b/bin/cylc
@@ -298,7 +298,7 @@ Version """ + CYLC_VERSION + """
 The graphical user interface for cylc is "gcylc" (a.k.a. "cylc gui").
 
 USAGE:
-  % cylc -v,--version                   # print cylc version
+  % cylc version,-v,--version           # print cylc version
   % cylc help,--help,-h,?               # print this help page
 
   % cylc help CATEGORY                  # print help by category
@@ -525,9 +525,6 @@ if len(args) == 1:
         pretty_print(catsum, categories)
         sys.exit(0)
     if (args[0] == '-v' or args[0] == '--version'):
-        # cylc -v,--version
-        # is now an alias for "cylc version"
-        args[0] = 'version'
         print CYLC_VERSION
         sys.exit(0)
 

--- a/bin/cylc
+++ b/bin/cylc
@@ -180,7 +180,8 @@ information_commands['dump'] = ['dump']
 information_commands['cat-state'] = ['cat-state']
 information_commands['show'] = ['show']
 information_commands['cat-log'] = ['cat-log', 'log']
-information_commands['get-cylc-version'] = ['get-cylc-version']
+information_commands['get-suite-version'] = ['get-suite-version', 'get-cylc-version']
+information_commands['version'] = ['version']
 
 information_commands['documentation'] = ['documentation', 'browse']
 information_commands['monitor'] = ['monitor']
@@ -397,7 +398,8 @@ comsum['monitor'] = 'An in-terminal suite monitor (see also gcylc)'
 comsum['get-suite-config'] = 'Print suite configuration items'
 comsum['get-site-config'] = 'Print site/user configuration items'
 comsum['get-gui-config'] = 'Print gcylc configuration items'
-comsum['get-cylc-version'] = 'Get the cylc-version running a daemon'
+comsum['get-suite-version'] = 'Print the cylc version of a running suite daemon'
+comsum['version'] = 'Print the cylc release version'
 comsum['gsummary'] = 'Summary GUI for monitoring multiple suites'
 comsum['gpanel'] = 'Internal interface for GNOME 2 panel applet'
 # control
@@ -524,6 +526,8 @@ if len(args) == 1:
         sys.exit(0)
     if (args[0] == '-v' or args[0] == '--version'):
         # cylc -v,--version
+        # is now an alias for "cylc version"
+        args[0] = 'version'
         print CYLC_VERSION
         sys.exit(0)
 

--- a/bin/cylc
+++ b/bin/cylc
@@ -298,7 +298,8 @@ Version """ + CYLC_VERSION + """
 The graphical user interface for cylc is "gcylc" (a.k.a. "cylc gui").
 
 USAGE:
-  % cylc version,-v,--version           # print cylc version
+  % cylc -v,--version                   # print cylc version
+  % cylc version                        # (ditto, by command)
   % cylc help,--help,-h,?               # print this help page
 
   % cylc help CATEGORY                  # print help by category

--- a/bin/cylc-check-versions
+++ b/bin/cylc-check-versions
@@ -16,103 +16,117 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import sys, os, re
-from subprocess import Popen, PIPE
+import sys
+import subprocess
+
+import cylc.flags
+from cylc.remote import remrun
 from cylc.CylcOptionParsers import cop
 from cylc.version import CYLC_VERSION
 from cylc.config import config, SuiteConfigError
-from cylc.run_get_stdout import run_get_stdout
 from cylc.host_select import get_task_host
-import cylc.flags
 
-parser = cop( usage = """cylc [discovery] check-versions [OPTIONS] ARGS
 
-Check the version of cylc invoked on each of SUITE's task host accounts
-when CYLC_VERSION is set to """ + CYLC_VERSION + """ (i.e. *this* version).
-Different versions are reported but are not considered an error unless
-the -e|--error option is specified, because different cylc versions are
-not necessarily (nor usually) incompatible.
+parser = cop(
+    """cylc [discovery] check-versions [OPTIONS] ARGS
+
+Check the version of cylc invoked on each of SUITE's task host accounts when
+CYLC_VERSION is set to """ + CYLC_VERSION + """ (i.e. *this* version).
+Different versions are reported but are not considered an error unless the
+-e|--error option is specified, because different cylc versions from 6.0.0
+onward should at least be backward compatible.
 
 It is recommended that cylc versions be installed in parallel and access
 configured via the cylc version wrapper as described in the cylc INSTALL
-file and User Guide. Users then get the latest installed version by
-default, or (like tasks) a particular version if $CYLC_VERSION is defined.
+file and User Guide. This must be done on suite and task hosts. Users then get
+the latest installed version by default, or (like tasks) a particular version
+if $CYLC_VERSION is defined.
 
-Remote cylc versions are interrogated like this:
-  ssh user@host \\
-     "bash --login -c 'CYLC_VERSION=""" + CYLC_VERSION + """ cylc -v'"
-A login shell is used because task job scripts currently source login
-scripts explicitly at start-up to configure access to cylc.""",
-prep=True, jset=True )
+User -v/--verbose to see the command invoked to determine the remote version
+(all remote cylc command invocations will be of the same form, which may be
+site dependent -- see cylc global config documentation.""",
+    prep=True, jset=True)
 
-parser.add_option( "-e", "--error", help="Exit with error status "
-        "if " + CYLC_VERSION + " is not available on all remote accounts.",
-        action="store_true", default=False, dest="error" )
+parser.add_option(
+    "-e", "--error", help="Exit with error status "
+    "if " + CYLC_VERSION + " is not available on all remote accounts.",
+    action="store_true", default=False, dest="error")
 
-( options, args ) = parser.parse_args(remove_opts=['--host','--user'])
+(options, args) = parser.parse_args(remove_opts=['--host', '--user'])
 
 # suite name or file path
 suite, suiterc, junk = parser.get_suite()
 
 # extract task host accounts from the suite
 try:
-    config = config( suite, suiterc,
-            template_vars=options.templatevars,
-            template_vars_file=options.templatevars_file)
-except Exception,x:
+    config = config(
+        suite, suiterc,
+        template_vars=options.templatevars,
+        template_vars_file=options.templatevars_file)
+except Exception as exc:
     if cylc.flags.debug:
         raise
-    raise SystemExit(x)
+    raise SystemExit(exc)
 else:
-    result = config.get_namespace_list( 'all tasks' )
+    result = config.get_namespace_list('all tasks')
     namespaces = result.keys()
     accounts = set()
     for name in namespaces:
-        host = get_task_host( config.get_config( ['runtime', name, 'remote', 'host'] ))
-        owner = config.get_config( ['runtime', name, 'remote', 'owner'] )
-        if owner:
-            account = owner + '@' + host
-        else:
-            account = host
-        accounts.add(account)
+        host = get_task_host(
+            config.get_config(['runtime', name, 'remote', 'host']))
+        owner = config.get_config(['runtime', name, 'remote', 'owner'])
+        accounts.add((owner, host))
     accounts = list(accounts)
 
-if cylc.flags.verbose:
-    print len(accounts), "task host accounts used by " + suite + ":"
-    for ac in accounts:
-        print " ", ac
+# Interrogate the each remote account with CYLC_VERSION set to our version.
+# Note that post backward compatibility concerns to do this we can just run:
+#   cylc version --host=HOST --user=USER
+# but this command only exists for version > 6.3.0.
+# So for the moment generate an actual remote invocation command string for
+# "cylc -v".
 
-# remote command to interrogate cylc version
-rcom = "bash --login -c 'CYLC_VERSION=" + CYLC_VERSION + " cylc -v'"
+# (save verbose flag as gets reset in remrun)
+verbose = cylc.flags.verbose
 
-# interrogate each account
 warn = {}
 contacted = 0
-for ac in accounts:
-    lcom = 'ssh ' + ac + ' "' + rcom + '"'
-    if cylc.flags.verbose:
-        print lcom
-
-    res = run_get_stdout( lcom )
-    if res[0]:
+for user, host in accounts:
+    argv = ["cylc", "--version"]
+    if user and host:
+        argv += ["--user=%s" % user, "--host=%s" % host]
+        user_at_host = "%s@%s" % (user, host)
+    elif user:
+        argv += ["--user=%s" % user]
+        user_at_host = "%s@localhost" % user
+    elif host:
+        argv += ["--host=%s" % host]
+        user_at_host = host
+    cmd = remrun(argv).execute(dry_run=True)
+    if verbose:
+        print "%s: %s" % (user_at_host, ' '.join(cmd))
+    p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = p.communicate()
+    res = p.wait()
+    if res == 0:
+        if verbose:
+            print "   %s" % out
         contacted += 1
-        out = res[1][0]
-        if cylc.flags.verbose:
-            print ' ', out
+        out = out.strip()
         if out != CYLC_VERSION:
-            warn[ac] = out
+            warn[user_at_host] = out
     else:
-        print >> sys.stderr, 'ERROR ' + ac + ':'
-        print >> sys.stderr, ' ', '\n'.join(res[1])
+        print >> sys.stderr, 'ERROR ' + user_at_host + ':'
+        print >> sys.stderr, err
 
 # report results
 if not warn:
     if contacted:
         print "All", contacted, "accounts have cylc-" + CYLC_VERSION
 else:
-    print "WARNING: failed to invoke cylc-" + CYLC_VERSION + " on " + str(len(warn.keys())) + " accounts:"
-    m = max( [ len(ac) for ac in warn.keys() ] )
-    for ac,warning in warn.items():
+    print "WARNING: failed to invoke cylc-%s on %d accounts:" % (
+        CYLC_VERSION, len(warn.keys()))
+    m = max([len(ac) for ac in warn.keys()])
+    for ac, warning in warn.items():
         print ' ', ac.ljust(m), warning
     if options.error:
         sys.exit(1)

--- a/bin/cylc-get-suite-version
+++ b/bin/cylc-get-suite-version
@@ -30,11 +30,11 @@ from cylc.command_prep import prep_pyro
 from cylc.cfgspec.globalcfg import GLOBAL_CFG
 import cylc.flags
 
-parser = cop("""cylc [info] get-cylc-version [OPTIONS] ARGS
+parser = cop("""cylc [info] get-suite-version [OPTIONS] ARGS
 
 Interrogate running suite REG to find what version of cylc is running it.
 
-Note: to find the cylc version at your command line, use "cylc -v".""",
+To find the version you've invoked at the command line see "cylc version".""",
     pyro=True,
     argdoc=[('REG', 'Suite name')])
 

--- a/bin/cylc-version
+++ b/bin/cylc-version
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Print the cylc release or git repository version number."""
+
+import sys
+from cylc.remote import remrun
+if remrun().execute():
+    sys.exit(0)
+
+from cylc.CylcOptionParsers import cop
+from cylc.cfgspec.globalcfg import GLOBAL_CFG
+from cylc.version import CYLC_VERSION
+import cylc.flags
+
+
+parser = cop("""cylc [info] version
+
+Print the cylc version that you've invoked at the command line.
+Note that "cylc --version" and "cylc -v" are aliased to this command.
+
+For the version running a suite daemon, see "cylc get-suite-version".""")
+
+print CYLC_VERSION

--- a/bin/cylc-version
+++ b/bin/cylc-version
@@ -31,9 +31,15 @@ import cylc.flags
 
 parser = cop("""cylc [info] version
 
-Print the cylc version that you've invoked at the command line.
-Note that "cylc --version" and "cylc -v" are aliased to this command.
+Print the cylc version invoked at the command line.
 
-For the version running a suite daemon, see "cylc get-suite-version".""")
+Note that "cylc -v,--version" just prints the version string from the main
+command interface, whereas this is a proper cylc command that can take the
+standard --host and --user options, etc.
+
+For the cylc version of running a suite daemon see
+  "cylc get-suite-version".""")
+
+(options, args) = parser.parse_args()
 
 print CYLC_VERSION

--- a/doc/cug.tex
+++ b/doc/cug.tex
@@ -792,17 +792,11 @@ one at first, see~\ref{SiteAndUserConfiguration} and~\ref{SiteRCReference}.
 \label{CUI}
 
 Cylc has command line (CLI) and graphical (GUI) user interfaces.
-To get access to them you just need the cylc bin directory in your shell
-search path:
-\lstset{language=bash}
-\begin{lstlisting}
-export PATH=/path/to/cylc/bin:$PATH
-\end{lstlisting}
-Note however that direct use of a specific installed version, like this, is 
-not recommended. Instead a special wrapper script provided with cylc should be
-installed centrally for all users. This points to a top level cylc release
-directory and allows use of multiple cylc versions at once if necessary.
-See the cylc INSTALL file for details (\ref{INSTALL}).
+To access them {\em do not simply put the bin directory of the current release
+the shell search path for users.} Instead, as described in the cylc INSTALL
+file (\ref{INSTALL}), configure the provided multi-version wrapper script to
+point to install location for any or all cylc releases. This allows existing
+suites to continue running at old cylc versions if necessary.
 
 \subsubsection{Command Line Interface (CLI)}
 

--- a/doc/siterc.tex
+++ b/doc/siterc.tex
@@ -498,7 +498,9 @@ environment.
 
 \paragraph[cylc executable]{[hosts] $\rightarrow$ HOST $\rightarrow$ cylc executable }
 
-The \lstinline=cylc= executable on a remote host.
+The \lstinline=cylc= executable on a remote host. Note this should point to the 
+cylc multi-version wrapper (see~\ref{CUI}) on the host, not
+\lstinline=bin/cylc= for a specific installed version.
 Specify a full path if \lstinline=cylc= is not in \lstinline=\$PATH= when it is
 invoked via \lstinline=ssh= on this host.
 

--- a/lib/cylc/remote.py
+++ b/lib/cylc/remote.py
@@ -71,7 +71,7 @@ class remrun(object):
         self.is_remote = (
             is_remote_user(self.owner) or is_remote_host(self.host))
 
-    def execute(self, force_required=False, env={}, path=None, dry_run=False):
+    def execute(self, force_required=False, env=None, path=None, dry_run=False):
         """Execute command on remote host.
 
         Returns False if remote re-invocation is not needed, True if it is
@@ -129,6 +129,8 @@ class remrun(object):
 
         command.append(name)
 
+        if env is None:
+            env = {}
         for var, val in env.iteritems():
             command.append("--env=%s=%s" % (var, val))
 

--- a/lib/cylc/remote.py
+++ b/lib/cylc/remote.py
@@ -28,6 +28,7 @@ from textwrap import TextWrapper
 from cylc.cfgspec.globalcfg import GLOBAL_CFG
 from cylc.suite_host import is_remote_host
 from cylc.owner import is_remote_user
+from cylc.version import CYLC_VERSION
 import cylc.flags
 
 
@@ -69,7 +70,7 @@ class remrun(object):
         self.is_remote = (
             is_remote_user(self.owner) or is_remote_host(self.host))
 
-    def execute(self, force_required=False, env=None, path=None):
+    def execute(self, force_required=False, env={}, path=None):
         """Execute command on remote host.
 
         Returns False if remote re-invocation is not needed, True if it is
@@ -108,6 +109,10 @@ class remrun(object):
         if ssh_login_shell is None:
             ssh_login_shell = GLOBAL_CFG.get_host_item(
                 "use login shell", self.host, self.owner)
+
+        # Pass cylc version through.
+        command += ["CYLC_VERSION=%s" % CYLC_VERSION]
+
         if ssh_login_shell:
             # A login shell will always source /etc/profile and the user's bash
             # profile file. To avoid having to quote the entire remote command
@@ -123,10 +128,9 @@ class remrun(object):
 
         command.append(name)
 
-        if env is None:
-            env = {}
         for var, val in env.iteritems():
             command.append("--env=%s=%s" % (var, val))
+
         for arg in self.args:
             command.append("'" + arg + "'")
             # above: args quoted to avoid interpretation by the shell,


### PR DESCRIPTION
Close #1335 

 * exports CYLC_VERSION before remote command invocation
 * aliases ```cylc -v``` to a new command ```cylc version``` which can take the ```--host``` and ```--user``` options (better for testing this sort of thing) [UPDATE: adds the new command but does not alias the old main-command options to it]
 * updates ```cylc check-versions``` which did not reflect global settings for remote login shell etc.
 * updates installation documentation to emphasize the need to use the version wrapper

@benfitzpatrick - please review.
