### PR TITLE
Allow shutdown if kill failed.

### DIFF
--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -390,7 +390,7 @@ class scheduler(object):
         TaskProxy.stop_sim_mode_job_submission = True
         self.shut_down_cleanly = True
         self.kill_on_shutdown = kill_active_tasks
-        self.next_kill_issue = datetime.datetime.utcnow()
+        self.next_kill_issue = time.time()
 
     def command_stop_now(self):
         """Shutdown immediately."""
@@ -1042,16 +1042,16 @@ class scheduler(object):
                 self.shut_down_now = True
 
             if (self.shut_down_cleanly and self.kill_on_shutdown):
-                if self.pool.unkillable_only():
+                if self.pool.has_unkillable_tasks_only():
                     if not self.pool.no_active_tasks():
                         self.log.warning('some tasks were not killable at shutdown')
                     proc_pool.close()
                     self.shut_down_now = True
                 else:
-                    if datetime.datetime.utcnow() > self.next_kill_issue:
+                    if time.time() > self.next_kill_issue:
                         self.pool.poll_tasks()
                         self.pool.kill_active_tasks()
-                        self.next_kill_issue = datetime.datetime.utcnow() + datetime.timedelta(seconds=10)
+                        self.next_kill_issue = time.time() + 10.0
 
             if self.options.profile_mode:
                 t1 = time.time()

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -1049,7 +1049,6 @@ class scheduler(object):
                     self.shut_down_now = True
                 else:
                     if datetime.datetime.utcnow() > self.next_kill_issue:
-                        print >>sys.stderr, "polling and killing"
                         self.pool.poll_tasks()
                         self.pool.kill_active_tasks()
                         self.next_kill_issue = datetime.datetime.utcnow() + datetime.timedelta(seconds=10)

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -391,6 +391,7 @@ class scheduler(object):
         if kill_active_tasks:
             self.pool.kill_active_tasks()
         self.shut_down_cleanly = True
+        self.kill_on_shutdown = kill_active_tasks
 
     def command_stop_now(self):
         """Shutdown immediately."""
@@ -1038,6 +1039,12 @@ class scheduler(object):
 
             if ((self.shut_down_cleanly or auto_stop) and
                     self.pool.no_active_tasks()):
+                proc_pool.close()
+                self.shut_down_now = True
+
+            if (self.shut_down_cleanly and self.pool.unkillable_only() and 
+                    self.kill_on_shutdown):
+                print '\nWARNING some tasks were not killable at shutdown'
                 proc_pool.close()
                 self.shut_down_now = True
 

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -643,6 +643,13 @@ class TaskPool(object):
                 return False
         return True
 
+    def unkillable_only(self):
+        for itask in self.get_tasks():
+            if itask.state.is_currently('running', 'submitted'):
+                if not itask.kill_failed:
+                    return False
+        return True
+
     def poll_tasks(self, ids=None):
         for itask in self.get_tasks():
             if itask.state.is_currently('running', 'submitted'):

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -643,7 +643,12 @@ class TaskPool(object):
                 return False
         return True
 
-    def unkillable_only(self):
+    def has_unkillable_tasks_only(self):
+        """Used to identify if a task pool contains unkillable tasks.
+
+        Return True if all running and submitted tasks in the pool have had
+        kill operations fail, False otherwise.
+        """
         for itask in self.get_tasks():
             if itask.state.is_currently('running', 'submitted'):
                 if not itask.kill_failed:

--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -249,6 +249,8 @@ class TaskProxy(object):
         self.expire_time_str = None
         self.expire_time = None
 
+        self.kill_failed = False
+
     def _add_prerequisites(self, point):
         """Add task prerequisites."""
         # NOTE: Task objects hold all triggers defined for the task
@@ -463,6 +465,7 @@ class TaskProxy(object):
         seen as incomplete outputs when the task finishes.
         """
         self.hold_on_retry = False
+        self.kill_failed = False
         for state in ["failed", "submit-failed", "expired"]:
             msg = "%s %s" % (self.identity, state)
             if self.outputs.exists(msg):
@@ -628,6 +631,7 @@ class TaskProxy(object):
             self.summary['latest_message'] = 'kill failed'
             self.log(WARNING, 'job(%02d) kill failed' % self.submit_num)
             flags.iflag = True
+            self.kill_failed = True
         elif self.state.is_currently('submitted'):
             self.log(INFO, 'job(%02d) killed' % self.submit_num)
             self.job_submission_failed()


### PR DESCRIPTION
Closes #1502 

If the kill part of shutdown --kill fails then a suite won't shutdown. This allows the suite to shutdown if the kill operation has failed.

@hjoliver - please review. I've been testing this by running a job on a remote machine and turning said machine off while the task was running then attempting to stop the suite. I'd imagine the same sort of testing would be possible if one were to disconnect from a network.

Can you give this a careful check over, I think this is right but am worried I may have missed one of the other shutdown combinations.