### PR TITLE
Allow suite.rc/global.rc to mix date-time syntax

### DIFF
--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -45,7 +45,7 @@ from cylc.network import PRIVILEGE_LEVELS
 coercers['interval_seconds'] = (
     lambda *args: coerce_interval(*args, check_syntax_version=False))
 coercers['interval_minutes'] = lambda *a: coerce_interval(
-    *a, back_comp_unit_factor=60)
+    *a, back_comp_unit_factor=60, check_syntax_version=False)
 coercers['interval_minutes_list'] = (
     lambda *args: coerce_interval_list(*args, back_comp_unit_factor=60,
                                        check_syntax_version=False))

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -42,13 +42,12 @@ from cylc.network import PRIVILEGE_LEVELS
 
 "Cylc site and user configuration file spec."
 
-coercers['interval_seconds'] = (
-    lambda *args: coerce_interval(*args, check_syntax_version=False))
-coercers['interval_minutes'] = lambda *a: coerce_interval(
-    *a, back_comp_unit_factor=60, check_syntax_version=False)
-coercers['interval_minutes_list'] = (
-    lambda *args: coerce_interval_list(*args, back_comp_unit_factor=60,
-                                       check_syntax_version=False))
+coercers['interval_seconds'] = lambda *args: coerce_interval(
+    *args, check_syntax_version=False)
+coercers['interval_minutes'] = lambda *args: coerce_interval(
+    *args, back_comp_unit_factor=60, check_syntax_version=False)
+coercers['interval_minutes_list'] = lambda *args: coerce_interval_list(
+    *args, back_comp_unit_factor=60, check_syntax_version=False)
 
 SPEC = {
     'process pool size'                   : vdr( vtype='integer', default=4 ),

--- a/tests/cylc-cat-log/01-remote.t
+++ b/tests/cylc-cat-log/01-remote.t
@@ -23,6 +23,7 @@ if [[ -z $CYLC_TEST_HOST ]]; then
     skip_all '[test battery]remote host: not defined'
 fi
 set_test_number 14
+export CYLC_CONF_PATH=
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 # Install suite passphrase.

--- a/tests/events/10-task-event-job-logs-retrieve.t
+++ b/tests/events/10-task-event-job-logs-retrieve.t
@@ -33,6 +33,8 @@ if [[ "${TEST_NAME_BASE}" == *-globalcfg ]]; then
 __GLOBALCFG__
     export CYLC_CONF_PATH="${PWD}/conf"
     OPT_SET='-s GLOBALCFG=True'
+else
+    export CYLC_CONF_PATH=
 fi
 
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"

--- a/tests/events/11-cycle-task-event-job-logs-retrieve.t
+++ b/tests/events/11-cycle-task-event-job-logs-retrieve.t
@@ -23,6 +23,7 @@ if [[ -z "${HOST}" ]]; then
     skip_all '[test battery]remote host: not defined'
 fi
 set_test_number 4
+export CYLC_CONF_PATH=
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 set -eu
 SSH='ssh -oBatchMode=yes -oConnectTimeout=5'

--- a/tests/validate/41-mixed-syntax-global-suite.t
+++ b/tests/validate/41-mixed-syntax-global-suite.t
@@ -15,9 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test validatation error message, LHS suicide.
+# Test validatation, global.rc and suite.rc with opposing syntax.
 . "$(dirname "$0")/test_header"
-set_test_number 1
+set_test_number 2
 
 cat >'global.rc' <<'__GLOBAL_RC__'
 [cylc]
@@ -34,6 +34,25 @@ cat >'suite.rc' <<'__SUITE_RC__'
         script = true
         [[[events]]]
             execution timeout = 10
+__SUITE_RC__
+
+CYLC_CONF_PATH="${PWD}" run_ok "${TEST_NAME_BASE}" cylc validate 'suite.rc'
+
+cat >'global.rc' <<'__GLOBAL_RC__'
+[cylc]
+    [[event hooks]]
+        timeout = 1440
+__GLOBAL_RC__
+
+cat >'suite.rc' <<'__SUITE_RC__'
+[scheduling]
+    [[dependencies]]
+        graph = t0
+[runtime]
+    [[t0]]
+        script = true
+        [[[events]]]
+            execution timeout = PT10M
 __SUITE_RC__
 
 CYLC_CONF_PATH="${PWD}" run_ok "${TEST_NAME_BASE}" cylc validate 'suite.rc'

--- a/tests/validate/41-mixed-syntax-global-suite.t
+++ b/tests/validate/41-mixed-syntax-global-suite.t
@@ -1,0 +1,40 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test validatation error message, LHS suicide.
+. "$(dirname "$0")/test_header"
+set_test_number 1
+
+cat >'global.rc' <<'__GLOBAL_RC__'
+[cylc]
+    [[event hooks]]
+        timeout = P1D
+__GLOBAL_RC__
+
+cat >'suite.rc' <<'__SUITE_RC__'
+[scheduling]
+    [[dependencies]]
+        graph = t0
+[runtime]
+    [[t0]]
+        script = true
+        [[[events]]]
+            execution timeout = 10
+__SUITE_RC__
+
+CYLC_CONF_PATH="${PWD}" run_ok "${TEST_NAME_BASE}" cylc validate 'suite.rc'
+exit


### PR DESCRIPTION
Validation of a `suite.rc` is currently failing if `global.rc` has
different date-time syntax for minutes intervals. This change fixes the
problem.

New test fails on current master (6.6.0).

@hjoliver @arjclark please review 1 and 2.