### PR TITLE
job submit: add filename to OSError

### DIFF
--- a/tests/job-submission/06-garbage.t
+++ b/tests/job-submission/06-garbage.t
@@ -1,0 +1,35 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test job submission, poll and kill with a garbage command.
+. "$(dirname "$0")/test_header"
+
+set_test_number 2
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+if [[ -n "${PYTHONPATH}" ]]; then
+    export PYTHONPATH="${PWD}/lib:${PYTHONPATH}"
+else
+    export PYTHONPATH="${PWD}/lib"
+fi
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+suite_run_ok "${TEST_NAME_BASE}-run" \
+    cylc run --debug --reference-test "${SUITE_NAME}"
+
+#-------------------------------------------------------------------------------
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/job-submission/06-garbage/lib/bad.py
+++ b/tests/job-submission/06-garbage/lib/bad.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Garbage batch system, for testing."""
+
+
+class BadSubmitHandler(object):
+
+    """Garbage batch system, for testing."""
+
+    SUBMIT_CMD_TMPL = "bad-bad-bad-submit '%(job)s'"
+
+
+BATCH_SYS_HANDLER = BadSubmitHandler()

--- a/tests/job-submission/06-garbage/reference.log
+++ b/tests/job-submission/06-garbage/reference.log
@@ -1,0 +1,6 @@
+2015-05-05T10:33:27+01 INFO - Run mode: live
+2015-05-05T10:33:27+01 INFO - Initial point: 1
+2015-05-05T10:33:27+01 INFO - Final point: 1
+2015-05-05T10:33:27+01 INFO - Cold Start 1
+2015-05-05T10:33:27+01 INFO - [t1.1] -triggered off []
+2015-05-05T10:33:28+01 INFO - [t2.1] -triggered off ['t1.1']

--- a/tests/job-submission/06-garbage/suite.rc
+++ b/tests/job-submission/06-garbage/suite.rc
@@ -1,0 +1,22 @@
+[cylc]
+   [[reference test]]
+       expected task failures = t1.1
+       required run mode = live
+       live mode suite timeout = PT30S
+
+[scheduling]
+    [[dependencies]]
+        graph = """t1:submit-fail => t2"""
+
+[runtime]
+    [[t1]]
+        script = true
+        [[[job submission]]]
+            method = bad
+    [[t2]]
+        script = """
+grep -q -F \
+    'OSError: [Errno 2] No such file or directory: '"'"'bad-bad-bad-submit'"'" \
+    "${CYLC_SUITE_LOG_DIR}/log"
+cylc shutdown "${CYLC_SUITE_NAME}"
+"""


### PR DESCRIPTION
Python's `subprocess.Popen` has a bad habit of not setting the command's
executable name in `OSError.filename` (e.g. command's executable does not
exist or does not have the correct permission).

@hjoliver Is this sufficient to close #1443?