### PR TITLE
cylc gui: handle invalid utf-8 bytes in log files

### DIFF
--- a/lib/cylc/gui/tailer.py
+++ b/lib/cylc/gui/tailer.py
@@ -32,6 +32,7 @@ class tailer(threading.Thread):
         self.tag = tag
         self.proc = proc
         self.freeze = False
+        self.has_warned_corrupt = False
         self.warning_re = warning_re
         self.critical_re = critical_re
         self.warning_tag = self.logbuffer.create_tag( None, foreground = "#a83fd3" )
@@ -116,6 +117,9 @@ class tailer(threading.Thread):
         try:
             line.decode('utf-8')
         except UnicodeDecodeError as exc:
+            if self.has_warned_corrupt:
+                return False
+            self.has_warned_corrupt = True
             dialog = warning_dialog("Problem reading file:\n    %s: %s" %
                                     (type(exc).__name__, exc))
             gobject.idle_add(dialog.warn)

--- a/lib/cylc/gui/tailer.py
+++ b/lib/cylc/gui/tailer.py
@@ -113,6 +113,13 @@ class tailer(threading.Thread):
             #print "Disconnecting from tailer thread"
 
     def update_gui( self, line ):
+        try:
+            line.decode('utf-8')
+        except UnicodeDecodeError as exc:
+            dialog = warning_dialog("Problem reading file:\n    %s: %s" %
+                                    (type(exc).__name__, exc))
+            gobject.idle_add(dialog.warn)
+            return False
         if self.critical_re and re.search( self.critical_re, line ):
             self.logbuffer.insert_with_tags( self.logbuffer.get_end_iter(), line, self.critical_tag )
         elif self.warning_re and re.search( self.warning_re, line ):


### PR DESCRIPTION
If invalid utf-8 bytes are present in a job's standard out or err, the log file viewer in `cylc gui` will have a blank display and some stderr may be spit out like this from gtk:

```
GtkWarning: gtk_text_buffer_emit_insert: assertion `g_utf8_validate (text, len, NULL)' failed
  self.logbuffer.insert( self.logbuffer.get_end_iter(), line )
```

This change tests for corrupt stuff.

Invalid log files can be created by running e.g. `head /dev/urandom >>job.err` (although it is possible it might produce totally sensible text!). Our software that produced the garbage bytes had been killed by Slurm in an out-of-memory situation.
