### PR TITLE
cylc.config: allow `clock-triggered=foo` syntax

### DIFF
--- a/doc/suiterc.tex
+++ b/doc/suiterc.tex
@@ -575,11 +575,11 @@ In delayed or historical operation clock-triggered tasks do not constrain the
 suite until they catch up to the wall clock.
 
 \begin{myitemize}
-    \item {\em type:} list of task or family names with offsets expressed as an
-        ISO8601 interval string, positive or negative, e.g. \lstinline=PT1H=
-        for 1 hour.
+    \item {\em type:} list of task or family names with optional offsets in
+        brackets. An offset should be expressed as an ISO8601 interval
+        string, positive or negative, e.g. \lstinline=PT1H= for 1 hour.
     \item {\em default:} (none)
-    \item {\em examples:} \lstinline=foo(PT1H30M)=, \lstinline=bar(PT1.5H)=
+    \item {\em examples:} \lstinline=foo(PT1H30M)=, \lstinline=bar(PT1.5H)=, \lstinline=baz=
 \end{myitemize}
 
 \paragraph[sequential]{[scheduling] $\rightarrow$ [[special tasks]] $\rightarrow$ sequential}

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -49,7 +49,7 @@ Parse and validate the suite definition file, do some consistency
 checking, then construct task proxy objects and graph structures.
 """
 
-CLOCK_OFFSET_RE = re.compile('(\w+)\s*\(\s*(.+)\s*\)')
+CLOCK_OFFSET_RE = re.compile(r'(' + TaskID.NAME_RE + r')(?:\(\s*(.+)\s*\))?')
 NUM_RUNAHEAD_SEQ_POINTS = 5  # Number of cycle points to look at per sequence.
 
 # TODO - unify this with task_state.py:
@@ -376,6 +376,8 @@ class config( object ):
                             Calendar.MODE_GREGORIAN
                         )
                     name, offset_string = m.groups()
+                    if not offset_string:
+                        offset_string = "PT0M"
                     offset_converted_from_prev = False
                     try:
                         float(offset_string)

--- a/tests/special/08-clock-triggered-0.t
+++ b/tests/special/08-clock-triggered-0.t
@@ -15,7 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test clock triggering is working
+# Test clock triggering is working, with no offset argument
+# https://github.com/cylc/cylc/issues/1417
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 set_test_number 4
@@ -23,25 +24,25 @@ set_test_number 4
 install_suite $TEST_NAME_BASE clock
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-validate
-run_ok $TEST_NAME cylc validate $SUITE_NAME -s START=$(date +%Y%m%d%H) \
-    -s HOUR=$(date +%H) -s UTC_MODE=False -s OFFSET=0 -s TIMEOUT=0.2
+run_ok $TEST_NAME cylc validate $SUITE_NAME -s START=$(date +%Y%m%dT%H%z) \
+    -s HOUR=T$(date +%H) -s UTC_MODE=False -s TIMEOUT=PT0.2M
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-run-now
-run_ok $TEST_NAME cylc run --debug $SUITE_NAME -s START=$(date +%Y%m%d%H) \
-    -s HOUR=$(date +%H) -s UTC_MODE=False -s OFFSET=0 -s TIMEOUT=0.2
+run_ok $TEST_NAME cylc run --debug $SUITE_NAME -s START=$(date +%Y%m%dT%H%z) \
+    -s HOUR=T$(date +%H) -s UTC_MODE=False -s TIMEOUT=PT0.2M
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-run-past
-NOW=$(date +%Y%m%d%H)
-START=$(cylc cycle-point $NOW --offset-hour=-10)
-HOUR=$(cylc cycle-point $NOW --offset-hour=-10 --print-hour)
+NOW=$(date +%Y%m%dT%H)
+START=$(cylc cycle-point $NOW --offset-hour=-10)$(date +%z)
+HOUR=T$(cylc cycle-point $NOW --offset-hour=-10 --print-hour)
 run_ok $TEST_NAME cylc run --debug $SUITE_NAME -s START=$START -s HOUR=$HOUR \
-    -s UTC_MODE=False -s OFFSET=0 -s TIMEOUT=1
+    -s UTC_MODE=False -s TIMEOUT=PT1M
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-run-later
-NOW=$(date +%Y%m%d%H)
-START=$(cylc cycle-point $NOW --offset-hour=10)
-HOUR=$(cylc cycle-point $NOW --offset-hour=10 --print-hour)
+NOW=$(date +%Y%m%dT%H)
+START=$(cylc cycle-point $NOW --offset-hour=10)$(date +%z)
+HOUR=T$(cylc cycle-point $NOW --offset-hour=10 --print-hour)
 run_fail $TEST_NAME cylc run --debug $SUITE_NAME -s START=$START \
-    -s HOUR=$HOUR -s UTC_MODE=False -s OFFSET=0 -s TIMEOUT=0.2
+    -s HOUR=$HOUR -s UTC_MODE=False -s TIMEOUT=PT0.2M
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/special/clock/suite.rc
+++ b/tests/special/clock/suite.rc
@@ -8,7 +8,7 @@
     initial cycle time = {{START}}
     final cycle time   = {{START}}
     [[special tasks]]
-        clock-triggered = clock({{OFFSET|default(0)}})
+        clock-triggered = clock{% if OFFSET is defined %}({{OFFSET}}){% endif %}
     [[dependencies]]
         [[[{{HOUR}}]]]
             graph = "clock"


### PR DESCRIPTION
Instead of forcing users to put `clock-triggered=foo(PT0H)`.

Close #1417. @benfitzpatrick please review.