### PR TITLE
suite.rc: Add backcompat for dummy section entries.

### DIFF
--- a/lib/cylc/cfgspec/suite.py
+++ b/lib/cylc/cfgspec/suite.py
@@ -418,6 +418,10 @@ def upg( cfg, descr ):
             ['runtime', '__MANY__', old],
             ['runtime', '__MANY__', new],
             silent=True)
+        u.deprecate('6.4.0',
+            ['runtime', '__MANY__', 'dummy mode', old],
+            ['runtime', '__MANY__', 'dummy mode', new],
+            silent=True)
     u.deprecate(
         '6.5.0',
         ['scheduling', 'special tasks', 'clock-triggered'],

--- a/tests/deprecations/00-all/suite.rc
+++ b/tests/deprecations/00-all/suite.rc
@@ -33,6 +33,8 @@
         pre-command scripting = "echo pre-script" # deprecate
         command scripting = "echo script" # deprecate
         post-command scripting = "echo post-script" # deprecate
+        [[[dummy mode]]]
+        command scripting = "echo script" # deprecate
 
 [visualization]
     enable live graph movie = True # obsolete


### PR DESCRIPTION
#1398 deprecated "command scripting" etc.

A suite like this fails to validate:
```
[scheduling]
[[dependencies]]
    graph = foo
[runtime]
    [[foo]]
        command scripting = true
        [[[dummy mode]]]
            command scripting = true
```
with:
```
'Illegal item: [runtime][foo][dummy mode]command scripting'
```

This change applies the deprecation fix to the dummy mode items as well.