### PR TITLE
Add divider and force a prompt for kill

### DIFF
--- a/doc/changes.html
+++ b/doc/changes.html
@@ -17,6 +17,7 @@
 <h3 style="margin:10px">versions</h3>
 <ul>
     <li><a href="#">TOP</a>
+    <li><a href="#6.6.1">6.6.1</a>
     <li><a href="#6.6.0">6.6.0</a>
     <li><a href="#6.5.0">6.5.0</a>
     <li><a href="#6.4.1">6.4.1</a>
@@ -60,6 +61,21 @@
 <p>Selected enhancements and bug fixes.  Some changes may be omitted from this
 page; for the definitive record see the cylc repository change log.</p>
 
+<a name="6.6.1"/>
+    <h2>6.6.1</h2>
+
+    <h3>6.6.1 fixes</h3>
+    <ul>
+        <li> At sites using ssh task messaging, 
+        prevent fall-through to Pyro RPC messaging after successful ssh
+        messaging (this would cause error messages in task output since
+        cylc-6.5.0, if using ssh messaging)
+        <li> Clearer error messages for invalid <code>cylc broadcast</code>
+        commands.
+        <li> Allow suite and global config files to have different
+        date-time syntax (pre and post ISO-8601) for time intervals.
+    </ul>
+ 
 <a name="6.6.0"/>
     <h2>6.6.0</h2>
 

--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -1282,6 +1282,8 @@ been defined for this suite""").inform()
         items.append(poll_item)
         poll_item.connect('activate', self.poll_task, task_id, task_is_family)
 
+        items.append(gtk.SeparatorMenuItem())
+
         kill_item = gtk.ImageMenuItem('Kill')
         img = gtk.image_new_from_stock(gtk.STOCK_CANCEL, gtk.ICON_SIZE_MENU)
         kill_item.set_image(img)
@@ -1625,8 +1627,8 @@ shown here in the state they were in at the time of triggering.''')
         self.quitters.remove(lv)
         w.destroy()
 
-    def get_confirmation(self, question):
-        if self.cfg.no_prompt:
+    def get_confirmation(self, question, force_prompt=False):
+        if self.cfg.no_prompt and not force_prompt:
             return True
         prompt = gtk.MessageDialog(self.window, gtk.DIALOG_MODAL,
                                    gtk.MESSAGE_QUESTION,
@@ -1679,7 +1681,7 @@ shown here in the state they were in at the time of triggering.''')
         self.put_pyro_command('poll_tasks', name, point_string, is_family)
 
     def kill_task(self, b, task_id, is_family=False):
-        if not self.get_confirmation("Kill %s?" % task_id):
+        if not self.get_confirmation("Kill %s?" % task_id, force_prompt=True):
             return
         name, point_string = TaskID.split(task_id)
         self.put_pyro_command('kill_tasks', name, point_string, is_family)


### PR DESCRIPTION
Closes #1566 

Adds a separator between poll and kill and forces a prompt to be raised in case of issuing a kill via the gui.

@benfitzpatrick - please review 1
@hjoliver - please review2