### PR TITLE
cylc broadcast: fix broadcasting a float setting

### DIFF
--- a/lib/cylc/broadcast_report.py
+++ b/lib/cylc/broadcast_report.py
@@ -73,6 +73,6 @@ def get_broadcast_change_report(modified_settings, is_cancel=False):
             if isinstance(value, dict):
                 data["setting"] += "[" + key + "]"
             else:
-                data["setting"] += key + "=" + value
+                data["setting"] += key + "=" + str(value)
         msg += CHANGE_FMT % data
     return msg

--- a/tests/broadcast/07-float-setting.t
+++ b/tests/broadcast/07-float-setting.t
@@ -1,0 +1,35 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test broadcasts
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 3
+#-------------------------------------------------------------------------------
+install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-validate
+run_ok $TEST_NAME cylc validate $SUITE_NAME
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-run
+suite_run_ok $TEST_NAME cylc run --reference-test --debug $SUITE_NAME
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-check-err
+cp $(cylc get-global-config --print-run-dir)/$SUITE_NAME/log/suite/err $TEST_NAME.log-err
+grep_ok "WARNING - \[timeout\.20100808T0000Z\] -job started PT1S ago, but has not finished" $TEST_NAME.log-err
+#-------------------------------------------------------------------------------
+purge_suite $SUITE_NAME

--- a/tests/broadcast/07-float-setting/reference.log
+++ b/tests/broadcast/07-float-setting/reference.log
@@ -1,0 +1,27 @@
+2015-05-01T07:41:43Z INFO - Suite starting at 2015-05-01T07:41:43Z
+2015-05-01T07:41:43Z INFO - Run mode: live
+2015-05-01T07:41:43Z INFO - Initial point: 20100808T0000Z
+2015-05-01T07:41:43Z INFO - Final point: 20100809T0000Z
+2015-05-01T07:41:43Z INFO - Cold Start 20100808T0000Z
+2015-05-01T07:41:43Z INFO - [send_broadcast.20100808T0000Z] -initiate job-submit
+2015-05-01T07:41:43Z INFO - [send_broadcast.20100808T0000Z] -triggered off []
+
+2015-05-01T07:41:44Z INFO - [send_broadcast.20100808T0000Z] -submit_method_id=18920
+2015-05-01T07:41:44Z INFO - [send_broadcast.20100808T0000Z] -submission succeeded
+2015-05-01T07:41:45Z INFO - [send_broadcast.20100808T0000Z] -(current:submitted)> send_broadcast.20100808T0000Z started at 2015-05-01T07:41:44Z
+2015-05-01T07:41:46Z INFO - Broadcast set:
++ [timeout.20100808T0000Z] [event hooks]execution timeout=1.0
+2015-05-01T07:41:57Z INFO - [send_broadcast.20100808T0000Z] -(current:running)> send_broadcast.20100808T0000Z succeeded at 2015-05-01T07:41:57Z
+2015-05-01T07:41:58Z INFO - [timeout.20100808T0000Z] -initiate job-submit
+2015-05-01T07:41:58Z INFO - [timeout.20100808T0000Z] -triggered off ['send_broadcast.20100808T0000Z']
+
+2015-05-01T07:41:59Z INFO - [timeout.20100808T0000Z] -submit_method_id=19061
+2015-05-01T07:41:59Z INFO - [timeout.20100808T0000Z] -submission succeeded
+2015-05-01T07:42:00Z INFO - [timeout.20100808T0000Z] -(current:submitted)> timeout.20100808T0000Z started at 2015-05-01T07:41:59Z
+2015-05-01T07:42:01Z WARNING - [timeout.20100808T0000Z] -job started PT1S ago, but has not finished
+2015-05-01T07:42:01Z INFO - [timeout.20100808T0000Z] -initiate job-poll
+2015-05-01T07:42:02Z INFO - polled timeout.20100808T0000Z started at 2015-05-01T07:41:59Z
+
+2015-05-01T07:42:02Z INFO - [timeout.20100808T0000Z] -(current:running)> polled timeout.20100808T0000Z started at 2015-05-01T07:41:59Z
+2015-05-01T07:42:11Z INFO - [timeout.20100808T0000Z] -(current:running)> timeout.20100808T0000Z succeeded at 2015-05-01T07:42:10Z
+2015-05-01T07:42:12Z INFO - Suite shutting down at 2015-05-01T07:42:12Z

--- a/tests/broadcast/07-float-setting/suite.rc
+++ b/tests/broadcast/07-float-setting/suite.rc
@@ -1,0 +1,27 @@
+
+title = "test suite for broadcast timeout functionality"
+
+[cylc]
+    UTC mode = True
+    [[reference test]]
+        live mode suite timeout = PT1M
+
+[scheduling]
+    initial cycle time = 20100808T0000Z
+    final cycle time   = 20100809T0000Z
+    [[dependencies]]
+        [[[R1]]]
+            graph = """
+                send_broadcast => timeout
+            """
+
+[runtime]
+    [[send_broadcast]]
+        script = """
+            cylc broadcast -n timeout --point=20100808T0000Z --set='[event hooks]execution timeout=PT1S' $CYLC_SUITE_NAME
+            sleep 10
+        """
+    [[timeout]]
+        script = sleep 10
+        [[[event hooks]]]
+            execution timeout = PT1M


### PR DESCRIPTION
This fixes `cylc broadcast` when the configuration setting to be changed is held as a float (e.g. the timeout settings).