### PR TITLE
Restart - create suite run tree if necessary.

### DIFF
--- a/lib/cylc/run.py
+++ b/lib/cylc/run.py
@@ -54,19 +54,15 @@ def main(name, start):
     # Print copyright and license information
     print_blurb()
 
-    # Before daemonizing attempt to create the suite output tree and get
-    # the suite port file.
-
+    # Create run directory tree and get port file.
     try:
-        if server.__class__.__name__ != 'restart':
-            GLOBAL_CFG.create_cylc_run_tree( server.suite )
+        GLOBAL_CFG.create_cylc_run_tree(server.suite)
         server.configure_pyro()
-    except Exception, x:
+    except Exception as exc:
         if flags.debug:
             raise
         else:
-            print >> sys.stderr, x
-            sys.exit(1)
+            sys.exit(exc)
 
     # Daemonize the suite
     if not server.options.no_detach and not flags.debug:

--- a/lib/cylc/run.py
+++ b/lib/cylc/run.py
@@ -25,10 +25,11 @@ from cylc.cfgspec.globalcfg import GLOBAL_CFG
 import flags
 from exceptions import SchedulerStop, SchedulerError
 
+
 def print_blurb():
     lines = []
-    lines.append( " The Cylc Suite Engine [" + CYLC_VERSION + "] " )
-    lines.append( " Copyright (C) 2008-2015 NIWA " )
+    lines.append(" The Cylc Suite Engine [" + CYLC_VERSION + "] ")
+    lines.append(" Copyright (C) 2008-2015 NIWA ")
 
     lic = """
  This program comes with ABSOLUTELY NO WARRANTY.  It is free software;
@@ -43,8 +44,9 @@ def print_blurb():
 
     print '*' * (mx + 2)
     for line in lines:
-        print '*' + line.center( mx ) + '*'
+        print '*' + line.center(mx) + '*'
     print '*' * (mx + 2)
+
 
 def main(name, start):
 
@@ -66,16 +68,14 @@ def main(name, start):
 
     # Daemonize the suite
     if not server.options.no_detach and not flags.debug:
-        daemonize( server.suite, server.port )
+        daemonize(server.suite, server.port)
 
     try:
         server.configure()
         server.run()
-        #   For profiling:
-        #import cProfile
-        #cProfile.run( 'server.run()', 'fooprof' )
-        #   and see Python docs "The Python Profilers"
-        #   for how to display the resulting stats.
+        # For profiling (see Python docs for how to display the stats).
+        # import cProfile
+        # cProfile.run('server.run()', 'fooprof')
     except SchedulerStop, x:
         # deliberate stop
         print str(x)
@@ -95,12 +95,12 @@ def main(name, start):
             traceback.print_exc(y)
             sys.exit(1)
 
-    except (KeyboardInterrupt,Exception) as x:
+    except (KeyboardInterrupt, Exception) as x:
         import traceback
         traceback.print_exc(x)
         print >> sys.stderr, "ERROR CAUGHT: cleaning up before exit"
         try:
-            server.shutdown( 'ERROR: ' + str(x) )
+            server.shutdown('ERROR: ' + str(x))
         except Exception, y:
             # In case of exceptions in the shutdown method itself
             traceback.print_exc(y)

--- a/tests/restart/21-deleted-logs.t
+++ b/tests/restart/21-deleted-logs.t
@@ -30,6 +30,11 @@ TEST_NAME=$TEST_NAME_BASE-run
 suite_run_ok $TEST_NAME cylc run --debug $SUITE_NAME
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-restart
+if [[ -z $SUITE_NAME ]]; then
+    # For safety, abort before attempting log tree removal.
+    echo "ERROR: \$SUITE_NAME does not exist" >&2
+    exit 1
+fi
 rm -r $(cylc get-global-config --print-run-dir)/$SUITE_NAME/log
 suite_run_ok $TEST_NAME cylc restart --debug $SUITE_NAME
 #-------------------------------------------------------------------------------

--- a/tests/restart/21-deleted-logs.t
+++ b/tests/restart/21-deleted-logs.t
@@ -1,0 +1,36 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test restarting a suite after its log directory tree has been removed.
+# (the suite run tree should be created if necessary on restart).
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 3
+#-------------------------------------------------------------------------------
+install_suite $TEST_NAME_BASE deleted-logs
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-validate
+run_ok $TEST_NAME cylc validate $SUITE_NAME
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-run
+suite_run_ok $TEST_NAME cylc run --debug $SUITE_NAME
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-restart
+rm -r $(cylc get-global-config --print-run-dir)/$SUITE_NAME/log
+suite_run_ok $TEST_NAME cylc restart --debug $SUITE_NAME
+#-------------------------------------------------------------------------------
+purge_suite $SUITE_NAME

--- a/tests/restart/deleted-logs/suite.rc
+++ b/tests/restart/deleted-logs/suite.rc
@@ -1,0 +1,15 @@
+[cylc]
+    [[event hooks]]
+        abort on timeout = True
+        timeout = PT20S
+[scheduling]
+    [[dependencies]]
+        graph = one => two
+[runtime]
+    [[one]]
+        command scripting = """
+# Tell the suite to stop after I've finished.
+cylc stop $CYLC_SUITE_NAME
+sleep 10"""
+    [[two]]
+        command scripting = true


### PR DESCRIPTION
The suite run tree is only being created at cold-start. #1217 added a new log sub-directory (for suite definitions), so suites started with an earlier cylc version will fail to restart at 6.2.0--6.3.0 when they attempt to use the new directory.

This is a trivial fix, plus PEP8 compliance, and a new test.

@benfitzpatrick - please review.