### PR TITLE
Use CLI final point before checking is > initial point.

### DIFF
--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -619,6 +619,7 @@ class scheduler(object):
             self.options.templatevars_file, run_mode=self.run_mode,
             cli_initial_point_string=self._cli_initial_point_string,
             cli_start_point_string=self._cli_start_point_string,
+            cli_final_point_string=self.options.final_point_string,
             is_restart=self.is_restart, is_reload=reconfigure
         )
 

--- a/tests/cli-cycle-points/00-simple.t
+++ b/tests/cli-cycle-points/00-simple.t
@@ -20,7 +20,7 @@
 
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
-set_test_number 3
+set_test_number 4
 #-------------------------------------------------------------------------------
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
@@ -31,6 +31,11 @@ TEST_NAME=$TEST_NAME_BASE-run
 suite_run_ok $TEST_NAME cylc run --debug $SUITE_NAME
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-run-override
+# This will fail if the in-suite final cycle point does not get overridden.
 suite_run_ok $TEST_NAME cylc run --until=2015-04 --debug $SUITE_NAME 2015-04
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-run-fail
+# This should fail as the final cycle point  is < the initial one.
+suite_run_fail $TEST_NAME cylc run --until=2015-03 --debug $SUITE_NAME 2015-04
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/cli-cycle-points/00-simple.t
+++ b/tests/cli-cycle-points/00-simple.t
@@ -1,0 +1,36 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test that initial and final cycle points can be overridden by the CLI.
+# Ref. Github Issue #1406.
+
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 3
+#-------------------------------------------------------------------------------
+install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-val
+run_ok $TEST_NAME cylc validate $SUITE_NAME
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-run
+suite_run_ok $TEST_NAME cylc run --debug $SUITE_NAME
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-run-override
+suite_run_ok $TEST_NAME cylc run --until=2015-04 --debug $SUITE_NAME 2015-04
+#-------------------------------------------------------------------------------
+purge_suite $SUITE_NAME

--- a/tests/cli-cycle-points/00-simple/suite.rc
+++ b/tests/cli-cycle-points/00-simple/suite.rc
@@ -1,0 +1,14 @@
+[cylc]
+    UTC mode = true
+    [[event hooks]]
+        abort on timeout = true
+        timeout = PT20S
+[scheduling]
+    initial cycle point = 2015-01
+    final cycle point = 2015-01
+    [[dependencies]]
+        [[[P1D]]]
+            graph = foo
+[runtime]
+    [[foo]]
+        command scripting = /bin/true

--- a/tests/cli-cycle-points/test_header
+++ b/tests/cli-cycle-points/test_header
@@ -1,0 +1,1 @@
+../lib/bash/test_header


### PR DESCRIPTION
```
[scheduling]
   initial cycle point = 2015-01
   final cycle point = 2015-02
   [[dependencies]]
         [[[P1M]]]
               graph = foo
```
Now override initial and final point on the command line:
```
cylc run --until=2015-05 my.suite 2015-04
...
SuiteConfigError: 'The initial cycle point:2015-04 is after the final cycle point:2015-02'
```
The CLI final cycle point is not being considered in the validation check against initial point.
