### PR TITLE
gcylc - fix handling of "running to" status.

### DIFF
--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -3158,15 +3158,30 @@ For more Stop options use the Control menu.""")
         self.tool_bar_box.pack2(self.tool_bars[1], resize=True, shrink=True)
 
     def _alter_status_toolbar_menu(self, new_status):
-        #But  Handle changes in status for some toolbar/menuitems.
+        """Handle changes in status for some toolbar/menuitems.
+        
+       Example status strings:
+         * stopped with 'running'
+         * connected
+         * initialising
+         * running
+         * held
+         * hold at 20150601T0000Z
+         * reloading
+         * running to 20150601T0000Z
+         * running to 2015-08-08T01:00:00+12:00
+         * stopping
+         * stopped
+         * stopped with 'succeeded' 
+        """
         if new_status == self._prev_status:
             return False
         self.info_bar.prog_bar_disabled = False
         self._prev_status = new_status
         run_ok = "stopped" in new_status
-        # Pause: avoid "stopped with running":
-        pause_ok = (new_status in ["running", "reloading"] and 
-                    "stopped" not in new_status)
+        # Pause: avoid "stopped with 'running'".
+        pause_ok = (new_status == "reloading" or 
+                "running" in new_status and not "stopped" in new_status)
         unpause_ok = "hold at" in new_status or "held" == new_status
         stop_ok = ("stopped" not in new_status and
                    "connected" != new_status and


### PR DESCRIPTION
Fixes issue #1485.

The gcylc suite status strings are quite varied; we need to be careful in matching them to determine widget sensitivities.

@kaday - please review.  Check that your problem was exactly the same as the one I've identified and fixed (i.e. that it was triggered by the use of final cycle point, and hence a "running to POINT" status string).