### PR TITLE
Reduce memory for suite configs with lots of defaults

### DIFF
--- a/lib/cylc/batch_sys_handlers/loadleveler.py
+++ b/lib/cylc/batch_sys_handlers/loadleveler.py
@@ -50,7 +50,8 @@ class LoadlevelerHandler(object):
         # executed* (that is determined by the '#!' at the top of the task
         # job script).
         directives["shell"] = "/bin/ksh"
-        directives.update(job_conf["directives"])
+        for key, value in job_conf["directives"].items():
+            directives[key] = value
         lines = []
         for key, value in directives.items():
             if value:

--- a/lib/cylc/batch_sys_handlers/lsf.py
+++ b/lib/cylc/batch_sys_handlers/lsf.py
@@ -44,7 +44,8 @@ class LSFHandler(object):
         directives['-J'] = job_conf['suite name'] + '.' + job_conf['task id']
         directives['-o'] = job_file_path + ".out"
         directives['-e'] = job_file_path + ".err"
-        directives.update(job_conf['directives'])
+        for key, value in job_conf['directives'].items():
+            directives[key] = value
         lines = []
         for key, value in directives.items():
             if value:

--- a/lib/cylc/batch_sys_handlers/pbs.py
+++ b/lib/cylc/batch_sys_handlers/pbs.py
@@ -45,7 +45,8 @@ class PBSHandler(object):
 
         directives["-o"] = job_file_path + ".out"
         directives["-e"] = job_file_path + ".err"
-        directives.update(job_conf["directives"])
+        for key, value in job_conf["directives"].items():
+            directives[key] = value
         lines = []
         for key, value in directives.items():
             if value and " " in key:

--- a/lib/cylc/batch_sys_handlers/sge.py
+++ b/lib/cylc/batch_sys_handlers/sge.py
@@ -39,7 +39,8 @@ class SGEHandler(object):
         directives['-N'] = job_conf['suite name'] + '.' + job_conf['task id']
         directives['-o'] = job_file_path + ".out"
         directives['-e'] = job_file_path + ".err"
-        directives.update(job_conf['directives'])
+        for key, value in job_conf['directives'].items():
+            directives[key] = value
         lines = []
         for key, value in directives.items():
             if value:

--- a/lib/cylc/batch_sys_handlers/slurm.py
+++ b/lib/cylc/batch_sys_handlers/slurm.py
@@ -47,7 +47,8 @@ class SLURMHandler(object):
             job_conf['suite name'] + '.' + job_conf['task id'])
         directives['--output'] = job_file_path + ".out"
         directives['--error'] = job_file_path + ".err"
-        directives.update(job_conf['directives'])
+        for key, value in job_conf['directives'].items():
+            directives[key] = value
         lines = []
         for key, value in directives.items():
             if value:

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -150,8 +150,13 @@ class SuiteConfig(object):
                  collapsed=[], cli_initial_point_string=None,
                  cli_start_point_string=None, cli_final_point_string=None,
                  is_restart=False, is_reload=False, write_proc=True,
-                 vis_start_string=None, vis_stop_string=None):
+                 vis_start_string=None, vis_stop_string=None,
+                 mem_log_func=None):
 
+        self.mem_log = mem_log_func
+        if mem_log_func is None:
+            self.mem_log = lambda *a: False
+        self.mem_log("config.py:config.py: start init config")
         self.suite = suite  # suite name
         self.fpath = fpath  # suite definition
         self.fdir  = os.path.dirname(fpath)
@@ -204,10 +209,14 @@ class SuiteConfig(object):
         self.feet = []
 
         # parse, upgrade, validate the suite, but don't expand with default items
+        self.mem_log("config.py: before get_suitecfg")        
         self.pcfg = get_suitecfg(
             fpath, force=is_reload, tvars=template_vars,
             tvars_file=template_vars_file, write_proc=write_proc)
+        self.mem_log("config.py: after get_suitecfg")
+        self.mem_log("config.py: before get(sparse=True")
         self.cfg = self.pcfg.get(sparse=True)
+        self.mem_log("config.py: after get(sparse=True)")
 
         # First check for the essential scheduling section.
         if 'scheduling' not in self.cfg:
@@ -309,9 +318,13 @@ class SuiteConfig(object):
         # check var names before inheritance to avoid repetition
         self.check_env_names()
 
+        self.mem_log("config.py: before compute_family_tree")
         # do sparse inheritance
         self.compute_family_tree()
+        self.mem_log("config.py: after compute_family_tree")
+        self.mem_log("config.py: before inheritance")
         self.compute_inheritance()
+        self.mem_log("config.py: after inheritance")
 
         #self.print_inheritance() # (debugging)
 
@@ -319,7 +332,9 @@ class SuiteConfig(object):
         self.filter_env()
 
         # now expand with defaults
+        self.mem_log("config.py: before get(sparse=False)")
         self.cfg = self.pcfg.get( sparse=False )
+        self.mem_log("config.py: after get(sparse=False)")
 
         # after the call to init_cyclers, we can start getting proper points.
         init_cyclers(self.cfg)
@@ -523,7 +538,9 @@ class SuiteConfig(object):
 
         self.process_directories()
 
+        self.mem_log("config.py: before load_graph()")
         self.load_graph()
+        self.mem_log("config.py: after load_graph()")
 
         self.compute_runahead_limits()
 
@@ -689,6 +706,7 @@ class SuiteConfig(object):
                     print >> sys.stderr, '  %s => %s' % e
                 raise SuiteConfigError('ERROR: cyclic dependence detected '
                                        '(graph the suite to see back-edges).')
+        self.mem_log("config.py: end init config")
  
     def dequote(self, s):
         """Strip quotes off a string."""

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -818,7 +818,10 @@ class SuiteConfig(object):
 
         already_done = {} # to store already computed namespaces by mro
 
-        for ns in self.cfg['runtime']:
+        # Loop through runtime members, 'root' first.
+        nses = self.cfg['runtime'].keys()
+        nses.sort(key=lambda ns: ns != 'root')
+        for ns in nses:
             # for each namespace ...
 
             hierarchy = copy(self.runtime['linearized ancestors'][ns])

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -127,7 +127,8 @@ class SuiteConfig(object):
                  collapsed=[], cli_initial_point_string=None,
                  cli_start_point_string=None, cli_final_point_string=None,
                  is_restart=False, is_reload=False, write_proc=True,
-                 vis_start_string=None, vis_stop_string=None):
+                 vis_start_string=None, vis_stop_string=None,
+                 mem_log_func=None):
         """Return a singleton instance.
 
         On 1st call, instantiate the singleton.
@@ -141,7 +142,7 @@ class SuiteConfig(object):
                 run_mode, validation, strict, collapsed,
                 cli_initial_point_string, cli_start_point_string,
                 cli_final_point_string, is_restart, is_reload, write_proc,
-                vis_start_string, vis_stop_string)
+                vis_start_string, vis_stop_string, mem_log_func)
         return cls._INSTANCE
 
 

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -188,6 +188,7 @@ class scheduler(object):
         self.parse_commandline()
 
     def configure(self):
+        self.log_memory("scheduler.py: start configure")
         SuiteProcPool.get_inst()
 
         self.info_commands = {}
@@ -212,7 +213,10 @@ class scheduler(object):
             'reload_suite',
             'add_prerequisite'
         ]
+
+        self.log_memory("scheduler.py: before configure_suite")
         self.configure_suite()
+        self.log_memory("scheduler.py: after configure_suite")
 
         reqmode = self.config.cfg['cylc']['required run mode']
         if reqmode:
@@ -243,7 +247,9 @@ class scheduler(object):
         self.request_handler.start()
 
         self.old_user_at_host_set = set()
+        self.log_memory("scheduler.py: before load_tasks")
         self.load_tasks()
+        self.log_memory("scheduler.py: after load_tasks")
 
         self.state_dumper.set_cts(self.initial_point, self.final_point)
         self.configure_suite_environment()
@@ -284,6 +290,7 @@ class scheduler(object):
         self.nudge_timer_start = None
         self.nudge_timer_on = False
         self.auto_nudge_interval = 5  # seconds
+        self.log_memory("scheduler.py: end configure")
 
     def process_command_queue(self):
         queue = self.command_queue.get_queue()
@@ -619,7 +626,8 @@ class scheduler(object):
             cli_initial_point_string=self._cli_initial_point_string,
             cli_start_point_string=self._cli_start_point_string,
             cli_final_point_string=self.options.final_point_string,
-            is_restart=self.is_restart, is_reload=reconfigure
+            is_restart=self.is_restart, is_reload=reconfigure,
+            mem_log_func=self.log_memory
         )
         # Dump the loaded suiterc for future reference.
         cfg_logdir = GLOBAL_CFG.get_derived_host_item(
@@ -916,6 +924,7 @@ class scheduler(object):
             'cylc']['event hooks']['abort if startup handler fails']
         self.run_event_handlers('startup', abort, 'suite starting')
 
+        self.log_memory("scheduler.py: begin run while loop")
         proc_pool = SuiteProcPool.get_inst()
 
         next_fs_check = time.time() + self.FS_CHECK_PERIOD
@@ -1072,13 +1081,13 @@ class scheduler(object):
                 self._update_profile_info("scheduler loop dt (s)", t1 - t0,
                                           amount_format="%.3f")
                 self._update_cpu_usage()
-                self._update_profile_info(
-                    "jobqueue.qsize",
-                    float(self.pool.jobqueue.qsize()),
-                    amount_format="%.1f"
-                )
+                if (int(t1) % 60 == 0):
+                    # Only get this every minute.
+                    self.log_memory("scheduler.py: loop: " +
+                                    get_current_time_string())
             time.sleep(1)
 
+        self.log_memory("scheduler.py: end main loop")
         # END MAIN LOOP
 
     def update_state_summary(self):
@@ -1413,6 +1422,14 @@ class scheduler(object):
             if temp_pub_db_file_name:
                 os.unlink(temp_pub_db_file_name)
             raise
+    def log_memory(self, message):
+        """Print a message to standard out with the current memory usage."""
+        if not self.options.profile_mode:
+            return
+        proc = subprocess.Popen(["ps", "h", "-orss", str(os.getpid())],
+                                stdout=subprocess.PIPE)
+        memory = int(proc.communicate()[0])
+        print "PROFILE: Memory: %d KiB: %s" % (memory, message)
 
     def _update_profile_info(self, category, amount, amount_format="%s"):
         # Update the 1, 5, 15 minute dt averages for a given category.

--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -1344,7 +1344,6 @@ class TaskProxy(object):
             'post-script': postcommand
             }.items()
         )
-        })
         self.db_inserts_map[self.TABLE_TASK_JOBS].append({
             "is_manual_submit": self.is_manual_submit,
             "try_num": self.run_try_state.num,

--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -56,6 +56,8 @@ from cylc.prerequisites.prerequisites import prerequisites
 from cylc.prerequisites.plain_prerequisites import plain_prerequisites
 from cylc.prerequisites.conditionals import conditional_prerequisites
 from cylc.suite_host import is_remote_host, get_suite_host
+from parsec.util import pdeepcopy, poverride
+from parsec.OrderedDict import OrderedDictWithDefaults
 from cylc.mp_pool import SuiteProcPool, SuiteProcContext
 from cylc.rundb import CylcSuiteDAO
 from cylc.task_id import TaskID
@@ -1339,7 +1341,9 @@ class TaskProxy(object):
             'use manual completion': use_manual,
             'pre-script': precommand,
             'script': command,
-            'post-script': postcommand,
+            'post-script': postcommand
+            }.items()
+        )
         })
         self.db_inserts_map[self.TABLE_TASK_JOBS].append({
             "is_manual_submit": self.is_manual_submit,
@@ -1374,7 +1378,7 @@ class TaskProxy(object):
             self, rtconfig, local_jobfile_path, common_job_log_path):
         """Populate the configuration for submitting or manipulating a job."""
         self.batch_sys_name = rtconfig['job submission']['method']
-        self.job_conf = {
+        self.job_conf = OrderedDictWithDefaults({
             'suite name': self.suite_name,
             'task id': self.identity,
             'batch system name': rtconfig['job submission']['method'],
@@ -1403,7 +1407,7 @@ class TaskProxy(object):
             'common job log path': common_job_log_path,
             'local job file path': local_jobfile_path,
             'job file path': local_jobfile_path,
-        }
+        }.items())
 
         log_files = self.job_conf['log files']
         log_files.add_path(local_jobfile_path)

--- a/lib/parsec/OrderedDict.py
+++ b/lib/parsec/OrderedDict.py
@@ -43,13 +43,11 @@ class OrderedDictWithDefaults(OrderedDict):
 
     """
 
-    def __contains_no_default__(self, key):
-        """No-default contains."""
-        return key in list(self)
-
     def __contains_default__(self, key):
         """Make sure "key in foo" works with our defaults."""
-        return key in self.keys()
+        if key in getattr(self, "defaults", {}):
+            return True
+        return OrderedDict.__contains__(self, key)
 
     def __getitem__(self, key):
         """Override to look in our special .defaults attribute, if it exists."""
@@ -61,7 +59,7 @@ class OrderedDictWithDefaults(OrderedDict):
             raise
 
     def __setitem__(self, *args, **kwargs):
-        self.__contains__ = self.__contains_no_default__
+        self.__contains__ = OrderedDict.__contains__
         return_value = OrderedDict.__setitem__(self, *args, **kwargs)
         self.__contains__ = self.__contains_default__
         return return_value

--- a/lib/parsec/OrderedDict.py
+++ b/lib/parsec/OrderedDict.py
@@ -18,6 +18,7 @@
 
 """Ordered Dictionary data structure used extensively in cylc."""
 
+
 try:
     # first try the fast ordereddict C implementation.
     # DOWNLOAD: http://anthon.home.xs4all.nl/Python/ordereddict/
@@ -43,32 +44,31 @@ class OrderedDictWithDefaults(OrderedDict):
 
     """
 
-    def __contains_default__(self, key):
-        """Make sure "key in foo" works with our defaults."""
-        if key in getattr(self, "defaults", {}):
-            return True
-        return OrderedDict.__contains__(self, key)
+    def __init__(self, *args, **kwargs):
+        """Allow a defaults argument."""
+        self._allow_contains_default = True
+        super(OrderedDictWithDefaults, self).__init__(*args, **kwargs)
 
     def __getitem__(self, key):
         """Override to look in our special .defaults attribute, if it exists."""
         try:
             return OrderedDict.__getitem__(self, key)
         except KeyError:
-            if hasattr(self, 'defaults'):
-                return self.defaults[key]
+            if hasattr(self, 'defaults_'):
+                return self.defaults_[key]
             raise
 
     def __setitem__(self, *args, **kwargs):
         """Make sure that we don't set the default value!"""
-        self.__contains__ = OrderedDict.__contains__
+        self._allow_contains_default = False
         return_value = OrderedDict.__setitem__(self, *args, **kwargs)
-        self.__contains__ = self.__contains_default__
+        self._allow_contains_default = True
         return return_value
 
     def keys(self):
         """Include the default keys, after the list of actually-set ones."""
         keys = list(self)
-        for key in getattr(self, 'defaults', []):
+        for key in getattr(self, 'defaults_', []):
             if key not in keys:
                 keys.append(key)
         return keys
@@ -96,6 +96,12 @@ class OrderedDictWithDefaults(OrderedDict):
         for k in self.keys():
             yield (k, self[k])
 
+    def __contains__(self, key):
+        if self._allow_contains_default:
+            if key in getattr(self, "defaults_", {}):
+                return True
+        return OrderedDict.__contains__(self, key)
+
     def __nonzero__(self):
         """Include any default keys in the nonzero calculation."""
         return bool(self.keys())
@@ -107,10 +113,8 @@ class OrderedDictWithDefaults(OrderedDict):
         for key in non_default_keys:
             non_default_items.append((key, self[key]))
         default_items = []
-        for key in getattr(self, 'defaults', []):
+        for key in getattr(self, 'defaults_', []):
             if key not in non_default_keys:
                 default_items.append((key, self[key]))
-        repr_map = {"": non_default_items, "defaults": default_items}
+        repr_map = {"": non_default_items, "defaults_": default_items}
         return "<" + type(self).__name__ + "(" + repr(repr_map) + ")>\n"
-
-    __contains__ = __contains_default__

--- a/lib/parsec/OrderedDict.py
+++ b/lib/parsec/OrderedDict.py
@@ -59,6 +59,7 @@ class OrderedDictWithDefaults(OrderedDict):
             raise
 
     def __setitem__(self, *args, **kwargs):
+        """Make sure that we don't set the default value!"""
         self.__contains__ = OrderedDict.__contains__
         return_value = OrderedDict.__setitem__(self, *args, **kwargs)
         self.__contains__ = self.__contains_default__
@@ -100,15 +101,17 @@ class OrderedDictWithDefaults(OrderedDict):
         return bool(self.keys())
 
     def __repr__(self):
+        """User-friendly-ish representation of defaults and others."""
         non_default_items = []
         non_default_keys = list(self)
         for key in non_default_keys:
-            non_default_items.append(key)
+            non_default_items.append((key, self[key]))
         default_items = []
         for key in getattr(self, 'defaults', []):
             if key not in non_default_keys:
-                default_items.append(key)
-        return "<" + type(self).__name__ + "({'': " + repr(non_default_items) + ", 'defaults':" + repr(default_items) + "})" + ")>\n"
+                default_items.append((key, self[key]))
+        repr_map = {"": non_default_items, "defaults": default_items}
+        return "<" + type(self).__name__ + "(" + repr(repr_map) + ")>\n"
 
     __contains__ = __contains_default__
 

--- a/lib/parsec/OrderedDict.py
+++ b/lib/parsec/OrderedDict.py
@@ -114,4 +114,3 @@ class OrderedDictWithDefaults(OrderedDict):
         return "<" + type(self).__name__ + "(" + repr(repr_map) + ")>\n"
 
     __contains__ = __contains_default__
-

--- a/lib/parsec/config.py
+++ b/lib/parsec/config.py
@@ -20,7 +20,7 @@ import os, sys, re
 from parsec.fileparse import parse, FileNotFoundError
 from parsec.util import printcfg
 from parsec.validate import validate, check_compulsory, expand, validator
-from parsec.OrderedDict import OrderedDict, OrderedDictWithDefaults
+from parsec.OrderedDict import OrderedDictWithDefaults
 from parsec.util import replicate, itemstr
 from parsec.upgrade import UpgradeError
 import cylc.flags

--- a/lib/parsec/config.py
+++ b/lib/parsec/config.py
@@ -20,7 +20,7 @@ import os, sys, re
 from parsec.fileparse import parse, FileNotFoundError
 from parsec.util import printcfg
 from parsec.validate import validate, check_compulsory, expand, validator
-from parsec.OrderedDict import OrderedDict
+from parsec.OrderedDict import OrderedDict, OrderedDictWithDefaults
 from parsec.util import replicate, itemstr
 from parsec.upgrade import UpgradeError
 import cylc.flags
@@ -45,8 +45,8 @@ class config( object ):
     def __init__( self, spec, upgrader=None, write_proc=False,
             tvars=[], tvars_file=None ):
 
-        self.sparse = OrderedDict()
-        self.dense = OrderedDict()
+        self.sparse = OrderedDictWithDefaults()
+        self.dense = OrderedDictWithDefaults()
         self.upgrader = upgrader
         self.tvars = tvars
         self.tvars_file = tvars_file

--- a/lib/parsec/fileparse.py
+++ b/lib/parsec/fileparse.py
@@ -21,7 +21,7 @@ import sys
 import re
 import traceback
 
-from parsec.OrderedDict import OrderedDict
+from parsec.OrderedDict import OrderedDict, OrderedDictWithDefaults
 from parsec.include import inline, IncludeFileNotFoundError
 from parsec.util import itemstr
 import cylc.flags
@@ -142,7 +142,7 @@ def addsect( cfig, sname, parents ):
         if cylc.flags.verbose:
             print 'Section already encountered: ' + itemstr( parents + [sname] )
     else:
-        cfig[sname] = OrderedDict()
+        cfig[sname] = OrderedDictWithDefaults()
 
 def addict( cfig, key, val, parents, index ):
     """Add a new [parents...]key=value pair to a nested dict."""
@@ -302,7 +302,7 @@ def parse( fpath, write_proc=False,
         f.close()
 
     nesting_level = 0
-    config = OrderedDict()
+    config = OrderedDictWithDefaults()
     sect_name = None
     parents = []
 

--- a/lib/parsec/fileparse.py
+++ b/lib/parsec/fileparse.py
@@ -21,7 +21,7 @@ import sys
 import re
 import traceback
 
-from parsec.OrderedDict import OrderedDict, OrderedDictWithDefaults
+from parsec.OrderedDict import OrderedDictWithDefaults
 from parsec.include import inline, IncludeFileNotFoundError
 from parsec.util import itemstr
 import cylc.flags

--- a/lib/parsec/util.py
+++ b/lib/parsec/util.py
@@ -19,7 +19,7 @@
 import os
 import sys
 from copy import copy
-from parsec.OrderedDict import OrderedDict, OrderedDictWithDefaults
+from parsec.OrderedDict import OrderedDictWithDefaults
 
 """
 Utility functions for printing and manipulating PARSEC NESTED DICTS.
@@ -94,7 +94,7 @@ def replicate( target, source ):
     otherwise adds elements to it.
     """
     if not source:
-        target = OrderedDict()
+        target = OrderedDictWithDefaults()
         return
     if hasattr(source, "defaults"):
         target.defaults = pdeepcopy(source.defaults)
@@ -102,7 +102,7 @@ def replicate( target, source ):
         if isinstance( val, dict ):
             if key not in target:
                 target[key] = OrderedDictWithDefaults()
-            elif hasattr(val, 'defaults'):
+            if hasattr(val, 'defaults'):
                 target[key].defaults = pdeepcopy(val.defaults)
             replicate( target[key], val )
         elif isinstance( val, list ):
@@ -119,7 +119,7 @@ def pdeepcopy(source):
 def poverride( target, sparse ):
     """Override items in a target pdict, target sub-dicts must already exist."""
     if not sparse:
-        target = OrderedDict()
+        target = OrderedDictWithDefaults()
         return
     for key,val in sparse.items():
         if isinstance( val, dict ):
@@ -133,33 +133,58 @@ def m_override( target, sparse ):
     """Override items in a target pdict. Target keys must already exist
     unless there is a "__MANY__" placeholder in the right position."""
     if not sparse:
-        target = OrderedDict()
+        target = OrderedDictWithDefaults()
         return
-    for key,val in sparse.items():
-        if isinstance( val, dict ):
-            if key not in target:
-                if '__MANY__' in target:
-                    target[key] = OrderedDictWithDefaults()
-                    target[key].defaults = target['__MANY__']
-                    replicate( target[key], val )
+    stack = [(sparse, target, [], OrderedDictWithDefaults())]
+    defaults_list = []
+    while stack:
+        source, dest, keylist, many_defaults = stack.pop(0)
+        if many_defaults:
+            defaults_list.append((dest, many_defaults))
+        for key, val in source.items():
+            if isinstance( val, dict ):
+                if key in many_defaults:
+                    child_many_defaults = many_defaults[key]
                 else:
-                    # TODO - validation prevents this, but handle properly for completeness.
-                    raise Exception( "parsec dict override: no __MANY__ placeholder" )
-            m_override( target[key], val )
-        else:
-            if key not in target:
-                if '__MANY__' in target:
-                    if isinstance( val, list ):
-                        target[key] = val[:]
+                    child_many_defaults = OrderedDictWithDefaults()
+                if key not in dest:
+                    if '__MANY__' in dest:
+                        dest[key] = OrderedDictWithDefaults()
+                        child_many_defaults = dest['__MANY__']
+                    elif '__MANY__' in many_defaults:
+                        # A 'sub-many' dict - would it ever exist in real life?
+                        dest[key] = OrderedDictWithDefaults()
+                        child_many_defaults = many_defaults['__MANY__']
+                    elif key in many_defaults:
+                        dest[key] = OrderedDictWithDefaults()
                     else:
-                        target[key] = val
-                else:
-                    # TODO - validation prevents this, but handle properly for completeness.
-                    raise Exception( "parsec dict override: no __MANY__ placeholder" )
-            if isinstance( val, list ):
-                target[key] = val[:]
+                        # TODO - validation prevents this, but handle properly for completeness.
+                        raise Exception(
+                            "parsec dict override: no __MANY__ placeholder" +
+                            "%s" % (keylist + [key])
+                        )
+                stack.append((val, dest[key], keylist + [key], child_many_defaults))
             else:
-                target[key] = val
+                if key not in dest:
+                    if '__MANY__' in dest or key in many_defaults or '__MANY__' in many_defaults:
+                        if isinstance( val, list ):
+                            dest[key] = val[:]
+                        else:
+                            dest[key] = val
+
+                    else:
+                        # TODO - validation prevents this, but handle properly for completeness.
+                        raise Exception(
+                            "parsec dict override: no __MANY__ placeholder" +
+                            "%s" % (keylist + [key])
+                        )
+                if isinstance( val, list ):
+                    dest[key] = val[:]
+                else:
+                    dest[key] = val
+    for dest_dict, defaults in defaults_list:
+        dest_dict.defaults = defaults
+
 
 def un_many( cfig ):
     """Remove any '__MANY__' items from a nested dict, in-place."""
@@ -167,7 +192,13 @@ def un_many( cfig ):
         return
     for key,val in cfig.items():
         if key == '__MANY__':
-            del cfig[key]
+            try:
+                del cfig[key]
+            except KeyError:
+                if hasattr(cfig, 'defaults') and key in cfig.defaults:
+                    del cfig.defaults[key]
+                else:
+                    raise
         elif isinstance( val, dict ):
             un_many( cfig[key] )
 

--- a/lib/parsec/util.py
+++ b/lib/parsec/util.py
@@ -96,14 +96,14 @@ def replicate( target, source ):
     if not source:
         target = OrderedDictWithDefaults()
         return
-    if hasattr(source, "defaults"):
-        target.defaults = pdeepcopy(source.defaults)
+    if hasattr(source, "defaults_"):
+        target.defaults_ = pdeepcopy(source.defaults_)
     for key,val in source.items():
         if isinstance( val, dict ):
             if key not in target:
                 target[key] = OrderedDictWithDefaults()
-            if hasattr(val, 'defaults'):
-                target[key].defaults = pdeepcopy(val.defaults)
+            if hasattr(val, 'defaults_'):
+                target[key].defaults_ = pdeepcopy(val.defaults_)
             replicate( target[key], val )
         elif isinstance( val, list ):
             target[key] = val[:]
@@ -183,7 +183,7 @@ def m_override( target, sparse ):
                 else:
                     dest[key] = val
     for dest_dict, defaults in defaults_list:
-        dest_dict.defaults = defaults
+        dest_dict.defaults_ = defaults
 
 
 def un_many( cfig ):
@@ -195,8 +195,8 @@ def un_many( cfig ):
             try:
                 del cfig[key]
             except KeyError:
-                if hasattr(cfig, 'defaults') and key in cfig.defaults:
-                    del cfig.defaults[key]
+                if hasattr(cfig, 'defaults_') and key in cfig.defaults_:
+                    del cfig.defaults_[key]
                 else:
                     raise
         elif isinstance( val, dict ):

--- a/lib/parsec/validate.py
+++ b/lib/parsec/validate.py
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys, re
-from parsec.OrderedDict import OrderedDict
+from parsec.OrderedDict import OrderedDict, OrderedDictWithDefaults
 from parsec.util import m_override, un_many, itemstr
 from copy import copy
 
@@ -111,14 +111,14 @@ def _populate_spec_defaults( defs, spec ):
     for key,val in spec.items():
         if isinstance( val, dict ):
             if key not in defs:
-                defs[key] = OrderedDict()
+                defs[key] = OrderedDictWithDefaults()
             _populate_spec_defaults( defs[key], spec[key] )
         else:
             defs[key] = spec[key].args['default']
 
 def get_defaults( spec ):
     """Return a nested dict of default values from a parsec spec."""
-    defs = OrderedDict()
+    defs = OrderedDictWithDefaults()
     _populate_spec_defaults( defs, spec )
     return defs
 

--- a/lib/parsec/validate.py
+++ b/lib/parsec/validate.py
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys, re
-from parsec.OrderedDict import OrderedDict, OrderedDictWithDefaults
+from parsec.OrderedDict import OrderedDictWithDefaults
 from parsec.util import m_override, un_many, itemstr
 from copy import copy
 

--- a/tests/inheritance/00-namespace-list.t
+++ b/tests/inheritance/00-namespace-list.t
@@ -30,19 +30,19 @@ TEST_NAME=$TEST_NAME_BASE-get-config
 cylc get-config --sparse -i runtime $SUITE_NAME > runtime.out
 cmp_ok runtime.out <<'__DONE__'
 [[root]]
+[[FAMILY]]
 [[m1]]
    inherit = FAMILY
    [[[environment]]]
       FOO = foo
-[[m3]]
-   inherit = FAMILY
-   [[[environment]]]
-      FOO = foo
-[[FAMILY]]
 [[m2]]
    inherit = FAMILY
    [[[environment]]]
       FOO = bar
+[[m3]]
+   inherit = FAMILY
+   [[[environment]]]
+      FOO = foo
 __DONE__
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME


### PR DESCRIPTION
This reduces parsec memory usage for configurations with lots of default settings. For a suite like this:
```ini
#!jinja2
[scheduling]
    [[dependencies]]
        graph = shutdown => LOTS
[runtime]
    [[shutdown]]
        command scripting = "cylc shutdown $CYLC_SUITE_NAME; sleep 60"
    [[LOTS]]
        command scripting = echo MY_NUM
    {%- for i in range(10000) %}
    {%- set i_label = "%05d" % i %}
    [[foo_{{i_label}}]]
        inherit = LOTS
        [[[environment]]]
            MY_NUM = {{i}}
    {%- endfor %}
```
it reduces total `cylc run` memory use by a factor of 2. It isn't quite as dramatic for some suites, though. It doesn't appear to significantly impact CPU usage.

When you have a parsec section with lots of defaults, the basic premise is that instead of copying them into the main configuration, you add a redirect reference to the defaults dictionary. Then, when a key isn't found, you just go to the defaults dict and look it up.

I freely admit that the implementation is a bit yucky. Suggestions welcome.

This is related to #1222.

I still need to test this with the "fast ordereddict C implementation" recipe.

@hjoliver, please review. I've put it in 'soon' in case we want to leave this out for now.