### PR TITLE
Remove $CYLC_DIR/util from init

### DIFF
--- a/lib/cylc/__init__.py
+++ b/lib/cylc/__init__.py
@@ -37,7 +37,7 @@ def environ_init(argv0=None):
         if cylc_dir != os.getenv('CYLC_DIR', ''):
             os.environ['CYLC_DIR'] = cylc_dir
 
-        dirs = [os.path.join(cylc_dir, 'util'), os.path.join(cylc_dir, 'bin')]
+        dirs = [os.path.join(cylc_dir, 'bin')]
         if os.getenv('CYLC_SUITE_DEF_PATH', ''):
             dirs.append(os.getenv('CYLC_SUITE_DEF_PATH'))
         environ_path_add(dirs)


### PR DESCRIPTION
It no longer exists.

@hjoliver please review.

Is there any reason why we need to add `$CYLC_DIR/bin` to `$PATH` and `$CYLC_DIR/lib` to `$PYTHONPATH` at this point? The only reason I can think of are:
* `$CYLC_DIR/bin` is not in path, and someone calls `cylc` with a full path. (Very unlikely.)
* Something like `./cylc/bin` is in `$PATH`. (Even less likely.)
* Somone needs to use cylc's Python library outside of the `cylc` executable. (Highly unlikely.)