### PR TITLE
Don't use "at" for remote hosts tests

### DIFF
--- a/tests/job-kill/01-remote/suite.rc
+++ b/tests/job-kill/01-remote/suite.rc
@@ -19,8 +19,6 @@ t2:start=>stop
 {% endif %}
     [[t1]]
         inherit=T
-        [[[job submission]]]
-            method=at
     [[t2]]
         inherit=T
     [[stop]]

--- a/tests/restart/22-bad-job-host/suite.rc
+++ b/tests/restart/22-bad-job-host/suite.rc
@@ -15,8 +15,6 @@ timeout 30 bash -c 'while [[ -e 'file' ]]; do sleep 1; done' || true
 """
         [[[remote]]]
             host = {{environ['CYLC_TEST_HOST']}}
-        [[[job submission]]]
-            method = at
     [[t-shutdown]]
         script = """
 # Shutdown and wait


### PR DESCRIPTION
These tests will work just fine in my environment with `background` job submission, but they could hang then fail if `at` does not work correctly on the tests' remote host.

@hjoliver please review.