### PR TITLE
integer-cycling satellite test: Increase timeout.

### DIFF
--- a/tests/integer-cycling/00-satellite/suite.rc
+++ b/tests/integer-cycling/00-satellite/suite.rc
@@ -19,7 +19,7 @@ with previous cycles if the data comes in quickly."""
 [cylc]
     [[reference test]]
         required run mode = live
-        live mode suite timeout = PT40S
+        live mode suite timeout = PT1M
 
 [scheduling]
     cycling mode = integer


### PR DESCRIPTION
This increases the timeout for this test suite.

Previously had been flakey in my environment as to whether or not the test would pass https://github.com/cylc/cylc/pull/1609#issuecomment-141375926

@hjoliver - please review.