### PR TITLE
Handle multiple calls to stop progress bar.

### DIFF
--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -443,6 +443,9 @@ Class to create an information bar.
 
     def prog_bar_start(self, msg):
         """Start the progress bar running"""
+        if self.prog_bar_active():
+            # Already started (multiple calls are possible via idle_add).
+            return False
         self.prog_bar_timer = gobject.timeout_add(100, self.prog_bar_pulse)
         self.prog_bar.set_text(msg)
         self.prog_bar.show()
@@ -459,6 +462,9 @@ Class to create an information bar.
 
     def prog_bar_stop(self):
         """Stop the progress bar running."""
+        if not self.prog_bar_active():
+            # Already stopped (multiple calls are possible via idle_add).
+            return False
         gobject.source_remove(self.prog_bar_timer)
         self.prog_bar.set_fraction(0)
         self.prog_bar.set_text('')


### PR DESCRIPTION
Close #1631.

Calls to `prog_bar_stop()` are made via `gobject.idle_add()` only if the prog bar is active.  Under load it is presumably possible for multiple callbacks to be queued before an idle period is reached.  Documentation of `gobject.idle_add()` http://www.pygtk.org/pygtk2reference/gobject-functions.html#function-gobject--idle-add says *If callback returns FALSE it is automatically removed from the list of event sources and will not be called again*.  I took this to imply that multiple calls would not be an issue, but I can artificially reproduce the bug by putting in an additional consecutive call to `gobject.idle_add(self.info_bar.prog_bar_stop)`, which shows we do need to be prepared for multiple calls to the stop method - which is what this fix does. 

@arjclark - please review.
