### PR TITLE
Allow suite state polling before a run db exists.

### DIFF
--- a/bin/cylc-suite-state
+++ b/bin/cylc-suite-state
@@ -92,7 +92,7 @@ class suite_poller(poller):
                 connected = True
                 # ... but ensure at least one poll after connection:
                 self.n_polls -= 1
-            except DBOperationError:
+            except (DBOperationError, DBNotFoundError):
                 if self.n_polls >= max_polls:
                     raise
                 if cylc.flags.verbose:

--- a/lib/cylc/dbstatecheck.py
+++ b/lib/cylc/dbstatecheck.py
@@ -31,7 +31,7 @@ class DBOperationError(Exception):
 
 class DBNotFoundError(Exception):
 
-    """An exception raised when a suite is already running."""
+    """An exception raised when a suite database is not found."""
 
     def __str__(self):
         return "Suite database not found at: %s" % self.args


### PR DESCRIPTION
From `cylc suite-state --help`:
```
The suite database does not need to exist at the time polling commences but allocated
polls are consumed waiting for it (consider max-polls*interval as an overall timeout).
```

However, on master polling aborts immediately if the db doesn't exist.  The intended behaviour is correct, as it means you don't have to start up interdependent suites in the right order.   Also tests in ```tests/authentication/``` are somewhat reliant on this (they start a suite daemon then immediately begin polling for a task to finish).

@matthewrmshin - please review 1.