### PR TITLE
Fail use of both runahead config items.

### DIFF
--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -178,6 +178,14 @@ class config( object ):
                 write_proc=write_proc )
         self.cfg = self.pcfg.get(sparse=True)
 
+        # The two runahead limiting schemes are mutually exclusive.
+        rlim = self.cfg['scheduling'].get('runahead limit', None) 
+        mact = self.cfg['scheduling'].get('max active cycle points', None)
+        if rlim is not None and mact is not None:
+            raise SuiteConfigError(
+                "ERROR: use 'runahead limit' OR "
+                "'max active cycle points', not both")
+
         if self._cli_initial_point_string is not None:
             self.cfg['scheduling']['initial cycle point'] = (
                 self._cli_initial_point_string)

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -178,6 +178,13 @@ class config( object ):
                 write_proc=write_proc )
         self.cfg = self.pcfg.get(sparse=True)
 
+        # First check for the essential scheduling section.
+        if 'scheduling' not in self.cfg:
+            raise SuiteConfigError("ERROR: missing [scheduling] section.")
+        if 'dependencies' not in self.cfg['scheduling']:
+            raise SuiteConfigError(
+                "ERROR: missing [scheduling][[dependencies]] section.")
+        # (The check that 'graph' is definied is below).
         # The two runahead limiting schemes are mutually exclusive.
         rlim = self.cfg['scheduling'].get('runahead limit', None) 
         mact = self.cfg['scheduling'].get('max active cycle points', None)

--- a/tests/validate/20-fail-no-scheduling.t
+++ b/tests/validate/20-fail-no-scheduling.t
@@ -24,6 +24,6 @@ install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE
 run_fail $TEST_NAME cylc validate --debug -v -v $SUITE_NAME
-grep_ok "No suite dependency graph defined\." $TEST_NAME.stderr
+grep_ok "missing \[scheduling\] section" $TEST_NAME.stderr
 #-------------------------------------------------------------------------------
 exit

--- a/tests/validate/21-fail-no-dependencies/suite.rc
+++ b/tests/validate/21-fail-no-dependencies/suite.rc
@@ -1,1 +1,2 @@
 [scheduling]
+    [[dependencies]]

--- a/tests/validate/37-fail-double-runahead.t
+++ b/tests/validate/37-fail-double-runahead.t
@@ -1,0 +1,30 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test validation catches use of 'runahead limit' and 'max active cycle points'
+# which are mutually exclusive.
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 2
+#-------------------------------------------------------------------------------
+install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE
+run_fail $TEST_NAME cylc validate --debug -v $SUITE_NAME
+grep_ok "ERROR: use 'runahead limit' OR 'max active cycle points', not both" \
+  $TEST_NAME.stderr
+#-------------------------------------------------------------------------------

--- a/tests/validate/37-fail-double-runahead/suite.rc
+++ b/tests/validate/37-fail-double-runahead/suite.rc
@@ -1,0 +1,7 @@
+[scheduling]
+    initial cycle point = 2015-01-01
+    runahead limit = P2D
+    max active cycle points = 2
+    [[dependencies]]
+        [[[P1D]]]
+            graph = foo


### PR DESCRIPTION
Currently you can set both ```runahead limit``` and ```max active cycle points```, and the former silently takes precedence.