### PR TITLE
Corrected a bad db error message.

### DIFF
--- a/lib/cylc/dbstatecheck.py
+++ b/lib/cylc/dbstatecheck.py
@@ -26,7 +26,7 @@ class DBOperationError(Exception):
     """An exception raised when a db operation fails, typically due to a lock."""
 
     def __str__(self):
-        return "Suite database not found at: %s" % self.args
+        return "Suite database operation failed: %s" % self.args
 
 
 class DBNotFoundError(Exception):


### PR DESCRIPTION
If suite polling fails because the target db is locked, we get:

```
cylc.dbstatecheck.DBOperationError: Suite database not found at: database is locked
```

This corrects the error message string.