### PR TITLE
Fix restart crash if remote job host unavailable

### DIFF
--- a/bin/cylc-restart
+++ b/bin/cylc-restart
@@ -463,7 +463,10 @@ determine what happened to them while the suite was down."""
                     itask.try_number = try_num
                     itask.user_at_host = user_at_host
                     # poll the task
-                    itask.poll()
+                    try:
+                        itask.poll()
+                    except Exception as exc:
+                        print >>sys.stderr, "WARNING: %s: poll failed" % id
                     # update poll timers in case regular polling is configured for itask
                     if '@' in user_at_host:
                         owner, host = user_at_host.split('@')

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from cylc_pyro_server import pyro_server
-from cylc.job_host import RemoteJobHostManager
+from cylc.job_host import RemoteJobHostManager, RemoteJobHostInitError
 from cylc.task_proxy import TaskProxy
 from cylc.job_file import JOB_FILE
 from cylc.suite_host import get_suite_host
@@ -286,8 +286,11 @@ class scheduler(object):
 
         # 2) restart only: copy to other accounts with still-running tasks
         for user_at_host in self.old_user_at_host_set:
-            RemoteJobHostManager.get_inst().init_suite_run_dir(
-                self.suite, user_at_host)
+            try:
+                RemoteJobHostManager.get_inst().init_suite_run_dir(
+                    self.suite, user_at_host)
+            except RemoteJobHostInitError as exc:
+                self.log.warning(str(exc))
 
         self.already_timed_out = False
         if self.config.cfg['cylc']['event hooks']['timeout']:

--- a/tests/restart/22-bad-job-host.t
+++ b/tests/restart/22-bad-job-host.t
@@ -1,0 +1,46 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test restarting a suite when the host of a submitted or running job is not
+# available. https://github.com/cylc/cylc/issues/1327
+. "$(dirname "$0")/test_header"
+export CYLC_TEST_HOST=$(cylc get-global-config -i '[test battery]remote host')
+if [[ -z "${CYLC_TEST_HOST}" ]]; then
+    skip_all '[test battery]remote host: not defined'
+fi
+set_test_number 3
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+ssh ${SSH_OPTS} "${CYLC_TEST_HOST}" \
+    "mkdir -p '.cylc/${SUITE_NAME}/' && cat >'.cylc/${SUITE_NAME}/passphrase'" \
+    <"${TEST_DIR}/${SUITE_NAME}/passphrase"
+#-------------------------------------------------------------------------------
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+suite_run_ok "${TEST_NAME_BASE}-run" cylc run --debug "${SUITE_NAME}"
+# Modify DB with garbage host
+CYLC_SUITE_RUN_DIR="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}"
+for DB_NAME in 'cylc-suite.db' 'state/cylc-suite.db'; do
+    sqlite3 "${CYLC_SUITE_RUN_DIR}/${DB_NAME}" \
+        'UPDATE task_states SET host="garbage" WHERE name=="t-remote";
+         UPDATE task_events SET misc="garbage"
+             WHERE name=="t-remote" AND event=="submission succeeded";'
+done
+suite_run_ok "${TEST_NAME_BASE}-restart" cylc restart --debug "${SUITE_NAME}"
+#-------------------------------------------------------------------------------
+ssh ${SSH_OPTS} $CYLC_TEST_HOST \
+    "rm -rf .cylc/$SUITE_NAME cylc-run/$SUITE_NAME"
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/restart/22-bad-job-host/suite.rc
+++ b/tests/restart/22-bad-job-host/suite.rc
@@ -1,0 +1,36 @@
+#!jinja2
+[scheduling]
+    [[dependencies]]
+            graph = """
+t-remote:start => t-shutdown
+t-shutdown => t-remote-2
+t-shutdown => t-check-log
+"""
+[runtime]
+    [[t-remote]]
+        command scripting = """
+# Hang the task on a remote host for up to 30 seconds
+touch 'file'
+timeout 30 bash -c 'while [[ -e 'file' ]]; do sleep 1; done' || true
+"""
+        [[[remote]]]
+            host = {{environ['CYLC_TEST_HOST']}}
+        [[[job submission]]]
+            method = at
+    [[t-shutdown]]
+        command scripting = """
+# Shutdown and wait
+cylc shutdown --now --max-polls=10 --interval=1 "${CYLC_SUITE_NAME}"
+"""
+    [[t-remote-2]]
+        command scripting = """
+# Release t-remote-1
+rm -f "${CYLC_SUITE_WORK_DIR}/${CYLC_TASK_CYCLE_POINT}/t-remote/file"
+"""
+        [[[remote]]]
+            host = {{environ['CYLC_TEST_HOST']}}
+    [[t-check-log]]
+        command scripting = """
+grep -q 'WARNING - garbage: initialisation did not complete' \
+    "${CYLC_SUITE_LOG_DIR}/log"
+"""


### PR DESCRIPTION
On restart, the suite attempts to re-initialise the suite run directory
on remote hosts with submitted or running jobs. The suite is currently
unable to restart if any of these remote hosts is unavailable. This
change allows the suite to restart with a warning message written to the
log.

Fix #1327.