### PR TITLE
cylc help kill: POINT is compulsory

### DIFF
--- a/bin/cylc-kill
+++ b/bin/cylc-kill
@@ -35,7 +35,7 @@ Kill a 'submitted' or 'running' task and update the suite state accordingly.
 """ + multitask_usage, pyro=True, multitask=True,
         argdoc=[ ('REG', 'Suite name'),
             ('MATCH', 'Task or family name matching regular expression'),
-            ('[POINT]', 'Task cycle point (e.g. date-time or integer)') ])
+            ('POINT', 'Task cycle point (e.g. date-time or integer)') ])
 
 (options, args) = parser.parse_args()
 


### PR DESCRIPTION
The logic suggests that POINT is compulsory, but the help string was
marking it as optional.

@arjclark please review.