### PR TITLE
Update state dump more often.

### DIFF
--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -906,8 +906,6 @@ class scheduler(object):
                 self.pool.remove_spent_tasks()
                 self.pool.remove_suiciding_tasks()
 
-                self.state_dumper.dump()
-
                 self.do_update_state_summary = True
 
                 self.pool.wireless.expire( self.pool.get_min_point() )
@@ -929,6 +927,7 @@ class scheduler(object):
                 flags.iflag = False
                 self.do_update_state_summary = False
                 self.update_state_summary()
+                self.state_dumper.dump()
 
             if self.config.cfg['cylc']['event hooks']['timeout']:
                 self.check_suite_timer()

--- a/tests/cylc-cat-state/01-issue1358.t
+++ b/tests/cylc-cat-state/01-issue1358.t
@@ -26,7 +26,6 @@ install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 TEST_NAME=$TEST_NAME_BASE-validate
 run_ok $TEST_NAME cylc validate $SUITE_NAME
 #-------------------------------------------------------------------------------
-set -x
 # Run suite.
 cylc run $SUITE_NAME
 # Wait for task foo to fail.

--- a/tests/cylc-cat-state/01-issue1358.t
+++ b/tests/cylc-cat-state/01-issue1358.t
@@ -1,0 +1,49 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test the state dump gets updated if a task is removed when nothing else is
+# happening (github #1358).
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 2
+#-------------------------------------------------------------------------------
+install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-validate
+run_ok $TEST_NAME cylc validate $SUITE_NAME
+#-------------------------------------------------------------------------------
+set -x
+# Run suite.
+cylc run $SUITE_NAME
+# Wait for task foo to fail.
+cylc suite-state $SUITE_NAME --task=foo --cycle=1 \
+    --status=failed --max-polls=10 --interval=2
+# Remove it.
+cylc remove $SUITE_NAME foo 1
+# (wait till foo is removed)
+sleep 5
+# Record the state dump.
+cylc cat-state -d $SUITE_NAME > state.out
+# Stop the suite.
+cylc stop $SUITE_NAME
+# Do the test.
+cmp_ok state.out << __DONE__
+bar, 1, waiting, spawned
+baz, 1, waiting, spawned
+__DONE__
+#-------------------------------------------------------------------------------
+purge_suite $SUITE_NAME

--- a/tests/cylc-cat-state/01-issue1358/suite.rc
+++ b/tests/cylc-cat-state/01-issue1358/suite.rc
@@ -1,0 +1,11 @@
+[cylc]
+    [[event hooks]]
+        timeout = PT1M
+        abort on timeout = True
+[scheduling]
+    [[dependencies]]
+        graph = foo => bar & baz
+[runtime]
+    [[bar, baz]]
+    [[foo]]
+        command scripting = /bin/false


### PR DESCRIPTION
Fix #1358.  Removing a task when nothing else is happening did not result in the state dump being updated.