### PR TITLE
Fixed an error message.

### DIFF
--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -107,7 +107,7 @@ class TaskNotDefinedError(SuiteConfigError):
     """A named task not defined."""
 
     def __str__(self):
-        return "Task not found: " + self.args[0]
+        return "Task not defined: %s" % self.msg
 
 # TODO: separate config for run and non-run purposes?
 


### PR DESCRIPTION
This just fixes a bug in the "task not defined" error message, which if triggered results in a traceback instead of the intended error message.  It looks like it might have originated in a cut-n-paste error, although I haven't checked.

@arjclark - please review.