### PR TITLE
cylc gcylc: ignore suicide triggers as default

### DIFF
--- a/doc/cug.tex
+++ b/doc/cug.tex
@@ -3447,7 +3447,8 @@ that trigger if they're needed but otherwise remove themselves from the
 suite (you can run the {\em AutoRecover.async} example suite to see how
 this works).  The dashed graph edges ending in solid dots indicate
 suicide triggers, and the open arrowheads indicate conditional triggers
-as usual.
+as usual. Note as default the suicide triggers are ignored in the graphing. 
+Under {\em View}, {\em Options} you can select to toggle {\em Ignore Suicide Triggers}. 
 
 \begin{figure}
 \begin{minipage}[b]{0.5\textwidth}

--- a/lib/cylc/cylc_xdot.py
+++ b/lib/cylc/cylc_xdot.py
@@ -275,7 +275,7 @@ class MyDotWindow( CylcDotViewerCommon ):
         self.subgraphs_on = subgraphs_on
         self.template_vars = template_vars
         self.template_vars_file = template_vars_file
-        self.ignore_suicide = False
+        self.ignore_suicide = True
         self.start_point_string = start_point_string
         self.stop_point_string = stop_point_string
         self.filter_recs = []

--- a/lib/cylc/gui/updater_graph.py
+++ b/lib/cylc/gui/updater_graph.py
@@ -60,7 +60,7 @@ class GraphUpdater(threading.Thread):
 
         self.quit = False
         self.cleared = False
-        self.ignore_suicide = False
+        self.ignore_suicide = True
         self.focus_start_point_string = None
         self.focus_stop_point_string = None
         self.xdot = xdot


### PR DESCRIPTION
This make graph mode more user friendly when there are lots of suicide triggers in a suites design.