### PR TITLE
cylc gui: preserve edges on node filter out

### DIFF
--- a/bin/cylc-graph
+++ b/bin/cylc-graph
@@ -141,6 +141,10 @@ parser.add_option( "-f", "--file",
     help="View a specific dot-language graphfile.",
     metavar="FILE", action="store", default=None, dest="filename" )
 
+parser.add_option( "--filter",
+    help="Filter out one or many nodes.",
+    metavar="NODE_NAME", action="append", dest="filter_nodes" )
+
 parser.add_option( "-O", "--output-file",
     help="Output to a specific file, with a format given by --output-format" +
          " or extrapolated from the extension. " +
@@ -219,6 +223,9 @@ else:
 
 window.widget.connect('clicked', on_url_clicked, window)
 window.get_graph()
+if options.filter_nodes:
+    filter_nodes = set(options.filter_nodes)
+    window.filter_graph_nodes(options.filter_nodes)
 
 if options.reference and options.output_filename is None:
     options.output_filename = "-"

--- a/bin/cylc-graph
+++ b/bin/cylc-graph
@@ -222,10 +222,10 @@ else:
             should_hide=should_hide_gtk_window)
 
 window.widget.connect('clicked', on_url_clicked, window)
-window.get_graph()
 if options.filter_patterns:
     filter_patterns = set(options.filter_patterns)
-    window.filter_graph_nodes(options.filter_patterns)
+    window.set_filter_graph_patterns(options.filter_patterns)
+window.get_graph()
 
 if options.reference and options.output_filename is None:
     options.output_filename = "-"

--- a/bin/cylc-graph
+++ b/bin/cylc-graph
@@ -143,7 +143,7 @@ parser.add_option( "-f", "--file",
 
 parser.add_option( "--filter",
     help="Filter out one or many nodes.",
-    metavar="NODE_NAME", action="append", dest="filter_nodes" )
+    metavar="NODE_NAME_PATTERN", action="append", dest="filter_patterns" )
 
 parser.add_option( "-O", "--output-file",
     help="Output to a specific file, with a format given by --output-format" +
@@ -223,9 +223,9 @@ else:
 
 window.widget.connect('clicked', on_url_clicked, window)
 window.get_graph()
-if options.filter_nodes:
-    filter_nodes = set(options.filter_nodes)
-    window.filter_graph_nodes(options.filter_nodes)
+if options.filter_patterns:
+    filter_patterns = set(options.filter_patterns)
+    window.filter_graph_nodes(options.filter_patterns)
 
 if options.reference and options.output_filename is None:
     options.output_filename = "-"

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -1687,7 +1687,7 @@ class config( object ):
                     nl, nr = self.close_families(l_id, r_id)
                     if point not in gr_edges:
                         gr_edges[point] = []
-                    gr_edges[point].append((nl, nr, False, e.suicide, e.conditional))
+                    gr_edges[point].append((nl, nr, None, e.suicide, e.conditional))
                 # Increment the cycle point.
                 point = e.sequence.get_next_point_on_sequence(point)
 

--- a/lib/cylc/cylc_xdot.py
+++ b/lib/cylc/cylc_xdot.py
@@ -55,9 +55,15 @@ class CylcDotViewerCommon(xdot.DotWindow):
         self.inherit = self.suiterc.get_parent_lists()
         return True
 
-    def filter_graph_nodes(self, nodes_to_filter):
-        """Filter out a list of graph nodes."""
-        self.graph.cylc_remove_nodes_from(nodes_to_filter)
+    def filter_graph_nodes(self, filter_patterns):
+        """Filter out graph nodes by regular expressions."""
+        filter_recs = [re.compile(_) for _ in filter_patterns]
+        filter_nodes = set()
+        for node in self.graph.nodes():
+            for filter_rec in filter_recs:
+                if filter_rec.search(node.get_name()):
+                    filter_nodes.add(node)
+        self.graph.cylc_remove_nodes_from(filter_nodes)
 
 
 class MyDotWindow2(CylcDotViewerCommon):

--- a/lib/cylc/cylc_xdot.py
+++ b/lib/cylc/cylc_xdot.py
@@ -55,12 +55,17 @@ class CylcDotViewerCommon(xdot.DotWindow):
         self.inherit = self.suiterc.get_parent_lists()
         return True
 
-    def filter_graph_nodes(self, filter_patterns):
-        """Filter out graph nodes by regular expressions."""
-        filter_recs = [re.compile(_) for _ in filter_patterns]
+    def set_filter_graph_patterns(self, filter_patterns):
+        """Set some regular expressions to filter out graph nodes."""
+        self.filter_recs = [re.compile(_) for _ in filter_patterns]
+
+    def filter_graph(self):
+        """Apply any filter patterns to remove graph nodes."""
+        if not self.filter_recs:
+            return
         filter_nodes = set()
         for node in self.graph.nodes():
-            for filter_rec in filter_recs:
+            for filter_rec in self.filter_recs:
                 if filter_rec.search(node.get_name()):
                     filter_nodes.add(node)
         self.graph.cylc_remove_nodes_from(filter_nodes)
@@ -98,6 +103,7 @@ class MyDotWindow2(CylcDotViewerCommon):
         self.template_vars_file = template_vars_file
         self.start_point_string = None
         self.stop_point_string = None
+        self.filter_recs = []
 
         util.setup_icons()
 
@@ -184,8 +190,9 @@ class MyDotWindow2(CylcDotViewerCommon):
                     n.attr['fillcolor'] = 'powderblue'
                     n.attr['color'] = 'royalblue'
 
-        self.set_dotcode( graph.string() )
         self.graph = graph
+        self.filter_graph()
+        self.set_dotcode( graph.string() )
 
     def on_left_to_right( self, toolitem ):
         if toolitem.get_active():
@@ -270,6 +277,7 @@ class MyDotWindow( CylcDotViewerCommon ):
         self.ignore_suicide = False
         self.start_point_string = start_point_string
         self.stop_point_string = stop_point_string
+        self.filter_recs = []
 
         util.setup_icons()
 
@@ -398,8 +406,9 @@ class MyDotWindow( CylcDotViewerCommon ):
                 else:
                     node.attr['shape'] = 'tripleoctagon'
 
-        self.set_dotcode( graph.string() )
         self.graph = graph
+        self.filter_graph()
+        self.set_dotcode( graph.string() )
 
     def on_left_to_right( self, toolitem ):
         if toolitem.get_active():

--- a/lib/cylc/cylc_xdot.py
+++ b/lib/cylc/cylc_xdot.py
@@ -55,6 +55,11 @@ class CylcDotViewerCommon(xdot.DotWindow):
         self.inherit = self.suiterc.get_parent_lists()
         return True
 
+    def filter_graph_nodes(self, nodes_to_filter):
+        """Filter out a list of graph nodes."""
+        self.graph.cylc_remove_nodes_from(nodes_to_filter)
+
+
 class MyDotWindow2(CylcDotViewerCommon):
     """Override xdot to get rid of some buttons and parse graph from suite.rc"""
     # used by "cylc graph" to plot runtime namespace graphs

--- a/lib/cylc/graphing.py
+++ b/lib/cylc/graphing.py
@@ -137,7 +137,7 @@ class CGraphPlain( pygraphviz.AGraph ):
 
         # Loop through all connected nuke nodes and group them up.
         group_num = -1
-        for l_node, r_node in internal_remove_edges:
+        for l_node, r_node in sorted(internal_remove_edges):
             l_group = remove_node_groups.get(l_node)
             r_group = remove_node_groups.get(r_node)
             if l_group is None:

--- a/lib/cylc/graphing.py
+++ b/lib/cylc/graphing.py
@@ -61,6 +61,7 @@ class CGraphPlain( pygraphviz.AGraph ):
         except ValueError:
             # Special node?
             if node_string.startswith("__remove_"):
+                node.attr['style'] = 'dashed'
                 node.attr['label'] = u'\u2702'
                 return
             raise

--- a/lib/cylc/graphing.py
+++ b/lib/cylc/graphing.py
@@ -39,7 +39,13 @@ class CGraphPlain( pygraphviz.AGraph ):
         self.suite_polling_tasks = suite_polling_tasks
 
     def node_attr_by_taskname( self, node_string ):
-        name, point_string = TaskID.split(node_string)
+        try:
+            name, point_string = TaskID.split(node_string)
+        except ValueError:
+            # Special node?
+            if node_string.startswith("__remove_"):
+                return []
+            raise
         if name in self.task_attr:
             return self.task_attr[name]
         else:
@@ -50,7 +56,14 @@ class CGraphPlain( pygraphviz.AGraph ):
 
     def style_node( self, node_string, autoURL, base=False ):
         node = self.get_node( node_string )
-        name, point_string = TaskID.split(node_string)
+        try:
+            name, point_string = TaskID.split(node_string)
+        except ValueError:
+            # Special node?
+            if node_string.startswith("__remove_"):
+                node.attr['label'] = u'\u2702'
+                return
+            raise
         label = name
         if name in self.suite_polling_tasks:
             label += "\\n" + self.suite_polling_tasks[name][3]
@@ -85,35 +98,137 @@ class CGraphPlain( pygraphviz.AGraph ):
             self.style_node( right, autoURL, base=True )
             self.style_edge( left, right )
 
+    def cylc_remove_nodes_from(self, nodes):
+        """Remove nodes, returning extra edge structure if possible.
+
+        Each group of connected to-be-removed nodes is replaced by a
+        single special node to preserve dependency info between the
+        remaining nodes.
+
+        """
+        if not nodes:
+            return
+        existing_nodes = set(self.nodes())
+        add_edges = set()
+        remove_nodes = set(nodes)
+        remove_node_groups = {}
+        groups = {}
+        group_new_nodes = {}
+        edges = self.edges()
+        incoming_remove_edges = []
+        outgoing_remove_edges = []
+        internal_remove_edges = []
+        for l_node, r_node in edges:
+            if l_node in remove_nodes:
+                if r_node in remove_nodes:
+                    # This is an edge between connected nuke nodes.
+                    internal_remove_edges.append((l_node, r_node))
+                else:
+                    # This is an edge between nuke and normal nodes.
+                    outgoing_remove_edges.append((l_node, r_node))
+            elif r_node in remove_nodes:
+                incoming_remove_edges.append((l_node, r_node))
+        
+        if not outgoing_remove_edges:
+            # Preserving edges doesn't matter - ditch this whole set.
+            self.remove_nodes_from(nodes)
+            return
+
+        # Loop through all connected nuke nodes and group them up.
+        group_num = -1
+        for l_node, r_node in internal_remove_edges:
+            l_group = remove_node_groups.get(l_node)
+            r_group = remove_node_groups.get(r_node)
+            if l_group is None:
+                if r_group is None:
+                    # Create a new group for l_node and r_node.
+                    group_num += 1
+                    groups[group_num] = set((l_node, r_node))
+                    remove_node_groups[l_node] = group_num
+                    remove_node_groups[r_node] = group_num
+                else:
+                    # r_node already in a group, l_node not - add l_node.
+                    groups[r_group].add(l_node)
+                    remove_node_groups[l_node] = r_group
+            elif r_group is None:
+                # l_node already in a group, r_node not - add r_node.
+                groups[l_group].add(r_node)
+                remove_node_groups[r_node] = l_group
+            elif l_group != r_group:
+                # They are members of different groups - combine them.
+                for node in groups[r_group]:
+                    remove_node_groups[node] = l_group
+                groups[l_group] = groups[l_group].union(groups[r_group])
+                groups.pop(r_group)
+        # Some nodes are their own group and don't have connections.
+        for node in nodes:
+            if node not in remove_node_groups:
+                # The node is its own group.
+                group_num += 1
+                groups[group_num] = set((node))
+                remove_node_groups[node] = group_num
+
+        # Create a new node name for the group.
+        names = set()
+        index = -1
+        for group, group_nodes in sorted(groups.items()):
+            index += 1
+            name = "__remove_%s__" % index
+            while name in existing_nodes or name in names:
+                index += 1
+                name = "__remove_%s__" % index
+            group_new_nodes[group] = name
+            names.add(name)
+
+        new_edges = set()
+        groups_have_outgoing = set()
+        for l_node, r_node in outgoing_remove_edges:
+            new_l_group = remove_node_groups[l_node]
+            new_l_node = group_new_nodes[new_l_group]
+            new_edges.add((new_l_node, r_node, True, False, False))
+            groups_have_outgoing.add(new_l_group)
+
+        for l_node, r_node in incoming_remove_edges:
+            new_r_group = remove_node_groups[r_node]
+            new_r_node = group_new_nodes[new_r_group]
+            if new_r_group not in groups_have_outgoing:
+                # Skip any groups that don't have edges on to normal nodes.
+                continue
+            new_edges.add((l_node, new_r_node, True, False, False))
+
+        self.remove_nodes_from(nodes)
+        self.add_edges(list(new_edges))
+
     def add_edges( self, edges, ignore_suicide=False ):
         edges.sort() # TODO: does sorting help layout stability?
         for edge in edges:
-            left, right, dashed, suicide, conditional = edge
+            left, right, skipped, suicide, conditional = edge
             if suicide and ignore_suicide:
                 continue
+            attrs = {}
             if conditional:
                 if suicide:
-                    style='dashed'
-                    arrowhead='odot'
+                    attrs['style'] = 'dashed'
+                    attrs['arrowhead'] = 'odot'
                 else:
-                    style='solid'
-                    arrowhead='onormal'
+                    attrs['style'] = 'solid'
+                    attrs['arrowhead'] = 'onormal'
             else:
                 if suicide:
-                    style='dashed'
-                    arrowhead='dot'
+                    attrs['style'] = 'dashed'
+                    attrs['arrowhead'] = 'dot'
                 else:
-                    style='solid'
-                    arrowhead='normal'
-            if dashed:
+                    attrs['style'] = 'solid'
+                    attrs['arrowhead'] = 'normal'
+            if skipped:
                 # override
-                style='dashed'
+                attrs['style'] = 'dotted'
+                attrs['arrowhead'] = 'oinv'
 
-            penwidth = 2
+            attrs['penwidth'] = 2
 
             self.cylc_add_edge(
-                left, right, True, style=style, arrowhead=arrowhead,
-                penwidth=penwidth
+                left, right, True, **attrs
             )
 
     def add_cycle_point_subgraphs( self, edges ):
@@ -123,7 +238,11 @@ class CGraphPlain( pygraphviz.AGraph ):
             for id_ in edge_entry[:2]:
                 if id_ is None:
                     continue
-                point_string = TaskID.split(id_)[1]
+                try:
+                    point_string = TaskID.split(id_)[1]
+                except IndexError:
+                    # Probably a special node - ignore it.
+                    continue
                 point_string_id_map.setdefault(point_string, [])
                 point_string_id_map[point_string].append(id_)
         for point_string, ids in point_string_id_map.items():

--- a/lib/cylc/gui/updater_graph.py
+++ b/lib/cylc/gui/updater_graph.py
@@ -427,7 +427,7 @@ class GraphUpdater(threading.Thread):
 
         # Set base node style defaults
         for node in self.graphw.nodes():
-            node.attr['style'] = 'filled'
+            node.attr.setdefault('style', 'filled')
             node.attr['color'] = '#888888'
             node.attr['fillcolor'] = 'white'
             node.attr['fontcolor'] = '#888888'

--- a/tests/graphing/03-filter.t
+++ b/tests/graphing/03-filter.t
@@ -1,0 +1,39 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test filtering out graph nodes, preserving edge structure.
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 3
+#-------------------------------------------------------------------------------
+install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-validate
+run_ok $TEST_NAME cylc validate "$SUITE_NAME"
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-as-is
+graph_suite $SUITE_NAME graph.plain.test.orig
+cmp_ok graph.plain.test.orig $TEST_SOURCE_DIR/$TEST_NAME_BASE/graph.plain.ref.orig
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-filtered
+graph_suite $SUITE_NAME graph.plain.test.filtered \
+    --filter=banana.1 --filter=blackberry.1 --filter=blueberry.1 \
+    --filter=cherry.1 --filter=date.1 --filter=durian.1 --filter=elderberry.1 \
+    --filter=grape.1  --filter=coconut.1 --filter=breadfruit.1
+cmp_ok graph.plain.test.filtered $TEST_SOURCE_DIR/$TEST_NAME_BASE/graph.plain.ref.filtered
+#-------------------------------------------------------------------------------
+purge_suite $SUITE_NAME

--- a/tests/graphing/03-filter.t
+++ b/tests/graphing/03-filter.t
@@ -31,9 +31,10 @@ cmp_ok graph.plain.test.orig $TEST_SOURCE_DIR/$TEST_NAME_BASE/graph.plain.ref.or
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-filtered
 graph_suite $SUITE_NAME graph.plain.test.filtered \
-    --filter=banana.1 --filter=blackberry.1 --filter=blueberry.1 \
-    --filter=cherry.1 --filter=date.1 --filter=durian.1 --filter=elderberry.1 \
-    --filter=grape.1  --filter=coconut.1 --filter=breadfruit.1
+    --filter='^banana.1$' --filter='^blackberry.1$' --filter=lueberry \
+    --filter='^cherry.1$' --filter='^date.1$' --filter='^durian.1$' \
+    --filter='^elderberry.1$' --filter='^grape.1$' --filter='^coconut.1$' \
+    --filter='^breadfruit.1$'
 cmp_ok graph.plain.test.filtered $TEST_SOURCE_DIR/$TEST_NAME_BASE/graph.plain.ref.filtered
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/graphing/03-filter/graph.plain.ref.filtered
+++ b/tests/graphing/03-filter/graph.plain.ref.filtered
@@ -1,11 +1,11 @@
 edge "artichoke.1" __remove_0__ dotted
-edge "arugula.1" __remove_2__ dotted
+edge "arugula.1" __remove_1__ dotted
 edge "asparagus.1" __remove_0__ dotted
 edge "azuki.1" __remove_0__ dotted
 edge __remove_0__ "celery.1" dotted
 edge __remove_0__ "fava.1" dotted
 edge __remove_0__ "fennel.1" dotted
-edge __remove_2__ "carrot.1" dotted
+edge __remove_1__ "carrot.1" dotted
 graph
 node "artichoke.1" "artichoke\n1" unfilled box black
 node "arugula.1" "arugula\n1" unfilled box black
@@ -15,6 +15,6 @@ node "carrot.1" "carrot\n1" unfilled box black
 node "celery.1" "celery\n1" unfilled box black
 node "fava.1" "fava\n1" unfilled box black
 node "fennel.1" "fennel\n1" unfilled box black
-node __remove_0__ ✂ unfilled box black
-node __remove_2__ ✂ unfilled box black
+node __remove_0__ ✂ dashed box black
+node __remove_1__ ✂ dashed box black
 stop

--- a/tests/graphing/03-filter/graph.plain.ref.filtered
+++ b/tests/graphing/03-filter/graph.plain.ref.filtered
@@ -1,0 +1,20 @@
+edge "artichoke.1" __remove_0__ dotted
+edge "arugula.1" __remove_2__ dotted
+edge "asparagus.1" __remove_0__ dotted
+edge "azuki.1" __remove_0__ dotted
+edge __remove_0__ "celery.1" dotted
+edge __remove_0__ "fava.1" dotted
+edge __remove_0__ "fennel.1" dotted
+edge __remove_2__ "carrot.1" dotted
+graph
+node "artichoke.1" "artichoke\n1" unfilled box black
+node "arugula.1" "arugula\n1" unfilled box black
+node "asparagus.1" "asparagus\n1" unfilled box black
+node "azuki.1" "azuki\n1" unfilled box black
+node "carrot.1" "carrot\n1" unfilled box black
+node "celery.1" "celery\n1" unfilled box black
+node "fava.1" "fava\n1" unfilled box black
+node "fennel.1" "fennel\n1" unfilled box black
+node __remove_0__ ✂ unfilled box black
+node __remove_2__ ✂ unfilled box black
+stop

--- a/tests/graphing/03-filter/graph.plain.ref.orig
+++ b/tests/graphing/03-filter/graph.plain.ref.orig
@@ -1,0 +1,42 @@
+edge "artichoke.1" "banana.1" solid
+edge "artichoke.1" "blackberry.1" solid
+edge "artichoke.1" "blueberry.1" solid
+edge "arugula.1" "breadfruit.1" solid
+edge "asparagus.1" "banana.1" solid
+edge "azuki.1" "banana.1" solid
+edge "azuki.1" "blackberry.1" solid
+edge "azuki.1" "blueberry.1" solid
+edge "banana.1" "celery.1" solid
+edge "banana.1" "cherry.1" solid
+edge "blackberry.1" "cherry.1" solid
+edge "blueberry.1" "cherry.1" solid
+edge "breadfruit.1" "carrot.1" solid
+edge "cherry.1" "date.1" solid
+edge "cherry.1" "durian.1" solid
+edge "coconut.1" "date.1" solid
+edge "date.1" "elderberry.1" solid
+edge "durian.1" "elderberry.1" solid
+edge "durian.1" "fennel.1" solid
+edge "elderberry.1" "fava.1" solid
+edge "elderberry.1" "fennel.1" solid
+edge "fennel.1" "grape.1" solid
+graph
+node "artichoke.1" "artichoke\n1" unfilled box black
+node "arugula.1" "arugula\n1" unfilled box black
+node "asparagus.1" "asparagus\n1" unfilled box black
+node "azuki.1" "azuki\n1" unfilled box black
+node "banana.1" "banana\n1" unfilled box black
+node "blackberry.1" "blackberry\n1" unfilled box black
+node "blueberry.1" "blueberry\n1" unfilled box black
+node "breadfruit.1" "breadfruit\n1" unfilled box black
+node "carrot.1" "carrot\n1" unfilled box black
+node "celery.1" "celery\n1" unfilled box black
+node "cherry.1" "cherry\n1" unfilled box black
+node "coconut.1" "coconut\n1" unfilled box black
+node "date.1" "date\n1" unfilled box black
+node "durian.1" "durian\n1" unfilled box black
+node "elderberry.1" "elderberry\n1" unfilled box black
+node "fava.1" "fava\n1" unfilled box black
+node "fennel.1" "fennel\n1" unfilled box black
+node "grape.1" "grape\n1" unfilled box black
+stop

--- a/tests/graphing/03-filter/suite.rc
+++ b/tests/graphing/03-filter/suite.rc
@@ -1,0 +1,27 @@
+[scheduling]
+    [[dependencies]]
+        graph = """
+                  artichoke & azuki => \
+            banana & blackberry & blueberry => \
+                        cherry => \
+                    date & durian => \
+                       elderberry => \
+                      fava & fennel
+
+                                    durian => \
+                                      fennel
+
+                             fennel => \
+                              grape
+
+            asparagus => \
+            banana => \
+            celery
+
+                 coconut => \
+                  date
+
+                         arugula => \
+                         breadfruit => \
+                         carrot
+       """

--- a/tests/graphing/04-filter-siblings.t
+++ b/tests/graphing/04-filter-siblings.t
@@ -1,0 +1,37 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test filtering out graph nodes for identically-edged nodes.
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 3
+#-------------------------------------------------------------------------------
+install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-validate
+run_ok $TEST_NAME cylc validate "$SUITE_NAME"
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-as-is
+graph_suite $SUITE_NAME graph.plain.test.orig
+cmp_ok graph.plain.test.orig $TEST_SOURCE_DIR/$TEST_NAME_BASE/graph.plain.ref.orig
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-filtered
+graph_suite $SUITE_NAME graph.plain.test.filtered \
+    --filter='^banana.1$' --filter='^blackberry.1$' --filter=lueberry
+cmp_ok graph.plain.test.filtered $TEST_SOURCE_DIR/$TEST_NAME_BASE/graph.plain.ref.filtered
+#-------------------------------------------------------------------------------
+purge_suite $SUITE_NAME

--- a/tests/graphing/04-filter-siblings/graph.plain.ref.filtered
+++ b/tests/graphing/04-filter-siblings/graph.plain.ref.filtered
@@ -1,0 +1,9 @@
+edge "artichoke.1" __remove_0__ dotted
+edge "azuki.1" __remove_0__ dotted
+edge __remove_0__ "carrot.1" dotted
+graph
+node "artichoke.1" "artichoke\n1" unfilled box black
+node "azuki.1" "azuki\n1" unfilled box black
+node "carrot.1" "carrot\n1" unfilled box black
+node __remove_0__ ✂ dashed box black
+stop

--- a/tests/graphing/04-filter-siblings/graph.plain.ref.orig
+++ b/tests/graphing/04-filter-siblings/graph.plain.ref.orig
@@ -1,0 +1,17 @@
+edge "artichoke.1" "banana.1" solid
+edge "artichoke.1" "blackberry.1" solid
+edge "artichoke.1" "blueberry.1" solid
+edge "azuki.1" "banana.1" solid
+edge "azuki.1" "blackberry.1" solid
+edge "azuki.1" "blueberry.1" solid
+edge "banana.1" "carrot.1" solid
+edge "blackberry.1" "carrot.1" solid
+edge "blueberry.1" "carrot.1" solid
+graph
+node "artichoke.1" "artichoke\n1" unfilled box black
+node "azuki.1" "azuki\n1" unfilled box black
+node "banana.1" "banana\n1" unfilled box black
+node "blackberry.1" "blackberry\n1" unfilled box black
+node "blueberry.1" "blueberry\n1" unfilled box black
+node "carrot.1" "carrot\n1" unfilled box black
+stop

--- a/tests/graphing/04-filter-siblings/suite.rc
+++ b/tests/graphing/04-filter-siblings/suite.rc
@@ -1,0 +1,3 @@
+[scheduling]
+    [[dependencies]]
+        graph = artichoke & azuki => banana & blackberry & blueberry => carrot


### PR DESCRIPTION
Currently, when a node is filtered out, the incoming
and outgoing edges from it are discarded. This can split the
graph and can mislead the user. This can be particularly bad
for runahead nodes/groups of nodes where intervening base
node cycles are filtered out.

This change replaces all connected groups of filtered-out nodes
with small placeholder special nodes.

This fixes #1423, but is more of an enhancement that's up for
critique - I'm not wedded to the display choices (scissors text, dotted lines, etc)
particularly.

It adds an extra option to cylc graph to turn on filtering for
test purposes.

The following image shows the extra functionality compared with the image in #1423:

![1423_with_placeholder](https://cloud.githubusercontent.com/assets/1138333/7298318/a3aa926a-e9c6-11e4-9bd8-d11a91ba3ad0.png)