### PR TITLE
cylc cat-log: improve message on bad suites

### DIFF
--- a/lib/cylc/rundb.py
+++ b/lib/cylc/rundb.py
@@ -425,12 +425,14 @@ class CylcSuiteDAO(object):
                 "keys_str": ",".join(keys),
                 "table": self.TABLE_TASK_JOBS}
             stmt_args = [cycle, name, submit_num]
-        ret = {}
-        for row in self.connect().execute(stmt, stmt_args):
-            ret = {}
-            for key, value in zip(keys, row):
-                ret[key] = value
-            return ret
+        try:
+            for row in self.connect().execute(stmt, stmt_args):
+                ret = {}
+                for key, value in zip(keys, row):
+                    ret[key] = value
+                return ret
+        except sqlite3.DatabaseError:
+            return None
 
     def select_task_states_by_task_ids(self, keys, task_ids=None):
         """Select items from task_states by task IDs.

--- a/tests/cylc-cat-log/03-bad-suite.t
+++ b/tests/cylc-cat-log/03-bad-suite.t
@@ -1,0 +1,35 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "cylc cat-log" with bad suite name.
+. "$(dirname "$0")/test_header"
+set_test_number 4
+
+CYLC_RUN_DIR="$(cylc get-global-config --print-run-dir)"
+BAD_NAME="$(basename "$(mktemp -u "${CYLC_RUN_DIR}/XXXXXXXX")")"
+
+run_fail "${TEST_NAME_BASE}-suite" cylc cat-log "${BAD_NAME}"
+cmp_ok "${TEST_NAME_BASE}-suite.stderr" <<__ERR__
+cat: ${CYLC_RUN_DIR}/${BAD_NAME}/log/suite/log: No such file or directory
+__ERR__
+
+run_fail "${TEST_NAME_BASE}-suite" cylc cat-log "${BAD_NAME}" "garbage.1"
+cmp_ok "${TEST_NAME_BASE}-suite.stderr" <<__ERR__
+cat: ${CYLC_RUN_DIR}/${BAD_NAME}/log/job/1/garbage/NN/job: No such file or directory
+__ERR__
+
+exit


### PR DESCRIPTION
`cylc cat-log 'bad-name' 'whatever.1'` was resulting in a trace back.
This change improves the error message.

Close #1637. @hjoliver @arjclark please review.