### PR TITLE
cylc gsummary: fix handling of cylc cat-state failure

### DIFF
--- a/lib/cylc/gui/gsummary.py
+++ b/lib/cylc/gui/gsummary.py
@@ -21,6 +21,7 @@ import os
 import re
 import shlex
 import subprocess
+import sys
 import threading
 import time
 
@@ -81,7 +82,8 @@ def get_task_cycle_statuses_updatetime(host, suite, owner=None):
     stdout = popen.stdout.read()
     res = popen.wait()
     if res != 0:
-        return None
+        sys.stderr.write(popen.stderr.read())
+        return None, None
     task_cycle_statuses = []
     for line in stdout.rpartition("Begin task states")[2].splitlines():
         task_result = re.match("([^ ]+) : status=([^,]+), spawned", line)


### PR DESCRIPTION
If `cylc cat-state` fails for a suite, `cylc gsummary` will crash with a traceback like this:
```
File "/opt/cylc/lib/cylc/gui/gsummary.py", line 972, in get_new_statuses_and_stop_summaries_updatetime
    get_task_cycle_statuses_updatetime(host, suite, owner=owner))
TypeError: 'NoneType' object is not iterable
```

This fixes the problem and outputs the stderr from the suite.

You can recreate the bug simply by removing an active suite's state file.

@arjclark, please review.
