### PR TITLE
The gcylc user config file should be optional.

### DIFF
--- a/lib/cylc/cfgspec/gcylc.py
+++ b/lib/cylc/cfgspec/gcylc.py
@@ -225,11 +225,13 @@ if not gcfg:
         sys.stderr.write(
             "WARNING: ignoring bad site GUI config %s:\n"
             "%s\n" % (SITE_FILE, str(exc)))
-    try:
-        gcfg.loadcfg(USER_FILE, "user config")
-    except ParsecError as exc:
-        sys.stderr.write("ERROR: bad user GUI config %s:\n" % USER_FILE)
-        raise
+
+    if os.access(USER_FILE, os.F_OK | os.R_OK):
+        try:
+            gcfg.loadcfg(USER_FILE, "user config")
+        except ParsecError as exc:
+            sys.stderr.write("ERROR: bad user GUI config %s:\n" % USER_FILE)
+            raise
 
     # check and correct initial view config etc.
     gcfg.check()


### PR DESCRIPTION
gcylc currently aborts if no user config file is found - probably broken by #1556 .

@matthewrmshin - please review.

