### PR TITLE
Narrower start-up blurb.

### DIFF
--- a/lib/cylc/run.py
+++ b/lib/cylc/run.py
@@ -33,7 +33,7 @@ def print_blurb():
             | |       
 ,_____,_, ,_| |_____, 
 | ,___| | | | | ,___| 
-| |___| |_| | | |___  
+| |___| |_| | | |___, 
 \_____\___, |_\_____| 
       ,___| |         
       \_____|         
@@ -41,10 +41,11 @@ def print_blurb():
     license = """
 The Cylc Suite Engine [%s]
 Copyright (C) 2008-2015 NIWA
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-This program comes with ABSOLUTELY NO WARRANTY.   It is
-free software; you are welcome to redistribute it under
-certain conditions: "cylc warranty", "cylc conditions".
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+This program comes with ABSOLUTELY NO WARRANTY;
+see `cylc warranty`.  It is free software, you
+are welcome to redistribute it under certain
+conditions; see `cylc conditions`.
  
   """ % CYLC_VERSION
     


### PR DESCRIPTION
The new start-up blurb can get screwed up by a narrow terminal window; this cuts its width down a bit.

@matthewrmshin - please review.

Old:
```
            ,_,                                                               
            | |                     The Cylc Suite Engine [6.6.0]             
,_____,_, ,_| |_____,               Copyright (C) 2008-2015 NIWA              
| ,___| | | | | ,___|  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
| |___| |_| | | |___   This program comes with ABSOLUTELY NO WARRANTY.   It is
\_____\___, |_\_____|  free software; you are welcome to redistribute it under
      ,___| |          certain conditions: "cylc warranty", "cylc conditions".
      \_____| 
```

New:
```
            ,_,                                                       
            | |            The Cylc Suite Engine [6.6.1-57-ge72d9]    
,_____,_, ,_| |_____,           Copyright (C) 2008-2015 NIWA          
| ,___| | | | | ,___|  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
| |___| |_| | | |___,  This program comes with ABSOLUTELY NO WARRANTY;
\_____\___, |_\_____|  see `cylc warranty`.  It is free software, you 
      ,___| |           are welcome to redistribute it under certain  
      \_____|                conditions; see `cylc conditions`. 
```