### PR TITLE
cylc: friendlier init for admin/cylc-wrapper

### DIFF
--- a/bin/cylc
+++ b/bin/cylc
@@ -17,9 +17,19 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, re, sys
-import subprocess
 
-sys.path.append(os.path.dirname(os.path.realpath(os.path.abspath(__file__))) + '/../lib')
+
+def prelude():
+    """Ensure cylc library is at the front of "sys.path"."""
+    lib = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), '..', 'lib')
+    if lib in sys.path:
+        sys.path.remove(lib)
+    sys.path.insert(0, lib)
+
+
+prelude()
+
 
 try:
     os.getcwd()
@@ -651,7 +661,7 @@ for item in command_args:
         args_new.append(item)
 args = args_new
 
-cmd = 'cylc-' + command
+cmd = sys.argv[0] + '-' + command
 
 ####BACKGROUNDED MESSAGING CALLS: this results in a currently
 ####undiagnosed error in Pyro core when the 'message' command is
@@ -665,5 +675,7 @@ cmd = 'cylc-' + command
 # Replace the current process with that of the sub-command.
 try:
     os.execvp(cmd, [cmd] + args)
-except OSError, x:
-    raise SystemExit(x)
+except OSError, exc:
+    if exc.filename is None:
+        exc.filename = cmd
+    raise SystemExit(exc)

--- a/bin/cylc-gsummary
+++ b/bin/cylc-gsummary
@@ -16,29 +16,29 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from optparse import OptionParser
 
-parser = OptionParser( """cylc gsummary [OPTIONS]
+from cylc.CylcOptionParsers import cop
+
+parser = cop(
+    """cylc gsummary [OPTIONS]
 cylc gsummary [OPTIONS]
 
 This is the cylc summary gui for monitoring running suites on a set of
 hosts.
 
 To customize themes copy $CYLC_DIR/conf/gcylcrc/gcylc.rc.eg to
-$HOME/.cylc/gcylc.rc and follow the instructions in the file.""")
-parser.add_option( "--user",
-                   help="User account name (defaults to $USER).",
-                   metavar="USER", default=None,
-                   action="store", dest="owner" )
-parser.add_option( "--host",
-                   help="Host names to monitor (override site default).",
-                   metavar="HOST", action="append",
-                   dest="hosts" )
-parser.add_option( "--poll-interval",
-                   help="Polling interval (time between updates) in seconds",
-                   type="int", metavar="SECONDS", dest="interval" )
+$HOME/.cylc/gcylc.rc and follow the instructions in the file.""",
+    argdoc=[])
+parser.remove_option("--host")
+parser.add_option("--host",
+                  help="Host names to monitor (override site default).",
+                  metavar="HOST", action="append",
+                  dest="hosts")
+parser.add_option("--poll-interval",
+                  help="Polling interval (time between updates) in seconds",
+                  type="int", metavar="SECONDS", dest="interval")
 
-( options, args ) = parser.parse_args()
+options, args = parser.parse_args()
 
 import gtk
 import warnings

--- a/lib/cylc/CylcOptionParsers.py
+++ b/lib/cylc/CylcOptionParsers.py
@@ -109,6 +109,8 @@ Arguments:"""
         usage = re.sub( 'ARGS', args, usage )
 
         OptionParser.__init__( self, usage )
+        if self.auto_add:
+            self.add_std_options()
 
     def add_std_options( self ):
         self.add_option( "--user",
@@ -215,8 +217,6 @@ Arguments:"""
 
     def parse_args( self, remove_opts=[] ):
 
-        if self.auto_add:
-            self.add_std_options()
         for opt in remove_opts:
             try:
                 self.remove_option( opt )

--- a/lib/cylc/__init__.py
+++ b/lib/cylc/__init__.py
@@ -15,12 +15,12 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-# Set up the cylc environment.
+"""Set up the cylc environment."""
 
 import os
 import socket
 import sys
+
 
 def environ_init(argv0=None):
     """Initialise cylc environment."""
@@ -37,11 +37,18 @@ def environ_init(argv0=None):
         if cylc_dir != os.getenv('CYLC_DIR', ''):
             os.environ['CYLC_DIR'] = cylc_dir
 
-        dirs = []
+        cylc_dir_lib = os.path.join(cylc_dir, 'lib')
+        my_lib = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+        if cylc_dir_lib == my_lib:
+            dirs = []
+        else:
+            # For backward compat, old versions of "cylc" may end up loading an
+            # incorrect version of this file.
+            dirs = [os.path.join(cylc_dir, 'bin')]
         if os.getenv('CYLC_SUITE_DEF_PATH', ''):
             dirs.append(os.getenv('CYLC_SUITE_DEF_PATH'))
         environ_path_add(dirs)
-        environ_path_add([os.path.join(cylc_dir, 'lib')], 'PYTHONPATH')
+        environ_path_add([cylc_dir_lib], 'PYTHONPATH')
 
     # Python output buffering delays appearance of stdout and stderr
     # when output is not directed to a terminal (this occurred when
@@ -49,17 +56,25 @@ def environ_init(argv0=None):
     # case in post-5.0 daemon-mode cylc?)
     os.environ['PYTHONUNBUFFERED'] = 'true'
 
+
 def environ_path_add(dirs, key='PATH'):
-    """For each dir in dirs, add dir to the front of the PATH environment
-    variable. If the 2nd argument key is specified, add each dir to the front of
-    the named environment variable instead of PATH.
+    """For each dir_ in dirs, prepend dir_ to the PATH environment variable.
+
+    If key is specified, prepend dir_ to the named environment variable instead
+    of PATH.
+
     """
 
-    paths = os.getenv(key, '').split(os.pathsep)
-    for dir in dirs:
-        while dir in paths:
-            paths.remove(dir)
-        paths.insert(0, dir)
+    paths_str = os.getenv(key, '')
+    # ''.split(os.pathsep) gives ['']
+    if paths_str.strip():
+        paths = paths_str.split(os.pathsep)
+    else:
+        paths = []
+    for dir_ in dirs:
+        while dir_ in paths:
+            paths.remove(dir_)
+        paths.insert(0, dir_)
     os.environ[key] = os.pathsep.join(paths)
 
 

--- a/lib/cylc/__init__.py
+++ b/lib/cylc/__init__.py
@@ -37,7 +37,7 @@ def environ_init(argv0=None):
         if cylc_dir != os.getenv('CYLC_DIR', ''):
             os.environ['CYLC_DIR'] = cylc_dir
 
-        dirs = [os.path.join(cylc_dir, 'bin')]
+        dirs = []
         if os.getenv('CYLC_SUITE_DEF_PATH', ''):
             dirs.append(os.getenv('CYLC_SUITE_DEF_PATH'))
         environ_path_add(dirs)


### PR DESCRIPTION
cylc:
* Prepend its `../lib/` to `sys.path` - if the `lib/` of a different version of `cylc` is already in the `PYTHONPATH`, it will ensure that the library of the current invocation of `cylc` is in the front. (The old logic *appends* `../lib/` to `sys.path`, which means that it loads `lib/cylc/__init__.py` from an incorrect version, but which would by chance sets `PYTHONPATH` correctly again to the correct version. It *works* but is not safe.)
* Don't add `CYLC_DIR` to front of `PATH` - this allows wrapper to look for `cylc` using `CYLC_VERSION`.
* `cylc` will no longer rely on sub-commands to be in `PATH`. It now calls them from its own location.
* On `OSError` executing a sub-command, it will now print the file name of the sub-command.

cylc gsummary:
* When launching `cylc gui`, it will now set `CYLC_VERSION` to match the cylc version of the suite daemon.
* Support  `--debug` option.