### PR TITLE
cylc gsummary: larger default window size

### DIFF
--- a/lib/cylc/gui/gsummary.py
+++ b/lib/cylc/gui/gsummary.py
@@ -447,7 +447,7 @@ class SummaryApp(object):
         self.updater.start()
         self.window.add(self.vbox)
         self.window.connect("destroy", self._on_destroy_event)
-        self.window.set_default_size(200, 100)
+        self.window.set_default_size(300, 150)
         self.suite_treeview.grab_focus()
         self.window.show()
 


### PR DESCRIPTION
This makes the `cylc gsummary` window slightly larger by default.
It was arguably over-small and cut off the `y` in our setup here.