### PR TITLE
cylc.batch_sys_manager: fix job kill ret code

### DIFF
--- a/lib/cylc/batch_sys_manager.py
+++ b/lib/cylc/batch_sys_manager.py
@@ -216,6 +216,8 @@ class BatchSysManager(object):
                     if not exc.filename:
                         exc.filename = command[0]
                     raise
+                else:
+                    return 0
         return 1
 
     def job_poll(self, st_file_path):

--- a/tests/job-kill/02-loadleveler/suite.rc
+++ b/tests/job-kill/02-loadleveler/suite.rc
@@ -27,6 +27,6 @@
 {% endif %}
     [[stop]]
         script="""
-cylc kill $CYLC_SUITE_REG_NAME t1 1 || true
+cylc kill $CYLC_SUITE_REG_NAME t1 1
 cylc stop $CYLC_SUITE_REG_NAME
 """

--- a/tests/job-kill/03-slurm/suite.rc
+++ b/tests/job-kill/03-slurm/suite.rc
@@ -29,6 +29,6 @@
 {% endif %}
     [[stop]]
         script="""
-cylc kill $CYLC_SUITE_REG_NAME t1 1 || true
+cylc kill $CYLC_SUITE_REG_NAME t1 1
 cylc stop $CYLC_SUITE_REG_NAME
 """

--- a/tests/job-kill/04-pbs/suite.rc
+++ b/tests/job-kill/04-pbs/suite.rc
@@ -24,6 +24,6 @@
 {% endif %}
     [[stop]]
         script="""
-cylc kill $CYLC_SUITE_REG_NAME t1 1 || true
+cylc kill $CYLC_SUITE_REG_NAME t1 1
 cylc stop $CYLC_SUITE_REG_NAME
 """


### PR DESCRIPTION
It was always returning 1.

Also ensure that the exit codes of submit, poll, kill, etc commands are
logged in the `job-activity.log`.

Fix #1472.