### PR TITLE
Group built-in task event handlers where possible

### DIFF
--- a/lib/cylc/mp_pool.py
+++ b/lib/cylc/mp_pool.py
@@ -54,7 +54,7 @@ def _run_command(ctx):
             print ' '.join([quote(cmd_str) for cmd_str in ctx.cmd])
 
     if (SuiteProcPool.STOP_JOB_SUBMISSION.value
-            and ctx.cmd_type == SuiteProcPool.JOB_SUBMIT):
+            and ctx.cmd_key == SuiteProcPool.JOB_SUBMIT):
         ctx.err = "job submission skipped (suite stopping)"
         ctx.ret_code = SuiteProcPool.JOB_SKIPPED_FLAG
         ctx.timestamp = get_current_time_string()
@@ -90,13 +90,13 @@ class SuiteProcContext(object):
     """Represent the context of a command to run."""
 
     # Format string for single line output
-    JOB_LOG_FMT_1 = "%(timestamp)s [%(cmd_type)s %(attr)s] %(mesg)s"
+    JOB_LOG_FMT_1 = "%(timestamp)s [%(cmd_key)s %(attr)s] %(mesg)s"
     # Format string for multi-line output
-    JOB_LOG_FMT_M = "%(timestamp)s [%(cmd_type)s %(attr)s]\n\n%(mesg)s\n"
+    JOB_LOG_FMT_M = "%(timestamp)s [%(cmd_key)s %(attr)s]\n\n%(mesg)s\n"
 
-    def __init__(self, cmd_type, cmd, **cmd_kwargs):
+    def __init__(self, cmd_key, cmd, **cmd_kwargs):
         self.timestamp = get_current_time_string()
-        self.cmd_type = cmd_type
+        self.cmd_key = cmd_key
         self.cmd = cmd
         self.cmd_kwargs = cmd_kwargs
 
@@ -129,7 +129,7 @@ class SuiteProcContext(object):
                     mesg += "\n"
                 ret += fmt % {
                     "timestamp": self.timestamp,
-                    "cmd_type": self.cmd_type,
+                    "cmd_key": self.cmd_key,
                     "attr": attr,
                     "mesg": mesg}
         return ret

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -998,7 +998,7 @@ class scheduler(object):
                         "END TASK PROCESSING (took " + str(seconds) + " sec)")
 
             self.pool.process_queued_task_messages()
-            self.pool.process_event_handler_retries()
+            self.pool.process_queued_task_event_handlers()
             try:
                 self.pool.process_queued_db_ops()
             except OSError as err:

--- a/tests/events/08-task-event-handler-retry.t
+++ b/tests/events/08-task-event-handler-retry.t
@@ -38,16 +38,16 @@ suite_run_ok "${TEST_NAME_BASE}-run" \
 
 SUITE_RUN_DIR="$(cylc get-global-config '--print-run-dir')"
 LOG="${SUITE_RUN_DIR}/${SUITE_NAME}/log/job/1/t1/NN/job-activity.log"
-sed "/('event-handler-00', 'succeeded', '01')/!d; s/^.* \[/[/" "${LOG}" \
+sed "/(('event-handler-00', 'succeeded'), 1)/!d; s/^.* \[/[/" "${LOG}" \
     >'edited-job-activity.log'
 cmp_ok 'edited-job-activity.log' <<'__LOG__'
-[('event-handler-00', 'succeeded', '01') cmd] hello-event-handler 't1' 'succeeded'
-[('event-handler-00', 'succeeded', '01') ret_code] 1
-[('event-handler-00', 'succeeded', '01') cmd] hello-event-handler 't1' 'succeeded'
-[('event-handler-00', 'succeeded', '01') ret_code] 1
-[('event-handler-00', 'succeeded', '01') cmd] hello-event-handler 't1' 'succeeded'
-[('event-handler-00', 'succeeded', '01') ret_code] 0
-[('event-handler-00', 'succeeded', '01') out] hello
+[(('event-handler-00', 'succeeded'), 1) cmd] hello-event-handler 't1' 'succeeded'
+[(('event-handler-00', 'succeeded'), 1) ret_code] 1
+[(('event-handler-00', 'succeeded'), 1) cmd] hello-event-handler 't1' 'succeeded'
+[(('event-handler-00', 'succeeded'), 1) ret_code] 1
+[(('event-handler-00', 'succeeded'), 1) cmd] hello-event-handler 't1' 'succeeded'
+[(('event-handler-00', 'succeeded'), 1) ret_code] 0
+[(('event-handler-00', 'succeeded'), 1) out] hello
 __LOG__
 
 purge_suite "${SUITE_NAME}"

--- a/tests/events/08-task-event-handler-retry/suite.rc
+++ b/tests/events/08-task-event-handler-retry/suite.rc
@@ -22,6 +22,6 @@ title=Task Event Handler Retry
     [[t2]]
         script="""
 LOG="${CYLC_SUITE_LOG_DIR}/../job/1/t1/NN/job-activity.log"
-STR="[('event-handler-00', 'succeeded', '01') ret_code] 0"
+STR="[(('event-handler-00', 'succeeded'), 1) ret_code] 0"
 timeout 30 bash -c "while ! grep -q -F \"${STR}\" '${LOG}'; do sleep 1; done"
 """

--- a/tests/events/09-task-event-mail.t
+++ b/tests/events/09-task-event-mail.t
@@ -17,7 +17,7 @@
 #-------------------------------------------------------------------------------
 # Test event mail.
 . "$(dirname "$0")/test_header"
-set_test_number 3
+set_test_number 5
 mock_smtpd_init
 OPT_SET=
 if [[ "${TEST_NAME_BASE}" == *-globalcfg ]]; then
@@ -39,14 +39,9 @@ run_ok "${TEST_NAME_BASE}-validate" \
 suite_run_ok "${TEST_NAME_BASE}-run" \
     cylc run --reference-test --debug ${OPT_SET} "${SUITE_NAME}"
 
-grep '^\(Subject:\|\[retry\]\|\[succeeded\]\) ' "${TEST_SMTPD_LOG}" \
-    >'edited-smtpd.log'
-cmp_ok 'edited-smtpd.log' <<__LOG__
-Subject: [retry]
-[retry] ${SUITE_NAME}.1.t1.01: job failed, retrying in PT1S
-Subject: [succeeded]
-[succeeded] ${SUITE_NAME}.1.t1.02: job succeeded
-__LOG__
+grep_ok 'Subject: \[1 task(s) retry\]' "${TEST_SMTPD_LOG}"
+grep_ok 'Subject: \[1 task(s) succeeded\]' "${TEST_SMTPD_LOG}"
+grep_ok '^1/t1/\(01: retry\|02: succeeded\)' "${TEST_SMTPD_LOG}"
 
 purge_suite "${SUITE_NAME}"
 mock_smtpd_kill

--- a/tests/events/10-task-event-job-logs-retrieve.t
+++ b/tests/events/10-task-event-job-logs-retrieve.t
@@ -76,15 +76,9 @@ sed "/'job-logs-retrieve'/!d; s/^[^ ]* //" \
     "${SUITE_RUN_DIR}/log/job/1/t1/"{01,02,03}"/job-activity.log" \
     >'edited-activities.log'
 cmp_ok 'edited-activities.log' <<__LOG__
-[('job-logs-retrieve', 'retry', '01') cmd] cylc job-logs-retrieve '${HOST}:\$HOME/cylc-run/${SUITE_NAME}/log/job/1/t1/01' ${SUITE_RUN_DIR}/log/job/1/t1/01
-[('job-logs-retrieve', 'retry', '01') ret_code] 0
-[('job-logs-retrieve', 'retry', '01') out]
-[('job-logs-retrieve', 'retry', '02') cmd] cylc job-logs-retrieve '${HOST}:\$HOME/cylc-run/${SUITE_NAME}/log/job/1/t1/02' ${SUITE_RUN_DIR}/log/job/1/t1/02
-[('job-logs-retrieve', 'retry', '02') ret_code] 0
-[('job-logs-retrieve', 'retry', '02') out]
-[('job-logs-retrieve', 'succeeded', '03') cmd] cylc job-logs-retrieve '${HOST}:\$HOME/cylc-run/${SUITE_NAME}/log/job/1/t1/03' ${SUITE_RUN_DIR}/log/job/1/t1/03
-[('job-logs-retrieve', 'succeeded', '03') ret_code] 0
-[('job-logs-retrieve', 'succeeded', '03') out]
+[('job-logs-retrieve', 1) ret_code] 0
+[('job-logs-retrieve', 2) ret_code] 0
+[('job-logs-retrieve', 3) ret_code] 0
 __LOG__
 
 ${SSH} "${HOST}" \

--- a/tests/events/11-cycle-task-event-job-logs-retrieve.t
+++ b/tests/events/11-cycle-task-event-job-logs-retrieve.t
@@ -63,15 +63,9 @@ sed "/'job-logs-retrieve'/!d; s/^[^ ]* //" \
     "${SUITE_RUN_DIR}/log/job/2020-02-02T02:02Z/t1/"{01,02,03}"/job-activity.log" \
     >'edited-activities.log'
 cmp_ok 'edited-activities.log' <<__LOG__
-[('job-logs-retrieve', 'retry', '01') cmd] cylc job-logs-retrieve '${HOST}:\$HOME/cylc-run/${SUITE_NAME}/log/job/2020-02-02T02:02Z/t1/01' ${SUITE_RUN_DIR}/log/job/2020-02-02T02:02Z/t1/01
-[('job-logs-retrieve', 'retry', '01') ret_code] 0
-[('job-logs-retrieve', 'retry', '01') out]
-[('job-logs-retrieve', 'retry', '02') cmd] cylc job-logs-retrieve '${HOST}:\$HOME/cylc-run/${SUITE_NAME}/log/job/2020-02-02T02:02Z/t1/02' ${SUITE_RUN_DIR}/log/job/2020-02-02T02:02Z/t1/02
-[('job-logs-retrieve', 'retry', '02') ret_code] 0
-[('job-logs-retrieve', 'retry', '02') out]
-[('job-logs-retrieve', 'succeeded', '03') cmd] cylc job-logs-retrieve '${HOST}:\$HOME/cylc-run/${SUITE_NAME}/log/job/2020-02-02T02:02Z/t1/03' ${SUITE_RUN_DIR}/log/job/2020-02-02T02:02Z/t1/03
-[('job-logs-retrieve', 'succeeded', '03') ret_code] 0
-[('job-logs-retrieve', 'succeeded', '03') out]
+[('job-logs-retrieve', 1) ret_code] 0
+[('job-logs-retrieve', 2) ret_code] 0
+[('job-logs-retrieve', 3) ret_code] 0
 __LOG__
 
 ${SSH} "${HOST}" \

--- a/tests/job-submission/05-activity-log.t
+++ b/tests/job-submission/05-activity-log.t
@@ -35,7 +35,7 @@ grep_ok '\[job-kill out\] [^|]*\|1/t1/01\|1' "${T1_ACTIVITY_LOG}"
 grep_ok '\[job-poll out\] [^|]*\|1/t1/01\|background\|[^|]*\|1\|\|\|\|[^|]*\|' \
     "${T1_ACTIVITY_LOG}"
 grep_ok \
-    "\\[('event-handler-00', 'failed', '01') out\\] failed ${SUITE_NAME} t1\\.1 job failed" \
+    "\\[(('event-handler-00', 'failed'), 1) out\\] failed ${SUITE_NAME} t1\\.1 job failed" \
     "${T1_ACTIVITY_LOG}"
 #-------------------------------------------------------------------------------
 purge_suite "${SUITE_NAME}"


### PR DESCRIPTION
This is the 2nd part of #1591.
* Send single email for similar task events - less clutter up of your mail box on multiple failures.
* Group `rsync` commands by remote hosts to retrieve job logs.

The task proxy objects will now create the contexts for the task event handlers, but will not run them immediately. The task pool will loop through them, group similar items together, before adding the items to the process pool.