### PR TITLE
Action initial gcylc filter settings.

### DIFF
--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -579,8 +579,12 @@ Main Control GUI that displays one or more views or interfaces to the suite.
         self.updater = Updater(self.cfg, self.info_bar,
                                self.restricted_display)
         self.updater.start()
-
         self.restart_views()
+
+        self.updater.filter_states_excl = self.filter_states_excl
+        self.updater.filter_name_string = self.filter_name_string
+        self.updater.refilter()
+        self.refresh_views()
 
     def setup_views(self):
         """Create our view containers."""


### PR DESCRIPTION
Initial gcylc task filter settings (namely filtering out runahead tasks) are displayed in the status bar but don't actually have any effect until the filter window is first popped up.  This fixes the bug.

@benfitzpatrick - please review (if possible I'd like this in the imminent new release as it's a completed bug fix).