### PR TITLE
Fix gui ancestors KeyError.

### DIFF
--- a/lib/cylc/gui/updater_tree.py
+++ b/lib/cylc/gui/updater_tree.py
@@ -368,7 +368,7 @@ class TreeUpdater(threading.Thread):
                         name = point_string
                     update_row_ids.append((point_string, name, is_fam))
 
-                if not is_fam:
+                if not is_fam and self.ancestors.has_key(name):
                     # Calculate the family nesting for tasks.
                     families = list(self.ancestors[name])
                     families.sort(lambda x, y: (y in self.ancestors[x]) -

--- a/lib/cylc/gui/updater_tree.py
+++ b/lib/cylc/gui/updater_tree.py
@@ -368,7 +368,7 @@ class TreeUpdater(threading.Thread):
                         name = point_string
                     update_row_ids.append((point_string, name, is_fam))
 
-                if not is_fam and name in self.ancestors.keys():
+                if not is_fam and name in self.ancestors:
                     # Calculate the family nesting for tasks.
                     families = list(self.ancestors[name])
                     families.sort(lambda x, y: (y in self.ancestors[x]) -

--- a/lib/cylc/gui/updater_tree.py
+++ b/lib/cylc/gui/updater_tree.py
@@ -368,7 +368,7 @@ class TreeUpdater(threading.Thread):
                         name = point_string
                     update_row_ids.append((point_string, name, is_fam))
 
-                if not is_fam and self.ancestors.has_key(name):
+                if not is_fam and name in self.ancestors.keys():
                     # Calculate the family nesting for tasks.
                     families = list(self.ancestors[name])
                     families.sort(lambda x, y: (y in self.ancestors[x]) -


### PR DESCRIPTION
Addresses @benfitzpatrick's reported error in https://github.com/cylc/cylc/issues/1564#issuecomment-127516311 

Simple suite to test with:
```
[scheduling]
    [[dependencies]]
        graph = foo => bar => baz
[runtime]
    [[foo,bar,baz]]
        command scripting = sleep 50
```
Testing steps:
 * run suite
 * remove all reference to "bar" from the suite.rc file
 * reload suite
 * master should throw an error, this branch should handle it

@benfitzpatrick - please review.

N.B. I don't think this fixes all the issues reported in #1564 