### PR TITLE
Support xdot format 1.7

### DIFF
--- a/lib/xdot.py
+++ b/lib/xdot.py
@@ -524,6 +524,7 @@ UNDERLINE = 4
 SUPERSCRIPT = 8
 SUBSCRIPT = 16
 STRIKE_THROUGH = 32
+OVERLINE = 64
 
 
 class XDotAttrParser:
@@ -1162,7 +1163,7 @@ class DotParser(Parser):
 
 class XDotParser(DotParser):
 
-    XDOTVERSION = '1.6'
+    XDOTVERSION = '1.7'
 
     def __init__(self, xdotcode):
         lexer = DotLexer(buf = xdotcode)


### PR DESCRIPTION
On my newer systems I've been getting a lot of this:
```
$ cylc graph foo
warning: xdot version 1.7, but supported is 1.6
```

This branch makes the same minor changes as https://github.com/jrfonseca/xdot.py/commit/cd75658cb56b2042433d62f4b6aa7dc84eaf3b5a

@matthewrmshin - please assign reviews.