### PR TITLE
Moved call to external trigger matching.

### DIFF
--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -962,13 +962,16 @@ class scheduler(object):
 
             proc_pool.handle_results_async()
 
+            # External triggers must be matched now. If any are matched pflag
+            # is set to tell process_tasks() that task processing is required.
+            self.pool.match_ext_triggers()
+
             if self.process_tasks():
                 if cylc.flags.debug:
                     self.log.debug("BEGIN TASK PROCESSING")
                     main_loop_start_time = time.time()
 
                 self.pool.match_dependencies()
-                self.pool.match_ext_triggers()
 
                 ready_tasks = self.pool.submit_tasks()
                 if (ready_tasks and

--- a/tests/ext-trigger/01-no-nudge.t
+++ b/tests/ext-trigger/01-no-nudge.t
@@ -1,0 +1,35 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#-------------------------------------------------------------------------------
+# Test that external trigger events stimulate task processing even when nothing
+# else is happening in the # suite. If not, the test suite will stall until
+# manually nudged.  Note this test will probably become irrelevant once we go
+# to entirely event-driven scheduling.
+
+. "$(dirname "$0")/test_header"
+
+set_test_number 2
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}" 
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+
+suite_run_ok "${TEST_NAME_BASE}-run" \
+    cylc run --no-detach "${SUITE_NAME}"
+
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/ext-trigger/01-no-nudge/suite.rc
+++ b/tests/ext-trigger/01-no-nudge/suite.rc
@@ -1,0 +1,29 @@
+title = "Test for Github Issue 1543"
+description = """
+External trigger events should stimulate task processing without requiring a
+manual suite nudge, even when nothing else is happening in the suite.  Here,
+long-running task bar ext-triggers foo when nothing else is happening.  If 
+task processing occurs foo will submit and kill bar, allowing the suite
+to shutdown.  Otherwise, foo won't submit, bar will keep running, and the suite
+will time out."""
+
+[cylc]
+    [[event hooks]]
+        abort on timeout = True
+        timeout = PT30S
+[scheduling]
+    [[special tasks]]
+        external-trigger = foo("drugs and money")
+    [[dependencies]]
+        graph = """foo & bar
+                   bar:fail => !bar"""
+[runtime]
+    [[foo]]
+        # If triggered, remove the long-running bar task
+        # to allow the suite to shut down quickly.
+        script = cylc kill $CYLC_SUITE_NAME bar 1
+    [[bar]]
+        script = """
+sleep 5
+cylc ext-trigger $CYLC_SUITE_NAME "drugs and money" 12345
+sleep 60"""


### PR DESCRIPTION
External triggers are similar to clock triggers: they have to be triggered outside of task processing (and if one is triggered, that should stimulate task processing).  The external trigger matching was being done in the task processing block, so task processing wasn't stimulated by an external trigger unless other things were happening in the suite at the same time (else a "nudge" was required). 

(yes, we need event-driven processing!)

@matthewrmshin - please review or reassign.