### PR TITLE
cylc broadcast: error message clarification

### DIFF
--- a/lib/cylc/broadcast_report.py
+++ b/lib/cylc/broadcast_report.py
@@ -20,7 +20,8 @@
 
 BAD_OPTIONS_FMT = "\n  --%s=%s"
 BAD_OPTIONS_TITLE = "ERROR: No broadcast to cancel/clear for these options:"
-BAD_OPTIONS_TITLE_SET = "ERROR: Invalid broadcast set options:"
+BAD_OPTIONS_TITLE_SET = ("ERROR: Rejected broadcast: settings are not" +
+                         " compatible with the suite")
 CHANGE_FMT = "\n%(change)s [%(namespace)s.%(point)s] %(key)s=%(value)s"
 CHANGE_PREFIX_CANCEL = "-"
 CHANGE_PREFIX_SET = "+"


### PR DESCRIPTION
Trying to make the broadcast error clearer when there is a mismatch in items set with the items in the suite. For example the name of the task.