### PR TITLE
cylc codebase: remove some bad sys.exit calls

### DIFF
--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -758,10 +758,9 @@ class config( object ):
                 exc_lines =  traceback.format_exc().splitlines()
                 if exc_lines[-1].startswith(
                     "RuntimeError: maximum recursion depth exceeded"):
-                    sys.stderr.write("ERROR: circular [runtime] inheritance?\n")
-                else:
-                    sys.stderr.write("ERROR: %s\n" % str(exc))
-                sys.exit(1)
+                    raise SuiteConfigError(
+                        "ERROR: circular [runtime] inheritance?")
+                raise
 
         for name in self.cfg['runtime']:
             ancestors = self.runtime['linearized ancestors'][name]

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -903,7 +903,7 @@ class scheduler(object):
                     if name == 'shutdown' and self.reference_test_mode:
                         # TODO - this isn't true, it just means the
                         # shutdown handler run successfully:
-                        print 'SUITE REFERENCE TEST PASSED\n'
+                        print 'SUITE REFERENCE TEST PASSED'
 
     def run(self):
 

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -893,16 +893,17 @@ class scheduler(object):
                     RunHandler(name, handler, self.suite, msg=msg, fg=fg)
                 except Exception, x:
                     # Note: test suites depends on this message:
-                    print >> sys.stderr, (
-                        '\nERROR: %s EVENT HANDLER FAILED' % name)
+                    sys.stderr.write(
+                        'ERROR: %s EVENT HANDLER FAILED\n' % name)
                     if name == 'shutdown' and self.reference_test_mode:
-                        sys.exit('\nERROR: SUITE REFERENCE TEST FAILED')
+                        sys.stderr.write(
+                            'ERROR: SUITE REFERENCE TEST FAILED\n')
                     raise SchedulerError(x)
                 else:
                     if name == 'shutdown' and self.reference_test_mode:
                         # TODO - this isn't true, it just means the
                         # shutdown handler run successfully:
-                        print '\nSUITE REFERENCE TEST PASSED'
+                        print 'SUITE REFERENCE TEST PASSED\n'
 
     def run(self):
 

--- a/lib/cylc/suite_host.py
+++ b/lib/cylc/suite_host.py
@@ -85,7 +85,7 @@ def get_host_ip_address():
     return host_ip_address
 
 def get_suite_host():
-    from cylc.cfgspec.globalcfg import GLOBAL_CFG
+    from cylc.cfgspec.globalcfg import GLOBAL_CFG, GlobalConfigError
     global suite_host
     if suite_host is None:
         hardwired = GLOBAL_CFG.get( ['suite host self-identification','host'] )
@@ -97,10 +97,16 @@ def get_suite_host():
             suite_host = get_host_ip_address()
         elif method == 'hardwired':
             if not hardwired:
-                sys.exit( 'ERROR, no hardwired hostname is configured' )
+                raise GlobalConfigError(
+                    'ERROR, no hardwired hostname is configured (%s)' %
+                    ['suite host self-identification', 'host']
+                )
             suite_host = hardwired
         else:
-            sys.exit( 'ERROR, unknown host method: ' + method )
+            raise GlobalConfigError(
+                'ERROR, unknown host method (%s): %s' % (
+                    ['suite host self-identification', 'method'], method)
+            )
     return suite_host
 
 def is_remote_host(name):

--- a/lib/cylc/task_state.py
+++ b/lib/cylc/task_state.py
@@ -183,7 +183,6 @@ class task_state(object):
             raise TaskStateError, 'ERROR, task spawned status not defined'
         if self.state[ 'spawned' ] not in [ 'true', 'false' ]:
             raise TaskStateError, 'ERROR, illegal task spawned status: ' + str( self.state[ 'spawned' ])
-            sys.exit(1)
 
     def dump( self ):
         # format: 'item1=value1, item2=value2, ...'

--- a/tests/inheritance/01-circular.t
+++ b/tests/inheritance/01-circular.t
@@ -27,7 +27,7 @@ run_fail $TEST_NAME cylc validate $SUITE_NAME
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-cmp
 cmp_ok $TEST_NAME_BASE-validate.stderr <<__ERR__
-ERROR: circular [runtime] inheritance?
+'ERROR: circular [runtime] inheritance?'
 __ERR__
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME


### PR DESCRIPTION
This closes #294. It removes some unnecessary/inappropriate sys.exit calls from the code.
The remaining calls are limited to code only used by clients (GUIs, commands).

The inheritance change in `lib/cylc/config.py` is probably the only one that can interfere with
threading and ports files.

@hjoliver, please review 1.
@kaday, please review 2.