### PR TITLE
cylc trigger --edit: fix Python 2.7 test failure.

### DIFF
--- a/bin/cylc-trigger
+++ b/bin/cylc-trigger
@@ -165,7 +165,9 @@ if options.edit_run:
     with open("%s-edit.diff" % jobfile_path, 'wb') as diff_file:
         for line in difflib.unified_diff(
                 open(jobfile_copy_path).readlines(),
-                open(jobfile_path).readlines()):
+                open(jobfile_path).readlines(),
+                fromfile="original",
+                tofile="edited"):
             diff_file.write(line)
     os.unlink(jobfile_copy_path)
 

--- a/tests/cylc-trigger/03-edit-run.t
+++ b/tests/cylc-trigger/03-edit-run.t
@@ -32,6 +32,8 @@ CYLC_CONF_PATH=$PWD/conf \
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-diff"
 DIFF_LOG=$(cylc cat-log -dl $SUITE_NAME broken-task.1)
+# Python 2.6 difflib adds an extra space after the filename,
+# but Python 2.7 does not. Remove it if it exists.
 sed -i 's/^--- original $/--- original/; s/^+++ edited $/+++ edited/' $DIFF_LOG
 cmp_ok $DIFF_LOG - <<__END__
 --- original

--- a/tests/cylc-trigger/03-edit-run.t
+++ b/tests/cylc-trigger/03-edit-run.t
@@ -32,9 +32,10 @@ CYLC_CONF_PATH=$PWD/conf \
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-diff"
 DIFF_LOG=$(cylc cat-log -dl $SUITE_NAME broken-task.1)
+sed -i 's/^--- original $/--- original/; s/^+++ edited $/+++ edited/' $DIFF_LOG
 cmp_ok $DIFF_LOG - <<__END__
----  
-+++  
+--- original
++++ edited
 @@ -128,7 +128,7 @@
  echo
  


### PR DESCRIPTION
The new test for cylc trigger --edit fails under Python 2.7 because
of a change in difflib output detailed here: https://bugs.python.org/issue7585

This change adds some dummy filenames (which aren't necessary, but are nice
to have) and strips the extra space from the Python 2.6 difflib output so that both
Python versions pass the test.

@hjoliver, please review.