### PR TITLE
Allow suite*.rc for syntax highlighting filenames

### DIFF
--- a/conf/cylc.lang
+++ b/conf/cylc.lang
@@ -41,7 +41,7 @@
 <language id="cylc-suite-rc" _name="cylc suite.rc" version="2.0" _section="Others">
   <metadata>
     <property name="mimetypes">jinja2</property>
-    <property name="globs">suite.rc</property>
+    <property name="globs">suite*.rc</property>
     <property name="line-comment-start">#</property>
   </metadata>
 

--- a/conf/cylc.vim
+++ b/conf/cylc.vim
@@ -11,7 +11,7 @@
 "    (without the leading "| characters):
 "
 "|augroup filetype
-"|  au! BufRead,BufnewFile *suite.rc   set filetype=cylc
+"|  au! BufRead,BufnewFile *suite*.rc   set filetype=cylc
 "|augroup END
 "
 " (the wildcard in '*suite.rc' handles temporary files generated

--- a/conf/cylc.xml
+++ b/conf/cylc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE language SYSTEM "language.dtd">
-<language name="Cylc suite.rc" section="Configuration" extensions="suite.rc" mimetype="" version="1.0" kateversion="2.0" author="" license="GPL">
+<language name="Cylc suite.rc" section="Configuration" extensions="suite*.rc" mimetype="" version="1.0" kateversion="2.0" author="" license="GPL">
 
 <!-- For use with Kate. To use it, place or symlink this file in ~/.kde/share/apps/katepart/syntax/,
  or if possible, /usr/share/kde4/apps/katepart/syntax/ -->


### PR DESCRIPTION
A common convention (at our site, anyway) is to name include files `suite-something.rc` (usually
runtime includes, specific to a particular subset of the suite). This sets `suite*.rc` to be the glob
for matching cylc suite.rc configuration files.

I haven't altered the emacs one because I couldn't find the relevant setting - I guess this is done
manually by the user.

@hjoliver, please review.