### PR TITLE
#1356: fix cylc gpanel cylc version path hardcoding.

### DIFF
--- a/bin/cylc-gpanel
+++ b/bin/cylc-gpanel
@@ -63,6 +63,12 @@ warnings.filterwarnings('ignore', 'use the new', Warning)
 import cylc.gui
 
 cylc_dir = os.path.dirname(os.path.dirname(os.path.realpath(os.path.abspath(__file__))))
+if os.path.basename(cylc_dir).startswith("cylc-"):
+    # If using the wrapper, reference 'cylc' rather than 'cylc-6.3.1'.
+    cylc_alt_dir = os.path.join(os.path.dirname(cylc_dir), "cylc")
+    if os.path.realpath(cylc_alt_dir) == os.path.realpath(cylc_dir):
+        cylc_dir = cylc_alt_dir
+
 if cylc_dir != os.getenv('CYLC_DIR', ''):
     os.environ['CYLC_DIR'] = cylc_dir
 


### PR DESCRIPTION
This fixes the hardcoding of e.g. `/some/path/to/cylc-6.3.1` in the bonobo server
files for cylc gpanel. When using the wrapper script (`/some/path/to/cylc` is a
symlink to `/some/path/to/cylc-6.3.1`), use the 'cylc' symlink if it evaluates the
same.

Fix #1356.

@matthewrmshin, please review.