### PR TITLE
Graph - don't add extra edges when grouping by cycle.

### DIFF
--- a/lib/cylc/graphing.py
+++ b/lib/cylc/graphing.py
@@ -296,10 +296,6 @@ class CGraphPlain( pygraphviz.AGraph ):
         nodes = self.prepare_nbunch(nbunch)
         subgraph.add_nodes_from(nodes)
 
-        for left, right in self.edges():
-            if left in subgraph and right in subgraph: 
-                subgraph.add_edge(left, right)
-
         return subgraph
 
 


### PR DESCRIPTION
My recent change (since last release) to use non "strict" graphs in order to reveal self-dependence loops, has also revealed that extra edges are added within cycle point sub-graphs when sub-graph grouping is turned on.  E.g. on master:
![bar-1](https://cloud.githubusercontent.com/assets/2362137/7857463/a250ddbe-0584-11e5-8678-a621e4ced9e8.png)
and on this branch:
![bar-2](https://cloud.githubusercontent.com/assets/2362137/7857476/b115f550-0584-11e5-80a5-ec487a519017.png)

@benfitzpatrick - can you review the small change here, and confirm that there isn't some circumstance under which the extra edges really do need to be added?
