### PR TITLE
1481.fix family edges

### DIFF
--- a/lib/cylc/graphing.py
+++ b/lib/cylc/graphing.py
@@ -32,7 +32,7 @@ class CGraphPlain( pygraphviz.AGraph ):
 
     def __init__( self, title, suite_polling_tasks={} ):
         self.title = title
-        pygraphviz.AGraph.__init__( self, directed=True, strict=False )
+        pygraphviz.AGraph.__init__( self, directed=True, strict=True )
         # graph attributes
         # - label (suite name)
         self.graph_attr['label'] = title

--- a/tests/validate/35-fail-self-edges.t
+++ b/tests/validate/35-fail-self-edges.t
@@ -24,5 +24,5 @@ install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE
 run_fail $TEST_NAME cylc validate --debug -v -v $SUITE_NAME
-grep_ok "ERROR: cyclic dependence detected" $TEST_NAME.stderr
+grep_ok "ERROR, self-edge detected:" $TEST_NAME.stderr
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Close #1481.  Restores graphviz ```strict=True``` and detects self-edges earlier on, when first creating the graph edges.

@benfitzpatrick - please review.