### PR TITLE
Add `.mailmap` to improve shortlog display

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,16 @@
+Ben Fitzpatrick            <ben.fitzpatrick@metoffice.gov.uk>   benfitzpatrick      <ben.fitzpatrick@metoffice.gov.uk>
+David Matthews             <david.matthews@metoffice.gov.uk>    dpmatthews          <david.matthews@metoffice.gov.uk>
+Hilary James Oliver        <h.oliver@niwa.co.nz>                Hilary James Oliver <hilary.j.oliver@gmail.com>
+Hilary James Oliver        <h.oliver@niwa.co.nz>                Hilary James Oliver <hilary.oliver@niwa.co.nz>
+Hilary James Oliver        <h.oliver@niwa.co.nz>                hilary.oliver       <holiver@eld084.desktop.frd.metoffice.com>
+Hilary James Oliver        <h.oliver@niwa.co.nz>                Hilary Oliver       <hilary@Megan-Olivers-MacBook-Pro.local>
+Hilary James Oliver        <h.oliver@niwa.co.nz>                Hilary James Oliver <hilary@localhost.localdomain>
+Hilary James Oliver        <h.oliver@niwa.co.nz>                Hilary Oliver       <hilary.j.oliver@gmail.com>
+Matt Shin                  <matthew.shin@metoffice.gov.uk>      matthew.shin        <matthew.shin@metoffice.gov.uk>
+Matt Shin                  <matthew.shin@metoffice.gov.uk>      matthewrmshin       <matthew.shin@metoffice.gov.uk>
+Matt Shin                  <matthew.shin@metoffice.gov.uk>      matthewrmshin       <matthewrmshin@yahoo.co.uk>
+Matt Shin                  <matthew.shin@metoffice.gov.uk>      Matt Shin           <matthewrmshin@yahoo.co.uk>
+Kerry Day                  <kerry.day@metoffice.gov.uk>         kaday               <kerry.day@metoffice.gov.uk>
+Kerry Day                  <kerry.day@metoffice.gov.uk>         Kerry Day           <kaday@users.noreply.github.com>
+Patrick Alexander Reinecke <alex.reinecke@nrlmry.navy.mil>      P. A. Reinecke      <alex.reinecke@nrlmry.navy.mil>
+Luis Kornblueh             <luis.kornblueh@zmaw.de>             Luis Kornblueh      <m214089@cinglung.fritz.box>


### PR DESCRIPTION
This should improve the output from `git shortlog` for the cylc repository.

@hjoliver please review.