### PR TITLE
poll/kill: send multiple requests per job host

### DIFF
--- a/bin/cylc
+++ b/bin/cylc
@@ -287,8 +287,10 @@ discovery_commands['check-versions'] = ['check-versions']
 task_commands = OrderedDict()
 task_commands['submit'] = ['submit', 'single']
 task_commands['message'] = ['message', 'task-message']
-task_commands['job-poll'] = ['job-poll']
+task_commands['jobs-kill'] = ['jobs-kill']
+task_commands['jobs-poll'] = ['jobs-poll']
 task_commands['job-kill'] = ['job-kill']
+task_commands['job-poll'] = ['job-poll']
 task_commands['job-submit'] = ['job-submit']
 
 all_commands = OrderedDict()
@@ -450,8 +452,10 @@ comsum['check-versions'] = 'Compare cylc versions on task host accounts'
 comsum['submit'] = 'Run a single task just as its parent suite would'
 comsum['message'] = '(task messaging) Report task messages'
 comsum['broadcast'] = 'Change suite [runtime] settings on the fly'
-comsum['job-poll'] = '(Internal) Retrieve job status for a task'
-comsum['job-kill'] = '(Internal) Kill a job for a task'
+comsum['jobs-kill'] = '(Internal) Kill task jobs'
+comsum['jobs-poll'] = '(Internal) Retrieve status for task jobs'
+comsum['job-kill'] = '(Internal) Kill a task job'
+comsum['job-poll'] = '(Internal) Retrieve status for a task job'
 comsum['job-submit'] = '(Internal) Submit a job'
 
 # utility

--- a/bin/cylc-jobs-kill
+++ b/bin/cylc-jobs-kill
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""cylc [control] jobs-kill JOB-LOG-ROOT [JOB-LOG-DIR ...]
+
+(This command is for internal use. Users should use "cylc kill".) Read job
+status files to obtain the names of the batch systems and the job IDs in the
+systems. Invoke the relevant batch system commands to ask the batch systems to
+terminate the jobs.
+
+"""
+
+
+import sys
+from cylc.remote import remrun
+
+
+def main():
+    """CLI main."""
+    parser = cop(__doc__, argdoc=[
+        ("JOB-LOG-ROOT", "The log/job sub-directory for the suite"),
+        ("[JOB-LOG-DIR ...]", "A point/name/submit_num sub-directory")])
+    args = parser.parse_args()[1]
+    sys.stdout.write(BATCH_SYS_MANAGER.jobs_kill(args[0], args[1:]))
+
+
+if __name__ == "__main__" and not remrun().execute():
+    from cylc.CylcOptionParsers import cop
+    from cylc.batch_sys_manager import BATCH_SYS_MANAGER
+    main()

--- a/bin/cylc-jobs-poll
+++ b/bin/cylc-jobs-poll
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""cylc [control] job-poll JOB-LOG-ROOT [JOB-LOG-DIR ...]
+
+(This command is for internal use. Users should use "cylc poll".) Read job
+status files to obtain the statuses of the jobs. If necessary, Invoke the
+relevant batch system commands to ask the batch systems for more statuses.
+
+"""
+
+
+import sys
+from cylc.remote import remrun
+
+
+def main():
+    """CLI main."""
+    parser = cop(__doc__, argdoc=[
+        ("JOB-LOG-ROOT", "The log/job sub-directory for the suite"),
+        ("[JOB-LOG-DIR ...]", "A point/name/submit_num sub-directory")])
+    args = parser.parse_args()[1]
+    sys.stdout.write(BATCH_SYS_MANAGER.jobs_poll(args[0], args[1:]))
+
+
+if __name__ == "__main__" and not remrun().execute():
+    from cylc.CylcOptionParsers import cop
+    from cylc.batch_sys_manager import BATCH_SYS_MANAGER
+    main()

--- a/bin/cylc-kill
+++ b/bin/cylc-kill
@@ -18,6 +18,12 @@
 
 """cylc [control] kill [OPTIONS] ARGS
 
+Kill jobs of active tasks (those in the 'submitted' or 'running' states) and
+update their statuses accordingly.
+
+To kill one or more tasks, "cylc kill REG MATCH POINT"; to kill all active
+tasks: "cylc kill REG".
+
 Kill a 'submitted' or 'running' task and update the suite state accordingly.
 """
 
@@ -39,17 +45,26 @@ def main():
         __doc__ + multitask_usage,
         pyro=True, multitask=True,
         argdoc=[('REG', 'Suite name'),
-                ('MATCH', 'Task or family name matching regular expression'),
-                ('POINT', 'Task cycle point (e.g. date-time or integer)')])
+                ('[MATCH]', 'Task or family name matching regular expression'),
+                ('[POINT]', 'Task cycle point (e.g. date-time or integer)')])
 
     (options, args) = parser.parse_args()
     suite = args[0]
 
-    name = args[1]
-    point_string = args[2]
+    if len(args) == 3:
+        name = args[1]
+        point_string = args[2]
+    elif len(args) == 1:
+        name = None
+        point_string = None
+    else:
+        parser.error("Wrong number of arguments.")
 
-    prompt('Kill task %s at %s in %s' % (name, point_string, suite),
-           options.force)
+    if name and point_string:
+        prompt('Kill task %s at %s in %s' % (name, point_string, suite),
+               options.force)
+    else:
+        prompt('Kill ALL task in %s' % (suite), options.force)
 
     pclient = SuiteCommandClient(
         suite, options.owner, options.host, options.pyro_timeout,

--- a/bin/cylc-poll
+++ b/bin/cylc-poll
@@ -18,8 +18,9 @@
 
 """cylc [control] poll [OPTIONS] ARGS
 
-Poll active tasks (those in the 'submitted' or 'running' states) to verify
-or update their statuses - even if they have suffered an external hard kill.
+Poll jobs of active tasks (those in the 'submitted' or 'running' states) to
+verify or update their statuses - even if they have suffered an external hard
+kill.
 
 To poll one or more tasks, "cylc poll REG MATCH POINT"; to poll all active
 tasks: "cylc poll REG".
@@ -60,13 +61,16 @@ def main():
         name = args[1]
         point_string = args[2]
     elif len(args) == 1:
-        name = str(None)
-        point_string = str(None)
+        name = None
+        point_string = None
     else:
         parser.error("Wrong number of arguments.")
 
-    prompt('Poll task %s at %s in %s' % (name, point_string, suite),
-           options.force)
+    if name and point_string:
+        prompt('Poll task %s at %s in %s' % (name, point_string, suite),
+               options.force)
+    else:
+        prompt('Poll ALL task in %s' % (suite), options.force)
 
     pclient = SuiteCommandClient(
         suite, options.owner, options.host, options.pyro_timeout,

--- a/bin/cylc-restart
+++ b/bin/cylc-restart
@@ -447,14 +447,9 @@ class restart(scheduler):
                 self.old_user_at_host_set.add(itask.user_at_host)
                 if itask.user_at_host is None:
                     itask.user_at_host = "localhost"
-                # poll the task
-                try:
-                    itask.poll()
-                except Exception as exc:
-                    print >>sys.stderr, "WARNING: %s: poll failed" % id
                 # update timers in case regular polling is configured for itask
                 if '@' in itask.user_at_host:
-                    owner, host = itask.user_at_host.split('@')
+                    host = itask.user_at_host.split('@', 1)[1]
                 else:
                     host = itask.user_at_host
                 itask.submission_poll_timer.set_host(host, set_timer=True)
@@ -478,6 +473,9 @@ class restart(scheduler):
                     'ERROR: unknown task state for %s' % itask.identity)
 
             self.pool.add_to_runahead_pool(itask)
+
+        # Poll all submitted and running task jobs
+        self.pool.poll_task_jobs()
 
 
 if __name__ == '__main__':

--- a/bin/cylc-trigger
+++ b/bin/cylc-trigger
@@ -58,6 +58,7 @@ from cylc.task_id import TaskID
 
 
 def main():
+    """CLI for "cylc trigger"."""
     parser = cop(
         __doc__ + multitask_usage, pyro=True, multitask=True,
         argdoc=[

--- a/lib/cylc/batch_sys_handlers/at.py
+++ b/lib/cylc/batch_sys_handlers/at.py
@@ -43,7 +43,8 @@ class AtCommandHandler(object):
     # process group, which allows the job script and its child processes to be
     # killed correctly.
     KILL_CMD_TMPL = "atrm '%(job_id)s'"
-    POLL_CMD_TMPL = "atq"
+    POLL_CMD = "atq"
+    POLL_CMD_TMPL = POLL_CMD
     REC_ERR_FILTERS = [
         re.compile("warning: commands will be executed using /bin/sh")]
     REC_ID_FROM_SUBMIT_ERR = re.compile(r"\Ajob\s(?P<id>\S+)\sat")

--- a/lib/cylc/batch_sys_handlers/background.py
+++ b/lib/cylc/batch_sys_handlers/background.py
@@ -35,7 +35,8 @@ class BgCommandHandler(object):
 
     CAN_KILL_PROC_GROUP = True
     IS_BG_SUBMIT = True
-    POLL_CMD_TMPL = "ps '%(job_id)s'"
+    POLL_CMD = "ps"
+    POLL_CMD_TMPL = POLL_CMD + " '%(job_id)s'"
     REC_ID_FROM_SUBMIT_OUT = re.compile(r"""\A(?P<id>\d+)\Z""")
 
     @classmethod

--- a/lib/cylc/batch_sys_handlers/loadleveler.py
+++ b/lib/cylc/batch_sys_handlers/loadleveler.py
@@ -26,7 +26,8 @@ class LoadlevelerHandler(object):
 
     DIRECTIVE_PREFIX = "# @ "
     KILL_CMD_TMPL = "llcancel '%(job_id)s'"
-    POLL_CMD_TMPL = "llq -f%%id '%(job_id)s'"
+    POLL_CMD = "llq"
+    POLL_CMD_TMPL = POLL_CMD + " -f%%id '%(job_id)s'"
     REC_ID_FROM_SUBMIT_OUT = re.compile(
         r"""\Allsubmit:\sThe\sjob\s"(?P<id>[^"]+)"\s""")
     REC_ERR_FILTERS = [

--- a/lib/cylc/batch_sys_handlers/lsf.py
+++ b/lib/cylc/batch_sys_handlers/lsf.py
@@ -25,7 +25,8 @@ class LSFHandler(object):
 
     DIRECTIVE_PREFIX = "#BSUB "
     KILL_CMD_TMPL = "bkill '%(job_id)s'"
-    POLL_CMD_TMPL = "bjobs -noheader '%(job_id)s'"
+    POLL_CMD = "bjobs"
+    POLL_CMD_TMPL = POLL_CMD + " -noheader '%(job_id)s'"
     REC_ID_FROM_SUBMIT_OUT = re.compile(r"^Job <(?P<id>\d+)>")
     SUBMIT_CMD_TMPL = "bsub"
     SUBMIT_CMD_STDIN_IS_JOB_FILE = True

--- a/lib/cylc/batch_sys_handlers/moab.py
+++ b/lib/cylc/batch_sys_handlers/moab.py
@@ -28,7 +28,8 @@ class MoabHandler(object):
     KILL_CMD_TMPL = "mjobctl -c '%(job_id)s'"
     # N.B. The "qstat JOB_ID" command returns 1 if JOB_ID is no longer in the
     # system, so there is no need to filter its output.
-    POLL_CMD_TMPL = "checkjob '%(job_id)s'"
+    POLL_CMD = "checkjob"
+    POLL_CMD_TMPL = POLL_CMD + " '%(job_id)s'"
     REC_ID_FROM_SUBMIT_OUT = re.compile(r"""\A\s*(?P<id>\S+)\s*\Z""")
     SUBMIT_CMD_TMPL = "msub '%s'"
 

--- a/lib/cylc/batch_sys_handlers/pbs.py
+++ b/lib/cylc/batch_sys_handlers/pbs.py
@@ -28,7 +28,8 @@ class PBSHandler(object):
     KILL_CMD_TMPL = "qdel '%(job_id)s'"
     # N.B. The "qstat JOB_ID" command returns 1 if JOB_ID is no longer in the
     # system, so there is no need to filter its output.
-    POLL_CMD_TMPL = "qstat '%(job_id)s'"
+    POLL_CMD = "qstat"
+    POLL_CMD_TMPL = POLL_CMD + " '%(job_id)s'"
     REC_ID_FROM_SUBMIT_OUT = re.compile(r"""\A\s*(?P<id>\S+)\s*\Z""")
     SUBMIT_CMD_TMPL = "qsub '%(job)s'"
 

--- a/lib/cylc/batch_sys_handlers/sge.py
+++ b/lib/cylc/batch_sys_handlers/sge.py
@@ -28,7 +28,8 @@ class SGEHandler(object):
     KILL_CMD_TMPL = "qdel '%(job_id)s'"
     # N.B. The "qstat -j JOB_ID" command returns 1 if JOB_ID is no longer in
     # the system, so there is no need to filter its output.
-    POLL_CMD_TMPL = "qstat -j '%(job_id)s'"
+    POLL_CMD = "qstat"
+    POLL_CMD_TMPL = POLL_CMD + " -j '%(job_id)s'"
     REC_ID_FROM_SUBMIT_OUT = re.compile(r"\D+(?P<id>\d+)\D+")
     SUBMIT_CMD_TMPL = "qsub '%(job)s'"
 

--- a/lib/cylc/batch_sys_handlers/slurm.py
+++ b/lib/cylc/batch_sys_handlers/slurm.py
@@ -74,5 +74,9 @@ class SLURMHandler(object):
         """
         return ["EXIT", "ERR", "XCPU"]
 
+    def get_poll_many_cmd(cls, job_ids):
+        """Return the poll command for a list of job IDs."""
+        return ["squeue", "-h", "-j", ",".join(job_ids)]
+
 
 BATCH_SYS_HANDLER = SLURMHandler()

--- a/lib/cylc/batch_sys_manager.py
+++ b/lib/cylc/batch_sys_manager.py
@@ -35,11 +35,21 @@ batch_sys.filter_poll_output(out, job_id) => boolean
       output to see if job_id is still alive in the batch system, and return
       True if so. See also "batch_sys.POLL_CMD_TMPL".
 
+batch_sys.filter_poll_many_output(out) => job_ids
+    * Called after the batch system's poll many command. The method should read
+      the output and return a list of job IDs that are still in the batch
+      system.
+
 batch_sys.filter_submit_output(out, err) => new_out, new_err
     * Filter the standard output and standard error of the job submission
       command. This is useful if the job submission command returns information
       that should just be ignored. See also "batch_sys.SUBMIT_CMD_TMPL" and
       "batch_sys.SUBMIT_CMD_STDIN_TMPL".
+
+batch_sys.format_directives(job_conf) => lines
+    * If relevant, this method formats the job directives for a job file, if
+      job file directives are relevant for the batch system. The argument
+      "job_conf" is a dict containing the job configuration.
 
 batch_sys.get_fail_signals(job_conf) => list of strings
     * Return a list of names of signals to trap for reporting errors. Default
@@ -47,14 +57,13 @@ batch_sys.get_fail_signals(job_conf) => list of strings
       EXIT is used to report premature stopping of the job script, and its trap
       is unset at the end of the script.
 
+batch_sys.get_poll_many_cmd(job-id-list) => list
+    * Return a list containing the shell command to poll the jobs in the
+      argument list.
+
 batch_sys.get_vacation_signal(job_conf) => str
     * If relevant, return a string containing the name of the signal that
       indicates the job has been vacated by the batch system.
-
-batch_sys.format_directives(job_conf) => lines
-    * If relevant, this method formats the job directives for a job file, if
-      job file directives are relevant for the batch system. The argument
-      "job_conf" is a dict containing the job configuration.
 
 batch_sys.submit(job_file_path) => proc
     * Submit a job and return an instance of the Popen object for the
@@ -103,16 +112,64 @@ batch_sys.SUBMIT_CMD_STDIN_IS_JOB_FILE
 
 """
 
-from datetime import datetime
 import os
 import shlex
 from signal import SIGKILL
 import stat
-from subprocess import check_call, Popen, PIPE
+from subprocess import call, Popen, PIPE
 import sys
+import traceback
 from cylc.mkdir_p import mkdir_p
 from cylc.task_id import TaskID
+from cylc.task_message import TaskMessage
 from cylc.wallclock import get_current_time_string
+
+
+class JobPollContext(object):
+    """Context object for a job poll.
+
+    0 ctx.job_log_dir -- cycle/task/submit_num
+    1 ctx.batch_sys_name -- batch system name
+    2 ctx.batch_sys_job_id -- job ID in batch system
+    3 ctx.batch_sys_exit_polled -- 0 for false, 1 for true
+    4 ctx.run_status -- 0 for success, 1 for failure
+    5 ctx.run_signal -- signal received on run failure
+    6 ctx.time_submit_exit -- submit (exit) time
+    7 ctx.time_run -- run start time
+    8 ctx.time_run_exit -- run exit time
+
+    """
+
+    def __init__(self, job_log_dir):
+        self.job_log_dir = job_log_dir
+        self.batch_sys_name = None
+        self.batch_sys_job_id = None
+        self.batch_sys_exit_polled = None
+        self.run_status = None
+        self.run_signal = None
+        self.time_submit_exit = None
+        self.time_run = None
+        self.time_run_exit = None
+        self.messages = []
+
+    def get_summary_str(self):
+        """Return the poll context as a summary string delimited by "|"."""
+        items = []
+        for item in [
+                self.job_log_dir,
+                self.batch_sys_name,
+                self.batch_sys_job_id,
+                self.batch_sys_exit_polled,
+                self.run_status,
+                self.run_signal,
+                self.time_submit_exit,
+                self.time_run,
+                self.time_run_exit]:
+            if item is None:
+                items.append("")
+            else:
+                items.append(str(item))
+        return "|".join(items)
 
 
 class BatchSysManager(object):
@@ -125,11 +182,14 @@ class BatchSysManager(object):
     CYLC_BATCH_SYS_NAME = "CYLC_BATCH_SYS_NAME"
     CYLC_BATCH_SYS_JOB_ID = "CYLC_BATCH_SYS_JOB_ID"
     CYLC_BATCH_SYS_JOB_SUBMIT_TIME = "CYLC_BATCH_SYS_JOB_SUBMIT_TIME"
+    CYLC_BATCH_SYS_EXIT_POLLED = "CYLC_BATCH_SYS_EXIT_POLLED"
     LINE_PREFIX_CYLC_DIR = "export CYLC_DIR="
     LINE_PREFIX_BATCH_SYS_NAME = "# Job submit method: "
     LINE_PREFIX_BATCH_SUBMIT_CMD_TMPL = "# Job submit command template: "
     LINE_UPDATE_CYLC_DIR = (
         "# N.B. CYLC_DIR has been updated on the remote host\n")
+    MESSAGE_PREFIX = "[CYLC MESSAGE]"
+    STATUS_SUMMARY_PREFIX = "[CYLC JOB STATUS SUMMARY]"
     _INSTANCES = {}
 
     @classmethod
@@ -178,10 +238,87 @@ class BatchSysManager(object):
         """Return True if batch_sys_name behaves like background submit."""
         return getattr(self.get_inst(batch_sys_name), "IS_BG_SUBMIT", False)
 
+    def jobs_kill(self, job_log_root, job_log_dirs):
+        """Kill multiple jobs.
+
+        job_log_root -- The log/job/ sub-directory of the suite.
+        job_log_dirs -- A list containing point/name/submit_num for task jobs.
+
+        """
+        # Note: The more efficient way to do this is to group the jobs by their
+        # batch systems, and call the kill command for each batch system once.
+        # However, this will make it more difficult to determine if the kill
+        # command for a particular job is successful or not.
+        if "$" in job_log_root:
+            job_log_root = os.path.expandvars(job_log_root)
+        ret = ""
+        now = get_current_time_string()
+        for job_log_dir in job_log_dirs:
+            ret_code = self.job_kill(
+                os.path.join(job_log_root, job_log_dir, "job.status"))
+            ret += "%s%s|%s|%d\n" % (
+                self.STATUS_SUMMARY_PREFIX, now, job_log_dir, ret_code)
+        return ret
+
+    def jobs_poll(self, job_log_root, job_log_dirs):
+        """Poll multiple jobs.
+
+        job_log_root -- The log/job/ sub-directory of the suite.
+        job_log_dirs -- A list containing point/name/submit_num for task jobs.
+
+        """
+        if "$" in job_log_root:
+            job_log_root = os.path.expandvars(job_log_root)
+
+        ctx_list = []  # Contexts for all relevant jobs
+        ctx_list_by_batch_sys = {}  # {batch_sys_name1: [ctx1, ...], ...}
+
+        for job_log_dir in job_log_dirs:
+            ctx = self._jobs_poll_status_files(job_log_root, job_log_dir)
+            if ctx is None:
+                continue
+            ctx_list.append(ctx)
+
+            if not ctx.batch_sys_name or not ctx.batch_sys_job_id:
+                sys.stderr.write(
+                    "%s/job.status: incomplete batch system info\n" % (
+                        ctx.job_log_dir))
+                continue
+
+            # We can trust:
+            # * Jobs previously polled to have exited the batch system.
+            # * Jobs succeeded or failed with ERR/EXIT.
+            if (ctx.batch_sys_exit_polled or ctx.run_status == 0 or
+                    ctx.run_signal in ["ERR", "EXIT"]):
+                continue
+
+            if ctx.batch_sys_name not in ctx_list_by_batch_sys:
+                ctx_list_by_batch_sys[ctx.batch_sys_name] = []
+            ctx_list_by_batch_sys[ctx.batch_sys_name].append(ctx)
+
+        for batch_sys_name, my_ctx_list in ctx_list_by_batch_sys.items():
+            self._jobs_poll_batch_sys(
+                job_log_root, batch_sys_name, my_ctx_list)
+
+        cur_time_str = get_current_time_string()
+        ret = ""
+        for ctx in ctx_list:
+            for message in ctx.messages:
+                ret += "%s%s|%s|%s\n" % (
+                    self.MESSAGE_PREFIX,
+                    cur_time_str,
+                    ctx.job_log_dir,
+                    message)
+            ret += "%s%s|%s\n" % (
+                self.STATUS_SUMMARY_PREFIX,
+                cur_time_str,
+                ctx.get_summary_str())
+        return ret
+
     def job_kill(self, st_file_path):
         """Ask batch system to terminate the job specified in "st_file_path".
 
-        Return zero on success, non-zero on failure.
+        Return 0 on success, non-zero integer on failure.
 
         """
         # SUITE_RUN_DIR/log/job/CYCLE/TASK/SUBMIT/job.status
@@ -198,8 +335,13 @@ class BatchSysManager(object):
             for line in st_file:
                 if line.startswith("CYLC_JOB_PID="):
                     pid = line.strip().split("=", 1)[1]
-                    os.killpg(int(pid), SIGKILL)
-                    return 0
+                    try:
+                        os.killpg(int(pid), SIGKILL)
+                    except OSError:
+                        traceback.print_exc()
+                        return 1
+                    else:
+                        return 0
         st_file.seek(0, 0)  # rewind
         if hasattr(batch_sys, "KILL_CMD_TMPL"):
             for line in st_file:
@@ -209,15 +351,16 @@ class BatchSysManager(object):
                 command = shlex.split(
                     batch_sys.KILL_CMD_TMPL % {"job_id": job_id})
                 try:
-                    check_call(command)
+                    ret_code = call(command)
                 except OSError as exc:
                     # subprocess.Popen has a bad habit of not setting the
                     # filename of the executable when it raises an OSError.
                     if not exc.filename:
                         exc.filename = command[0]
-                    raise
+                    traceback.print_exc()
+                    return 1
                 else:
-                    return 0
+                    return ret_code
         return 1
 
     def job_poll(self, st_file_path):
@@ -413,6 +556,92 @@ class BatchSysManager(object):
         if hasattr(batch_sys, "filter_submit_output"):
             out, err = batch_sys.filter_submit_output(out, err)
         return out, err, job_id
+
+    def _jobs_poll_status_files(self, job_log_root, job_log_dir):
+        """Helper 1 for self.jobs_poll(job_log_root, job_log_dirs)."""
+        ctx = JobPollContext(job_log_dir)
+        try:
+            handle = open(os.path.join(
+                job_log_root, ctx.job_log_dir, "job.status"))
+        except IOError as exc:
+            sys.stderr.write(str(exc))
+            return
+        for line in handle:
+            if "=" not in line:
+                continue
+            key, value = line.strip().split("=", 1)
+            if key == self.CYLC_BATCH_SYS_NAME:
+                ctx.batch_sys_name = value
+            elif key == self.CYLC_BATCH_SYS_JOB_ID:
+                ctx.batch_sys_job_id = value
+            elif key == self.CYLC_BATCH_SYS_EXIT_POLLED:
+                ctx.batch_sys_exit_polled = 1
+            elif key == self.CYLC_BATCH_SYS_JOB_SUBMIT_TIME:
+                ctx.time_submit_exit = value
+            elif key == TaskMessage.CYLC_JOB_INIT_TIME:
+                ctx.time_run = value
+            elif key == TaskMessage.CYLC_JOB_EXIT_TIME:
+                ctx.time_run_exit = value
+            elif key == TaskMessage.CYLC_JOB_EXIT:
+                if value == TaskMessage.SUCCEEDED.upper():
+                    ctx.run_status = 0
+                else:
+                    ctx.run_status = 1
+                    ctx.run_signal = value
+            elif key == TaskMessage.CYLC_MESSAGE:
+                ctx.messages.append(value)
+        handle.close()
+
+        return ctx
+
+    def _jobs_poll_batch_sys(self, job_log_root, batch_sys_name, my_ctx_list):
+        """Helper 2 for self.jobs_poll(job_log_root, job_log_dirs)."""
+        batch_sys = self.get_inst(batch_sys_name)
+        all_job_ids = [ctx.batch_sys_job_id for ctx in my_ctx_list]
+        if hasattr(batch_sys, "get_poll_many_cmd"):
+            # Some poll commands may not be as simple
+            cmd = batch_sys.get_poll_many_cmd(all_job_ids)
+        else:  # if hasattr(batch_sys, "POLL_CMD"):
+            # Simple poll command that takes a list of job IDs
+            cmd = [batch_sys.POLL_CMD] + all_job_ids
+        try:
+            proc = Popen(cmd, stderr=PIPE, stdout=PIPE)
+        except OSError as exc:
+            # subprocess.Popen has a bad habit of not setting the
+            # filename of the executable when it raises an OSError.
+            if not exc.filename:
+                exc.filename = cmd[0]
+            sys.stderr.write(str(exc))
+            return
+        proc.wait()
+        out, err = proc.communicate()
+        sys.stderr.write(err)
+        if hasattr(batch_sys, "filter_poll_many_output"):
+            # Allow custom filter
+            job_ids = batch_sys.filter_poll_many_output(out)
+        else:
+            # Just about all poll commands return a table, with column 1
+            # being the job ID. The logic here should be sufficient to
+            # ensure that any table header is ignored.
+            job_ids = []
+            for line in out.splitlines():
+                head = line.split(None, 1)[0]
+                if head in all_job_ids:
+                    job_ids.append(head)
+        for ctx in my_ctx_list:
+            ctx.batch_sys_exit_polled = int(
+                ctx.batch_sys_job_id not in job_ids)
+            # Add information to "job.status"
+            if ctx.batch_sys_exit_polled:
+                try:
+                    handle = open(os.path.join(
+                        job_log_root, ctx.job_log_dir, "job.status"), "a")
+                    handle.write("%s=%s\n" % (
+                        self.CYLC_BATCH_SYS_EXIT_POLLED,
+                        get_current_time_string()))
+                    handle.close()
+                except IOError as exc:
+                    sys.stderr.write(str(exc))
 
     def _job_submit_prepare_remote(self, job_file_path):
         """Prepare a remote job file.

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -462,23 +462,27 @@ class scheduler(object):
 
     def command_poll_tasks(self, name, point_string, is_family):
         """Poll all tasks or a task/family if options are provided."""
-        if name == "None" and point_string == "None":
-            self.pool.poll_tasks()
-        else:
+        if name and point_string:
             matches = self.get_matching_task_names(name, is_family)
             if not matches:
                 raise TaskNotFoundError("No matching tasks found: %s" % name)
             point_string = self.get_standardised_point_string(point_string)
             task_ids = [TaskID.get(i, point_string) for i in matches]
-            self.pool.poll_tasks(task_ids)
+            self.pool.poll_task_jobs(task_ids)
+        else:
+            self.pool.poll_task_jobs()
 
     def command_kill_tasks(self, name, point_string, is_family):
-        matches = self.get_matching_task_names(name, is_family)
-        if not matches:
-            raise TaskNotFoundError("No matching tasks found: %s" % name)
-        point_string = self.get_standardised_point_string(point_string)
-        task_ids = [TaskID.get(i, point_string) for i in matches]
-        self.pool.kill_tasks(task_ids)
+        """Kill all tasks or a task/family if options are provided."""
+        if name and point_string:
+            matches = self.get_matching_task_names(name, is_family)
+            if not matches:
+                raise TaskNotFoundError("No matching tasks found: %s" % name)
+            point_string = self.get_standardised_point_string(point_string)
+            task_ids = [TaskID.get(i, point_string) for i in matches]
+            self.pool.kill_task_jobs(task_ids)
+        else:
+            self.pool.kill_task_jobs()
 
     def command_release_suite(self):
         self.release_suite()
@@ -1072,8 +1076,8 @@ class scheduler(object):
                     self.shut_down_now = True
                 else:
                     if time.time() > self.next_kill_issue:
-                        self.pool.poll_tasks()
-                        self.pool.kill_active_tasks()
+                        self.pool.poll_task_jobs()
+                        self.pool.kill_task_jobs()
                         self.next_kill_issue = time.time() + 10.0
 
             if self.options.profile_mode:

--- a/lib/cylc/task_message.py
+++ b/lib/cylc/task_message.py
@@ -34,6 +34,12 @@ class TaskMessage(object):
     SUCCEEDED = "succeeded"
     STATUSES = (STARTED, SUCCEEDED, FAILED)
 
+    CYLC_JOB_PID = "CYLC_JOB_PID"
+    CYLC_JOB_INIT_TIME = "CYLC_JOB_INIT_TIME"
+    CYLC_JOB_EXIT = "CYLC_JOB_EXIT"
+    CYLC_JOB_EXIT_TIME = "CYLC_JOB_EXIT_TIME"
+    CYLC_MESSAGE = "CYLC_MESSAGE"
+
     FAIL_MESSAGE_PREFIX = "Task job script received signal "
     VACATION_MESSAGE_PREFIX = "Task job script vacated by signal "
 
@@ -270,19 +276,23 @@ class TaskMessage(object):
             if job_status_file:
                 if message == self.STARTED:
                     job_status_file.write(
-                        ("CYLC_JOB_PID=%s\n" % os.getenv("CYLC_JOB_PID")) +
-                        ("CYLC_JOB_INIT_TIME=%s\n" % self.true_event_time))
+                        ("%s=%s\n" % (
+                            self.CYLC_JOB_PID, os.getenv(self.CYLC_JOB_PID))) +
+                        ("%s=%s\n" % (
+                            self.CYLC_JOB_INIT_TIME, self.true_event_time)))
                 elif message == self.SUCCEEDED:
                     job_status_file.write(
-                        ("CYLC_JOB_EXIT=%s\n" % self.SUCCEEDED.upper()) +
-                        ("CYLC_JOB_EXIT_TIME=%s\n" % self.true_event_time))
+                        ("%s=%s\n" % (
+                            self.CYLC_JOB_EXIT, self.SUCCEEDED.upper())) +
+                        ("%s=%s\n" % (
+                            self.CYLC_JOB_EXIT_TIME, self.true_event_time)))
                 elif message == self.FAILED:
-                    job_status_file.write(
-                        ("CYLC_JOB_EXIT_TIME=%s\n" % self.true_event_time))
+                    job_status_file.write("%s=%s\n" % (
+                        self.CYLC_JOB_EXIT_TIME, self.true_event_time))
                 elif message.startswith(self.FAIL_MESSAGE_PREFIX):
-                    job_status_file.write(
-                        "CYLC_JOB_EXIT=%s\n" %
-                        message.replace(self.FAIL_MESSAGE_PREFIX, ""))
+                    job_status_file.write("%s=%s\n" % (
+                        self.CYLC_JOB_EXIT,
+                        message.replace(self.FAIL_MESSAGE_PREFIX, "")))
                 elif message.startswith(self.VACATION_MESSAGE_PREFIX):
                     # Job vacated, remove entries related to current job
                     job_status_file_name = job_status_file.name
@@ -294,11 +304,13 @@ class TaskMessage(object):
                     job_status_file = open(job_status_file_name, "wb")
                     for line in lines:
                         job_status_file.write(line)
-                    job_status_file.write("CYLC_MESSAGE=%s [%s] %s\n" % (
-                        self.true_event_time, self.priority, message))
+                    job_status_file.write("%s=%s|%s|%s\n" % (
+                        self.CYLC_MESSAGE, self.true_event_time, self.priority,
+                        message))
                 else:
-                    job_status_file.write("CYLC_MESSAGE=%s [%s] %s\n" % (
-                        self.true_event_time, self.priority, message))
+                    job_status_file.write("%s=%s|%s|%s\n" % (
+                        self.CYLC_MESSAGE, self.true_event_time, self.priority,
+                        message))
             if message in self.STATUSES:
                 messages[i] = "%s %s" % (self.task_id, message)
             messages[i] += ' at ' + self.true_event_time

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -1343,7 +1343,7 @@ class TaskPool(object):
             if (itask.task_host, itask.task_owner) not in auth_itasks:
                 auth_itasks[(itask.task_host, itask.task_owner)] = []
             auth_itasks[(itask.task_host, itask.task_owner)].append(itask)
-        for auth, itasks in auth_itasks.items():
+        for auth, itasks in sorted(auth_itasks.items()):
             cmd = ["cylc", cmd_key]
             host, owner = auth
             for key, value, test_func in [
@@ -1353,7 +1353,7 @@ class TaskPool(object):
                     cmd.append('--%s=%s' % (key, value))
             cmd.append(GLOBAL_CFG.get_derived_host_item(
                 self.suite_name, 'suite job log directory', host, owner))
-            for itask in itasks:
+            for itask in sorted(itasks, key=lambda itask: itask.identity):
                 cmd.append(itask.get_job_log_dir(
                     itask.tdef.name, itask.point, itask.submit_num))
             SuiteProcPool.get_inst().put_command(

--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -15,6 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Provide a class to represent a task proxy in a running suite."""
 
 import Queue
 import os
@@ -23,7 +24,6 @@ import socket
 import time
 from copy import copy
 from random import randrange
-from collections import deque
 from logging import getLogger, CRITICAL, ERROR, WARNING, INFO, DEBUG
 from pipes import quote
 import shlex
@@ -143,7 +143,7 @@ class TaskProxy(object):
     JOB_LOGS_RETRIEVE = "job-logs-retrieve"
     JOB_POLL = "job-poll"
     JOB_SUBMIT = SuiteProcPool.JOB_SUBMIT
-    POLL_SUFFIX_RE = re.compile(
+    MESSAGE_SUFFIX_RE = re.compile(
         ' at (' + RE_DATE_TIME_FORMAT_EXTENDED + '|unknown-time)$')
 
     LOGGING_LVL_OF = {
@@ -165,19 +165,19 @@ class TaskProxy(object):
 
     @classmethod
     def get_job_log_dir(
-            cls, suite, task_name, task_point, submit_num="NN", rel=False):
+            cls, task_name, task_point, submit_num="NN", suite=None):
         """Return the latest job log path on the suite host."""
         try:
             submit_num = "%02d" % submit_num
         except TypeError:
             pass
-        if rel:
-            return os.path.join(str(task_point), task_name, submit_num)
-        else:
-            suite_job_log_dir = GLOBAL_CFG.get_derived_host_item(
-                suite, "suite job log directory")
+        if suite:
             return os.path.join(
-                suite_job_log_dir, str(task_point), task_name, submit_num)
+                GLOBAL_CFG.get_derived_host_item(
+                    suite, "suite job log directory"),
+                str(task_point), task_name, submit_num)
+        else:
+            return os.path.join(str(task_point), task_name, submit_num)
 
     def __init__(
             self, tdef, start_point, initial_state, stop_point=None,
@@ -461,42 +461,21 @@ class TaskProxy(object):
 
     def command_log(self, ctx):
         """Log an activity for a job of this task proxy."""
+        ctx_str = str(ctx)
+        if not ctx_str:
+            return
         submit_num = "NN"
         if isinstance(ctx.cmd_type, tuple):  # An event handler
             submit_num = ctx.cmd_type[-1]
         job_log_dir = self.get_job_log_dir(
-            self.suite_name, self.tdef.name, self.point, submit_num)
+            self.tdef.name, self.point, submit_num, self.suite_name)
         handle = open(os.path.join(job_log_dir, "job-activity.log"), "a")
-        for attr in "cmd", "ret_code", "out", "err":
-            value = getattr(ctx, attr, None)
-            if value is not None and str(value).strip():
-                if attr == "cmd" and isinstance(value, list):
-                    mesg = " ".join(quote(item) for item in value)
-                else:
-                    mesg = str(value).strip()
-                if attr == "cmd":
-                    if ctx.cmd_kwargs.get("stdin_file_path"):
-                        mesg += " <%s" % quote(
-                            ctx.cmd_kwargs.get("stdin_file_path"))
-                    elif ctx.cmd_kwargs.get("stdin_str"):
-                        mesg += " <<<%s" % quote(
-                            ctx.cmd_kwargs.get("stdin_str"))
-                if getattr(ctx, "ret-code", None):
-                    self.log(ERROR, mesg)
-                else:
-                    self.log(DEBUG, mesg)
-                if len(mesg.splitlines()) > 1:
-                    fmt = self.JOB_LOG_FMT_M
-                else:
-                    fmt = self.JOB_LOG_FMT_1
-                if not mesg.endswith("\n"):
-                    mesg += "\n"
-                handle.write(fmt % {
-                    "timestamp": ctx.timestamp,
-                    "cmd_type": ctx.cmd_type,
-                    "attr": attr,
-                    "mesg": mesg})
+        handle.write(ctx_str)
         handle.close()
+        if ctx.cmd and ctx.ret_code:
+            self.log(ERROR, ctx_str)
+        elif ctx.cmd:
+            self.log(DEBUG, ctx_str)
 
     def _db_events_insert(self, event="", message=""):
         """Record an event to the DB."""
@@ -685,7 +664,7 @@ class TaskProxy(object):
             self.turn_off_timeouts()
             self._db_events_insert(event="reset to held")
             self.log(INFO, '%s => held' % self.state_before_held.get_status())
-        elif self.state.is_currently('submitted', 'running'):
+        elif self.is_active():
             self.hold_on_retry = True
 
     def reset_state_unheld(self, stop_point=None):
@@ -742,30 +721,70 @@ class TaskProxy(object):
                 "submit_status": 0})
         self.job_submission_succeeded()
 
-    def job_poll_callback(self, result):
+    def job_poll_callback(self, line):
         """Callback on job poll."""
-        self.command_log(result)
-        if result.ret_code:  # non-zero exit status
-            self.summary['latest_message'] = 'poll failed'
-            self.log(WARNING, 'job(%02d) poll failed' % self.submit_num)
-            flags.iflag = True
-        elif self.state.is_currently('submitted', 'running'):
-            # poll results emulate task messages
-            for line in result.out.splitlines():
-                if line.startswith('polled %s' % (self.identity)):
-                    self.process_incoming_message(('NORMAL', line))
-                    break
-        else:
-            # Poll results can come in after a task finishes
-            msg = "Ignoring late poll result: task not active"
-            self.command_log(SuiteProcContext(
-                self.JOB_POLL, None,
-                err="Ignoring late poll result: task not active",))
+        ctx = SuiteProcContext(self.JOB_POLL, None)
+        ctx.out = line
+        ctx.ret_code = 0
+        self.command_log(ctx)
 
-    def job_kill_callback(self, result):
+        items = line.split("|")
+        # See cylc.batch_sys_manager.JobPollContext
+        batch_sys_exit_polled, run_status, run_signal, _, time_run = items[4:9]
+        if run_status == "1" and run_signal in ["ERR", "EXIT"]:
+            # Failed normally
+            self._process_poll_message(INFO, TaskMessage.FAILED)
+        elif run_status == "1" and batch_sys_exit_polled == "1":
+            # Failed by a signal, and no longer in batch system
+            self._process_poll_message(INFO, TaskMessage.FAILED)
+            self._process_poll_message(
+                INFO, TaskMessage.FAIL_MESSAGE_PREFIX + run_signal)
+        elif run_status == "1":
+            # The job has terminated, but is still managed by batch system.
+            # Some batch system may restart a job in this state, so don't
+            # mark as failed yet.
+            self._process_poll_message(INFO, TaskMessage.STARTED)
+        elif run_status == "0":
+            # The job succeeded
+            self._process_poll_message(INFO, TaskMessage.SUCCEEDED)
+        elif time_run and batch_sys_exit_polled == "1":
+            # The job has terminated without executing the error trap
+            self._process_poll_message(INFO, TaskMessage.FAILED)
+        elif time_run:
+            # The job has started, and is still managed by batch system
+            self._process_poll_message(INFO, TaskMessage.STARTED)
+        elif batch_sys_exit_polled == "1":
+            # The job never ran, and no longer in batch system
+            self._process_poll_message(INFO, "submission failed")
+        else:
+            # The job never ran, and is in batch system
+            self._process_poll_message(INFO, "submitted")
+
+    def job_poll_message_callback(self, line):
+        """Callback on job poll message."""
+        ctx = SuiteProcContext(self.JOB_POLL, None)
+        ctx.out = line
+        ctx.ret_code = 0
+        self.command_log(ctx)
+
+        items = line.split("|")
+        priority, message = line.split("|")[3:5]
+        self._process_poll_message(priority, message)
+
+    def _process_poll_message(self, priority, message):
+        """Wraps self.process_incoming_message for poll messages."""
+        self.process_incoming_message(
+            (priority, "%s %s" % (self.identity, message)),
+            msg_was_polled=True)
+
+    def job_kill_callback(self, line):
         """Callback on job kill."""
-        self.command_log(result)
-        if result.ret_code:  # non-zero exit status
+        ctx = SuiteProcContext(self.JOB_KILL, None)
+        ctx.timestamp, _, ctx.ret_code = line.split("|", 2)
+        ctx.out = line
+        ctx.ret_code = int(ctx.ret_code)
+        self.command_log(ctx)
+        if ctx.ret_code:  # non-zero exit status
             self.summary['latest_message'] = 'kill failed'
             self.log(WARNING, 'job(%02d) kill failed' % self.submit_num)
             flags.iflag = True
@@ -1156,7 +1175,7 @@ class TaskProxy(object):
         data = []
         if result is None:
             job_log_dir = self.get_job_log_dir(
-                self.suite_name, self.tdef.name, self.point, submit_num)
+                self.tdef.name, self.point, submit_num, self.suite_name)
             try:
                 for filename in os.listdir(job_log_dir):
                     try:
@@ -1181,7 +1200,7 @@ class TaskProxy(object):
                     has_found_delim = True
 
         rel_job_log_dir = self.get_job_log_dir(
-            self.suite_name, self.tdef.name, self.point, submit_num, rel=True)
+            self.tdef.name, self.point, submit_num)
         for mtime, size, filename in data:
             self.db_inserts_map[self.TABLE_TASK_JOB_LOGS].append({
                 "submit_num": submit_num,
@@ -1189,7 +1208,6 @@ class TaskProxy(object):
                 "location": os.path.join(rel_job_log_dir, filename),
                 "mtime": mtime,
                 "size": size})
-
 
     def submit(self, dry_run=False, overrides=None):
         """Submit a job for this task."""
@@ -1210,19 +1228,13 @@ class TaskProxy(object):
                 # Could be a bad command template.
                 if flags.debug:
                     traceback.print_exc()
-                ret_code = 1
-                if hasattr(exc, "errno"):
-                    ret_code = exc.errno
                 self.command_log(SuiteProcContext(
-                    self.JOB_SUBMIT, None,
-                    err="Failed to construct job submission command",
+                    self.JOB_SUBMIT, '(prepare job file)', err=exc,
                     ret_code=1))
-                self.command_log(SuiteProcContext(
-                    self.JOB_SUBMIT, None, err=exc, ret_code=1))
                 self.job_submission_failed()
                 return
             if dry_run:
-                msg = "job file written for edit-run"
+                msg = 'job file written for edit-run'
                 self.log(WARNING, msg)
                 # This will be shown next to submit num in gcylc:
                 self.summary['latest_message'] = msg
@@ -1353,7 +1365,7 @@ class TaskProxy(object):
         })
         self.is_manual_submit = False
 
-    def _prepare_manip(self):
+    def prep_manip(self):
         """A cut down version of prepare_submit().
 
         This provides access to job poll commands before the task is submitted,
@@ -1446,65 +1458,26 @@ class TaskProxy(object):
             log_files.add_path(self.job_conf['job file path'] + '.out')
             log_files.add_path(self.job_conf['job file path'] + '.err')
 
-    def check_timers(self):
-        """Check submission and execution timeout timers.
+    def handle_submission_timeout(self):
+        """Handle submission timeout, only called if in "submitted" state."""
+        msg = 'job submitted %s ago, but has not started' % (
+            get_seconds_as_interval_string(
+                self.event_hooks['submission timeout'])
+        )
+        self.log(WARNING, msg)
+        self.handle_event('submission timeout', msg)
 
-        Not called in simulation mode.
-
-        """
-        if self.state.is_currently('submitted'):
-            self.check_submission_timeout()
-            if self.submission_poll_timer:
-                if self.submission_poll_timer.get():
-                    self.poll()
-                    self.submission_poll_timer.set_timer()
-        elif self.state.is_currently('running'):
-            self.check_execution_timeout()
-            if self.execution_poll_timer:
-                if self.execution_poll_timer.get():
-                    self.poll()
-                    self.execution_poll_timer.set_timer()
-
-    def check_submission_timeout(self):
-        """Check submission timeout, only called if in "submitted" state."""
-        if self.submission_timer_timeout is None:
-            # (explicit None in case of a zero timeout!)
-            # no timer set
-            return
-
-        # if timed out, log warning, poll, queue event handler, and turn off
-        # the timer
-        if time.time() > self.submission_timer_timeout:
-            msg = 'job submitted %s ago, but has not started' % (
-                get_seconds_as_interval_string(
-                    self._get_events_conf('submission timeout'))
-            )
-            self.log(WARNING, msg)
-            self.poll()
-            self.handle_event('submission timeout', msg)
-            self.submission_timer_timeout = None
-
-    def check_execution_timeout(self):
-        """Check execution timeout, only called if in "running" state."""
-        if self.execution_timer_timeout is None:
-            # (explicit None in case of a zero timeout!)
-            # no timer set
-            return
-
-        # if timed out: log warning, poll, queue event handler, and turn off
-        # the timer
-        if time.time() > self.execution_timer_timeout:
-            if self._get_events_conf('reset timer'):
-                # the timer is being re-started by put messages
-                msg = 'last message %s ago, but job not finished'
-            else:
-                msg = 'job started %s ago, but has not finished'
-            msg = msg % get_seconds_as_interval_string(
-                self._get_events_conf('execution timeout'))
-            self.log(WARNING, msg)
-            self.poll()
-            self.handle_event('execution timeout', msg)
-            self.execution_timer_timeout = None
+    def handle_execution_timeout(self):
+        """Handle execution timeout, only called if in "running" state."""
+        if self.event_hooks['reset timer']:
+            # the timer is being re-started by put messages
+            msg = 'last message %s ago, but job not finished'
+        else:
+            msg = 'job started %s ago, but has not finished'
+        msg = msg % get_seconds_as_interval_string(
+            self.event_hooks['execution timeout'])
+        self.log(WARNING, msg)
+        self.handle_event('execution timeout', msg)
 
     def sim_time_check(self):
         """Check simulation time."""
@@ -1554,7 +1527,8 @@ class TaskProxy(object):
                 break
             queue.task_done()
 
-    def process_incoming_message(self, (priority, message)):
+    def process_incoming_message(
+            self, (priority, message), msg_was_polled=False):
         """Parse an incoming task message and update task state.
 
         Correctly handle late (out of order) message which would otherwise set
@@ -1576,26 +1550,8 @@ class TaskProxy(object):
             # Failed tasks do not send messages unless declared resurrectable
             return
 
-        msg_was_polled = False
-        if message.startswith('polled '):
-            if not self.state.is_currently('submitted', 'running'):
-                # Polling can take a few seconds or more, so it is
-                # possible for a poll result to come in after a task
-                # finishes normally (success or failure) - in which case
-                # we should ignore the poll result.
-                self.log(
-                    WARNING,
-                    "Ignoring late poll result: task is not active")
-                return
-            # remove polling prefix and treat as a normal task message
-            msg_was_polled = True
-            message = message[7:]
-
-        # remove the remote event time (or "unknown-time" from polling) from
-        # the end:
-        message = self.POLL_SUFFIX_RE.sub('', message)
-
         # Remove the prepended task ID.
+        message = self.MESSAGE_SUFFIX_RE.sub('', message)
         content = message.replace(self.identity + ' ', '')
 
         # If the message matches a registered output, record it as completed.
@@ -1605,9 +1561,6 @@ class TaskProxy(object):
                 self.outputs.set_completed(message)
                 self._db_events_insert(
                     event="output completed", message=content)
-            elif content == 'started' and self.job_vacated:
-                self.job_vacated = False
-                self.log(WARNING, "Vacated job restarted: " + message)
             elif not msg_was_polled:
                 # This output has already been reported complete. Not an error
                 # condition - maybe the network was down for a bit. Ok for
@@ -1615,6 +1568,16 @@ class TaskProxy(object):
                 self.log(
                     WARNING,
                     "Unexpected output (already completed):\n  " + message)
+
+        if msg_was_polled and not self.is_active():
+            # Polling can take a few seconds or more, so it is
+            # possible for a poll result to come in after a task
+            # finishes normally (success or failure) - in which case
+            # we should ignore the poll result.
+            self.log(
+                WARNING,
+                "Ignoring late poll result: task is not active")
+            return
 
         if priority == TaskMessage.WARNING:
             self.handle_event('warning', content, db_update=False)
@@ -1630,6 +1593,9 @@ class TaskProxy(object):
         elif (content == TaskMessage.STARTED and
                 self.state.is_currently(
                     'ready', 'submitted', 'submit-failed')):
+            if self.job_vacated:
+                self.job_vacated = False
+                self.log(WARNING, "Vacated job restarted: " + message)
             # Received a 'task started' message
             flags.pflag = True
             self.set_status('running')
@@ -1736,7 +1702,7 @@ class TaskProxy(object):
 
     def process_event_handler_retries(self):
         """Run delayed event handlers or retry failed ones."""
-        for key, try_state in self.event_handler_try_states.items():
+        for try_state in self.event_handler_try_states.values():
             if try_state.ctx and try_state.is_delay_done():
                 try_state.timeout = None
                 ctx = SuiteProcContext(
@@ -1796,6 +1762,10 @@ class TaskProxy(object):
         return (
             self.state.is_currently('succeeded') and self.state.has_spawned())
 
+    def is_active(self):
+        """Return True if task is in "submitted" or "running" state."""
+        return self.state.is_currently('submitted', 'running')
+
     def get_state_summary(self):
         """Return a dict containing the state summary of this task proxy."""
         self.summary['state'] = self.state.get_status()
@@ -1827,18 +1797,6 @@ class TaskProxy(object):
         if adjusted:
             p_next = min(adjusted)
         return p_next
-
-    def poll(self):
-        """Poll my live task job and update status accordingly."""
-        return self._manip_job_status(
-            self.JOB_POLL, self.job_poll_callback)
-
-    def kill(self):
-        """Kill current job of this task."""
-        self.reset_state_held()
-        return self._manip_job_status(
-            self.JOB_KILL,
-            self.job_kill_callback, ['running', 'submitted'])
 
     def _create_job_log_path(self, new_mode=False):
         """Return a new job log path on the suite host, in two parts.
@@ -1881,45 +1839,6 @@ class TaskProxy(object):
                 exc.filename = target
             raise exc
         return suite_job_log_dir, the_rest
-
-    def _manip_job_status(self, cmd_key, callback, ok_states=None):
-        """Manipulate the job status, e.g. poll or kill."""
-        # No real jobs in simulation mode.
-        if self.tdef.run_mode == 'simulation':
-            if cmd_key == self.JOB_KILL:
-                self.reset_state_failed()
-            return
-        # Check that task states are compatible with the manipulation
-        if ok_states and not self.state.is_currently(*ok_states):
-            self.log(
-                WARNING,
-                'Can only do %s when in %s states' % (cmd_key, str(ok_states)))
-            return
-        # Detached tasks
-        if self.tdef.rtconfig['manual completion']:
-            self.log(
-                WARNING,
-                "Cannot %s detaching tasks (job ID unknown)" % (cmd_key))
-            return
-
-        # Invoke the manipulation
-        return self._run_job_command(
-            cmd_key,
-            args=[self.get_job_conf_item("job file path") + ".status"],
-            callback=callback)
-
-    def get_job_conf_item(self, item):
-        if self.job_conf is None:
-            # Job hasn't run yet, or it ran before a suite restart.
-            # Ensure settings are ready for manipulation on restart, etc.
-            self._prepare_manip()
-        return self.job_conf[item]
-
-    def get_task_log_dir(self):
-        """Return my job log dir, sans submit number."""
-        suite_job_log_dir = GLOBAL_CFG.get_derived_host_item(
-            self.suite_name, "suite job log directory")
-        return os.path.join(suite_job_log_dir, str(self.point), self.tdef.name)
 
     def _run_job_command(
             self, cmd_key, args, callback, is_bg_submit=None,

--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -760,6 +760,12 @@ class TaskProxy(object):
             # The job never ran, and is in batch system
             self._process_poll_message(INFO, "submitted")
 
+    def _process_poll_message(self, priority, message):
+        """Wraps self.process_incoming_message for poll messages."""
+        self.process_incoming_message(
+            (priority, "%s %s" % (self.identity, message)),
+            msg_was_polled=True)
+
     def job_poll_message_callback(self, line):
         """Callback on job poll message."""
         ctx = SuiteProcContext(self.JOB_POLL, None)
@@ -769,13 +775,7 @@ class TaskProxy(object):
 
         items = line.split("|")
         priority, message = line.split("|")[3:5]
-        self._process_poll_message(priority, message)
-
-    def _process_poll_message(self, priority, message):
-        """Wraps self.process_incoming_message for poll messages."""
-        self.process_incoming_message(
-            (priority, "%s %s" % (self.identity, message)),
-            msg_was_polled=True)
+        self.process_incoming_message((priority, message), msg_was_polled=True)
 
     def job_kill_callback(self, line):
         """Callback on job kill."""

--- a/tests/cylc-kill/00-kill-multi-hosts.t
+++ b/tests/cylc-kill/00-kill-multi-hosts.t
@@ -1,0 +1,55 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test kill multiple jobs on localhost and a remote host
+. "$(dirname "$0")/test_header"
+export CYLC_TEST_HOST=$(cylc get-global-config -i '[test battery]remote host')
+if [[ -z "${CYLC_TEST_HOST}" ]]; then
+    skip_all '[test battery]remote host: not defined'
+fi
+
+set_test_number 3
+
+export CYLC_CONF_PATH=
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+set -eu
+SSH='ssh -oBatchMode=yes -oConnectTimeout=5'
+${SSH} "${CYLC_TEST_HOST}" \
+    "mkdir -p .cylc/${SUITE_NAME}/ && cat >.cylc/${SUITE_NAME}/passphrase" \
+    <"${TEST_DIR}/${SUITE_NAME}/passphrase"
+set +eu
+
+run_ok "${TEST_NAME_BASE}-validate" \
+    cylc validate "${SUITE_NAME}" -s "CYLC_TEST_HOST=${CYLC_TEST_HOST}"
+
+suite_run_ok "${TEST_NAME_BASE}-run" \
+    cylc run --reference-test --debug "${SUITE_NAME}" \
+    -s "CYLC_TEST_HOST=${CYLC_TEST_HOST}"
+
+RUN_DIR="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}"
+LOG="${RUN_DIR}/log/suite/log"
+sed -n 's/^.*\(cylc jobs-kill\)/\1/p' "${LOG}" | sort >'edited-suite-log'
+
+sort >'edited-suite-log-ref' <<__LOG__
+cylc jobs-kill ${RUN_DIR}/log/job 1/local-1/01 1/local-2/01 1/local-3/01
+cylc jobs-kill --host=${CYLC_TEST_HOST} '\$HOME/cylc-run/${SUITE_NAME}/log/job' 1/remote-1/01 1/remote-2/01
+__LOG__
+cmp_ok 'edited-suite-log' 'edited-suite-log-ref'
+
+$SSH -n "$CYLC_TEST_HOST" "rm -rf '.cylc/$SUITE_NAME' 'cylc-run/$SUITE_NAME'"
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/cylc-kill/00-kill-multi-hosts/reference.log
+++ b/tests/cylc-kill/00-kill-multi-hosts/reference.log
@@ -1,0 +1,10 @@
+2015-08-24T15:20:15Z INFO - Run mode: live
+2015-08-24T15:20:15Z INFO - Initial point: 1
+2015-08-24T15:20:15Z INFO - Final point: 1
+2015-08-24T15:20:15Z INFO - Cold Start 1
+2015-08-24T15:20:16Z INFO - [remote-1.1] -triggered off []
+2015-08-24T15:20:16Z INFO - [local-1.1] -triggered off []
+2015-08-24T15:20:16Z INFO - [local-2.1] -triggered off []
+2015-08-24T15:20:16Z INFO - [remote-2.1] -triggered off []
+2015-08-24T15:20:16Z INFO - [local-3.1] -triggered off []
+2015-08-24T15:20:19Z INFO - [killer.1] -triggered off ['local-1.1', 'local-2.1', 'local-3.1', 'remote-1.1', 'remote-2.1']

--- a/tests/cylc-kill/00-kill-multi-hosts/suite.rc
+++ b/tests/cylc-kill/00-kill-multi-hosts/suite.rc
@@ -1,0 +1,26 @@
+#!Jinja2
+[cylc]
+    UTC mode = True
+    [[reference test]]
+        required run mode = live
+        live mode suite timeout = PT1M
+        expected task failures = local-1.1, local-2.1, local-3.1, remote-1.1, remote-2.1
+[scheduling]
+    [[dependencies]]
+        graph="""
+KILLABLE:start-all => killer
+"""
+[runtime]
+    [[KILLABLE]]
+        script=sleep 60
+    [[local-1, local-2, local-3]]
+        inherit = KILLABLE
+    [[remote-1, remote-2]]
+        inherit = KILLABLE
+        [[[remote]]]
+            host={{CYLC_TEST_HOST}}
+    [[killer]]
+        script="""
+cylc kill -m "${CYLC_SUITE_NAME}" KILLABLE 1
+cylc stop "${CYLC_SUITE_NAME}"
+"""

--- a/tests/cylc-kill/test_header
+++ b/tests/cylc-kill/test_header
@@ -1,0 +1,1 @@
+../lib/bash/test_header

--- a/tests/cylc-poll/04-poll-multi-hosts.t
+++ b/tests/cylc-poll/04-poll-multi-hosts.t
@@ -1,7 +1,7 @@
 #!/bin/bash
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
 # Copyright (C) 2008-2015 NIWA
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
@@ -15,15 +15,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Suite database content, "task_jobs" table with a remote job.
+# Test poll multiple jobs on localhost and a remote host
 . "$(dirname "$0")/test_header"
 export CYLC_TEST_HOST=$(cylc get-global-config -i '[test battery]remote host')
 if [[ -z "${CYLC_TEST_HOST}" ]]; then
     skip_all '[test battery]remote host: not defined'
 fi
+
 set_test_number 3
+
+export CYLC_CONF_PATH=
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
-# Install suite passphrase.
 set -eu
 SSH='ssh -oBatchMode=yes -oConnectTimeout=5'
 ${SSH} "${CYLC_TEST_HOST}" \
@@ -31,25 +33,23 @@ ${SSH} "${CYLC_TEST_HOST}" \
     <"${TEST_DIR}/${SUITE_NAME}/passphrase"
 set +eu
 
-run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+run_ok "${TEST_NAME_BASE}-validate" \
+    cylc validate "${SUITE_NAME}" -s "CYLC_TEST_HOST=${CYLC_TEST_HOST}"
+
 suite_run_ok "${TEST_NAME_BASE}-run" \
-    cylc run --debug --reference-test "${SUITE_NAME}"
+    cylc run --reference-test --debug "${SUITE_NAME}" \
+    -s "CYLC_TEST_HOST=${CYLC_TEST_HOST}"
 
-DB_FILE="$(cylc get-global-config '--print-run-dir')/${SUITE_NAME}/cylc-suite.db"
+RUN_DIR="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}"
+LOG="${RUN_DIR}/log/suite/log"
+sed -n 's/^.*\(cylc jobs-poll\)/\1/p' "${LOG}" | sort >'edited-suite-log'
 
-NAME='select-task-jobs.out'
-sqlite3 "${DB_FILE}" \
-    'SELECT cycle, name, submit_num, try_num, submit_status, run_status,
-            user_at_host, batch_sys_name
-     FROM task_jobs ORDER BY name' \
-    >"${NAME}"
-cmp_ok "${NAME}" <<__SELECT__
-20200101T0000Z|t1|1|1|0|0|localhost|background
-20200101T0000Z|t2|1|1|0|0|${CYLC_TEST_HOST}|background
-__SELECT__
+sort >'edited-suite-log-ref' <<__LOG__
+cylc jobs-poll ${RUN_DIR}/log/job 1/local-fail-1/01 1/local-fail-2/01 1/local-success-1/01
+cylc jobs-poll --host=${CYLC_TEST_HOST} '\$HOME/cylc-run/${SUITE_NAME}/log/job' 1/remote-fail-1/01 1/remote-success-1/01 1/remote-success-2/01
+__LOG__
+cmp_ok 'edited-suite-log' 'edited-suite-log-ref'
 
-if [[ "$CYLC_TEST_HOST" != 'localhost' ]]; then
-    $SSH -n "$CYLC_TEST_HOST" "rm -rf '.cylc/$SUITE_NAME' 'cylc-run/$SUITE_NAME'"
-fi
+$SSH -n "$CYLC_TEST_HOST" "rm -rf '.cylc/$SUITE_NAME' 'cylc-run/$SUITE_NAME'"
 purge_suite "${SUITE_NAME}"
 exit

--- a/tests/cylc-poll/04-poll-multi-hosts/reference.log
+++ b/tests/cylc-poll/04-poll-multi-hosts/reference.log
@@ -1,0 +1,11 @@
+2015-08-24T13:53:25Z INFO - Run mode: live
+2015-08-24T13:53:25Z INFO - Initial point: 1
+2015-08-24T13:53:25Z INFO - Final point: 1
+2015-08-24T13:53:25Z INFO - Cold Start 1
+2015-08-24T13:53:26Z INFO - [remote-success-1.1] -triggered off []
+2015-08-24T13:53:26Z INFO - [remote-fail-1.1] -triggered off []
+2015-08-24T13:53:26Z INFO - [local-fail-2.1] -triggered off []
+2015-08-24T13:53:26Z INFO - [remote-success-2.1] -triggered off []
+2015-08-24T13:53:26Z INFO - [local-success-1.1] -triggered off []
+2015-08-24T13:53:26Z INFO - [local-fail-1.1] -triggered off []
+2015-08-24T13:53:31Z INFO - [poller.1] -triggered off ['local-fail-1.1', 'local-fail-2.1', 'local-success-1.1', 'remote-fail-1.1', 'remote-success-1.1', 'remote-success-2.1']

--- a/tests/cylc-poll/04-poll-multi-hosts/suite.rc
+++ b/tests/cylc-poll/04-poll-multi-hosts/suite.rc
@@ -1,0 +1,52 @@
+#!Jinja2
+[cylc]
+    UTC mode = True
+    [[reference test]]
+        required run mode = live
+        live mode suite timeout = PT1M
+        expected task failures = local-fail-1.1, local-fail-2.1, remote-fail-1.1
+[scheduling]
+    [[dependencies]]
+        graph="""
+POLLABLE:start-all => poller
+"""
+[runtime]
+    [[POLLABLE]]
+        pre-script="""
+# Stop script from reporting anything back
+trap '' 'EXIT'
+trap '' 'ERR'
+"""
+    [[FAIL]]
+        inherit = POLLABLE
+        script="""
+echo 'I am failing...' >&2
+exit 1
+"""
+    [[local-fail-1, local-fail-2]]
+        inherit = FAIL
+    [[remote-fail-1]]
+        inherit = FAIL
+        [[[remote]]]
+            host={{CYLC_TEST_HOST}}
+    [[SUCCESS]]
+        inherit = POLLABLE
+        script="""
+echo 'I am OK.'
+{
+    echo 'CYLC_JOB_EXIT=SUCCEEDED'
+    echo "CYLC_JOB_EXIT_TIME=$(date +%FT%H:%M:%SZ)"
+} >>"${CYLC_TASK_LOG_ROOT}.status"
+exit
+"""
+    [[local-success-1]]
+        inherit = SUCCESS
+    [[remote-success-1, remote-success-2]]
+        inherit = SUCCESS
+        [[[remote]]]
+            host={{CYLC_TEST_HOST}}
+    [[poller]]
+        script="""
+cylc poll -m "${CYLC_SUITE_NAME}" POLLABLE 1
+cylc stop "${CYLC_SUITE_NAME}"
+"""

--- a/tests/cylc-poll/05-poll-multi-messages.t
+++ b/tests/cylc-poll/05-poll-multi-messages.t
@@ -1,0 +1,31 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test poll multiple messages
+. "$(dirname "$0")/test_header"
+set_test_number 2
+
+export CYLC_CONF_PATH=
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+
+suite_run_ok "${TEST_NAME_BASE}-run" \
+    cylc run --reference-test --debug "${SUITE_NAME}"
+
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/cylc-poll/05-poll-multi-messages/reference.log
+++ b/tests/cylc-poll/05-poll-multi-messages/reference.log
@@ -1,0 +1,8 @@
+2015-08-24T16:19:01Z INFO - Run mode: live
+2015-08-24T16:19:01Z INFO - Initial point: 1
+2015-08-24T16:19:01Z INFO - Final point: 1
+2015-08-24T16:19:01Z INFO - Cold Start 1
+2015-08-24T16:19:01Z INFO - [speaker1.1] -triggered off []
+2015-08-24T16:19:01Z INFO - [speaker2.1] -triggered off []
+2015-08-24T16:19:04Z INFO - [poller.1] -triggered off ['speaker1.1', 'speaker2.1']
+2015-08-24T16:19:07Z INFO - [finisher.1] -triggered off ['speaker1.1', 'speaker1.1', 'speaker2.1']

--- a/tests/cylc-poll/05-poll-multi-messages/suite.rc
+++ b/tests/cylc-poll/05-poll-multi-messages/suite.rc
@@ -1,0 +1,45 @@
+#!Jinja2
+[cylc]
+    UTC mode = True
+    [[reference test]]
+        required run mode = live
+        live mode suite timeout = PT1M
+[scheduling]
+    [[dependencies]]
+        graph="""
+speaker1:start & speaker2:start => poller
+speaker1:hello1 & speaker1:hello2 & speaker2:greet => finisher
+"""
+[runtime]
+    [[speaker1]]
+        script="""
+# Wait for "cylc task message started" command
+wait
+# Simulate "cylc task message", messages written to status file but failed to
+# get sent back to the suite
+{
+    echo "CYLC_MESSAGE=$(date +%FT%H:%M:%SZ)|NORMAL|hello1 ${CYLC_TASK_CYCLE_POINT}"
+    echo "CYLC_MESSAGE=$(date +%FT%H:%M:%SZ)|NORMAL|hello2 ${CYLC_TASK_CYCLE_POINT}"
+} >>"${CYLC_TASK_LOG_ROOT}.status"
+sleep 30
+"""
+        [[[outputs]]]
+            hello1 = "hello1 []"
+            hello2 = "hello2 []"
+    [[speaker2]]
+        script="""
+# Wait for "cylc task message started" command
+wait
+# Simulate "cylc task message", messages written to status file but failed to
+# get sent back to the suite
+{
+    echo "CYLC_MESSAGE=$(date +%FT%H:%M:%SZ)|NORMAL|greet ${CYLC_TASK_CYCLE_POINT}"
+} >>"${CYLC_TASK_LOG_ROOT}.status"
+sleep 30
+"""
+        [[[outputs]]]
+            greet = "greet []"
+    [[finisher]]
+        script=true
+    [[poller]]
+        script=cylc poll "${CYLC_SUITE_NAME}" 'speaker[12]' '1'

--- a/tests/job-submission/05-activity-log.t
+++ b/tests/job-submission/05-activity-log.t
@@ -30,9 +30,9 @@ SUITE_RUN_DIR="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}"
 T1_ACTIVITY_LOG="${SUITE_RUN_DIR}/log/job/1/t1/NN/job-activity.log"
 
 grep_ok '\[job-submit ret_code\] 0' "${T1_ACTIVITY_LOG}"
-grep_ok '\[job-kill err\]' "${T1_ACTIVITY_LOG}"
-grep_ok 'OSError: \[Errno 3\] No such process' "${T1_ACTIVITY_LOG}"
-grep_ok '\[job-poll out\] polled t1\.1 failed at unknown-time' \
+grep_ok '\[job-kill ret_code\] 1' "${T1_ACTIVITY_LOG}"
+grep_ok '\[job-kill out\] [^|]*\|1/t1/01\|1' "${T1_ACTIVITY_LOG}"
+grep_ok '\[job-poll out\] [^|]*\|1/t1/01\|background\|[^|]*\|1\|\|\|\|[^|]*\|' \
     "${T1_ACTIVITY_LOG}"
 grep_ok \
     "\\[('event-handler-00', 'failed', '01') out\\] failed ${SUITE_NAME} t1\\.1 job failed" \

--- a/tests/message-triggers/01-new/suite.rc
+++ b/tests/message-triggers/01-new/suite.rc
@@ -23,8 +23,8 @@ echo HELLO
 MESSAGE_X="file 1 for $CYLC_TASK_CYCLE_POINT done"
 MESSAGE_Y="file 2 for $(cylc cycle-point --offset P2M) done"
 cylc message "${MESSAGE_X}" "${MESSAGE_Y}"
-grep -q "CYLC_MESSAGE=.* \[NORMAL\] ${MESSAGE_X}" "$0.status"
-grep -q "CYLC_MESSAGE=.* \[NORMAL\] ${MESSAGE_Y}" "$0.status"
+grep -q "CYLC_MESSAGE=.*|NORMAL|${MESSAGE_X}" "$0.status"
+grep -q "CYLC_MESSAGE=.*|NORMAL|${MESSAGE_Y}" "$0.status"
 """
         [[[outputs]]]
             x = "file 1 for [] done"


### PR DESCRIPTION
On receiving a request to poll/kill multiple task jobs, the system will now group them together by job hosts, so we only need to do a single SSH per job host. On the job host, if we need to poll the batch systems, it will attempt to run a single command (e.g. `qstat JOB1 JOB2 ...` for PBS) instead of multiple commands (e.g. `qstat JOB1; qstat JOB2; ...`). This should make it more efficient for users to poll/kill all jobs.

In addition, polling will now return custom task messages as well as the task job status.

Address poll and kill part of #1505, close #1549.