### PR TITLE
cylc test-battery: check for orphaned pyc files

### DIFF
--- a/tests/pyc/00-simple.t
+++ b/tests/pyc/00-simple.t
@@ -1,0 +1,25 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test extra pyc files that may allow imports from non-existent modules.
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 1
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE
+py_files=$(find "$CYLC_HOME" -name "*.pyc" -type f | sed "s/pyc$/py/g")
+run_ok $TEST_NAME ls $py_files

--- a/tests/pyc/00-simple.t
+++ b/tests/pyc/00-simple.t
@@ -21,5 +21,5 @@
 set_test_number 1
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE
-py_files=$(find "$CYLC_HOME" -name "*.pyc" -type f | sed "s/pyc$/py/g")
+py_files=$(find "$CYLC_DIR" -name "*.pyc" -type f | sed "s/pyc$/py/g")
 run_ok $TEST_NAME ls $py_files

--- a/tests/pyc/test_header
+++ b/tests/pyc/test_header
@@ -1,0 +1,1 @@
+../lib/bash/test_header


### PR DESCRIPTION
This checks for any remaining `.pyc` files that do not have a `.py` module. These can
cause imports to succeed where they should really fail.