### PR TITLE
Fix and tidy the show command.

### DIFF
--- a/bin/cylc-show
+++ b/bin/cylc-show
@@ -50,8 +50,8 @@ try:
     if len(args) == 1:
         # Print suite info.
         suite_info = proxy.get('suite info')
-        for key, value in suite_info.items():
-            print key + ':', value
+        for key, value in sorted(suite_info.items(), reverse=True):
+            print '%s: %s' % (key,value or "(not given)")
         sys.exit(0)
 
     point_string = None
@@ -68,8 +68,8 @@ try:
     info = proxy.get('task info', name)
     if not info:
         sys.exit("ERROR: task not found: %s" % name)
-    for key, value in info.items():
-        print key + ':', value
+    for key, value in sorted(info.items(), reverse=True):
+        print "%s: %s" % (key, value or "(not given)")
 
     if point_string is not None:
         result = proxy.get('task requisites', name, point_string)

--- a/bin/cylc-show
+++ b/bin/cylc-show
@@ -18,7 +18,7 @@
 
 import sys
 if '--use-ssh' in sys.argv[1:]:
-    sys.argv.remove( '--use-ssh' )
+    sys.argv.remove('--use-ssh')
     from cylc.remote import remrun
     if remrun().execute():
         sys.exit(0)
@@ -29,116 +29,83 @@ from cylc.task_id import TaskID
 from cylc.command_prep import prep_pyro
 import cylc.flags
 
-parser = cop( """cylc [info] show [OPTIONS] ARGS
+parser = cop(
+    """cylc [info] show [OPTIONS] ARGS
 
-Interrogate a running suite for its title and task list, task
-descriptions, current state of task prerequisites and outputs and, for
-clock-triggered tasks, whether or not the trigger time is up yet.""",
+Interrogate a suite daemon for the suite title and description; or for the
+title and description of one of its tasks; or for the current state of the
+prerequisites, outputs, and clock-triggering of a specific task instance.""",
     pyro=True, noforce=True,
     argdoc=[('REG', 'Suite name'),
             ('[' + TaskID.SYNTAX_OPT_POINT + ']', 'Task name or ID')])
 
 (options, args) = parser.parse_args()
-
-suite, pphrase = prep_pyro( args[0], options ).execute()
-
-prnt_suite = False
-prnt_name = False
-prnt_id = False
-
-if len(args) == 2:
-    target = args[1]
-    try:
-        name, point_string = TaskID.split(target)
-    except ValueError:
-        # just a task name
-        prnt_name = True
-        name = target
-    else:
-        # task ID
-        prnt_id = True
-        task_id = target
-else:
-    prnt_suite = True
+suite, pphrase = prep_pyro(args[0], options).execute()
 
 try:
-    proxy = cylc_pyro_client.client( suite, pphrase, options.owner,
-            options.host, options.pyro_timeout,
-            options.port ).get_proxy( 'suite-info' )
-    title, username = proxy.get( 'suite info' )
-except Exception, x:
+    proxy = cylc_pyro_client.client(
+        suite, pphrase, options.owner, options.host, options.pyro_timeout,
+        options.port).get_proxy('suite-info')
+
+    if len(args) == 1:
+        # Print suite info.
+        suite_info = proxy.get('suite info')
+        for key, value in suite_info.items():
+            print key + ':', value
+        sys.exit(0)
+
+    point_string = None
+    arg = args[1]
+    try:
+        name, point_string = TaskID.split(arg)
+    except ValueError:
+        # Print task info.
+        name = arg
+    else:
+        # Print task instance info.
+        task_id = arg
+
+    info = proxy.get('task info', name)
+    if not info:
+        sys.exit("ERROR: task not found: %s" % name)
+    for key, value in info.items():
+        print key + ':', value
+
+    if point_string is not None:
+        result = proxy.get('task requisites', name, point_string)
+        if not result:
+            sys.exit("ERROR: task instance not found: %s" % task_id)
+
+        for task_id in result.keys():
+            [pre, out, extra_info] = result[task_id]
+
+            print '\nprerequisites (- => not satisfied):'
+            if len(pre) == 0:
+                print '  (None)'
+            for item in sorted(pre):
+                [msg, state] = item
+                if state:
+                    descr = '  + '
+                else:
+                    descr = '  - '
+                print descr + msg
+
+            print '\noutputs (- => not completed):'
+            if len(out) == 0:
+                print '  (None)'
+            for item in sorted(out):
+                [msg, state] = item
+                if state:
+                    descr = '  + '
+                else:
+                    descr = '  - '
+                print descr + msg
+
+            if len(extra_info.keys()) > 0:
+                print '\nother:'
+                for item in extra_info:
+                    print '  o ', item, '...', extra_info[item]
+except Exception as exc:
     if cylc.flags.debug:
         raise
-    sys.exit(x)
-
-if prnt_suite:
-    print suite + ' (' + options.owner + ')'
-    print title
-
-    try:
-        for task in proxy.get( 'task list' ):
-            print ' + ', task
-    except Exception,x:
-        if cylc.flags.debug:
-            raise
-        sys.exit(x)
-
-if prnt_name or prnt_id:
-    try:
-        info = proxy.get( 'task info', [ name ] )
-    except Exception,x:
-        if cylc.flags.debug:
-            raise
-        sys.exit(x)
-    idx = name
-    if prnt_id:
-        idx = task_id
-    print 'TASK ' + idx + ' in suite ' + suite + ':'
-    for name in info.keys():
-        print ' ', info[name]
-
-if prnt_id:
-    # PREREQUISITES AND OUTPUTS
-    try:
-        result = proxy.get( 'task requisites', [ task_id ] )
-    except Exception,x:
-        if cylc.flags.debug:
-            raise
-        sys.exit(x)
-
-    if not result or task_id not in result:
-        print "Task " + task_id + " not found in " + suite
-        sys.exit(1)
-
-    for task_id in result.keys():
-        [ pre, out, extra_info ] = result[ task_id ]
-
-        print 'PREREQUISITES (- => not satisfied):'
-        if len( pre ) == 0:
-            print '  (None)'
-        for item in sorted(pre):
-            [ msg, state ] = item
-            if state:
-                descr = '  + '
-            else:
-                descr = '  - '
-            print descr + msg
-
-        print 'OUTPUTS (- => not completed):'
-        if len( out ) == 0:
-            print '  (None)'
-        for item in sorted(out):
-            [ msg, state ] = item
-            if state:
-                descr = '  + '
-            else:
-                descr = '  - '
-            print descr + msg
-
-        if len( extra_info.keys() ) > 0:
-            print 'Other:'
-            for item in extra_info:
-                print '  o ', item, '...', extra_info[ item ]
-        print """
-NOTE: for tasks that have triggered already, prerequisites are
-shown here in the state they were in at the time of triggering."""
+    sys.exit(exc)

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -2004,5 +2004,5 @@ class config( object ):
         return TaskProxy(tdef, *args, **kwargs)
 
     def describe(self, name):
-        """Return a string that describe the named task."""
+        """Return title and description of the named task."""
         return self.taskdefs[name].describe()

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -353,16 +353,16 @@ class scheduler(object):
         return self.pool.get_task_jobfile_path(task_id)
 
     def info_get_suite_info( self ):
-        return [ self.config.cfg['title'], user ]
-
-    def info_get_task_info( self, task_names ):
         info = {}
-        for name in task_names:
-            if self._task_type_exists( name ):
-                info[ name ] = self.config.describe(name)
-            else:
-                info[ name ] = ['ERROR: no such task type']
+        for item in 'title', 'description':
+            info[item] = self.config.cfg[item]
         return info
+
+    def info_get_task_info(self, name):
+        try:
+            return self.config.describe(name)
+        except KeyError:
+            return {}
 
     def info_get_all_families( self, exclude_root=False ):
         fams = self.config.get_first_parent_descendants().keys()
@@ -389,13 +389,10 @@ class scheduler(object):
                         self.config.suite_polling_tasks, \
                         self.config.leaves, self.config.feet
 
-    def info_get_task_requisites( self, in_ids ):
-        ids = []
-        for id in in_ids:
-            if not self._task_type_exists( id ):
-                continue
-            ids.append( id )
-        return self.pool.get_task_requisites( ids )
+    def info_get_task_requisites(self, name, point_string):
+        point_string = standardise_point_string(point_string)
+        return self.pool.get_task_requisites(
+            TaskID.get(name, point_string))
 
     def command_set_stop_cleanly(self, kill_active_tasks=False):
         """Stop job submission and set the flag for clean shutdown."""

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -1035,12 +1035,12 @@ class TaskPool(object):
         else:
             return True, jobfile_path
 
-    def get_task_requisites(self, ids):
+    def get_task_requisites(self, taskid):
         info = {}
         found = False
         for itask in self.get_tasks():
             id_ = itask.identity
-            if id_ in ids:
+            if id_ == taskid:
                 found = True
                 extra_info = {}
                 # extra info for clocktriggered tasks

--- a/lib/cylc/taskdef.py
+++ b/lib/cylc/taskdef.py
@@ -96,8 +96,11 @@ class TaskDef(object):
                 self.implicit_sequences.append(sequence)
 
     def describe(self):
-        """Return a string that describes the current task."""
-        return "%(title)s\n%(description)s" % self.rtconfig
+        """Return title and description of the current task."""
+        info = {}
+        for item in 'title', 'description':
+            info[item] = self.rtconfig[item]
+        return info
 
     def check_for_explicit_cycling(self):
         """Check for explicitly somewhere.

--- a/tests/cylc-show/00-simple.t
+++ b/tests/cylc-show/00-simple.t
@@ -34,8 +34,12 @@ suite_run_ok $TEST_NAME cylc run --reference-test --debug \
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-show
 cmp_ok $TEST_NAME.stdout <<__SHOW_OUTPUT__
-title: (not given)
-description: (not given)
+title: a test suite
+description: the quick brown fox
+title: a task
+description: jumped over the lazy dog
+title: a task
+description: jumped over the lazy dog
 
 prerequisites (- => not satisfied):
   - show.20141106T0900Z succeeded

--- a/tests/cylc-show/00-simple.t
+++ b/tests/cylc-show/00-simple.t
@@ -34,18 +34,16 @@ suite_run_ok $TEST_NAME cylc run --reference-test --debug \
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-show
 cmp_ok $TEST_NAME.stdout <<__SHOW_OUTPUT__
-TASK foo.20141106T0900Z in suite $SUITE_NAME:
-  
+title: (not given)
+description: (not given)
 
-PREREQUISITES (- => not satisfied):
+prerequisites (- => not satisfied):
   - show.20141106T0900Z succeeded
-OUTPUTS (- => not completed):
+
+outputs (- => not completed):
   - foo.20141106T0900Z started
   - foo.20141106T0900Z submitted
   - foo.20141106T0900Z succeeded
-
-NOTE: for tasks that have triggered already, prerequisites are
-shown here in the state they were in at the time of triggering.
 __SHOW_OUTPUT__
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/cylc-show/01-clock-triggered.t
+++ b/tests/cylc-show/01-clock-triggered.t
@@ -34,21 +34,20 @@ suite_run_ok $TEST_NAME cylc run --reference-test --debug \
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-show
 cmp_ok $TEST_NAME.stdout <<__SHOW_OUTPUT__
-TASK foo.20141106T0900Z in suite $SUITE_NAME:
-  
+title: (not given)
+description: (not given)
 
-PREREQUISITES (- => not satisfied):
+prerequisites (- => not satisfied):
   - show.20141106T0900Z succeeded
-OUTPUTS (- => not completed):
+
+outputs (- => not completed):
   - foo.20141106T0900Z started
   - foo.20141106T0900Z submitted
   - foo.20141106T0900Z succeeded
-Other:
+
+other:
   o  Clock trigger time reached ... True
   o  Triggers at ... 2014-11-06T09:05:00Z
-
-NOTE: for tasks that have triggered already, prerequisites are
-shown here in the state they were in at the time of triggering.
 __SHOW_OUTPUT__
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/cylc-show/02-clock-triggered-alt-tz.t
+++ b/tests/cylc-show/02-clock-triggered-alt-tz.t
@@ -34,21 +34,20 @@ suite_run_ok $TEST_NAME cylc run --reference-test --debug \
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-show
 cmp_ok $TEST_NAME.stdout <<__SHOW_OUTPUT__
-TASK foo.20140808T0900Z in suite $SUITE_NAME:
-  
+title: (not given)
+description: (not given)
 
-PREREQUISITES (- => not satisfied):
+prerequisites (- => not satisfied):
   - show.20140808T0900Z succeeded
-OUTPUTS (- => not completed):
+
+outputs (- => not completed):
   - foo.20140808T0900Z started
   - foo.20140808T0900Z submitted
   - foo.20140808T0900Z succeeded
-Other:
+
+other:
   o  Clock trigger time reached ... True
   o  Triggers at ... 2014-08-08T09:05:00Z
-
-NOTE: for tasks that have triggered already, prerequisites are
-shown here in the state they were in at the time of triggering.
 __SHOW_OUTPUT__
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/cylc-show/03-clock-triggered-non-utc-mode.t
+++ b/tests/cylc-show/03-clock-triggered-non-utc-mode.t
@@ -46,21 +46,20 @@ suite_run_ok $TEST_NAME cylc run --reference-test --debug \
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-show
 cmp_ok $TEST_NAME.stdout <<__SHOW_OUTPUT__
-TASK foo.20140808T0900$TZ_OFFSET_BASIC in suite $SUITE_NAME:
-  
+title: (not given)
+description: (not given)
 
-PREREQUISITES (- => not satisfied):
+prerequisites (- => not satisfied):
   - show.20140808T0900$TZ_OFFSET_BASIC succeeded
-OUTPUTS (- => not completed):
+
+outputs (- => not completed):
   - foo.20140808T0900$TZ_OFFSET_BASIC started
   - foo.20140808T0900$TZ_OFFSET_BASIC submitted
   - foo.20140808T0900$TZ_OFFSET_BASIC succeeded
-Other:
+
+other:
   o  Clock trigger time reached ... True
   o  Triggers at ... 2014-08-08T09:05:00$TZ_OFFSET_EXTENDED
-
-NOTE: for tasks that have triggered already, prerequisites are
-shown here in the state they were in at the time of triggering.
 __SHOW_OUTPUT__
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/cylc-show/simple/suite.rc
+++ b/tests/cylc-show/simple/suite.rc
@@ -1,4 +1,6 @@
 #!jinja2
+title = a test suite
+description = the quick brown fox
 [cylc]
     UTC mode = True
 [scheduling]
@@ -13,10 +15,17 @@
             """
 [runtime]
     [[foo]]
+        title = a task
+        description = jumped over the lazy dog
         command scripting = sleep 10
     [[bar,baz]]
         command scripting = true
     [[show]]
         command scripting = """
-cylc show "$CYLC_SUITE_NAME" foo.20141106T0900Z >{{ TEST_OUTPUT_PATH }}
+# suite info
+cylc show "$CYLC_SUITE_NAME" >{{ TEST_OUTPUT_PATH }}
+# task info
+cylc show "$CYLC_SUITE_NAME" foo >>{{ TEST_OUTPUT_PATH }}
+# task instance info
+cylc show "$CYLC_SUITE_NAME" foo.20141106T0900Z >>{{ TEST_OUTPUT_PATH }}
 """

--- a/tests/graph-equivalence/00-oneline.t
+++ b/tests/graph-equivalence/00-oneline.t
@@ -32,15 +32,15 @@ suite_run_ok $TEST_NAME cylc run --reference-test --debug $SUITE_NAME
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-check-a
 cylc run $SUITE_NAME --hold
-cylc show $SUITE_NAME a.1 | sed -n "/PREREQUISITES/,/OUTPUTS/p" > a-prereqs
+cylc show $SUITE_NAME a.1 | sed -n "/prerequisites/,/outputs/p" > a-prereqs
 cmp_ok $TEST_SOURCE_DIR/splitline_refs/a-ref a-prereqs
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-check-b
-cylc show $SUITE_NAME b.1 | sed -n "/PREREQUISITES/,/OUTPUTS/p" > b-prereqs
+cylc show $SUITE_NAME b.1 | sed -n "/prerequisites/,/outputs/p" > b-prereqs
 cmp_ok $TEST_SOURCE_DIR/splitline_refs/b-ref b-prereqs
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-check-c
-cylc show $SUITE_NAME c.1 | sed -n "/PREREQUISITES/,/OUTPUTS/p" > c-prereqs
+cylc show $SUITE_NAME c.1 | sed -n "/prerequisites/,/outputs/p" > c-prereqs
 cmp_ok $TEST_SOURCE_DIR/splitline_refs/c-ref c-prereqs
 #-------------------------------------------------------------------------------
 cylc shutdown $SUITE_NAME --now -f

--- a/tests/graph-equivalence/01-twolines.t
+++ b/tests/graph-equivalence/01-twolines.t
@@ -32,15 +32,15 @@ suite_run_ok $TEST_NAME cylc run --reference-test --debug $SUITE_NAME
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-check-a
 cylc run $SUITE_NAME --hold
-cylc show $SUITE_NAME a.1 | sed -n "/PREREQUISITES/,/OUTPUTS/p" > a-prereqs
+cylc show $SUITE_NAME a.1 | sed -n "/prerequisites/,/outputs/p" > a-prereqs
 cmp_ok $TEST_SOURCE_DIR/splitline_refs/a-ref a-prereqs
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-check-b
-cylc show $SUITE_NAME b.1 | sed -n "/PREREQUISITES/,/OUTPUTS/p" > b-prereqs
+cylc show $SUITE_NAME b.1 | sed -n "/prerequisites/,/outputs/p" > b-prereqs
 cmp_ok $TEST_SOURCE_DIR/splitline_refs/b-ref b-prereqs
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-check-c
-cylc show $SUITE_NAME c.1 | sed -n "/PREREQUISITES/,/OUTPUTS/p" > c-prereqs
+cylc show $SUITE_NAME c.1 | sed -n "/prerequisites/,/outputs/p" > c-prereqs
 cmp_ok $TEST_SOURCE_DIR/splitline_refs/c-ref c-prereqs
 #-------------------------------------------------------------------------------
 cylc shutdown $SUITE_NAME --now -f

--- a/tests/graph-equivalence/02-splitline.t
+++ b/tests/graph-equivalence/02-splitline.t
@@ -33,15 +33,15 @@ suite_run_ok $TEST_NAME cylc run --reference-test --debug $SUITE_NAME
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-check-a
 cylc run $SUITE_NAME --hold
-cylc show $SUITE_NAME a.1 | sed -n "/PREREQUISITES/,/OUTPUTS/p" > a-prereqs
+cylc show $SUITE_NAME a.1 | sed -n "/prerequisites/,/outputs/p" > a-prereqs
 cmp_ok $TEST_SOURCE_DIR/splitline_refs/a-ref a-prereqs
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-check-b
-cylc show $SUITE_NAME b.1 | sed -n "/PREREQUISITES/,/OUTPUTS/p" > b-prereqs
+cylc show $SUITE_NAME b.1 | sed -n "/prerequisites/,/outputs/p" > b-prereqs
 cmp_ok $TEST_SOURCE_DIR/splitline_refs/b-ref b-prereqs
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-check-c
-cylc show $SUITE_NAME c.1 | sed -n "/PREREQUISITES/,/OUTPUTS/p" > c-prereqs
+cylc show $SUITE_NAME c.1 | sed -n "/prerequisites/,/outputs/p" > c-prereqs
 cmp_ok $TEST_SOURCE_DIR/splitline_refs/c-ref c-prereqs
 #-------------------------------------------------------------------------------
 cylc shutdown $SUITE_NAME --now -f

--- a/tests/graph-equivalence/03-multiline_and1.t
+++ b/tests/graph-equivalence/03-multiline_and1.t
@@ -33,7 +33,7 @@ suite_run_ok $TEST_NAME cylc run --reference-test --debug $SUITE_NAME
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-check-c
 cylc run $SUITE_NAME --hold
-cylc show $SUITE_NAME c.1 | sed -n "/PREREQUISITES/,/OUTPUTS/p" > c-prereqs
+cylc show $SUITE_NAME c.1 | sed -n "/prerequisites/,/outputs/p" > c-prereqs
 cmp_ok $TEST_SOURCE_DIR/multiline_and_refs/c-ref c-prereqs
 cylc shutdown $SUITE_NAME --now -f
 #-------------------------------------------------------------------------------

--- a/tests/graph-equivalence/04-multiline_and2.t
+++ b/tests/graph-equivalence/04-multiline_and2.t
@@ -34,7 +34,7 @@ suite_run_ok $TEST_NAME cylc run --reference-test --debug $SUITE_NAME
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-check-c
 cylc run $SUITE_NAME --hold
-cylc show $SUITE_NAME c.1 | sed -n "/PREREQUISITES/,/OUTPUTS/p" > c-prereqs
+cylc show $SUITE_NAME c.1 | sed -n "/prerequisites/,/outputs/p" > c-prereqs
 cmp_ok $TEST_SOURCE_DIR/multiline_and_refs/c-ref c-prereqs
 cylc shutdown $SUITE_NAME --now -f
 #-------------------------------------------------------------------------------

--- a/tests/graph-equivalence/multiline_and_refs/c-ref
+++ b/tests/graph-equivalence/multiline_and_refs/c-ref
@@ -1,4 +1,5 @@
-PREREQUISITES (- => not satisfied):
+prerequisites (- => not satisfied):
   - a.1 succeeded
   - b.1 succeeded
-OUTPUTS (- => not completed):
+
+outputs (- => not completed):

--- a/tests/graph-equivalence/splitline_refs/a-ref
+++ b/tests/graph-equivalence/splitline_refs/a-ref
@@ -1,3 +1,4 @@
-PREREQUISITES (- => not satisfied):
+prerequisites (- => not satisfied):
   (None)
-OUTPUTS (- => not completed):
+
+outputs (- => not completed):

--- a/tests/graph-equivalence/splitline_refs/b-ref
+++ b/tests/graph-equivalence/splitline_refs/b-ref
@@ -1,3 +1,4 @@
-PREREQUISITES (- => not satisfied):
+prerequisites (- => not satisfied):
   - a.1 succeeded
-OUTPUTS (- => not completed):
+
+outputs (- => not completed):

--- a/tests/graph-equivalence/splitline_refs/c-ref
+++ b/tests/graph-equivalence/splitline_refs/c-ref
@@ -1,3 +1,4 @@
-PREREQUISITES (- => not satisfied):
+prerequisites (- => not satisfied):
   - b.1 succeeded
-OUTPUTS (- => not completed):
+
+outputs (- => not completed):

--- a/tests/manual/00-reset-with-deps.t
+++ b/tests/manual/00-reset-with-deps.t
@@ -39,9 +39,9 @@ poll_while ! test -e "$SUITE_RUN_DIR/log/job/1/t1/02/job.status"
 #-------------------------------------------------------------------------------
 # Ensure that t2.1.2 is waiting for t1.1.2
 TEST_NAME="$TEST_NAME_BASE-show-t2.1.out"
-cylc show "$SUITE_NAME" t2.1 | sed -n '/^PREREQUISITES/{N;p;}' >"$TEST_NAME"
+cylc show "$SUITE_NAME" t2.1 | sed -n '/^prerequisites/{N;p;}' >"$TEST_NAME"
 cmp_ok "$TEST_NAME" <<__OUT__
-PREREQUISITES (- => not satisfied):
+prerequisites (- => not satisfied):
   - t1.1 succeeded
 __OUT__
 touch "$SUITE_RUN_DIR/t1.1.txt" # Release t1.1.2


### PR DESCRIPTION
The ```cylc-show``` command was slightly broken:
 * it failed for the suite-only case (no task argument)
 * it didn't exit with error status if a non-existent task name or instance was given
 * cycle point input was not standardized

And the output formatting was a bit crap (e.g. blank lines printed if the suite had no title or description).