### PR TITLE
Fix special task name check

### DIFF
--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -1050,7 +1050,10 @@ class config( object ):
                         'ERROR: Illegal %s task name: %s' % (task_type, name))
                 if name not in self.taskdefs and name not in self.cfg['runtime']:
                     msg = '%s task "%s" is not defined.' % (task_type % name)
-                    raise SuiteConfigError("ERROR: " + msg)
+                    if self.strict:
+                        raise SuiteConfigError("ERROR: " + msg)
+                    else:
+                        print >> sys.stderr, "WARNING: " + msg
 
         try:
             import Pyro.constants

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -1041,14 +1041,16 @@ class config( object ):
                         print >> sys.stderr, '  WARNING: task "' + name + '" is not used in the graph.'
 
         # warn if listed special tasks are not defined
-        for type in self.cfg['scheduling']['special tasks']:
-            for name in self.cfg['scheduling']['special tasks'][type]:
-                if type == 'clock-triggered':
+        for task_type in self.cfg['scheduling']['special tasks']:
+            for name in self.cfg['scheduling']['special tasks'][task_type]:
+                if task_type == 'clock-triggered':
                     name = re.sub('\(.*\)','',name)
-                if re.search( '[^0-9a-zA-Z_]', name ):
-                    raise SuiteConfigError, 'ERROR: Illegal ' + type + ' task name: ' + name
+                if not TaskID.is_valid_name(name):
+                    raise SuiteConfigError(
+                        'ERROR: Illegal %s task name: %s' % (task_type, name))
                 if name not in self.taskdefs and name not in self.cfg['runtime']:
-                    raise SuiteConfigError, 'ERROR: special task "' + name + '" is not defined.'
+                    msg = '%s task "%s" is not defined.' % (task_type % name)
+                    raise SuiteConfigError("ERROR: " + msg)
 
         try:
             import Pyro.constants

--- a/tests/validate/36-pass-special-tasks-non-word-names.t
+++ b/tests/validate/36-pass-special-tasks-non-word-names.t
@@ -1,0 +1,41 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test validation of special tasks names with non-word characters
+. "$(dirname "$0")/test_header"
+set_test_number 1
+cat >'suite.rc' <<'__SUITE_RC__'
+[scheduling]
+    initial cycle point = 20200202
+    final cycle point = 20300303
+    [[special tasks]]
+        clock-triggered = t-1, t+1, t%1, t@1
+    [[dependencies]]
+        [[[P1D]]]
+            graph = """
+t-1
+t+1
+t%1
+t@1
+"""
+
+[runtime]
+    [[t-1, t+1, t%1, t@1]]
+        script = true
+__SUITE_RC__
+run_ok "${TEST_NAME_BASE}" cylc validate --strict "${PWD}/suite.rc"
+exit


### PR DESCRIPTION
This fixes the task name validity check for special task configuration.

It also allows undefined task names in special task config lists, except in strict validation mode - so
you can temporarily comment tasks out of the graph without having to alter the ```[[special tasks]]``` section as well - which I think is consistent with allowing naked dummy tasks in non-strict mode.

@matthewrmshin - please review.