### PR TITLE
tests/restart: remove unnecessary env

### DIFF
--- a/tests/restart/retrying/suite.rc
+++ b/tests/restart/retrying/suite.rc
@@ -82,7 +82,6 @@
         description = "Force a shutdown and restart of the suite"
         [[[environment]]]
             CYLC_TEST_BATCH_TASK_HOST={{ HOST }}
-            CYLC_TEST_BATCH_SITE_DIRECTIVES={{ SITE_DIRECTIVES }}
             TEST_DIR={{ TEST_DIR }}
     [[output_states]]
         script = """

--- a/tests/restart/running/suite.rc
+++ b/tests/restart/running/suite.rc
@@ -75,7 +75,6 @@
         description = "Force a shutdown and restart of the suite"
         [[[environment]]]
             CYLC_TEST_BATCH_TASK_HOST={{ HOST }}
-            CYLC_TEST_BATCH_SITE_DIRECTIVES={{ SITE_DIRECTIVES }}
             TEST_DIR={{ TEST_DIR }}
     [[output_states]]
         script = """

--- a/tests/restart/submit-failed/suite.rc
+++ b/tests/restart/submit-failed/suite.rc
@@ -77,7 +77,6 @@
         description = "Force a shutdown and restart of the suite"
         [[[environment]]]
             CYLC_TEST_BATCH_TASK_HOST={{ HOST }}
-            CYLC_TEST_BATCH_SITE_DIRECTIVES={{ SITE_DIRECTIVES }}
             TEST_DIR={{ TEST_DIR }}
     [[output_states]]
         script = """


### PR DESCRIPTION
Writing the directives as a Jinja2 string as an environment variable
casuses the tests to die in error if we add multiple lines of site
specific directives to a batch system and that the key of line 2(+)
contains an invalid identifier as an environment variable.

@benfitzpatrick please review.