### PR TITLE
Made graph equivalence tests etc. more stable.

### DIFF
--- a/tests/cylc-cat-log/00-local.t
+++ b/tests/cylc-cat-log/00-local.t
@@ -27,6 +27,7 @@ run_ok $TEST_NAME cylc validate $SUITE_NAME
 TEST_NAME=$TEST_NAME_BASE-run
 # Run detached so we get suite out and err logs.
 suite_run_ok $TEST_NAME cylc run $SUITE_NAME
+sleep 5
 # Wait for the suite to finish.
 cylc stop --max-polls=10 --interval=2 $SUITE_NAME 
 #-------------------------------------------------------------------------------

--- a/tests/events/task-iso/suite.rc
+++ b/tests/events/task-iso/suite.rc
@@ -40,7 +40,7 @@ printf "%-20s %-8s %s\n" EVENT TASK MESSAGE > $EVNTLOG
 if [[ $CYLC_TASK_TRY_NUMBER == 1 ]]; then
     false
 else
-    sleep 5; cylc task message -p WARNING 'this is a user-defined warning message'
+    sleep 10; cylc task message -p WARNING 'this is a user-defined warning message'
 fi"""
         [[[event hooks]]]
             succeeded handler = {{ HANDLER }}

--- a/tests/events/task/suite.rc
+++ b/tests/events/task/suite.rc
@@ -38,7 +38,7 @@ printf "%-20s %-8s %s\n" EVENT TASK MESSAGE > {{ EVNTLOG }}
 if [[ $CYLC_TASK_TRY_NUMBER == 1 ]]; then
     false
 else
-    sleep 5; cylc task message -p WARNING 'this is a user-defined warning message'
+    sleep 10; cylc task message -p WARNING 'this is a user-defined warning message'
 fi"""
         [[[event hooks]]]
             succeeded handler = {{ HANDLER }}

--- a/tests/graph-equivalence/00-oneline.t
+++ b/tests/graph-equivalence/00-oneline.t
@@ -32,6 +32,7 @@ suite_run_ok $TEST_NAME cylc run --reference-test --debug $SUITE_NAME
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-check-a
 cylc run $SUITE_NAME --hold
+sleep 5
 cylc show $SUITE_NAME a.1 | sed -n "/prerequisites/,/outputs/p" > a-prereqs
 cmp_ok $TEST_SOURCE_DIR/splitline_refs/a-ref a-prereqs
 #-------------------------------------------------------------------------------

--- a/tests/graph-equivalence/01-twolines.t
+++ b/tests/graph-equivalence/01-twolines.t
@@ -32,6 +32,7 @@ suite_run_ok $TEST_NAME cylc run --reference-test --debug $SUITE_NAME
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-check-a
 cylc run $SUITE_NAME --hold
+sleep 5
 cylc show $SUITE_NAME a.1 | sed -n "/prerequisites/,/outputs/p" > a-prereqs
 cmp_ok $TEST_SOURCE_DIR/splitline_refs/a-ref a-prereqs
 #-------------------------------------------------------------------------------

--- a/tests/graph-equivalence/02-splitline.t
+++ b/tests/graph-equivalence/02-splitline.t
@@ -33,6 +33,7 @@ suite_run_ok $TEST_NAME cylc run --reference-test --debug $SUITE_NAME
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-check-a
 cylc run $SUITE_NAME --hold
+sleep 5
 cylc show $SUITE_NAME a.1 | sed -n "/prerequisites/,/outputs/p" > a-prereqs
 cmp_ok $TEST_SOURCE_DIR/splitline_refs/a-ref a-prereqs
 #-------------------------------------------------------------------------------

--- a/tests/graph-equivalence/03-multiline_and1.t
+++ b/tests/graph-equivalence/03-multiline_and1.t
@@ -33,6 +33,7 @@ suite_run_ok $TEST_NAME cylc run --reference-test --debug $SUITE_NAME
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-check-c
 cylc run $SUITE_NAME --hold
+sleep 5
 cylc show $SUITE_NAME c.1 | sed -n "/prerequisites/,/outputs/p" > c-prereqs
 cmp_ok $TEST_SOURCE_DIR/multiline_and_refs/c-ref c-prereqs
 cylc shutdown $SUITE_NAME --now -f

--- a/tests/graph-equivalence/04-multiline_and2.t
+++ b/tests/graph-equivalence/04-multiline_and2.t
@@ -34,6 +34,7 @@ suite_run_ok $TEST_NAME cylc run --reference-test --debug $SUITE_NAME
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-check-c
 cylc run $SUITE_NAME --hold
+sleep 5
 cylc show $SUITE_NAME c.1 | sed -n "/prerequisites/,/outputs/p" > c-prereqs
 cmp_ok $TEST_SOURCE_DIR/multiline_and_refs/c-ref c-prereqs
 cylc shutdown $SUITE_NAME --now -f

--- a/tests/runahead/no_final/suite.rc
+++ b/tests/runahead/no_final/suite.rc
@@ -1,7 +1,7 @@
 [cylc]
     cycle point time zone = Z
     [[event hooks]]
-        timeout = PT0.1M
+        timeout = PT0.3M
         abort on timeout = True
 [scheduling]
     runahead limit = PT18H
@@ -17,4 +17,6 @@
     [[bar]]
         script = true
     [[shutdown]]
-        script = cylc shutdown $CYLC_SUITE_REG_NAME
+        script = """
+sleep 5
+cylc shutdown $CYLC_SUITE_REG_NAME"""


### PR DESCRIPTION
The final tests in ```tests/graph-equivalence/*.t``` could fail due to the suite not being initialized before ```cylc show``` is called on it.

@matthewrmshin - please review 1.