### PR TITLE
Remove early gtk import

### DIFF
--- a/bin/cylc-graph
+++ b/bin/cylc-graph
@@ -63,7 +63,6 @@ GRAPH VIEWER CONTROLS:
     * "recursive ungroup" - ungroup all families below this node."""
 
 import sys
-import gtk
 import StringIO
 
 import cylc.flags


### PR DESCRIPTION
Prevented "make" and "cylc graph --help" if X Windows not available.

@matthewrmshin - please review (trivial).