### PR TITLE
Fixed tests/validate/45-jinja2-template-error-main.t

### DIFF
--- a/tests/validate/45-jinja2-template-error-main.t
+++ b/tests/validate/45-jinja2-template-error-main.t
@@ -23,9 +23,11 @@ install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-val
 run_fail "$TEST_NAME" cylc validate suite.rc
+# Filter Python version specific output, e.g.:
+#   File "/usr/lib/python2.6/site-packages/jinja2/filters.py", line 183, in do_dictsort
+sed -i '/File.*in do_dictsort/d' "$TEST_NAME.stderr"
 cmp_ok "$TEST_NAME.stderr" <<'__ERROR__'
 Jinja2Error:
-  File "/usr/lib/python2.6/site-packages/jinja2/filters.py", line 183, in do_dictsort
     raise FilterArgumentError('You can only sort by either '
 FilterArgumentError: You can only sort by either "key" or "value"
 __ERROR__


### PR DESCRIPTION
The test was Python 2.6 specific.

@benfitzpatrick - please review.  Was revealed by your #1593 (but not caused by it ... my Python version has gone up).