### PR TITLE
cylc gui: fix family graph filtering base nodes.

### DIFF
--- a/lib/cylc/gui/updater_graph.py
+++ b/lib/cylc/gui/updater_graph.py
@@ -367,6 +367,9 @@ class GraphUpdater(threading.Thread):
                                 break
                         if remove:
                             nodes_to_remove.add(node)
+                    elif id in self.updater.full_fam_state_summary:
+                        # An updater-filtered-out family.
+                        nodes_to_remove.add(node)
 
             # Base node cropping.
             if self.crop:


### PR DESCRIPTION
This fixes a bug where filtered out family nodes can reappear as
base nodes in the graph view. They are only filtered out if they
appear in the fam_state_summary, which itself is prone to being
filtered.

Closes #1517.

@hjoliver, please review 1.