### PR TITLE
Fix tests error messages before skip alls

### DIFF
--- a/tests/cylc-cat-log/01-remote.t
+++ b/tests/cylc-cat-log/01-remote.t
@@ -18,7 +18,8 @@
 # Test "cylc cat-log" for remote tasks.
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
-export CYLC_TEST_HOST=$(cylc get-global-config -i '[test battery]remote host')
+RC_ITEM='[test battery]remote host'
+export CYLC_TEST_HOST=$(cylc get-global-config -i "${RC_ITEM}" 2>'/dev/null')
 if [[ -z $CYLC_TEST_HOST ]]; then
     skip_all '[test battery]remote host: not defined'
 fi

--- a/tests/cylc-cat-log/02-remote-custom-runtime-viewer-pbs.t
+++ b/tests/cylc-cat-log/02-remote-custom-runtime-viewer-pbs.t
@@ -18,20 +18,19 @@
 # Test "cylc cat-log" for viewing PBS runtime STDOUT/STDERR by a custom command
 . "$(dirname "$0")/test_header"
 
-export CYLC_TEST_HOST="$(cylc get-global-config -i \
-    '[test battery][batch systems][pbs]host')"
+RC_PREF='[test battery][batch systems][pbs]'
+export CYLC_TEST_HOST="$( \
+    cylc get-global-config -i "${RC_PREF}host" 2>'/dev/null')"
 if [[ -z "${CYLC_TEST_HOST}" ]]; then
     skip_all '[test battery][batch systems][pbs]host: not defined'
 fi
-ERR_VIEWER="$(cylc get-global-config -i \
-    "[test battery][batch systems][pbs]err viewer")"
-OUT_VIEWER="$(cylc get-global-config -i \
-    "[test battery][batch systems][pbs]out viewer")"
+ERR_VIEWER="$(cylc get-global-config -i "${RC_PREF}err viewer" 2>'/dev/null')"
+OUT_VIEWER="$(cylc get-global-config -i "${RC_PREF}out viewer" 2>'/dev/null')"
 if [[ -z "${ERR_VIEWER}" || -z "${OUT_VIEWER}" ]]; then
     skip_all "[test battery][pbs]* viewer: not defined"
 fi
-export CYLC_TEST_DIRECTIVES="$(cylc get-global-config -i \
-    "[test battery][batch systems][pbs][directives]")"
+export CYLC_TEST_DIRECTIVES="$( \
+    cylc get-global-config -i "${RC_PREF}[directives]" 2>'/dev/null')"
 set_test_number 2
 
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"

--- a/tests/cylc-job-poll/02-loadleveler.t
+++ b/tests/cylc-job-poll/02-loadleveler.t
@@ -77,7 +77,7 @@ __PYTHON__
 #-------------------------------------------------------------------------------
 if ! ${IS_AT_T_HOST:-false}; then
     RC_ITEM='[test battery][batch systems]loadleveler]host'
-    T_HOST=$(cylc get-global-config -i "${RC_ITEM}")
+    T_HOST=$(cylc get-global-config -i "${RC_ITEM}" 2>'/dev/null')
     if [[ -z $T_HOST ]]; then
         skip_all "\"${RC_ITEM}\" not defined"
     fi
@@ -99,7 +99,8 @@ fi
 T_DIRECTIVES_MORE=
 if ! ${HAS_READ_T_DIRECTIVES_MORE:-false}; then
     RC_ITEM='[test battery][batch systems]loadleveler][directives]'
-    export T_DIRECTIVES_MORE=$(cylc get-global-config -i "${RC_ITEM}")
+    export T_DIRECTIVES_MORE=$( \
+        cylc get-global-config -i "${RC_ITEM}" 2>'/dev/null')
     export HAS_READ_T_DIRECTIVES_MORE=true
 fi
 FAKE_JOB_ID=$(get_fake_job_id)

--- a/tests/cylc-job-poll/03-slurm.t
+++ b/tests/cylc-job-poll/03-slurm.t
@@ -78,7 +78,7 @@ __PYTHON__
 #-------------------------------------------------------------------------------
 if ! ${IS_AT_T_HOST:-false}; then
     RC_ITEM='[test battery][batch systems][slurm]host'
-    T_HOST=$(cylc get-global-config -i "${RC_ITEM}")
+    T_HOST=$(cylc get-global-config -i "${RC_ITEM}" 2>'/dev/null')
     if [[ -z $T_HOST ]]; then
         skip_all "\"${RC_ITEM}\" not defined"
     fi
@@ -100,7 +100,8 @@ fi
 T_DIRECTIVES_MORE=
 if ! ${HAS_READ_T_DIRECTIVES_MORE:-false}; then
     RC_ITEM='[test battery][batch systems][slurm][directives]'
-    export T_DIRECTIVES_MORE=$(cylc get-global-config -i "${RC_ITEM}")
+    export T_DIRECTIVES_MORE=$( \
+        cylc get-global-config -i "${RC_ITEM}" 2>'/dev/null')
     export HAS_READ_T_DIRECTIVES_MORE=true
 fi
 FAKE_JOB_ID=$(get_fake_job_id)

--- a/tests/cylc-job-poll/04-pbs.t
+++ b/tests/cylc-job-poll/04-pbs.t
@@ -74,7 +74,7 @@ __PYTHON__
 #-------------------------------------------------------------------------------
 if ! ${IS_AT_T_HOST:-false}; then
     RC_ITEM='[test battery][batch systems][pbs]host'
-    T_HOST=$(cylc get-global-config -i "${RC_ITEM}")
+    T_HOST=$(cylc get-global-config -i "${RC_ITEM}" 2>'/dev/null')
     if [[ -z $T_HOST ]]; then
         skip_all "\"${RC_ITEM}\" not defined"
     fi
@@ -96,7 +96,8 @@ fi
 T_DIRECTIVES_MORE=
 if ! ${HAS_READ_T_DIRECTIVES_MORE:-false}; then
     RC_ITEM='[test battery][batch systems][pbs][directives]'
-    export T_DIRECTIVES_MORE=$(cylc get-global-config -i "${RC_ITEM}")
+    export T_DIRECTIVES_MORE=$( \
+        cylc get-global-config -i "${RC_ITEM}" 2>'/dev/null')
     export HAS_READ_T_DIRECTIVES_MORE=true
 fi
 FAKE_JOB_ID=$(get_fake_job_id)

--- a/tests/cylc-job-poll/05-lsf.t
+++ b/tests/cylc-job-poll/05-lsf.t
@@ -75,7 +75,7 @@ __PYTHON__
 #-------------------------------------------------------------------------------
 if ! ${IS_AT_T_HOST:-false}; then
     RC_ITEM='[test battery][batch systems][lsf]host'
-    T_HOST=$(cylc get-global-config -i "${RC_ITEM}")
+    T_HOST=$(cylc get-global-config -i "${RC_ITEM}" 2>'/dev/null')
     if [[ -z $T_HOST ]]; then
         skip_all "\"${RC_ITEM}\" not defined"
     fi
@@ -97,7 +97,8 @@ fi
 T_DIRECTIVES_MORE=
 if ! ${HAS_READ_T_DIRECTIVES_MORE:-false}; then
     RC_ITEM='[test battery][batch systems][lsf][directives]'
-    export T_DIRECTIVES_MORE=$(cylc get-global-config -i "${RC_ITEM}")
+    export T_DIRECTIVES_MORE=$( \
+        cylc get-global-config -i "${RC_ITEM}" 2>'/dev/null')
     export HAS_READ_T_DIRECTIVES_MORE=true
 fi
 FAKE_JOB_ID=$(get_fake_job_id)

--- a/tests/cylc-kill/00-kill-multi-hosts.t
+++ b/tests/cylc-kill/00-kill-multi-hosts.t
@@ -17,7 +17,8 @@
 #-------------------------------------------------------------------------------
 # Test kill multiple jobs on localhost and a remote host
 . "$(dirname "$0")/test_header"
-export CYLC_TEST_HOST=$(cylc get-global-config -i '[test battery]remote host')
+export CYLC_TEST_HOST=$(
+    cylc get-global-config -i '[test battery]remote host' 2>'/dev/null')
 if [[ -z "${CYLC_TEST_HOST}" ]]; then
     skip_all '[test battery]remote host: not defined'
 fi

--- a/tests/cylc-message/00-ssh.t
+++ b/tests/cylc-message/00-ssh.t
@@ -19,7 +19,8 @@
 # installed on the remote host.
 . "$(dirname "$0")/test_header"
 #-------------------------------------------------------------------------------
-CYLC_TEST_HOST="$(cylc get-global-config -i '[test battery]remote host')"
+CYLC_TEST_HOST="$( \
+    cylc get-global-config -i '[test battery]remote host' 2>'/dev/null')"
 if [[ -z "${CYLC_TEST_HOST}" ]]; then
     skip_all '[test battery]remote host: not defined'
 fi

--- a/tests/cylc-poll/04-poll-multi-hosts.t
+++ b/tests/cylc-poll/04-poll-multi-hosts.t
@@ -17,7 +17,8 @@
 #-------------------------------------------------------------------------------
 # Test poll multiple jobs on localhost and a remote host
 . "$(dirname "$0")/test_header"
-export CYLC_TEST_HOST=$(cylc get-global-config -i '[test battery]remote host')
+export CYLC_TEST_HOST=$( \
+    cylc get-global-config -i '[test battery]remote host' 2>'/dev/null')
 if [[ -z "${CYLC_TEST_HOST}" ]]; then
     skip_all '[test battery]remote host: not defined'
 fi

--- a/tests/cylc-scan/01-hosts.t
+++ b/tests/cylc-scan/01-hosts.t
@@ -17,7 +17,8 @@
 #-------------------------------------------------------------------------------
 # Test cylc scan with multiple hosts
 . "$(dirname "$0")/test_header"
-HOSTS="$(cylc get-global-config '--item=[suite host scanning]hosts')"
+HOSTS="$( \
+    cylc get-global-config '--item=[suite host scanning]hosts' 2>'/dev/null')"
 if [[ -z "${HOSTS}" || "${HOSTS}" == 'localhost' ]]; then
     skip_all '"[suite host scanning]hosts" not defined with remote suite hosts'
 fi

--- a/tests/cylc-submit/00-bg.t
+++ b/tests/cylc-submit/00-bg.t
@@ -24,7 +24,8 @@ if [[ "${TEST_NAME_BASE}" == *remote* ]]; then
     if [[ "${TEST_NAME_BASE}" == *remote-with-shared-fs* ]]; then
         CONF_KEY='remote host with shared fs'
     fi
-    HOST="$(cylc get-global-config "--item=[test battery]${CONF_KEY}")"
+    RC_ITEM="[test battery]${CONF_KEY}"
+    HOST="$(cylc get-global-config "--item=${RC_ITEM}" 2>'/dev/null')"
     if [[ -z "${HOST}" ]]; then
         skip_all "[test battery]${CONF_KEY} not set"
     fi
@@ -44,12 +45,14 @@ then
 fi
 if [[ -n "${CONFIGURED_SYS_NAME}" ]]; then
     ITEM_KEY="[test battery][batch systems][$CONFIGURED_SYS_NAME]host"
-    CYLC_TEST_HOST="$(cylc get-global-config "--item=${ITEM_KEY}")"
+    CYLC_TEST_HOST="$( \
+        cylc get-global-config "--item=${ITEM_KEY}" 2>'/dev/null')"
     if [[ -z "${CYLC_TEST_HOST}" ]]; then
         skip_all "${ITEM_KEY} not set"
     fi
     ITEM_KEY="[test battery][batch systems][$CONFIGURED_SYS_NAME][directives]"
-    CYLC_TEST_DIRECTIVES="$(cylc get-global-config "--item=${ITEM_KEY}")"
+    CYLC_TEST_DIRECTIVES="$( \
+        cylc get-global-config "--item=${ITEM_KEY}" 2>'/dev/null')"
     CYLC_TEST_BATCH_SYS_NAME=$CONFIGURED_SYS_NAME
 fi
 export CYLC_CONF_DIR=

--- a/tests/database/03-remote.t
+++ b/tests/database/03-remote.t
@@ -17,7 +17,8 @@
 #-------------------------------------------------------------------------------
 # Suite database content, "task_jobs" table with a remote job.
 . "$(dirname "$0")/test_header"
-export CYLC_TEST_HOST=$(cylc get-global-config -i '[test battery]remote host')
+export CYLC_TEST_HOST=$( \
+    cylc get-global-config -i '[test battery]remote host' 2>'/dev/null')
 if [[ -z "${CYLC_TEST_HOST}" ]]; then
     skip_all '[test battery]remote host: not defined'
 fi

--- a/tests/directives/00-loadleveler.t
+++ b/tests/directives/00-loadleveler.t
@@ -24,10 +24,11 @@
 # export an environment variable for this - allows a script to be used to 
 # select a compute node and have that same host used by the suite.
 BATCH_SYS_NAME="${TEST_NAME_BASE##??-}"
-export CYLC_TEST_BATCH_TASK_HOST=$(cylc get-global-config -i \
-    "[test battery][batch systems][$BATCH_SYS_NAME]host")
-export CYLC_TEST_BATCH_SITE_DIRECTIVES=$(cylc get-global-config -i \
-    "[test battery][batch systems][$BATCH_SYS_NAME][directives]")
+RC_PREF="[test battery][batch systems][${BATCH_SYS_NAME}]"
+export CYLC_TEST_BATCH_TASK_HOST=$( \
+    cylc get-global-config -i "${RC_PREF}host" 2>'/dev/null')
+export CYLC_TEST_BATCH_SITE_DIRECTIVES=$( \
+    cylc get-global-config -i "${RC_PREF}[directives]" 2>'/dev/null')
 if [[ -z "${CYLC_TEST_BATCH_TASK_HOST}" || "${CYLC_TEST_BATCH_TASK_HOST}" == None ]]
 then
     skip_all "[directive tests]$BATCH_SYS_NAME host not defined"

--- a/tests/events/10-task-event-job-logs-retrieve.t
+++ b/tests/events/10-task-event-job-logs-retrieve.t
@@ -18,7 +18,7 @@
 # Test remote job logs retrieval, requires compatible version of cylc on remote
 # job host.
 . "$(dirname "$0")/test_header"
-HOST=$(cylc get-global-config -i '[test battery]remote host')
+HOST=$(cylc get-global-config -i '[test battery]remote host' 2>'/dev/null')
 if [[ -z "${HOST}" ]]; then
     skip_all '[test battery]remote host: not defined'
 fi

--- a/tests/events/11-cycle-task-event-job-logs-retrieve.t
+++ b/tests/events/11-cycle-task-event-job-logs-retrieve.t
@@ -18,7 +18,7 @@
 # Test remote job logs retrieval, requires compatible version of cylc on remote
 # job host.
 . "$(dirname "$0")/test_header"
-HOST=$(cylc get-global-config -i '[test battery]remote host')
+HOST=$(cylc get-global-config -i '[test battery]remote host' 2>'/dev/null')
 if [[ -z "${HOST}" ]]; then
     skip_all '[test battery]remote host: not defined'
 fi

--- a/tests/job-kill/01-remote.t
+++ b/tests/job-kill/01-remote.t
@@ -18,7 +18,8 @@
 # Test killing of jobs on a remote host.
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
-export CYLC_TEST_HOST=$(cylc get-global-config -i '[test battery]remote host')
+export CYLC_TEST_HOST=$( \
+    cylc get-global-config -i '[test battery]remote host' 2>'/dev/null')
 if [[ -z $CYLC_TEST_HOST ]]; then
     skip_all '[test battery]remote host: not defined'
 fi

--- a/tests/job-kill/02-loadleveler.t
+++ b/tests/job-kill/02-loadleveler.t
@@ -19,10 +19,11 @@
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 BATCH_SYS_NAME="${TEST_NAME_BASE##??-}"
-export CYLC_TEST_BATCH_TASK_HOST=$(cylc get-global-config -i \
-    "[test battery][batch systems][$BATCH_SYS_NAME]host")
-export CYLC_TEST_BATCH_SITE_DIRECTIVES=$(cylc get-global-config -i \
-    "[test battery][batch systems][$BATCH_SYS_NAME][directives]")
+RC_PREF="[test battery][batch systems][$BATCH_SYS_NAME]"
+export CYLC_TEST_BATCH_TASK_HOST=$( \
+    cylc get-global-config -i "${RC_PREF}host" 2>'/dev/null')
+export CYLC_TEST_BATCH_SITE_DIRECTIVES=$( \
+    cylc get-global-config -i "${RC_PREF}[directives]" 2>'/dev/null')
 if [[ -z "${CYLC_TEST_BATCH_TASK_HOST}" || "${CYLC_TEST_BATCH_TASK_HOST}" == None ]]
 then
     skip_all "\"[test battery][batch systems][$BATCH_SYS_NAME]host\" not defined"

--- a/tests/job-submission/02-job-nn-remote-host.t
+++ b/tests/job-submission/02-job-nn-remote-host.t
@@ -19,7 +19,7 @@
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 export CYLC_TEST_HOST=$( \
-    cylc get-global-config -i '[test battery]remote host')
+    cylc get-global-config -i '[test battery]remote host' 2>'/dev/null')
 if [[ -z "$CYLC_TEST_HOST" ]]; then
     skip_all '[test battery]remote host: not defined'
 fi

--- a/tests/job-submission/03-job-nn-remote-host-with-shared-fs.t
+++ b/tests/job-submission/03-job-nn-remote-host-with-shared-fs.t
@@ -19,7 +19,8 @@
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 export CYLC_TEST_HOST=$( \
-    cylc get-global-config -i '[test battery]remote host with shared fs')
+    cylc get-global-config -i '[test battery]remote host with shared fs' \
+    2>'/dev/null')
 if [[ -z "$CYLC_TEST_HOST" ]]; then
     skip_all '[test battery]remote host with shared fs: not defined'
 fi

--- a/tests/job-submission/07-multi.t
+++ b/tests/job-submission/07-multi.t
@@ -17,7 +17,8 @@
 #-------------------------------------------------------------------------------
 # Test job submission, multiple jobs per host.
 . "$(dirname "$0")/test_header"
-CYLC_TEST_HOST="$(cylc get-global-config -i '[test battery]remote host')"
+CYLC_TEST_HOST="$( \
+    cylc get-global-config -i '[test battery]remote host' 2>'/dev/null')"
 if [[ -z "${CYLC_TEST_HOST}" ]]; then
     skip_all '[test battery]remote host: not defined'
 fi

--- a/tests/restart/13-bad-job-host.t
+++ b/tests/restart/13-bad-job-host.t
@@ -18,7 +18,8 @@
 # Test restarting a suite when the host of a submitted or running job is not
 # available. https://github.com/cylc/cylc/issues/1327
 . "$(dirname "$0")/test_header"
-export CYLC_TEST_HOST=$(cylc get-global-config -i '[test battery]remote host')
+export CYLC_TEST_HOST=$( \
+    cylc get-global-config -i '[test battery]remote host' 2>'/dev/null')
 if [[ -z "${CYLC_TEST_HOST}" ]]; then
     skip_all '[test battery]remote host: not defined'
 fi

--- a/tests/vacation/01-loadleveler.t
+++ b/tests/vacation/01-loadleveler.t
@@ -21,15 +21,15 @@
 # require a site admin to pre-empt a job.
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
+RC_PREV="[test battery][batch systems][loadleveler]"
 export CYLC_TEST_HOST=$( \
-    cylc get-global-config -i '[test battery][batch systems][loadleveler]host')
+    cylc get-global-config -i "${RC_PREV}host" 2>'/dev/null')
 if [[ -z $CYLC_TEST_HOST ]]; then
     skip_all '[test battery][batch systems][loadleveler]host: not defined'
 fi
 set_test_number 6
 export CYLC_TEST_DIRECTIVES=$( \
-    cylc get-global-config \
-    -i '[test battery][batch systems][loadleveler][directives]')
+    cylc get-global-config -i "${RC_PREV}[directives]" 2>'/dev/null')
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 set -eu
 if [[ $CYLC_TEST_HOST != 'localhost' ]]; then


### PR DESCRIPTION
Test battery was outputting extra error messages for skipped tests. This was mostly due to error messages from `cylc get-global-cfg`.

@hjoliver @arjclark please review.