### PR TITLE
cylc insert: fix DatabaseIntegrityError warning when old task re-inserted

### DIFF
--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -218,7 +218,7 @@ class TaskProxy(object):
 
         # An initial db state entry is created at task proxy init. On reloading
         # or restarting the suite, the task proxies already have this db entry.
-        if not is_reload:
+        if not is_reload and self.submit_num == 0:
             self.record_db_state()
 
         if self.submit_num > 0:

--- a/tests/cylc-insert/03-insert-old.t
+++ b/tests/cylc-insert/03-insert-old.t
@@ -1,0 +1,53 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test cylc insert command for a task that has already run.
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 6
+#-------------------------------------------------------------------------------
+install_suite $TEST_NAME_BASE insert-old
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-validate
+run_ok $TEST_NAME cylc validate $SUITE_NAME
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-run
+suite_run_ok $TEST_NAME cylc run -v -v --reference-test --debug $SUITE_NAME
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-suite-err
+RUN_DIR=$(cylc get-global-config --print-run-dir)
+cp $RUN_DIR/$SUITE_NAME/log/suite/err $TEST_NAME
+# Note: this will be sensitive to deprecation warnings, etc... but we need it
+# to catch the DatabaseIntegrityError and friends.
+cmp_ok $TEST_NAME </dev/null
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-db-end
+RUN_DIR=$(cylc get-global-config --print-run-dir)
+run_ok "$TEST_NAME" sqlite3 $RUN_DIR/$SUITE_NAME/cylc-suite.db \
+    "select name, cycle, submit_num, status from task_states order by name, cycle"
+cmp_ok "$TEST_NAME.stdout" <<'__OUT__'
+foo|20140101T0000Z|1|succeeded
+foo|20140102T0000Z|1|succeeded
+foo|20140103T0000Z|1|succeeded
+foo|20140104T0000Z|1|succeeded
+foo|20140105T0000Z|0|held
+foo_cold|20140101T0000Z|2|succeeded
+reinsert_foo|20140102T0000Z|1|succeeded
+__OUT__
+cmp_ok "$TEST_NAME.stderr" </dev/null
+#-------------------------------------------------------------------------------
+purge_suite $SUITE_NAME

--- a/tests/cylc-insert/insert-old/reference.log
+++ b/tests/cylc-insert/insert-old/reference.log
@@ -1,0 +1,59 @@
+2015-04-17T11:07:19Z INFO - Suite starting at 2015-04-17T11:07:19Z
+2015-04-17T11:07:19Z INFO - Run mode: live
+2015-04-17T11:07:19Z INFO - Initial point: 20140101T0000Z
+2015-04-17T11:07:19Z INFO - Final point: 20140104T0000Z
+2015-04-17T11:07:19Z INFO - Cold Start 20140101T0000Z
+2015-04-17T11:07:19Z INFO - [foo_cold.20140101T0000Z] -initiate job-submit
+2015-04-17T11:07:19Z INFO - [foo_cold.20140101T0000Z] -triggered off []
+
+2015-04-17T11:07:20Z INFO - [foo_cold.20140101T0000Z] -submit_method_id=29118
+2015-04-17T11:07:20Z INFO - [foo_cold.20140101T0000Z] -submission succeeded
+2015-04-17T11:07:21Z INFO - [foo_cold.20140101T0000Z] -(current:submitted)> foo_cold.20140101T0000Z started at 2015-04-17T11:07:20Z
+2015-04-17T11:07:21Z INFO - [foo_cold.20140101T0000Z] -(current:running)> foo_cold.20140101T0000Z succeeded at 2015-04-17T11:07:21Z
+2015-04-17T11:07:22Z INFO - [foo.20140101T0000Z] -initiate job-submit
+2015-04-17T11:07:22Z INFO - [foo.20140101T0000Z] -triggered off ['foo_cold.20140101T0000Z']
+
+2015-04-17T11:07:23Z INFO - [foo.20140101T0000Z] -submit_method_id=29242
+2015-04-17T11:07:23Z INFO - [foo.20140101T0000Z] -submission succeeded
+2015-04-17T11:07:24Z INFO - [foo.20140101T0000Z] -(current:submitted)> foo.20140101T0000Z started at 2015-04-17T11:07:23Z
+2015-04-17T11:07:24Z INFO - [foo.20140101T0000Z] -(current:running)> foo.20140101T0000Z succeeded at 2015-04-17T11:07:24Z
+2015-04-17T11:07:25Z INFO - [reinsert_foo.20140102T0000Z] -initiate job-submit
+2015-04-17T11:07:25Z INFO - [reinsert_foo.20140102T0000Z] -triggered off ['foo.20140101T0000Z']
+
+2015-04-17T11:07:26Z INFO - [reinsert_foo.20140102T0000Z] -submit_method_id=29366
+2015-04-17T11:07:26Z INFO - [reinsert_foo.20140102T0000Z] -submission succeeded
+2015-04-17T11:07:27Z INFO - [reinsert_foo.20140102T0000Z] -(current:submitted)> reinsert_foo.20140102T0000Z started at 2015-04-17T11:07:26Z
+2015-04-17T11:07:27Z INFO - Command succeeded: insert task(foo_cold,20140101T0000Z,False,None)
+2015-04-17T11:07:28Z INFO - [foo_cold.20140101T0000Z] -initiate job-submit
+2015-04-17T11:07:28Z INFO - [foo_cold.20140101T0000Z] -triggered off []
+2015-04-17T11:07:28Z INFO - [reinsert_foo.20140102T0000Z] -(current:running)> reinsert_foo.20140102T0000Z succeeded at 2015-04-17T11:07:28Z
+
+2015-04-17T11:07:29Z INFO - [foo_cold.20140101T0000Z] -submit_method_id=29499
+2015-04-17T11:07:29Z INFO - [foo_cold.20140101T0000Z] -submission succeeded
+2015-04-17T11:07:29Z INFO - [foo.20140102T0000Z] -initiate job-submit
+2015-04-17T11:07:29Z INFO - [foo.20140102T0000Z] -triggered off ['foo.20140101T0000Z', 'reinsert_foo.20140102T0000Z']
+
+2015-04-17T11:07:30Z INFO - [foo.20140102T0000Z] -submit_method_id=29606
+2015-04-17T11:07:30Z INFO - [foo.20140102T0000Z] -submission succeeded
+2015-04-17T11:07:30Z INFO - [foo_cold.20140101T0000Z] -(current:submitted)> foo_cold.20140101T0000Z started at 2015-04-17T11:07:29Z
+2015-04-17T11:07:31Z INFO - [foo.20140102T0000Z] -(current:submitted)> foo.20140102T0000Z started at 2015-04-17T11:07:31Z
+2015-04-17T11:07:31Z INFO - [foo_cold.20140101T0000Z] -(current:running)> foo_cold.20140101T0000Z succeeded at 2015-04-17T11:07:30Z
+2015-04-17T11:07:32Z INFO - [foo.20140102T0000Z] -(current:running)> foo.20140102T0000Z succeeded at 2015-04-17T11:07:31Z
+2015-04-17T11:07:33Z INFO - [foo.20140103T0000Z] -initiate job-submit
+2015-04-17T11:07:33Z INFO - [foo.20140103T0000Z] -triggered off ['foo.20140102T0000Z']
+
+2015-04-17T11:07:34Z INFO - [foo.20140103T0000Z] -submit_method_id=29747
+2015-04-17T11:07:34Z INFO - [foo.20140103T0000Z] -submission succeeded
+2015-04-17T11:07:35Z INFO - [foo.20140103T0000Z] -(current:submitted)> foo.20140103T0000Z started at 2015-04-17T11:07:34Z
+2015-04-17T11:07:35Z INFO - [foo.20140103T0000Z] -(current:running)> foo.20140103T0000Z succeeded at 2015-04-17T11:07:35Z
+2015-04-17T11:07:36Z INFO - [foo.20140104T0000Z] -initiate job-submit
+2015-04-17T11:07:36Z INFO - [foo.20140104T0000Z] -triggered off ['foo.20140103T0000Z']
+2015-04-17T11:07:37Z INFO - 29871
+
+2015-04-17T11:07:37Z INFO - [foo.20140104T0000Z] -submit_method_id=29871
+2015-04-17T11:07:37Z INFO - [foo.20140104T0000Z] -submission succeeded
+2015-04-17T11:07:37Z INFO - [foo.20140105T0000Z] -holding (beyond suite stop point) 20140104T0000Z
+2015-04-17T11:07:37Z INFO - [foo.20140105T0000Z] -waiting => held
+2015-04-17T11:07:38Z INFO - [foo.20140104T0000Z] -(current:submitted)> foo.20140104T0000Z started at 2015-04-17T11:07:37Z
+2015-04-17T11:07:38Z INFO - [foo.20140104T0000Z] -(current:running)> foo.20140104T0000Z succeeded at 2015-04-17T11:07:38Z
+2015-04-17T11:07:39Z INFO - Suite shutting down at 2015-04-17T11:07:39Z

--- a/tests/cylc-insert/insert-old/suite.rc
+++ b/tests/cylc-insert/insert-old/suite.rc
@@ -1,0 +1,26 @@
+title = "Test insertion of a task that has previously run"
+
+[cylc]
+    UTC mode = True
+    [[reference test]]
+        required run mode = live
+        live mode suite timeout = PT1M
+
+[scheduling]
+    initial cycle point = 20140101T00
+    final cycle point   = 20140104T00
+    [[dependencies]]
+        [[[R1]]]
+            graph = "foo_cold => foo"
+        [[[T00]]]
+            graph = "foo[-P1D] => foo"
+        [[[R1/+P1D]]]
+            graph = "foo[-P1D] => reinsert_foo => foo"
+
+[runtime]
+    [[foo_cold, foo]]
+        command scripting = "true"
+    [[reinsert_foo]]
+        command scripting = """
+            cylc insert $CYLC_SUITE_NAME foo_cold 20140101T0000Z
+        """


### PR DESCRIPTION
This fixes #1422. Inserting a task that has been removed from the task pool causes
a `DatabaseIntegrityError` warning in the log/suite/err. This is due to the task already
having an entry in the `task_states` table when the new task proxy is created.

@arjclark, please review.