### PR TITLE
gcylc - initialize log viewer with correct log file.

### DIFF
--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -2371,7 +2371,6 @@ or remove task definitions without restarting the suite."""
                 if ":" not in log:
                     log_paths[i] = auth + ":" + log
         window.set_title(task_id + ": Log Files")
-        print init_active_index
         lv = ComboLogViewer(task_id, log_paths, init_active_index)
         self.quitters.append(lv)
 

--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -1221,12 +1221,19 @@ The Cylc Suite Engine.
             js_item.connect('button-press-event', self.view_task_info, task_id,
                             'job')
 
-            info_item = gtk.ImageMenuItem('log files')
+            out_item = gtk.ImageMenuItem('job stdout')
             img = gtk.image_new_from_stock(gtk.STOCK_DND, gtk.ICON_SIZE_MENU)
-            info_item.set_image(img)
-            view_menu.append(info_item)
-            info_item.connect(
-                'button-press-event', self.view_task_info, task_id, None)
+            out_item.set_image(img)
+            view_menu.append(out_item)
+            out_item.connect('button-press-event', self.view_task_info, task_id,
+                             'job.out')
+
+            err_item = gtk.ImageMenuItem('job stderr')
+            img = gtk.image_new_from_stock(gtk.STOCK_DND, gtk.ICON_SIZE_MENU)
+            err_item.set_image(img)
+            view_menu.append(err_item)
+            err_item.connect('button-press-event', self.view_task_info, task_id,
+                             'job.err')
 
             info_item = gtk.ImageMenuItem('prereq\'s & outputs')
             img = gtk.image_new_from_stock(
@@ -2364,6 +2371,7 @@ or remove task definitions without restarting the suite."""
                 if ":" not in log:
                     log_paths[i] = auth + ":" + log
         window.set_title(task_id + ": Log Files")
+        print init_active_index
         lv = ComboLogViewer(task_id, log_paths, init_active_index)
         self.quitters.append(lv)
 

--- a/lib/cylc/gui/combo_logviewer.py
+++ b/lib/cylc/gui/combo_logviewer.py
@@ -37,7 +37,7 @@ class ComboLogViewer(logviewer):
         self.file_list = file_list
         self.init_active_index = init_active_index
         self.common_dir = os.path.dirname(os.path.commonprefix(self.file_list))
-        logviewer.__init__(self, name, None, self.file_list[0])
+        logviewer.__init__(self, name, None, self.file_list[init_active_index])
 
     def create_gui_panel(self):
         """Create the panel."""


### PR DESCRIPTION
Fixes a bug introduced by #1385 - the combo log viewer started off showing the content of ```job.out``` even if *View -> job script* was chosen (although the filename on the drop-down combo box was correct).

For good measure I've allowed choice of job out or err directly from the right-click menu.

@matthewrmshin - please review (another small bug fix, it might as well go in *next release* if possible)