### PR TITLE
Changed db max commit attempts to 10.

### DIFF
--- a/lib/cylc/rundb.py
+++ b/lib/cylc/rundb.py
@@ -99,7 +99,7 @@ class BulkDBOperObject(object):
 class ThreadedCursor(Thread):
     def __init__(self, db, dump, restart=False):
         super(ThreadedCursor, self).__init__()
-        self.max_commit_attempts = 5
+        self.max_commit_attempts = 10
         self.db=db
         self.db_dump_name = dump
         self.reqs=Queue.Queue()


### PR DESCRIPTION
@arjclark - on NIWA's biggest suite we occasionally have db retries reach the current max of 5, causing suite shutdown.  Any problem with upping it to 10 (which I have done already in our installation)?