### PR TITLE
parsec: jinja2 error reporting

### DIFF
--- a/doc/changes.html
+++ b/doc/changes.html
@@ -17,6 +17,7 @@
 <h3 style="margin:10px">versions</h3>
 <ul>
     <li><a href="#">TOP</a>
+    <li><a href="#6.6.1">6.6.1</a>
     <li><a href="#6.6.0">6.6.0</a>
     <li><a href="#6.5.0">6.5.0</a>
     <li><a href="#6.4.1">6.4.1</a>
@@ -60,6 +61,21 @@
 <p>Selected enhancements and bug fixes.  Some changes may be omitted from this
 page; for the definitive record see the cylc repository change log.</p>
 
+<a name="6.6.1"/>
+    <h2>6.6.1</h2>
+
+    <h3>6.6.1 fixes</h3>
+    <ul>
+        <li> At sites using ssh task messaging, 
+        prevent fall-through to Pyro RPC messaging after successful ssh
+        messaging (this would cause error messages in task output since
+        cylc-6.5.0, if using ssh messaging)
+        <li> Clearer error messages for invalid <code>cylc broadcast</code>
+        commands.
+        <li> Allow suite and global config files to have different
+        date-time syntax (pre and post ISO-8601) for time intervals.
+    </ul>
+ 
 <a name="6.6.0"/>
     <h2>6.6.0</h2>
 

--- a/lib/parsec/Jinja2Support.py
+++ b/lib/parsec/Jinja2Support.py
@@ -21,10 +21,7 @@ import glob
 from jinja2 import (
         Environment,
         FileSystemLoader,
-        TemplateSyntaxError,
         TemplateError,
-        TemplateNotFound,
-        UndefinedError,
         StrictUndefined)
 import cylc.flags
 
@@ -96,14 +93,16 @@ def Jinja2Process( flines, dir, inputs=[], inputs_file=None ):
     # CALLERS SHOULD HANDLE JINJA2 TEMPLATESYNTAXERROR AND TEMPLATEERROR
     # try:
     template = env.from_string( '\n'.join(flines[1:]) )
-    # except Exception, x:
+    # except Exception as exc:
     #     # This happens if we use an unknown Jinja2 filter, for example.
     ##     # TODO - THIS IS CAUGHT BY VALIDATE BUT NOT BY VIEW COMMAND...
-    #     raise TemplateError( x )
+    #     raise TemplateError(exc)
     try:
         template_vars = load_template_vars( inputs, inputs_file )
-    except Exception, x:
-        raise TemplateError( x )
+    except Exception as exc:
+        if isinstance(exc, TemplateError):
+            raise
+        raise TemplateError(exc)
 
     # CALLERS SHOULD HANDLE JINJA2 TEMPLATESYNTAXERROR AND TEMPLATEERROR
     # AND TYPEERROR (e.g. for not using "|int" filter on number inputs.

--- a/lib/parsec/__init__.py
+++ b/lib/parsec/__init__.py
@@ -3,4 +3,4 @@ class ParsecError(Exception):
     def __init__(self, msg):
         self.msg = msg
     def __str__(self):
-        return repr(self.msg)
+        return str(self.msg)

--- a/tests/validate/42-jinja2-template-syntax-error-main.t
+++ b/tests/validate/42-jinja2-template-syntax-error-main.t
@@ -15,16 +15,23 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test validation missing include-file.
+# Test validation for a bad Jinja2 TemplateSyntaxError suite.
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 set_test_number 2
-echo '%include foo.rc' >suite.rc
-echo '%include bar.rc' >foo.rc
-run_fail "$TEST_NAME_BASE" cylc validate suite.rc
-cmp_ok "$TEST_NAME_BASE.stderr" <<__ERR__
-FileParseError:
-Include-file not found: bar.rc via foo.rc from $PWD/suite.rc
-__ERR__
+install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-val
+run_fail "$TEST_NAME" cylc validate suite.rc
+cmp_ok "$TEST_NAME.stderr" <<'__ERROR__'
+Jinja2Error:
+  File "<unknown>", line 6, in template
+TemplateSyntaxError: Encountered unknown tag 'end'. Jinja was looking for the following tags: 'elif' or 'else' or 'endif'. The innermost block that needs to be closed is 'if'.
+Context lines:
+    [[dependencies]]
+        {% if true %}
+        graph = foo
+        {% end if %	<-- Jinja2Error
+__ERROR__
 #-------------------------------------------------------------------------------
 exit

--- a/tests/validate/42-jinja2-template-syntax-error-main/suite.rc
+++ b/tests/validate/42-jinja2-template-syntax-error-main/suite.rc
@@ -1,0 +1,10 @@
+#!jinja2
+
+[scheduling]
+    [[dependencies]]
+        {% if true %}
+        graph = foo
+        {% end if %
+[runtime]
+    [[foo]]
+        script = sleep 1

--- a/tests/validate/43-jinja2-template-syntax-error-cylc-include.t
+++ b/tests/validate/43-jinja2-template-syntax-error-cylc-include.t
@@ -15,16 +15,23 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test validation missing include-file.
+# Test validation for a bad Jinja2 TemplateSyntaxError in a suite cylc include.
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 set_test_number 2
-echo '%include foo.rc' >suite.rc
-echo '%include bar.rc' >foo.rc
-run_fail "$TEST_NAME_BASE" cylc validate suite.rc
-cmp_ok "$TEST_NAME_BASE.stderr" <<__ERR__
-FileParseError:
-Include-file not found: bar.rc via foo.rc from $PWD/suite.rc
-__ERR__
+install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-val
+run_fail "$TEST_NAME" cylc validate suite.rc
+cmp_ok "$TEST_NAME.stderr" <<'__ERROR__'
+Jinja2Error:
+  File "<unknown>", line 7, in template
+TemplateSyntaxError: Encountered unknown tag 'end'. Jinja was looking for the following tags: 'elif' or 'else' or 'endif'. The innermost block that needs to be closed is 'if'.
+Context lines:
+# This is a bit of graph configuration.
+        {% if true %}
+        graph = foo
+        {% end if %	<-- Jinja2Error
+__ERROR__
 #-------------------------------------------------------------------------------
 exit

--- a/tests/validate/43-jinja2-template-syntax-error-cylc-include/suite-includeme.rc
+++ b/tests/validate/43-jinja2-template-syntax-error-cylc-include/suite-includeme.rc
@@ -1,0 +1,4 @@
+# This is a bit of graph configuration.
+        {% if true %}
+        graph = foo
+        {% end if %

--- a/tests/validate/43-jinja2-template-syntax-error-cylc-include/suite.rc
+++ b/tests/validate/43-jinja2-template-syntax-error-cylc-include/suite.rc
@@ -1,0 +1,8 @@
+#!jinja2
+
+[scheduling]
+    [[dependencies]]
+%include suite-includeme.rc
+[runtime]
+    [[foo]]
+        script = sleep 1

--- a/tests/validate/44-jinja2-template-syntax-error-jinja-include/suite-includeme.rc
+++ b/tests/validate/44-jinja2-template-syntax-error-jinja-include/suite-includeme.rc
@@ -1,0 +1,3 @@
+        {% if true %}
+        graph = foo
+        {% end if %

--- a/tests/validate/44-jinja2-template-syntax-error-jinja-include/suite.rc
+++ b/tests/validate/44-jinja2-template-syntax-error-jinja-include/suite.rc
@@ -1,0 +1,7 @@
+#!jinja2
+[scheduling]
+    [[dependencies]]
+{% include 'suite-includeme.rc' %}
+[runtime]
+    [[foo]]
+        script = sleep 1

--- a/tests/validate/45-jinja2-template-error-main.t
+++ b/tests/validate/45-jinja2-template-error-main.t
@@ -15,16 +15,19 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test validation missing include-file.
+# Test validation for a bad no-line-number Jinja2 error.
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 set_test_number 2
-echo '%include foo.rc' >suite.rc
-echo '%include bar.rc' >foo.rc
-run_fail "$TEST_NAME_BASE" cylc validate suite.rc
-cmp_ok "$TEST_NAME_BASE.stderr" <<__ERR__
-FileParseError:
-Include-file not found: bar.rc via foo.rc from $PWD/suite.rc
-__ERR__
+install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-val
+run_fail "$TEST_NAME" cylc validate suite.rc
+cmp_ok "$TEST_NAME.stderr" <<'__ERROR__'
+Jinja2Error:
+  File "/usr/lib/python2.6/site-packages/jinja2/filters.py", line 183, in do_dictsort
+    raise FilterArgumentError('You can only sort by either '
+FilterArgumentError: You can only sort by either "key" or "value"
+__ERROR__
 #-------------------------------------------------------------------------------
 exit

--- a/tests/validate/45-jinja2-template-error-main.t
+++ b/tests/validate/45-jinja2-template-error-main.t
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test validation for a bad no-line-number Jinja2 error.
+# Test validation for a filter Jinja2 error with no line number.
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 set_test_number 2

--- a/tests/validate/45-jinja2-template-error-main/suite.rc
+++ b/tests/validate/45-jinja2-template-error-main/suite.rc
@@ -1,0 +1,8 @@
+#!jinja2
+{% set foo = {} %}
+[scheduling]
+    [[dependencies]]
+        graph = {{ foo|dictsort(by='by') }}
+[runtime]
+    [[foo]]
+        script = sleep 1

--- a/tests/validate/46-jinja2-template-not-found.t
+++ b/tests/validate/46-jinja2-template-not-found.t
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test validation for a bad no-line-number Jinja2 error.
+# Test validation for a template-not-found, no-line-number Jinja2 error.
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 set_test_number 2

--- a/tests/validate/46-jinja2-template-not-found.t
+++ b/tests/validate/46-jinja2-template-not-found.t
@@ -15,16 +15,20 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test validation missing include-file.
+# Test validation for a bad no-line-number Jinja2 error.
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 set_test_number 2
-echo '%include foo.rc' >suite.rc
-echo '%include bar.rc' >foo.rc
-run_fail "$TEST_NAME_BASE" cylc validate suite.rc
-cmp_ok "$TEST_NAME_BASE.stderr" <<__ERR__
-FileParseError:
-Include-file not found: bar.rc via foo.rc from $PWD/suite.rc
-__ERR__
+install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-val
+run_fail "$TEST_NAME" cylc validate suite.rc
+sed -i 's/^  File ".*/  File "FILE", line NN, in ROUTINE/g' "$TEST_NAME.stderr"
+cmp_ok "$TEST_NAME.stderr" <<'__ERROR__'
+Jinja2Error:
+  File "FILE", line NN, in ROUTINE
+    raise TemplateNotFound(template)
+TemplateNotFound: suite-foo.rc
+__ERROR__
 #-------------------------------------------------------------------------------
 exit

--- a/tests/validate/46-jinja2-template-not-found/suite.rc
+++ b/tests/validate/46-jinja2-template-not-found/suite.rc
@@ -1,0 +1,6 @@
+#!jinja2
+[scheduling]
+    [[dependencies]]
+        graph = foo
+[runtime]
+{% include 'suite-foo.rc' %}

--- a/tests/validate/47-jinja2-type-error.t
+++ b/tests/validate/47-jinja2-type-error.t
@@ -15,16 +15,18 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test validation missing include-file.
+# Test validation for a bad no-line-number Jinja2 error.
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 set_test_number 2
-echo '%include foo.rc' >suite.rc
-echo '%include bar.rc' >foo.rc
-run_fail "$TEST_NAME_BASE" cylc validate suite.rc
-cmp_ok "$TEST_NAME_BASE.stderr" <<__ERR__
-FileParseError:
-Include-file not found: bar.rc via foo.rc from $PWD/suite.rc
-__ERR__
+install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-val
+run_fail "$TEST_NAME" cylc validate suite.rc
+cmp_ok "$TEST_NAME.stderr" <<'__ERROR__'
+Jinja2Error:
+  File "<template>", line 5, in top-level template code
+TypeError: unsupported operand type(s) for /: 'int' and 'str'
+__ERROR__
 #-------------------------------------------------------------------------------
 exit

--- a/tests/validate/47-jinja2-type-error.t
+++ b/tests/validate/47-jinja2-type-error.t
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test validation for a bad no-line-number Jinja2 error.
+# Test validation for a Jinja2 type error, with no line number info.
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 set_test_number 2

--- a/tests/validate/47-jinja2-type-error/suite.rc
+++ b/tests/validate/47-jinja2-type-error/suite.rc
@@ -1,0 +1,6 @@
+#!jinja2
+
+[scheduling]
+    [[dependencies]]
+        graph = foo
+{{ 1 / 'foo' }}


### PR DESCRIPTION
This improves the output of some Jinja2 template error messages.

I've included some tests for the situations where Jinja2 doesn't provide
any line information.

The change to the list of exceptions that are handled is because
they inherited from the Jinja2 `TemplateError` anyway!

@hjoliver, please review 1.
@matthewrmshin, please review 2.