### PR TITLE
global.rc: fix retrieve job logs retry delays

### DIFF
--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -966,23 +966,20 @@ class TaskPool(object):
                 # Set timer if timeout is None.
                 if not try_state.is_timeout_set():
                     if try_state.next() is None:
-                        itask.log(ERROR, "%s failed:\n\t%s" % (
-                            key,
-                            try_state.ctx))
+                        itask.log(ERROR, "%s failed" % (key))
                         del itask.event_handler_try_states[key]
                         continue
                     # Report 1st and retries
                     if try_state.num == 1:
                         level = INFO
-                        tmpl = "%s will run after %s (after %s):\n\t%s"
+                        tmpl = "%s will run after %s (after %s)"
                     else:
                         level = WARNING
-                        tmpl = "%s failed, retrying in %s (after %s):\n\t%s"
+                        tmpl = "%s failed, retrying in %s (after %s)"
                     itask.log(level, tmpl % (
                         key,
                         try_state.delay_as_seconds(),
-                        try_state.timeout_as_str(),
-                        try_state.ctx))
+                        try_state.timeout_as_str()))
                 # Ready to run?
                 if not try_state.is_delay_done():
                     continue

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -966,7 +966,7 @@ class TaskPool(object):
                 # Set timer if timeout is None.
                 if not try_state.is_timeout_set():
                     if try_state.next() is None:
-                        itask.log(ERROR, "%s failed" % (key))
+                        itask.log(ERROR, "%s failed" % str(key))
                         del itask.event_handler_try_states[key]
                         continue
                     # Report 1st and retries
@@ -977,7 +977,7 @@ class TaskPool(object):
                         level = WARNING
                         tmpl = "%s failed, retrying in %s (after %s)"
                     itask.log(level, tmpl % (
-                        key,
+                        str(key),
                         try_state.delay_as_seconds(),
                         try_state.timeout_as_str()))
                 # Ready to run?

--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -879,7 +879,7 @@ class TaskProxy(object):
                 self.user_at_host,
                 self._get_host_conf("retrieve job logs max size"),  # max_size
             ),
-            self._get_events_conf("retrieve job logs retry delays", []))
+            self._get_host_conf("retrieve job logs retry delays", []))
 
     def setup_event_mail(self, event, message):
         """Event notification, by email."""


### PR DESCRIPTION
The logic was not reading the setting correctly.
Also reduced the amount of internal object information going into the log.

@hjoliver @arjclark please review.