### PR TITLE
Clickable task documentation URLs

### DIFF
--- a/bin/cylc-documentation
+++ b/bin/cylc-documentation
@@ -20,68 +20,112 @@ import sys, os, re
 import subprocess
 from optparse import OptionParser
 from cylc.cfgspec.globalcfg import GLOBAL_CFG
+from cylc.run_get_stdout import run_get_stdout
 
-parser = OptionParser( """cylc [info] documentation|browse [OPTIONS]
+parser = OptionParser(
+    """cylc [info] documentation|browse [OPTIONS] [SUITE]
 
-By default this command opens the cylc documentation index in your
-browser in file:// mode. Alternatively it can open the PDF Cylc User
-Guide directly, or browse the cylc internet homepage, or - if your site
-has a web server with access to the cylc documentation - an intranet
-documentation URL. The browser and PDF reader to use, and the intranet
-URL, is determined by cylc site/user configuration - for details see
-  $ cylc site-config --help""" )
+Open cylc or suite documentation in your browser or PDF viewer (as defined
+in cylc global config files).
 
-intranet = GLOBAL_CFG.get( ['documentation','urls','local index'] )
-internet = GLOBAL_CFG.get( ['documentation','urls','internet homepage'] )
+% cylc doc [OPTIONS]
+   Open local or internet [--www] cylc documentation (locations must be
+specified in cylc global config files).
 
-parser.add_option( "-p", "--pdf",
-        help="Open the PDF User Guide directly",
-        action="store_true", default=False, dest="pdf" )
+% cylc doc -u [-t TASK] SUITE
+    Open suite or task documentation if corresponding URL items are specified
+in the suite definition.
+                      
+Arguments:
+   [TARGET]    File, URL, or suite name""")
 
-parser.add_option( "-w", "--internet",
-        help="Browse the cylc internet homepage",
-        action="store_true", default=False, dest="www" )
+parser.add_option(
+    "-p", "--pdf", help="Open the PDF User Guide directly.",
+    action="store_true", default=False, dest="pdf")
 
-if intranet:
-    parser.add_option( "-x", "--intranet",
-        help="Browse local cylc documentation",
-        action="store_true", default=False, dest="xxx" )
+parser.add_option(
+    "-w", "--www", help="Open the cylc internet homepage",
+    action="store_true", default=False, dest="www")
 
-( options, args ) = parser.parse_args()
+parser.add_option(
+    "-t", "--task", help="Browse task documentation URLs.",
+    metavar="TASK_NAME", action="store", default=None, dest="task_name")
 
-http = False
-if options.pdf:
-    viewer = GLOBAL_CFG.get( ['document viewers','pdf'] )
-    target = GLOBAL_CFG.get( ['documentation','files','pdf user guide'] )
-elif options.www:
-    http = True
-    viewer = GLOBAL_CFG.get( ['document viewers','html'] )
-    target = GLOBAL_CFG.get( ['documentation','urls','internet homepage'] )
-elif intranet and options.xxx:
-    http = True
-    viewer = GLOBAL_CFG.get( ['document viewers','html'] )
-    target = GLOBAL_CFG.get( ['documentation','urls','local index'] )
+parser.add_option(
+    "-s", "--stdout", help="Just print the URL to stdout.",
+    action="store_true", default=False, dest="stdout")
+
+(options, args) = parser.parse_args()
+
+intranet_url = GLOBAL_CFG.get(['documentation','urls','local index'])
+internet_url = GLOBAL_CFG.get(['documentation','urls','internet homepage'])
+html_file = GLOBAL_CFG.get(['documentation','files','html index'])
+html_viewer = GLOBAL_CFG.get(['document viewers','html'])
+pdf_file = GLOBAL_CFG.get(['documentation','files','pdf user guide'])
+pdf_viewer = GLOBAL_CFG.get(['document viewers','pdf'])
+if len(args) == 0:
+    # Cylc documentation.
+    if options.pdf:
+        # Force PDF.
+        viewer = pdf_viewer
+        target = pdf_file
+    else:
+        # HTML documentation index.
+        viewer = html_viewer
+        if options.www:
+            # Force internet.
+            if internet_url is not None:
+                target = internet_url
+            else:
+                sys.exit("ERROR: cylc internet URL not defined.")
+        elif intranet_url is not None:
+            # Intranet.
+            target = intranet_url
+        else:
+            # Open in file:// mode as a last resort.
+            print >> sys.stderr, (
+                "WARNING: cylc intranet URL not defined, trying file mode.")
+            target = html_file
+
+elif len(args) == 1:
+    # Suite or task documentation.
+    if options.pdf or options.www:
+        print >> sys.stderr, (
+            "(Note: --pdf and --www are ignored for suite documentation).")
+    suite = args[0]
+    if options.task_name:
+        # Task documentation.
+        res, stdout = run_get_stdout(
+            "cylc get-suite-config -i [runtime][%s]URL %s" % (
+                options.task_name, suite))
+    else:
+        # Suite documentation.
+        res, stdout = run_get_stdout(
+            "cylc get-suite-config -i URL %s" % suite)
+    if not res:
+        # (Illegal config item)
+        sys.exit(stdout)
+    elif len(stdout) == 0:
+        sys.exit("ERROR: No URL defined for %s in %s." % (
+            options.task_name, suite))
+    target = stdout[0]
+    viewer = html_viewer
+
 else:
-    # default
-    viewer = GLOBAL_CFG.get( ['document viewers','html'] )
-    target = GLOBAL_CFG.get( ['documentation','files','html index'] )
+    parser.error("Too many arguments.")
 
-if not http and not os.path.isfile( target ):
-    print >> sys.stderr, "ERROR, file not found: " + target
-    print >> sys.stderr, """(if you are running from a cylc repository the document
-not have been generated; see your local cylc administrator)"""
-    sys.exit(1)
+if target in [pdf_file, html_file] and not os.path.isfile(target):
+    sys.exit("ERROR, file not found: %s (see your cylc admin)" % target)
 
 # viewer may have spaces (e.g. 'firefox --no-remote'):
-command_list = re.split( ' ', viewer )
-command_list.append( target )
-command = ' '.join( command_list )
-try:
-    # THIS BLOCKS UNTIL THE COMMAND COMPLETES
-    retcode = subprocess.call( command_list )
-    if retcode != 0:
-        # the command returned non-zero exist status
-        raise SystemExit( command + ' failed: ' + str( retcode ))
-except OSError:
-    # the command was not invoked
-    raise SystemExit( 'ERROR: unable to execute: ' + command )
+command = '%s %s' % (viewer, target)
+command_list = re.split(' ', command)
+
+if options.stdout:
+    print target
+    sys.exit(0)
+
+retcode = subprocess.call(command_list)
+if retcode != 0:
+    print >> sys.stderr, 'ERROR, command failed: %s' % command
+sys.exit(retcode)

--- a/bin/cylc-documentation
+++ b/bin/cylc-documentation
@@ -16,11 +16,21 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import sys, os, re
+import sys
+for arg in sys.argv[1:]:
+    if arg.startswith('--host=') or arg.startswith('--user='):
+        from cylc.remote import remrun
+        if remrun().execute(force_required=True):
+            sys.exit(0)
+
+import os
+import re
 import subprocess
 from optparse import OptionParser
 from cylc.cfgspec.globalcfg import GLOBAL_CFG
 from cylc.run_get_stdout import run_get_stdout
+from cylc.suite_host import get_hostname
+from cylc.owner import user
 
 parser = OptionParser(
     """cylc [info] documentation|browse [OPTIONS] [SUITE]
@@ -54,6 +64,18 @@ parser.add_option(
 parser.add_option(
     "-s", "--stdout", help="Just print the URL to stdout.",
     action="store_true", default=False, dest="stdout")
+
+parser.add_option(
+    "--user",
+    help="Other user account name. This results in "
+         "command reinvocation on the remote account.",
+    metavar="USER", default=user, action="store", dest="owner")
+
+parser.add_option(
+    "--host",
+    help="Other host name. This results in "
+         "command reinvocation on the remote account.",
+    metavar="HOST", action="store", default=get_hostname(), dest="host")
 
 (options, args) = parser.parse_args()
 

--- a/doc/suiterc.tex
+++ b/doc/suiterc.tex
@@ -34,6 +34,20 @@ right-click menu, or at run time with the \lstinline=cylc show= command.
 \item {\em default:} (none)
 \end{myitemize}
 
+\subsubsection{URL} \label{SuiteURL} 
+
+A web URL to suite documentation.  If present it can be browsed with the
+\lstinline=cylc doc= command, or from the gcylc Suite menu.  The variable
+\lstinline=${CYLC_SUITE_NAME}= will be replaced with the actual suite name
+(note this is not a shell environment variable in this context). See also
+task URLs (\ref{TaskURL}).
+
+\begin{myitemize}
+\item {\em type:} string (URL)
+\item {\em default:} (none)
+\item {\em example:} \lstinline=http://suites/${CYLC_SUITE_NAME}/index.html=
+\end{myitemize}
+
 \subsection{[cylc]}
 
 This section is for configuration that is not specifically task-related.
@@ -797,6 +811,30 @@ A multi-line description of this namespace, retrievable from running tasks with 
 \item {\em root default:} (none)
 \end{myitemize}
 
+\paragraph[URL]{[runtime] $\rightarrow$ [[\_\_NAME\_\_]] $\rightarrow$ URL}
+\label{TaskURL}
+
+A web URL to task documentation for this suite.  If present it can be browsed
+with the \lstinline=cylc doc= command, or by right-clicking on the task in
+gcylc.  The variables \lstinline=${CYLC_SUITE_NAME}= and
+\lstinline=${CYLC_TASK_NAME}= will be replaced with the actual suite and task
+names (note that these are not environment variables in this context). See also
+suite URLs (\ref{SuiteURL}).
+
+\begin{myitemize}
+\item {\em type:} string (URL)
+\item {\em default:} (none)
+\item {\em example:} you can set URLs to all tasks in a suite by putting
+    something like the following in the root namespace:
+    \begin{lstlisting}
+[runtime]
+    [[root]]
+        URL = http://suites/${CYLC_SUITE_NAME}/${CYLC_TASK_NAME}.html
+    \end{lstlisting}
+\end{myitemize}
+
+(Note that URLs containing the suite comment delimiter
+\lstinline=#= must be protected by quotes).
 
 \paragraph[init-script]{[runtime] $\rightarrow$ [[\_\_NAME\_\_]] $\rightarrow$ init-script}
 

--- a/lib/cylc/cfgspec/suite.py
+++ b/lib/cylc/cfgspec/suite.py
@@ -216,6 +216,7 @@ coercers['interval_seconds_list'] = coerce_interval_list
 SPEC = {
     'title'                                   : vdr( vtype='string', default="" ),
     'description'                             : vdr( vtype='string', default="" ),
+    'URL'                                     : vdr( vtype='string', default="" ),
     'cylc' : {
         'UTC mode'                            : vdr( vtype='boolean', default=False),
         'cycle point format'                  : vdr( vtype='cycletime_format', default=None),
@@ -293,6 +294,7 @@ SPEC = {
             'inherit'                         : vdr( vtype='string_list', default=[] ),
             'title'                           : vdr( vtype='string', default="" ),
             'description'                     : vdr( vtype='string', default="" ),
+            'URL'                             : vdr( vtype='string', default="" ),
             'init-script'                     : vdr( vtype='string' ),
             'env-script'                      : vdr( vtype='string' ),
             'pre-script'                      : vdr( vtype='string' ),

--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -1171,17 +1171,20 @@ The Cylc Suite Engine.
 
         return False
 
-    def get_right_click_menu(self, task_id, hide_task=False,
-                             task_is_family=False):
+    def get_right_click_menu(self, task_id, task_is_family=False):
         """Return the default menu for a task."""
         menu = gtk.Menu()
-        if not hide_task:
-            menu_root = gtk.MenuItem(task_id)
-            menu_root.set_submenu(menu)
+        menu_root = gtk.MenuItem(task_id)
+        menu_root.set_submenu(menu)
 
-            title_item = gtk.MenuItem('Task: ' + task_id.replace("_", "__"))
-            title_item.set_sensitive(False)
-            menu.append(title_item)
+        title_item = gtk.MenuItem('Task: ' + task_id.replace("_", "__"))
+        title_item.set_sensitive(False)
+        menu.append(title_item)
+
+        url_item = gtk.MenuItem('_Browse task URL')
+        name, point_string = TaskID.split(task_id)
+        url_item.connect('activate', self.browse, "-t", name, self.cfg.suite)
+        menu.append(url_item)
 
         menu_items = self._get_right_click_menu_items(task_id, task_is_family)
         for item in menu_items:
@@ -2690,6 +2693,12 @@ to reduce network traffic.""")
         tools_menu_root = gtk.MenuItem('_Suite')
         tools_menu_root.set_submenu(tools_menu)
 
+        url_item = gtk.ImageMenuItem('_Browse suite URL')
+        img = gtk.image_new_from_stock(gtk.STOCK_APPLY, gtk.ICON_SIZE_MENU)
+        url_item.set_image(img)
+        tools_menu.append(url_item)
+        url_item.connect('activate', self.browse, self.cfg.suite)
+
         val_item = gtk.ImageMenuItem('_Validate')
         img = gtk.image_new_from_stock(gtk.STOCK_APPLY, gtk.ICON_SIZE_MENU)
         val_item.set_image(img)
@@ -3458,8 +3467,8 @@ For more Stop options use the Control menu.""")
     def get_remote_run_opts(self):
         return " --host=" + self.cfg.host + " --user=" + self.cfg.owner
 
-    def browse(self, b, option=''):
-        command = 'cylc doc ' + option
+    def browse(self, b, *args):
+        command = 'cylc doc ' + ' '.join(args)
         foo = gcapture_tmpfile(command, self.cfg.cylc_tmpdir, 700)
         self.gcapture_windows.append(foo)
         foo.run()

--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -1016,10 +1016,9 @@ Main Control GUI that displays one or more views or interfaces to the suite.
         item1 = " -i '[scheduling]initial cycle point'"
         item2 = " -i '[scheduling]final cycle point'"
         command = (
-            "cylc get-suite-config --mark-up --host=" + self.cfg.host +
-            " " + self.cfg.template_vars_opts + " " + " --user=" +
-            self.cfg.owner + " --one-line" + item1 + item2 + " " +
-            self.cfg.suite)
+            "cylc get-suite-config --mark-up" + self.get_remote_run_opts() +
+            " " + self.cfg.template_vars_opts + " --one-line" + item1 +
+            item2 + " " + self.cfg.suite)
         res = run_get_stdout(command, filter=True)  # (T/F, ['ct ct'])
 
         if res[0]:
@@ -1086,7 +1085,7 @@ been defined for this suite""").inform()
             options += group.get_options()
         window.destroy()
 
-        options += ' --user=' + self.cfg.owner + ' --host=' + self.cfg.host
+        options += self.get_remote_run_opts()
 
         command += ' ' + options + ' ' + self.cfg.suite + ' ' + point_string
 
@@ -1130,8 +1129,8 @@ The Cylc Suite Engine.
         about.destroy()
 
     def view_task_descr(self, w, e, task_id):
-        command = ("cylc show --host=" + self.cfg.host + " --user=" +
-                   self.cfg.owner + " " + self.cfg.suite + " " + task_id)
+        command = ("cylc show" + self.get_remote_run_opts() + " " +
+                   self.cfg.suite + " " + task_id)
         foo = gcapture_tmpfile(command, self.cfg.cylc_tmpdir, 600, 400)
         self.gcapture_windows.append(foo)
         foo.run()
@@ -2312,7 +2311,7 @@ shown here in the state they were in at the time of triggering.''')
             warning_dialog(result[1], self.window).warn()
 
     def poll_all(self, w):
-        command = "cylc poll " + self.cfg.suite + " --host=" + self.cfg.host
+        command = "cylc poll" + self.get_remote_run_opts() + " " + self.cfg.suite
         foo = gcapture_tmpfile(command, self.cfg.cylc_tmpdir, 600, 400)
         self.gcapture_windows.append(foo)
         foo.run()
@@ -2337,8 +2336,7 @@ or remove task definitions without restarting the suite."""
             return
 
         command = (
-            "cylc reload -f --host=" + self.cfg.host +
-            " --user=" + self.cfg.owner + " " + self.cfg.suite)
+            "cylc reload -f" + self.get_remote_run_opts() + " " + self.cfg.suite)
         foo = gcapture_tmpfile(command, self.cfg.cylc_tmpdir, 600, 400)
         self.gcapture_windows.append(foo)
         foo.run()
@@ -3468,7 +3466,7 @@ For more Stop options use the Control menu.""")
         return " --host=" + self.cfg.host + " --user=" + self.cfg.owner
 
     def browse(self, b, *args):
-        command = 'cylc doc ' + ' '.join(args)
+        command = 'cylc doc ' + self.get_remote_run_opts() + ' ' + ' '.join(args)
         foo = gcapture_tmpfile(command, self.cfg.cylc_tmpdir, 700)
         self.gcapture_windows.append(foo)
         foo.run()

--- a/lib/cylc/gui/view_graph.py
+++ b/lib/cylc/gui/view_graph.py
@@ -161,10 +161,6 @@ Dependency graph suite control interface.
                                        name not in self.t.leaves)
         ungroup_rec_item.connect('activate', self.grouping, name, False, True)
 
-        title_item = gtk.MenuItem('Task: ' + task_id.replace("_", "__"))
-        title_item.set_sensitive(False)
-        menu.append(title_item)
-
         menu.append(gtk.SeparatorMenuItem())
 
         if type is not 'live task':
@@ -193,9 +189,14 @@ Dependency graph suite control interface.
 
         if type == 'live task':
             is_fam = (name in self.t.descendants)
-            default_menu = self.get_right_click_menu(task_id, hide_task=True,
-                                                     task_is_family=is_fam)
-            for item in default_menu.get_children():
+            default_menu = self.get_right_click_menu(task_id, task_is_family=is_fam)
+            dm_kids = default_menu.get_children()
+            for item in reversed(dm_kids[:2]):
+                # Put task name and URL at the top.
+                default_menu.remove(item)
+                menu.prepend(item)
+            for item in dm_kids[2:]:
+                # And the rest of the default menu at the bottom.
                 default_menu.remove(item)
                 menu.append(item)
 

--- a/lib/cylc/remote.py
+++ b/lib/cylc/remote.py
@@ -81,12 +81,6 @@ class remrun(object):
         if not self.is_remote:
             return False
 
-        if (force_required and
-                '-f' not in self.argv[1:] and '--force' not in self.argv[1:]):
-            sys.exit(
-                "ERROR: force (-f) required for non-interactive " +
-                "command invocation.")
-
         name = os.path.basename(self.argv[0])[5:]  # /path/to/cylc-foo => foo
 
         user_at_host = ''

--- a/lib/cylc/state_summary.py
+++ b/lib/cylc/state_summary.py
@@ -181,12 +181,10 @@ def get_id_summary( id_, task_state_summary, fam_state_summary, id_family_map ):
         if id_ in summary:
             title = summary[id_].get('title')
             if title:
-                meta_text += title.strip() + "\n"
+                meta_text += "\n" + title.strip()
             description = summary[id_].get('description')
             if description:
-                meta_text += description.strip()
-    if meta_text:
-        meta_text = "\n" + meta_text.rstrip()
+                meta_text += "\n" + description.strip()
     while stack:
         this_id, depth = stack.pop( 0 )
         if this_id in done_ids:  # family dive down will give duplicates

--- a/tests/cylc-doc/00-cylc-doc.t
+++ b/tests/cylc-doc/00-cylc-doc.t
@@ -1,0 +1,48 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test the cylc-doc command on printing cylc URLs.
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 2
+#-------------------------------------------------------------------------------
+mkdir 'conf'
+export CYLC_CONF_PATH="${PWD}/conf"
+cat > "$PWD/conf/global.rc" <<__GLOBAL_RC__
+[documentation]
+   [[files]]
+      pdf user guide = ${PWD}/doc/pdf/cug-pdf.pdf
+      multi-page html user guide = /home/bob/cylc/cylc.git/doc/html/multi/cug-html.html
+      html index = /home/bob/cylc/cylc.git/doc/index.html
+      single-page html user guide = /home/bob/cylc/cylc.git/doc/html/single/cug-html.html
+   [[urls]]
+      internet homepage = http://cylc.github.com/cylc/
+      local index = http://localhost/cylc/index.html
+__GLOBAL_RC__
+#-------------------------------------------------------------------------------
+mkdir -p doc/pdf
+touch doc/pdf/cug-pdf.pdf
+cylc doc -s -p > stdout1.txt
+cmp_ok stdout1.txt <<__END__
+$PWD/doc/pdf/cug-pdf.pdf
+__END__
+#-------------------------------------------------------------------------------
+cylc doc -s > stdout2.txt
+cmp_ok stdout2.txt <<__END__
+http://localhost/cylc/index.html
+__END__
+#-------------------------------------------------------------------------------

--- a/tests/cylc-doc/01-suite-urls.t
+++ b/tests/cylc-doc/01-suite-urls.t
@@ -1,0 +1,55 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test the cylc-doc command on printing suite and task URLs.
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 3
+#-------------------------------------------------------------------------------
+mkdir 'conf'
+export CYLC_CONF_PATH="${PWD}/conf"
+cat > "$PWD/conf/global.rc" <<__GLOBAL_RC__
+[documentation]
+   [[files]]
+      pdf user guide = ${PWD}/doc/pdf/cug-pdf.pdf
+      multi-page html user guide = /home/bob/cylc/cylc.git/doc/html/multi/cug-html.html
+      html index = /home/bob/cylc/cylc.git/doc/index.html
+      single-page html user guide = /home/bob/cylc/cylc.git/doc/html/single/cug-html.html
+   [[urls]]
+      internet homepage = http://cylc.github.com/cylc/
+      local index = http://localhost/cylc/index.html
+__GLOBAL_RC__
+#-------------------------------------------------------------------------------
+install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+#-------------------------------------------------------------------------------
+TEST_NAME=${TEST_NAME_BASE}-validate
+run_ok $TEST_NAME cylc validate "$SUITE_NAME"
+#-------------------------------------------------------------------------------
+TEST_NAME=${TEST_NAME_BASE}-suite-url
+cylc doc -s $SUITE_NAME > stdout1.txt
+cmp_ok stdout1.txt <<__END__
+http://localhost/suite-docs/${SUITE_NAME}.html
+__END__
+#-------------------------------------------------------------------------------
+TEST_NAME=${TEST_NAME_BASE}-task-url
+cylc doc -s -t bar $SUITE_NAME > stdout2.txt
+cmp_ok stdout2.txt <<__END__
+http://localhost/suite-docs/${SUITE_NAME}.html#bar
+__END__
+#-------------------------------------------------------------------------------
+purge_suite $SUITE_NAME
+#-------------------------------------------------------------------------------

--- a/tests/cylc-doc/01-suite-urls/suite.rc
+++ b/tests/cylc-doc/01-suite-urls/suite.rc
@@ -1,0 +1,11 @@
+
+URL = http://localhost/suite-docs/${CYLC_SUITE_NAME}.html
+[scheduling]
+   [[dependencies]]
+        graph = foo => FAM
+[runtime]
+    [[root]]
+        URL = 'http://localhost/suite-docs/${CYLC_SUITE_NAME}.html#${CYLC_TASK_NAME}'
+    [[FAM]]
+    [[bar,baz]]
+        inherit = FAM

--- a/tests/cylc-doc/test_header
+++ b/tests/cylc-doc/test_header
@@ -1,0 +1,1 @@
+../lib/bash/test_header

--- a/tests/cylc-get-config/00-simple/section2.stdout
+++ b/tests/cylc-get-config/00-simple/section2.stdout
@@ -6,6 +6,7 @@
    env-script = 
    execution polling intervals = 
    title = 
+   URL = 
    extra log files = 
    work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
    submission polling intervals = 
@@ -70,6 +71,7 @@
    env-script = 
    execution polling intervals = 
    title = 
+   URL = 
    extra log files = 
    work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
    submission polling intervals = 
@@ -133,6 +135,7 @@
    env-script = 
    execution polling intervals = 
    title = 
+   URL = 
    extra log files = 
    work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
    submission polling intervals = 
@@ -197,6 +200,7 @@
    env-script = 
    execution polling intervals = 
    title = 
+   URL = 
    extra log files = 
    work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
    submission polling intervals = 
@@ -261,6 +265,7 @@
    env-script = 
    execution polling intervals = 
    title = 
+   URL = 
    extra log files = 
    work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
    submission polling intervals = 
@@ -325,6 +330,7 @@
    env-script = 
    execution polling intervals = 
    title = 
+   URL = 
    extra log files = 
    work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
    submission polling intervals = 
@@ -389,6 +395,7 @@
    env-script = 
    execution polling intervals = 
    title = 
+   URL = 
    extra log files = 
    work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
    submission polling intervals = 
@@ -453,6 +460,7 @@
    env-script = 
    execution polling intervals = 
    title = 
+   URL = 
    extra log files = 
    work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
    submission polling intervals = 
@@ -516,6 +524,7 @@
    env-script = 
    execution polling intervals = 
    title = 
+   URL = 
    extra log files = 
    work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
    submission polling intervals = 
@@ -580,6 +589,7 @@
    env-script = 
    execution polling intervals = 
    title = 
+   URL = 
    extra log files = 
    work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
    submission polling intervals = 
@@ -644,6 +654,7 @@
    env-script = 
    execution polling intervals = 
    title = 
+   URL = 
    extra log files = 
    work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
    submission polling intervals = 
@@ -707,6 +718,7 @@
    env-script = 
    execution polling intervals = 
    title = 
+   URL = 
    extra log files = 
    work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
    submission polling intervals = 
@@ -771,6 +783,7 @@
    env-script = 
    execution polling intervals = 
    title = 
+   URL = 
    extra log files = 
    work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
    submission polling intervals = 


### PR DESCRIPTION
Close #1399.

This adds a ```URL``` item to runtime namespaces, and a top level one for the suite too.  If present, it is shown in task tooltips in the GUI, and can be browsed via the task right-click menu. Uses global config browser. [update: not in tooltips; can be browsed from gcylc or the ```cylc doc``` command]

Motivation: NIWA's operational system has extensive web documentation on each task for operational suite operators - too much to put in the in-suite task ```description```s.  This makes it much easier to find the documentation for a failed task, for example.