### PR TITLE
global.rc: remote shell template is now a prefix

### DIFF
--- a/doc/siterc.tex
+++ b/doc/siterc.tex
@@ -463,14 +463,15 @@ on the suite host unless you run local tasks under another user account.
 
 \paragraph[remote shell template]{[hosts] $\rightarrow$ HOST $\rightarrow$ remote shell template }
 
-A string template, containing \lstinline@\%s@ as a placeholder for the host name,
-for the command used to invoke commands on this host.
+A string for the command used to invoke commands on this host.
 This is not used on the suite host unless you run local tasks under
-another user account.
+another user account. (N.B. This setting used to be a string template with a \%s
+being a placeholder for the name of the host. This is no longer the case. Any
+\%s in the string will now be discarded.)
 
 \begin{myitemize}
 \item {\em type:} string
-\item {\em localhost default:} \lstinline@ssh -oBatchMode=yes -oConnectTimeout=10 \%s@
+\item {\em localhost default:} \lstinline@ssh -oBatchMode=yes -oConnectTimeout=10@
 \end{myitemize}
 
 \paragraph[use login shell]{[hosts] $\rightarrow$ HOST $\rightarrow$ use login shell }

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -104,7 +104,7 @@ SPEC = {
             'work directory'              : vdr( vtype='string', default="$HOME/cylc-run" ),
             'task communication method'   : vdr( vtype='string', options=[ "pyro", "ssh", "poll"], default="pyro" ),
             'remote copy template'        : vdr( vtype='string', default='scp -oBatchMode=yes -oConnectTimeout=10' ),
-            'remote shell template'       : vdr( vtype='string', default='ssh -oBatchMode=yes -oConnectTimeout=10 %s' ),
+            'remote shell template'       : vdr( vtype='string', default='ssh -oBatchMode=yes -oConnectTimeout=10' ),
             'use login shell'             : vdr( vtype='boolean', default=True ),
             'cylc executable'             : vdr( vtype='string', default='cylc'  ),
             'global initial scripting'    : vdr( vtype='string', default='' ),

--- a/lib/cylc/job_host.py
+++ b/lib/cylc/job_host.py
@@ -73,11 +73,12 @@ class RemoteJobHostManager(object):
             user_at_host, r_suite_run_dir))
 
         ssh_tmpl = GLOBAL_CFG.get_host_item(
-            'remote shell template', host, owner)
+            'remote shell template', host, owner).replace(" %s", "")
         scp_tmpl = GLOBAL_CFG.get_host_item(
             'remote copy template', host, owner)
 
-        cmd1 = shlex.split(ssh_tmpl % user_at_host) + [
+        cmd1 = shlex.split(ssh_tmpl) + [
+            user_at_host,
             'mkdir -p "%s" "%s"' % (r_suite_run_dir, r_log_job_dir)]
         cmd2 = shlex.split(scp_tmpl) + ["-r"] + sources + [
             user_at_host + ":" + r_suite_run_dir + "/"]

--- a/lib/cylc/remote.py
+++ b/lib/cylc/remote.py
@@ -101,9 +101,8 @@ class remrun(object):
 
         # ssh command and options (X forwarding)
         ssh_tmpl = str(GLOBAL_CFG.get_host_item(
-            "remote shell template", self.host, self.owner))
-        ssh_tmpl = ssh_tmpl.replace("%s", "-Y %s")
-        command = shlex.split(ssh_tmpl % user_at_host)
+            "remote shell template", self.host, self.owner)).replace(" %s", "")
+        command = shlex.split(ssh_tmpl) + ["-Y", user_at_host]
 
         # Use bash -l?
         ssh_login_shell = self.ssh_login_shell

--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -1524,7 +1524,9 @@ class TaskProxy(object):
             cmd = ["cylc", cmd_key] + list(args)
         else:  # if it is a remote job
             ssh_tmpl = GLOBAL_CFG.get_host_item(
-                'remote shell template', self.task_host, self.task_owner)
+                'remote shell template',
+                self.task_host,
+                self.task_owner).replace(" %s", "")
             r_cylc = GLOBAL_CFG.get_host_item(
                 'cylc executable', self.task_host, self.task_owner)
             sh_tmpl = "CYLC_VERSION='%s' "
@@ -1538,7 +1540,7 @@ class TaskProxy(object):
                 sh_cmd += " --remote-mode"
             for arg in args:
                 sh_cmd += ' "%s"' % (arg)
-            cmd = shlex.split(ssh_tmpl % str(self.user_at_host)) + [sh_cmd]
+            cmd = shlex.split(ssh_tmpl) + [str(self.user_at_host), sh_cmd]
 
         # Queue the command for execution
         self.log(INFO, "initiate %s" % (cmd_key))


### PR DESCRIPTION
This should make it more consistent with the `remote copy template`
setting.