### PR TITLE
cylc validate: fix error format logic

### DIFF
--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -1094,7 +1094,7 @@ class config( object ):
                     raise SuiteConfigError(
                         'ERROR: Illegal %s task name: %s' % (task_type, name))
                 if name not in self.taskdefs and name not in self.cfg['runtime']:
-                    msg = '%s task "%s" is not defined.' % (task_type % name)
+                    msg = '%s task "%s" is not defined.' % (task_type, name)
                     if self.strict:
                         raise SuiteConfigError("ERROR: " + msg)
                     else:

--- a/tests/validate/38-clock-trigger-task-not-defined.t
+++ b/tests/validate/38-clock-trigger-task-not-defined.t
@@ -1,0 +1,37 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test validation of special tasks names with non-word characters
+. "$(dirname "$0")/test_header"
+set_test_number 2
+cat >'suite.rc' <<'__SUITE_RC__'
+[scheduling]
+    initial cycle point = 20200101
+    [[special tasks]]
+        clock-triggered = foo(PT0M)
+    [[dependencies]]
+        [[[T00]]]
+            graph = bar
+[runtime]
+    [[bar]]
+        script = true
+__SUITE_RC__
+run_fail "${TEST_NAME_BASE}" cylc validate --strict "${PWD}/suite.rc"
+cmp_ok "${TEST_NAME_BASE}.stderr" <<'__ERR__'
+'ERROR: clock-triggered task "foo" is not defined.'
+__ERR__
+exit


### PR DESCRIPTION
On clock triggered task not defined.

Fix #1498. @kaday please review.