### PR TITLE
cylc.task_proxy: more info in summary messages

### DIFF
--- a/lib/cylc/gui/updater_graph.py
+++ b/lib/cylc/gui/updater_graph.py
@@ -186,33 +186,22 @@ class GraphUpdater(threading.Thread):
         # this when checking for changes. So: just extract the critical
         # info here:
         states = {}
-        for id_ in states_full:
+        for id_, state_full in states_full.items():
             if id_ not in states:
                 states[id_] = {}
-            states[id_]['name'] = states_full[id_]['name']
-            # TODO: remove the following backwards compatibility condition.
-            if 'description' in states_full[id_]:
-                states[id_]['description'] = states_full[id_]['description']
-            # TODO: remove the following backwards compatibility condition.
-            if 'title' in states_full[id_]:
-                states[id_]['title'] = states_full[id_]['title']
-            states[id_]['label'] = states_full[id_]['label']
-            states[id_]['state'] = states_full[id_]['state']
+            for key in [
+                    'name', 'description', 'title', 'label', 'state',
+                    'submit_num']:
+                if key in state_full:  # ensure backward compatible
+                    states[id_][key] = state_full[key]
 
         f_states = {}
-        for id_ in fam_states_full:
+        for id_, fam_state_full in fam_states_full.items():
             if id_ not in states:
                 f_states[id_] = {}
-            f_states[id_]['name'] = fam_states_full[id_]['name']
-            # TODO: remove the following backwards compatibility condition.
-            if 'description' in fam_states_full[id_]:
-                f_states[id_]['description'] = (
-                    fam_states_full[id_]['description'])
-            # TODO: remove the following backwards compatibility condition.
-            if 'title' in fam_states_full[id_]:
-                f_states[id_]['title'] = fam_states_full[id_]['title']
-            f_states[id_]['label'] = fam_states_full[id_]['label']
-            f_states[id_]['state'] = fam_states_full[id_]['state']
+            for key in ['name', 'description', 'title', 'label', 'state']:
+                if key in fam_state_full:  # ensure backward compatible
+                    f_states[id_][key] = fam_state_full[key]
 
         if states and not self.state_summary:
             # This is basically equivalent to a first-update case.

--- a/lib/cylc/gui/updater_tree.py
+++ b/lib/cylc/gui/updater_tree.py
@@ -311,8 +311,13 @@ class TreeUpdater(threading.Thread):
                 batch_sys_name = summary[id].get('batch_sys_name')
                 host = summary[id].get('host')
                 message = summary[ id ].get('latest_message')
-                if message is not None and last_update_date is not None:
-                    message = message.replace(last_update_date + "T", "", 1)
+                if message is not None:
+                    if last_update_date is not None:
+                        message = message.replace(
+                            last_update_date + "T", "", 1)
+                    submit_num = summary[id].get('submit_num')
+                    if submit_num:
+                        message = "job(%02d) " % submit_num + message
                 if is_fam:
                     dot_type = 'family'
                     job_id = job_id or ""

--- a/lib/cylc/state_summary.py
+++ b/lib/cylc/state_summary.py
@@ -190,15 +190,18 @@ def get_id_summary( id_, task_state_summary, fam_state_summary, id_family_map ):
         if this_id in done_ids:  # family dive down will give duplicates
             continue
         done_ids.append( this_id )
-        prefix = "\n" + " " * 4 * depth + this_id + " "
+        prefix = "\n" + " " * 4 * depth + this_id
         if this_id in task_state_summary:
+            submit_num = task_state_summary[this_id].get('submit_num')
+            if submit_num:
+                prefix += "(%02d)" % submit_num
             state = task_state_summary[this_id]['state']
-            sub_text += prefix + state
+            sub_text += prefix + " " + state
             sub_states.setdefault( state, 0 )
             sub_states[state] += 1
         elif this_id in fam_state_summary:
             name, point_string = TaskID.split(this_id)
-            sub_text += prefix + fam_state_summary[this_id]['state']
+            sub_text += prefix + " " + fam_state_summary[this_id]['state']
             for child in reversed( sorted( id_family_map[name] ) ):
                 child_id = TaskID.get(child, point_string)
                 stack.insert( 0, ( child_id, depth + 1 ) )

--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -28,6 +28,7 @@ from collections import deque
 from logging import getLogger, CRITICAL, ERROR, WARNING, INFO, DEBUG
 import shlex
 import traceback
+from isodatetime.data import get_timepoint_from_seconds_since_unix_epoch
 from isodatetime.timezone import get_local_time_zone
 
 from cylc.task_state import task_state
@@ -154,8 +155,6 @@ class TaskProxy(object):
         self.hold_on_retry = False
         self.manual_trigger = False
 
-        self.latest_message = ""
-
         self.submission_timer_timeout = None
         self.execution_timer_timeout = None
 
@@ -163,9 +162,10 @@ class TaskProxy(object):
         self.started_time = None
         self.finished_time = None
         self.summary = {
-            'latest_message': self.latest_message,
+            'latest_message': "",
             'submitted_time': None,
             'submitted_time_string': None,
+            'submit_num': self.submit_num,
             'started_time': None,
             'started_time_string': None,
             'finished_time': None,
@@ -667,13 +667,17 @@ class TaskProxy(object):
         else:
             # There is a submission retry lined up.
             self.sub_retry_delay = sub_retry_delay
-            delay_msg = "submit-retrying in %s" % (
-                get_seconds_as_interval_string(sub_retry_delay))
-            msg = "job submission failed, " + delay_msg
-            self.log(INFO, msg)
-
             self.sub_retry_delay_timer_timeout = (
                 time.time() + sub_retry_delay)
+            timeout_str = str(get_timepoint_from_seconds_since_unix_epoch(
+                int(self.sub_retry_delay_timer_timeout)))
+
+            delay_msg = "submit-retrying in %s" % (
+                get_seconds_as_interval_string(sub_retry_delay))
+            msg = "submission failed, %s (after %s)" % (delay_msg, timeout_str)
+            self.log(INFO, "job(%02d) " % self.submit_num + msg)
+            self.summary['latest_message'] = msg
+
             self.sub_try_number += 1
             self.set_status('submit-retrying')
             self.record_db_event(event="submission failed",
@@ -685,7 +689,8 @@ class TaskProxy(object):
             self.record_db_event(
                 event="submission failed",
                 message="submit-retrying in " + str(sub_retry_delay))
-            self.handle_event('submission retry', msg)
+            self.handle_event(
+                "submission retry", "job submission failed, " + delay_msg)
             if self.hold_on_retry:
                 self.reset_state_held()
 
@@ -727,13 +732,7 @@ class TaskProxy(object):
         self.summary['submit_method_id'] = self.submit_method_id
         self.summary['batch_sys_name'] = self.batch_sys_name
         self.summary['host'] = self.task_host
-        if self.submit_method_id:
-            self.latest_message = "%s submitted as '%s'" % (
-                self.identity, self.submit_method_id)
-        else:
-            self.latest_message = outp
-        self.summary['latest_message'] = (
-            self.latest_message.replace(self.identity, "", 1).strip())
+        self.summary['latest_message'] = "submitted"
         self.handle_event(
             'submitted', 'job submitted', db_event='submission succeeded')
 
@@ -774,16 +773,22 @@ class TaskProxy(object):
         else:
             # There is a retry lined up
             self.retry_delay = retry_delay
+            self.retry_delay_timer_timeout = (time.time() + retry_delay)
+            timeout_str = str(get_timepoint_from_seconds_since_unix_epoch(
+                int(self.retry_delay_timer_timeout)))
+
             delay_msg = "retrying in %s" % (
                 get_seconds_as_interval_string(retry_delay))
-            msg = "job failed, " + delay_msg
-            self.log(INFO, msg)
-            self.retry_delay_timer_timeout = (time.time() + retry_delay)
+            msg = "failed, %s (after %s)" % (delay_msg, timeout_str)
+            self.log(INFO, "job(%02d) " % self.submit_num + msg)
+            self.summary['latest_message'] = msg
+
             self.try_number += 1
             self.set_status('retrying')
             self.prerequisites.set_all_satisfied()
             self.outputs.set_all_incomplete()
-            self.handle_event('retry', msg, db_msg=delay_msg)
+            self.handle_event(
+                "retry", "job failed, " + delay_msg, db_msg=delay_msg)
             if self.hold_on_retry:
                 self.reset_state_held()
 
@@ -858,6 +863,7 @@ class TaskProxy(object):
         """Increment and record the submit number."""
         self.log(DEBUG, "incrementing submit number")
         self.submit_num += 1
+        self.summary['submit_num'] = self.submit_num
         self.record_db_event(event="incrementing submit number")
         self.record_db_update("task_states", submit_num=self.submit_num)
 
@@ -1240,9 +1246,8 @@ class TaskProxy(object):
             '(current:' + self.state.get_status() + ')> ' + message
         )
         # always update the suite state summary for latest message
-        self.latest_message = message
-        self.summary['latest_message'] = (
-            self.latest_message.replace(self.identity, "", 1).strip())
+        self.summary['latest_message'] = message.replace(
+            self.identity, "", 1).strip()
         flags.iflag = True
 
         if self.reject_if_failed(message):
@@ -1543,6 +1548,6 @@ class TaskProxy(object):
             cmd = shlex.split(ssh_tmpl) + [str(self.user_at_host), sh_cmd]
 
         # Queue the command for execution
-        self.log(INFO, "initiate %s" % (cmd_key))
+        self.log(INFO, "job(%02d) initiate %s" % (self.submit_num, cmd_key))
         return SuiteProcPool.get_inst().put_command(
             cmd_type, cmd, callback, is_bg_submit, stdin_file_path)

--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -28,7 +28,6 @@ from collections import deque
 from logging import getLogger, CRITICAL, ERROR, WARNING, INFO, DEBUG
 import shlex
 import traceback
-from isodatetime.data import get_timepoint_from_seconds_since_unix_epoch
 from isodatetime.timezone import get_local_time_zone
 
 from cylc.task_state import task_state
@@ -68,7 +67,6 @@ from cylc.mp_pool import (
 )
 from cylc.task_id import TaskID
 from cylc.task_output_logs import logfiles
-from cylc.wallclock import get_time_string_from_unix_time
 
 
 class TaskProxySequenceBoundsError(ValueError):
@@ -669,8 +667,8 @@ class TaskProxy(object):
             self.sub_retry_delay = sub_retry_delay
             self.sub_retry_delay_timer_timeout = (
                 time.time() + sub_retry_delay)
-            timeout_str = str(get_timepoint_from_seconds_since_unix_epoch(
-                int(self.sub_retry_delay_timer_timeout)))
+            timeout_str = get_time_string_from_unix_time(
+                self.sub_retry_delay_timer_timeout)
 
             delay_msg = "submit-retrying in %s" % (
                 get_seconds_as_interval_string(sub_retry_delay))
@@ -774,8 +772,8 @@ class TaskProxy(object):
             # There is a retry lined up
             self.retry_delay = retry_delay
             self.retry_delay_timer_timeout = (time.time() + retry_delay)
-            timeout_str = str(get_timepoint_from_seconds_since_unix_epoch(
-                int(self.retry_delay_timer_timeout)))
+            timeout_str = get_time_string_from_unix_time(
+                self.retry_delay_timer_timeout)
 
             delay_msg = "retrying in %s" % (
                 get_seconds_as_interval_string(retry_delay))

--- a/tests/hold-release/11-retrying/suite.rc
+++ b/tests/hold-release/11-retrying/suite.rc
@@ -21,7 +21,7 @@ t-retry-able => t-analyse
         retry delays = PT15S, 2*PT1S
     [[t-hold-release]]
         script = """
-timeout 30s my-log-grepper '[t-retry-able.1] -job failed, retrying in PT15S'
+timeout 30s my-log-grepper '[t-retry-able.1] -job(01) failed, retrying in PT15S'
 cylc hold "${CYLC_SUITE_NAME}" 't-retry-able' '1'
 timeout 30s my-log-grepper '[t-retry-able.1] -retrying => held'
 cylc release "${CYLC_SUITE_NAME}" 't-retry-able' '1'


### PR DESCRIPTION
Task summary now includes the submit number. This gets displayed by `cylc gui` tree view latest message, and tool tips in other views.

On retry, the latest message includes the delay interval and the time after which it will retry.

On initiation of job submit, poll and kill, log the submit number.

Close #30.