### PR TITLE
cylc scan: do not report id requests unless overwhelmed

### DIFF
--- a/lib/cylc/network/client_reporter.py
+++ b/lib/cylc/network/client_reporter.py
@@ -58,7 +58,7 @@ class PyroClientReporter(object):
             name in ["SuiteCommandServer",
                      "ExtTriggerServer",
                      "BroadcastServer"] or
-            (name != "TaskMessageServer" and
+            (name not in ["SuiteIdServer", "TaskMessageServer"] and
              caller.uuid not in self.clients))
         if log_me:
             logging.getLogger("main").info(

--- a/lib/cylc/network/client_reporter.py
+++ b/lib/cylc/network/client_reporter.py
@@ -72,8 +72,8 @@ class PyroClientReporter(object):
                     request, caller.user, caller.host, caller.prog_name,
                     caller.uuid))
         if name == "SuiteIdServer":
+            self._num_id_requests += 1            
             self.report_id_requests()
-            self._num_id_requests += 1
         self.clients[caller.uuid] = datetime.datetime.utcnow()
         self._housekeep()
 


### PR DESCRIPTION
This closes #1623.

Client identify requests are not logged unless in debug mode.

There will be a warning logged if there is a really high rate of ID requests.
I've chosen >=1 per second over the last hour, but this is fairly arbitrary.

I've tested this by setting `CLIENT_ID_REPORT_SECONDS = 10` and launching
quite a lot of parallel cylc scans.

@matthewrmshin, please test and review 1.
@hjoliver, please review 2.