### PR TITLE
Allow setting of cylc section hooks at site level.

### DIFF
--- a/doc/siterc.tex
+++ b/doc/siterc.tex
@@ -658,3 +658,4 @@ of which can be found under ~\ref{SuiteEventHandling}:
 
 \subparagraph{[cylc] $\rightarrow$ [event hooks] $\rightarrow$ timeout}
 
+\subparagraph{[cylc] $\rightarrow$ [event hooks] $\rightarrow$ abort on timeout}

--- a/doc/siterc.tex
+++ b/doc/siterc.tex
@@ -637,3 +637,24 @@ running the test battery.
 
 The minimum set of directives that must be supplied to the batch system on the
 site to initiate jobs for the tests.
+
+\subsubsection[{[[}cylc suite settings{]]}]{[cylc] $\rightarrow$ [UTC mode]}
+\label{SiteUTCMode}
+
+Allows you to set a default value for UTC mode in a suite at the site level.
+See ~\ref{UTC-mode} for details.
+
+\subsubsection[{[[}cylc suite settings{]]}]{[cylc] $\rightarrow$ [event hooks]}
+\label{SiteCylcHooks}
+
+You can define site defaults for each of the following options, details 
+of which can be found under ~\ref{SuiteEventHandling}:
+
+\subparagraph{[cylc] $\rightarrow$ [event hooks] $\rightarrow$ startup handler}
+
+\subparagraph{[cylc] $\rightarrow$ [event hooks] $\rightarrow$ shutdown handler}
+
+\subparagraph{[cylc] $\rightarrow$ [event hooks] $\rightarrow$ timeout handler}
+
+\subparagraph{[cylc] $\rightarrow$ [event hooks] $\rightarrow$ timeout}
+

--- a/doc/suiterc.tex
+++ b/doc/suiterc.tex
@@ -72,11 +72,12 @@ Cylc runs off the suite host's system clock by default. This item allows
 you to run the suite in UTC even if the system clock is set to local time.
 Clock-triggered tasks will trigger when the current UTC time is equal to
 their cycle point date-time plus offset; other time values used, reported,
-or logged by the suite daemon will usually also be in UTC.
+or logged by the suite daemon will usually also be in UTC. The default for
+this can be set at the site level (see ~\ref{SiteUTCMode}).
 
 \begin{myitemize}
     \item {\em type:} boolean
-    \item {\em default:} False
+    \item {\em default:} False, unless overridden at site level.
 \end{myitemize}
 
 \subsubsection[cycle point format]{ [cylc] $\rightarrow$ cycle point format}
@@ -221,10 +222,13 @@ following EVENTs occurs:
     \item {\bf timeout}  - the suite has timed out
 \end{myitemize}
 
+Default values for these can be set at the site level via the siterc file
+(see ~\ref{SiteCylcHooks}).
+
 Item details:
 \begin{myitemize}
     \item {\em type:} string (event handler script name)
-    \item {\em default:} None
+    \item {\em default:} None, unless defined at the site level.
     \item {\em example:} \lstinline@startup handler = my-handler.sh@
 \end{myitemize}
 
@@ -232,12 +236,13 @@ Item details:
 
 If a timeout is set and the timeout event is handled, the timeout event
 handler(s) will be called if the suite times out before it finishes.
-The timer is set initially at suite start up.
+The timer is set initially at suite start up. It is possible to set a default
+for this at the site level (see ~\ref{SiteCylcHooks}).
 
 \begin{myitemize}
     \item {\em type:} ISO 8601 duration/interval representation (e.g.
  \lstinline=PT5S=, 5 seconds, \lstinline=PT1S=, 1 second) - minimum 0 seconds.
-    \item {\em default:} (none)
+    \item {\em default:} (none), unless set at the site level.
 \end{myitemize}
 
 \paragraph[reset timer]{[cylc] $\rightarrow$ [[event hooks]] $\rightarrow$ reset timer}
@@ -255,11 +260,12 @@ time.
 \paragraph[abort on timeout]{[cylc] $\rightarrow$ [[event hooks]] $\rightarrow$ abort on timeout}
 
 If a suite timer is set (above) this will cause the suite to abort with
-error status if the suite times out while still running.
+error status if the suite times out while still running. It is possible to set 
+a default for this at the site level (see ~\ref{SiteCylcHooks}).
 
 \begin{myitemize}
     \item {\em type:} boolean
-    \item {\em default:} False
+    \item {\em default:} False, unless set at the site level.
 \end{myitemize}
 
 \paragraph[abort if startup handler fails]{[cylc] $\rightarrow$ [[event hooks]] $\rightarrow$ abort if EVENT handler fails}

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -73,6 +73,7 @@ SPEC = {
             'timeout handler'                 : vdr( vtype='string_list', default=[] ),
             'shutdown handler'                : vdr( vtype='string_list', default=[] ),
             'timeout'                         : vdr( vtype='interval_minutes'),
+            'abort on timeout'                : vdr( vtype='boolean', default=False ),
             },
         },
 

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -34,14 +34,16 @@ from cylc.owner import user
 from cylc.envvar import expandvars
 from cylc.mkdir_p import mkdir_p
 import cylc.flags
-from cylc.cfgspec.suite import coerce_interval
-from cylc.cfgspec.suite import coerce_interval_list
+from cylc.cfgspec.utils import coerce_interval
+from cylc.cfgspec.utils import coerce_interval_list
 
 
 "Cylc site and user configuration file spec."
 
 coercers['interval_seconds'] = (
     lambda *args: coerce_interval(*args, check_syntax_version=False))
+coercers['interval_minutes'] = lambda *a: coerce_interval(
+    *a, back_comp_unit_factor=60)
 coercers['interval_minutes_list'] = (
     lambda *args: coerce_interval_list(*args, back_comp_unit_factor=60,
                                        check_syntax_version=False))
@@ -62,6 +64,16 @@ SPEC = {
         'maximum number of tries'         : vdr( vtype='integer', vmin=1, default=7 ),
         'connection timeout'              : vdr( vtype='interval_seconds', default=30),
 
+        },
+
+    'cylc' : {
+        'UTC mode'                            : vdr( vtype='boolean', default=False),
+        'event hooks' : {
+            'startup handler'                 : vdr( vtype='string_list', default=[] ),
+            'timeout handler'                 : vdr( vtype='string_list', default=[] ),
+            'shutdown handler'                : vdr( vtype='string_list', default=[] ),
+            'timeout'                         : vdr( vtype='interval_minutes'),
+            },
         },
 
     'suite logging' : {

--- a/lib/cylc/cfgspec/suite.py
+++ b/lib/cylc/cfgspec/suite.py
@@ -35,9 +35,12 @@ from isodatetime.data import Calendar, TimePoint
 from isodatetime.parsers import TimePointParser, DurationParser
 from cylc.cycling.integer import REC_INTERVAL as REC_INTEGER_INTERVAL
 
+from cylc.cfgspec.utils import coerce_interval
+from cylc.cfgspec.utils import coerce_interval_list
+from cylc.cfgspec.globalcfg import GLOBAL_CFG
+
 "Define all legal items and values for cylc suite definition files."
 
-interval_parser = DurationParser()
 
 def _coerce_cycleinterval( value, keys, args ):
     """Coerce value to a cycle interval."""
@@ -153,51 +156,6 @@ def _coerce_final_cycletime( value, keys, args ):
     return value
 
 
-def coerce_interval(value, keys, args, back_comp_unit_factor=1,
-                    check_syntax_version=True):
-    """Coerce an ISO 8601 interval (or number: back-comp) into seconds."""
-    value = _strip_and_unquote( keys, value )
-    try:
-        backwards_compat_value = float(value) * back_comp_unit_factor
-    except (TypeError, ValueError):
-        pass
-    else:
-        if check_syntax_version:
-            set_syntax_version(VERSION_PREV,
-                               "integer interval: %s" % itemstr(
-                                   keys[:-1], keys[-1], value))
-        return backwards_compat_value
-    try:
-        interval = interval_parser.parse(value)
-    except ValueError:
-        raise IllegalValueError("ISO 8601 interval", keys, value)
-    if check_syntax_version:
-        try:
-            set_syntax_version(VERSION_NEW,
-                               "ISO 8601 interval: %s" % itemstr(
-                                   keys[:-1], keys[-1], value))
-        except SyntaxVersionError as exc:
-            raise Exception(str(exc))
-    days, seconds = interval.get_days_and_seconds()
-    seconds += days * Calendar.default().SECONDS_IN_DAY
-    return seconds
-
-
-def coerce_interval_list(value, keys, args, back_comp_unit_factor=1,
-                         check_syntax_version=True):
-    """Coerce a list of intervals (or numbers: back-comp) into seconds."""
-    values_list = _strip_and_unquote_list( keys, value )
-    type_converter = (
-        lambda v: coerce_interval(
-            v, keys, args,
-            back_comp_unit_factor=back_comp_unit_factor,
-            check_syntax_version=check_syntax_version,
-        )
-    )
-    seconds_list = _expand_list( values_list, keys, type_converter, True )
-    return seconds_list
-
-
 coercers['cycletime'] = _coerce_cycletime
 coercers['cycletime_format'] = _coerce_cycletime_format
 coercers['cycletime_time_zone'] = _coerce_cycletime_time_zone
@@ -218,7 +176,7 @@ SPEC = {
     'description'                             : vdr( vtype='string', default="" ),
     'URL'                                     : vdr( vtype='string', default="" ),
     'cylc' : {
-        'UTC mode'                            : vdr( vtype='boolean', default=False),
+        'UTC mode'                            : vdr( vtype='boolean', default=GLOBAL_CFG.get( ['cylc','UTC mode'] )),
         'cycle point format'                  : vdr( vtype='cycletime_format', default=None),
         'cycle point num expanded year digits': vdr( vtype='integer', default=0),
         'cycle point time zone'               : vdr( vtype='cycletime_time_zone', default=None),
@@ -230,10 +188,10 @@ SPEC = {
             '__MANY__'                        : vdr( vtype='string' ),
             },
         'event hooks' : {
-            'startup handler'                 : vdr( vtype='string_list', default=[] ),
-            'timeout handler'                 : vdr( vtype='string_list', default=[] ),
-            'shutdown handler'                : vdr( vtype='string_list', default=[] ),
-            'timeout'                         : vdr( vtype='interval_minutes'  ),
+            'startup handler'                 : vdr( vtype='string_list', default=GLOBAL_CFG.get( ['cylc','event hooks', 'startup handler'] ) ),
+            'timeout handler'                 : vdr( vtype='string_list', default=GLOBAL_CFG.get( ['cylc','event hooks', 'timeout handler'] ) ),
+            'shutdown handler'                : vdr( vtype='string_list', default=GLOBAL_CFG.get( ['cylc','event hooks', 'shutdown handler'] ) ),
+            'timeout'                         : vdr( vtype='interval_minutes', default=GLOBAL_CFG.get( ['cylc','event hooks', 'timeout'] ) ),
             'reset timer'                     : vdr( vtype='boolean', default=True ),
             'abort if startup handler fails'  : vdr( vtype='boolean', default=False ),
             'abort if shutdown handler fails' : vdr( vtype='boolean', default=False ),

--- a/lib/cylc/cfgspec/suite.py
+++ b/lib/cylc/cfgspec/suite.py
@@ -196,7 +196,7 @@ SPEC = {
             'abort if startup handler fails'  : vdr( vtype='boolean', default=False ),
             'abort if shutdown handler fails' : vdr( vtype='boolean', default=False ),
             'abort if timeout handler fails'  : vdr( vtype='boolean', default=False ),
-            'abort on timeout'                : vdr( vtype='boolean', default=False ),
+            'abort on timeout'                : vdr( vtype='boolean', default=GLOBAL_CFG.get( ['cylc','event hooks', 'abort on timeout'] ) ),
             },
         'simulation mode' : {
             'disable suite event hooks'       : vdr( vtype='boolean', default=True ),

--- a/lib/cylc/cfgspec/utils.py
+++ b/lib/cylc/cfgspec/utils.py
@@ -1,0 +1,63 @@
+import re
+
+from parsec.validate import validator as vdr
+from parsec.validate import (
+    coercers, _strip_and_unquote, _strip_and_unquote_list, _expand_list,
+    IllegalValueError
+)
+from parsec.util import itemstr
+from parsec.upgrade import upgrader, converter
+from parsec.fileparse import parse
+from parsec.config import config
+from cylc.syntax_flags import (
+    set_syntax_version, VERSION_PREV, VERSION_NEW, SyntaxVersionError
+)
+from isodatetime.dumpers import TimePointDumper
+from isodatetime.data import Calendar, TimePoint
+from isodatetime.parsers import TimePointParser, DurationParser
+from cylc.cycling.integer import REC_INTERVAL as REC_INTEGER_INTERVAL
+
+interval_parser = DurationParser()
+
+def coerce_interval(value, keys, args, back_comp_unit_factor=1,
+                    check_syntax_version=True):
+    """Coerce an ISO 8601 interval (or number: back-comp) into seconds."""
+    value = _strip_and_unquote( keys, value )
+    try:
+        backwards_compat_value = float(value) * back_comp_unit_factor
+    except (TypeError, ValueError):
+        pass
+    else:
+        if check_syntax_version:
+            set_syntax_version(VERSION_PREV,
+                               "integer interval: %s" % itemstr(
+                                   keys[:-1], keys[-1], value))
+        return backwards_compat_value
+    try:
+        interval = interval_parser.parse(value)
+    except ValueError:
+        raise IllegalValueError("ISO 8601 interval", keys, value)
+    if check_syntax_version:
+        try:
+            set_syntax_version(VERSION_NEW,
+                               "ISO 8601 interval: %s" % itemstr(
+                                   keys[:-1], keys[-1], value))
+        except SyntaxVersionError as exc:
+            raise Exception(str(exc))
+    days, seconds = interval.get_days_and_seconds()
+    seconds += days * Calendar.default().SECONDS_IN_DAY
+    return seconds
+
+def coerce_interval_list(value, keys, args, back_comp_unit_factor=1,
+                         check_syntax_version=True):
+    """Coerce a list of intervals (or numbers: back-comp) into seconds."""
+    values_list = _strip_and_unquote_list( keys, value )
+    type_converter = (
+        lambda v: coerce_interval(
+            v, keys, args,
+            back_comp_unit_factor=back_comp_unit_factor,
+            check_syntax_version=check_syntax_version,
+        )
+    )
+    seconds_list = _expand_list( values_list, keys, type_converter, True )
+    return seconds_list


### PR DESCRIPTION
Addresses setting of the [cylc] section entries at site level from #802.

This change allows the following to have defaults set at the site level (and if not set use the existing defaults):

 * [cylc] -> UTC mode
 * [cylc] -> [event hooks] -> startup handler
 * [cylc] -> [event hooks] -> shutdown handler
 * [cylc] -> [event hooks] -> timeout handler
 * [cylc] -> [event hooks] -> timeout

I've made a minor documentation addition but this should probably be expanded on.

@hjoliver - can you take an initial look and see what you think? If you're happy then I'll finish up the documentation. The main aim here is to be able to set timeout handlers at the site level (the other entries are an added bonus).