### PR TITLE
scheduler.py : fix for deleting a suite out from under a process

### DIFF
--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -18,6 +18,7 @@
 
 import os
 import re
+import signal
 import sys
 import time
 import traceback
@@ -893,14 +894,16 @@ class scheduler(object):
 
         fs_check_period = datetime.timedelta(minutes=10)
         next_fs_check = datetime.datetime.utcnow() + fs_check_period
+
+        suite_run_dir = GLOBAL_CFG.get_derived_host_item(
+            self.suite, 'suite run directory')
+
         while True:  # MAIN LOOP
 
             # Periodic check that the suite directory still exists
             if datetime.datetime.now() > next_fs_check:
-                if not os.path.exists(self.suite_dir):
-                    self.shutdown(
-                        "ERROR: Suite directory not found at " + self.suite_dir)
-                    raise
+                if not os.path.exists(suite_run_dir):
+                    os.kill(os.getpid(), signal.SIGKILL)
                 else:
                     next_fs_check = datetime.datetime.utcnow() + fs_check_period
 

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -901,6 +901,8 @@ class scheduler(object):
         while True:  # MAIN LOOP
 
             # Periodic check that the suite directory still exists
+            # - designed to catch stalled suite daemons where the suite 
+            # directory has been deleted out from under itself
             if datetime.datetime.now() > next_fs_check:
                 if not os.path.exists(suite_run_dir):
                     os.kill(os.getpid(), signal.SIGKILL)

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -890,7 +890,20 @@ class scheduler(object):
         self.run_event_handlers('startup', abort, 'suite starting')
 
         proc_pool = SuiteProcPool.get_inst()
+
+        fs_check_period = datetime.timedelta(minutes=10)
+        next_fs_check = datetime.datetime.utcnow() + fs_check_period
         while True:  # MAIN LOOP
+
+            # Periodic check that the suite directory still exists
+            if datetime.datetime.now() > next_fs_check:
+                if not os.path.exists(self.suite_dir):
+                    self.shutdown(
+                        "ERROR: Suite directory not found at " + self.suite_dir)
+                    raise
+                else:
+                    next_fs_check = datetime.datetime.utcnow() + fs_check_period
+
             # PROCESS ALL TASKS whenever something has changed that might
             # require renegotiation of dependencies, etc.
 


### PR DESCRIPTION
This adds a check in the main scheduler loop that checks the suite directory still exists.

We have seen the situation where users will have a suite fail, have notifications from the handlers and not take any action. Some time later they will delete the suite directory, leaving suite processes lying around on our servers. This adds a periodic check to make sure the suite directory is still there and shut it down if not.

@hjoliver - please review. N.B. I can adjust the check to be frequent if so desired.