### PR TITLE
cylc performance: speed up suite elapsed time

### DIFF
--- a/admin/get-repo-version
+++ b/admin/get-repo-version
@@ -31,13 +31,11 @@ VN=$(git describe --abbrev=4 --tags HEAD 2>/dev/null)
 case "$VN" in
     *$LF*) (exit 1) ;;
     [0-9]*)
-        # If uncommited changes exist append "-dirty".
+        # If uncommitted changes exist append "-dirty".
 
-        # The git update-index and diff-index expect a working tree;
-        # notably they don't work in a detached checkout from a bare
-        # repo - so send errors to /dev/null and ignore.
-        git update-index -q --refresh 2> /dev/null 
-        test -z "$(git diff-index --name-only HEAD -- 2> /dev/null)" || VN="$VN-dirty" ;;
+        if [[ -n "$(git status --untracked-files=no --porcelain)" ]]; then
+            VN="$VN-dirty"
+        fi
 esac
 # echo to stdout
 echo "$VN"

--- a/bin/cylc
+++ b/bin/cylc
@@ -314,7 +314,7 @@ cycling weather and climate forecasting suites and related processing
 (but it can also be used for one-off workflows of non-cycling tasks).
 For detailed documentation see the Cylc User Guide (cylc doc --help).
 
-Version %s
+Version __CYLC_VERSION__
 
 The graphical user interface for cylc is "gcylc" (a.k.a. "cylc gui").
 
@@ -510,7 +510,7 @@ def set_environment_vars(args):
 # no arguments: print help and exit
 if len(sys.argv) == 1:
     from cylc.version import CYLC_VERSION
-    print usage % CYLC_VERSION
+    print usage.replace("__CYLC_VERSION__", CYLC_VERSION)
     pretty_print(catsum, categories)
     sys.exit(1)
 
@@ -544,7 +544,7 @@ if len(args) == 1:
     if is_help(args[0]):
         # cylc help
         from cylc.version import CYLC_VERSION        
-        print usage % CYLC_VERSION
+        print usage.replace("__CYLC_VERSION__", CYLC_VERSION)
         pretty_print(catsum, categories)
         sys.exit(0)
     if (args[0] == '-v' or args[0] == '--version'):

--- a/bin/cylc
+++ b/bin/cylc
@@ -43,7 +43,8 @@ except OSError as exc:
     # (cylc reg SUITE PATH).
     sys.exit(exc)
 
-from cylc.version import CYLC_VERSION
+# Import cylc to initialise CYLC_DIR and the path for python (__init__.py).
+import cylc
 from parsec.OrderedDict import OrderedDict
 
 
@@ -313,7 +314,7 @@ cycling weather and climate forecasting suites and related processing
 (but it can also be used for one-off workflows of non-cycling tasks).
 For detailed documentation see the Cylc User Guide (cylc doc --help).
 
-Version """ + CYLC_VERSION + """
+Version %s
 
 The graphical user interface for cylc is "gcylc" (a.k.a. "cylc gui").
 
@@ -508,7 +509,8 @@ def set_environment_vars(args):
 
 # no arguments: print help and exit
 if len(sys.argv) == 1:
-    print usage
+    from cylc.version import CYLC_VERSION
+    print usage % CYLC_VERSION
     pretty_print(catsum, categories)
     sys.exit(1)
 
@@ -541,10 +543,12 @@ if len(args) == 1:
         sys.exit(0)
     if is_help(args[0]):
         # cylc help
-        print usage
+        from cylc.version import CYLC_VERSION        
+        print usage % CYLC_VERSION
         pretty_print(catsum, categories)
         sys.exit(0)
     if (args[0] == '-v' or args[0] == '--version'):
+        from cylc.version import CYLC_VERSION                
         print CYLC_VERSION
         sys.exit(0)
 

--- a/bin/cylc-submit
+++ b/bin/cylc-submit
@@ -54,6 +54,7 @@ from cylc.regpath import RegPath
 from cylc.suite_logging import suite_log
 from cylc.cfgspec.globalcfg import GLOBAL_CFG
 from cylc.mp_pool import SuiteProcPool
+import cylc.version  # Ensures '$CYLC_VERSION' is set.
 
 
 def commandline_parser():

--- a/lib/cylc/remote.py
+++ b/lib/cylc/remote.py
@@ -25,10 +25,6 @@ import subprocess
 import sys
 from textwrap import TextWrapper
 
-from cylc.cfgspec.globalcfg import GLOBAL_CFG
-from cylc.suite_host import is_remote_host
-from cylc.owner import is_remote_user
-from cylc.version import CYLC_VERSION
 import cylc.flags
 
 
@@ -68,8 +64,13 @@ class remrun(object):
             else:
                 self.args.append(arg)
 
-        self.is_remote = (
-            is_remote_user(self.owner) or is_remote_host(self.host))
+        if self.owner is None and self.host is None:
+            self.is_remote = False
+        else:
+            from cylc.suite_host import is_remote_host
+            from cylc.owner import is_remote_user
+            self.is_remote = (
+                is_remote_user(self.owner) or is_remote_host(self.host))
 
     def execute(self, force_required=False, env=None, path=None, dry_run=False):
         """Execute command on remote host.
@@ -80,6 +81,9 @@ class remrun(object):
         """
         if not self.is_remote:
             return False
+
+        from cylc.cfgspec.globalcfg import GLOBAL_CFG
+        from cylc.version import CYLC_VERSION
 
         name = os.path.basename(self.argv[0])[5:]  # /path/to/cylc-foo => foo
 

--- a/lib/cylc/rundb.py
+++ b/lib/cylc/rundb.py
@@ -299,7 +299,6 @@ class CylcSuiteDAO(object):
         """Connect to the database."""
         if self.conn is None:
             self.conn = sqlite3.connect(self.db_file_name, self.CONN_TIMEOUT)
-            self.conn.execute("BEGIN TRANSACTION;")
         return self.conn
 
     def create_tables(self):
@@ -353,13 +352,7 @@ class CylcSuiteDAO(object):
                 if cylc.flags.debug:
                     traceback.print_exc()
                     sys.stderr.write(
-                        "WARNING: %(file)s: %(table)s: %(stmt)s\n" % {
-                            "file": self.db_file_name,
-                            "table": table.name,
-                            "stmt": stmt})
-                    for stmt_args in stmt_args_list:
-                        sys.stderr.write("\t%(stmt_args)s\n" % {
-                            "stmt_args": stmt_args})
+                        "WARNING: %s: db commit failed\n" % self.db_file_name)
                 will_retry = True
         
         if will_retry:

--- a/tests/vacation/00-sigusr1.t
+++ b/tests/vacation/00-sigusr1.t
@@ -59,7 +59,7 @@ while ! sqlite3 $SUITE_RUN_DIR/cylc-suite.db \
 do
     sleep 1
 done
-cmp_ok "$TEST_NAME-db-t1" - <<<'submitted'
+grep_ok "^\(submitted\|running\)$" "$TEST_NAME-db-t1"
 # Start the job again and see what happens
 mkdir -p $SUITE_RUN_DIR/work/1/t1/
 touch $SUITE_RUN_DIR/work/1/t1/file # Allow t1 to complete


### PR DESCRIPTION
This change speeds up suite and test-battery elapsed times.

It leads to fewer database commits and fewer calls to cylc.version,
both of which can be slow under certain circumstances. For example,
importing cylc.version under a cylc git clone can lead to a 0.5 second
overhead for each call to `cylc jobs-submit` and `cylc task message`.

I can now happily run the test battery with `-j 30`!

@matthewrmshin, please review.