### PR TITLE
parsec: fix import module conflict in tests

### DIFF
--- a/lib/parsec/config.py
+++ b/lib/parsec/config.py
@@ -17,12 +17,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, sys, re
-from fileparse import parse, FileNotFoundError
-from util import printcfg
-from validate import validate, check_compulsory, expand, validator
-from OrderedDict import OrderedDict
-from util import replicate, itemstr
-from upgrade import UpgradeError
+from parsec.fileparse import parse, FileNotFoundError
+from parsec.util import printcfg
+from parsec.validate import validate, check_compulsory, expand, validator
+from parsec.OrderedDict import OrderedDict
+from parsec.util import replicate, itemstr
+from parsec.upgrade import UpgradeError
 import cylc.flags
 
 class ParsecError( Exception ):

--- a/lib/parsec/example/cfgspec.py
+++ b/lib/parsec/example/cfgspec.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from validate import validator as vdr
+from parsec.validate import validator as vdr
 
 """
 Legal items and validators for the parsec test config file.

--- a/lib/parsec/fileparse.py
+++ b/lib/parsec/fileparse.py
@@ -21,9 +21,9 @@ import sys
 import re
 import traceback
 
-from OrderedDict import OrderedDict
-from include import inline, IncludeFileNotFoundError
-from util import itemstr
+from parsec.OrderedDict import OrderedDict
+from parsec.include import inline, IncludeFileNotFoundError
+from parsec.util import itemstr
 import cylc.flags
 
 """

--- a/lib/parsec/tests/getcfg/bin/one-line.py
+++ b/lib/parsec/tests/getcfg/bin/one-line.py
@@ -10,9 +10,9 @@ sys.path.append( fpath + '/../../..' )
 Check that single-line config print works
 """ 
 
-from config import config
-from validate import validator as vdr
-from OrderedDict import OrderedDict
+from parsec.config import config
+from parsec.validate import validator as vdr
+from parsec.OrderedDict import OrderedDict
 
 SPEC = { 'foo' : { 'bar' : { '__MANY__' : vdr( vtype="string" ) } } }
 cfg = config( SPEC )

--- a/lib/parsec/tests/nullcfg/bin/empty.py
+++ b/lib/parsec/tests/nullcfg/bin/empty.py
@@ -10,9 +10,9 @@ sys.path.append( fpath + '/../../..' )
 An empty config file should successfully yield an empty sparse config dict.
 """ 
 
-from config import config
-from validate import validator as vdr
-from OrderedDict import OrderedDict
+from parsec.config import config
+from parsec.validate import validator as vdr
+from parsec.OrderedDict import OrderedDict
 
 SPEC = { 'title' : vdr( vtype="string" ) }
 cfg = config( SPEC )

--- a/lib/parsec/tests/nullcfg/bin/missing.py
+++ b/lib/parsec/tests/nullcfg/bin/missing.py
@@ -10,9 +10,9 @@ sys.path.append( fpath + '/../../..' )
 A missing config file should successfully yield an empty sparse config dict.
 """ 
 
-from config import config
-from validate import validator as vdr
-from OrderedDict import OrderedDict
+from parsec.config import config
+from parsec.validate import validator as vdr
+from parsec.OrderedDict import OrderedDict
 
 SPEC = { 'title' : vdr( vtype="string" ) }
 cfg = config( SPEC )

--- a/lib/parsec/tests/synonyms/lib/python/cfgspec.py
+++ b/lib/parsec/tests/synonyms/lib/python/cfgspec.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from validate import validator as vdr
+from parsec.validate import validator as vdr
 
 SPEC = {
         'boolean' : {

--- a/lib/parsec/upgrade.py
+++ b/lib/parsec/upgrade.py
@@ -22,7 +22,7 @@ if __name__ == '__main__':
     here = os.path.dirname( __file__ )
     sys.path.append( here + '/..' )
 
-from OrderedDict import OrderedDict
+from parsec.OrderedDict import OrderedDict
 import cylc.flags
 
 """Support automatic deprecation and obsoletion of parsec config items."""

--- a/lib/parsec/util.py
+++ b/lib/parsec/util.py
@@ -19,7 +19,7 @@
 import os
 import sys
 from copy import copy
-from OrderedDict import OrderedDict
+from parsec.OrderedDict import OrderedDict
 
 """
 Utility functions for printing and manipulating PARSEC NESTED DICTS.

--- a/lib/parsec/validate.py
+++ b/lib/parsec/validate.py
@@ -17,8 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys, re
-from OrderedDict import OrderedDict
-from util import m_override, un_many, itemstr
+from parsec.OrderedDict import OrderedDict
+from parsec.util import m_override, un_many, itemstr
 from copy import copy
 
 """


### PR DESCRIPTION
On some machines (distributions), the parsec tests (but not parsec itself) can fail with:
```
Traceback (most recent call last):
  File "/opt/cylc/lib/parsec/tests/getcfg/bin/one-line.py", line 13, in <module>
    from config import config
  File "/opt/cylc-master/lib/parsec/tests/getcfg/bin/../../../config.py", line 212, in <module>
    from validate import validate, check_compulsory, expand, validator
ImportError: cannot import name validate
```
This is due to a `validate.py` module shipped with the distribution.

This change makes sure that the parsec modules are imported with the 'parsec' namespace.

@hjoliver, please review.