### PR TITLE
Fix test battery on VMs

### DIFF
--- a/bin/cylc-test-battery
+++ b/bin/cylc-test-battery
@@ -83,8 +83,11 @@ if [[ "$PWD" != "$CYLC_DIR" ]]; then
     cd "$CYLC_DIR"
 fi
 
-# Remove pyc files to ensure we are running the current code.
-find $CYLC_DIR -name '*.pyc' | xargs rm
+# Recompile *.pyc files to ensure we are running the current code.
+if [[ -w "$CYLC_DIR/lib" ]]; then
+    find "$CYLC_DIR/lib" -name '*.pyc' -type 'f' -delete
+    python -mcompileall -q "$CYLC_DIR/lib"
+fi
 
 if perl -e 'use Test::Harness 3.00' 2>/dev/null; then
     NPROC=$(cylc get-global-config '--item=process pool size')

--- a/tests/events/09-task-event-mail.t
+++ b/tests/events/09-task-event-mail.t
@@ -17,6 +17,9 @@
 #-------------------------------------------------------------------------------
 # Test event mail.
 . "$(dirname "$0")/test_header"
+if ! mail -V 2>'/dev/null'; then
+    skip_all '"mail" command not available'
+fi
 set_test_number 5
 mock_smtpd_init
 OPT_SET=

--- a/tests/vacation/00-sigusr1.t
+++ b/tests/vacation/00-sigusr1.t
@@ -19,68 +19,71 @@
 # Obviously, job vacation does not happen with background job, and the job
 # will no longer be poll-able after the kill.
 . $(dirname $0)/test_header
-#-------------------------------------------------------------------------------
-set_test_number 6
-install_suite $TEST_NAME_BASE $TEST_NAME_BASE
-#-------------------------------------------------------------------------------
-TEST_NAME=$TEST_NAME_BASE-validate
-run_ok $TEST_NAME cylc validate $SUITE_NAME
-#-------------------------------------------------------------------------------
-TEST_NAME=$TEST_NAME_BASE-run
-suite_run_ok $TEST_NAME cylc run --reference-test $SUITE_NAME
-#-------------------------------------------------------------------------------
-SUITE_RUN_DIR=$(cylc get-global-config --print-run-dir)/$SUITE_NAME
 
-# Make sure t1.1.1's status file is in place
-T1_STATUS_FILE=$SUITE_RUN_DIR/log/job/1/t1/01/job.status
+run_tests() {
+    set_test_number 6
+    install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+    TEST_NAME=$TEST_NAME_BASE-validate
+    run_ok $TEST_NAME cylc validate $SUITE_NAME
+    TEST_NAME=$TEST_NAME_BASE-run
+    suite_run_ok $TEST_NAME cylc run --reference-test $SUITE_NAME
+    SUITE_RUN_DIR=$(cylc get-global-config --print-run-dir)/$SUITE_NAME
 
-poll '!' test -e "${T1_STATUS_FILE}"
-poll '!' grep 'CYLC_JOB_PID=' "${T1_STATUS_FILE}"
+    # Make sure t1.1.1's status file is in place
+    T1_STATUS_FILE=$SUITE_RUN_DIR/log/job/1/t1/01/job.status
 
-# Kill the job and see what happens
-T1_PID=$(awk -F= '$1=="CYLC_JOB_PID" {print $2}' "${T1_STATUS_FILE}")
-kill -s USR1 $T1_PID
-while ps $T1_PID 1>/dev/null 2>&1; do
-    sleep 1
-done
-run_fail "${T1_STATUS_FILE}" grep -q '^CYLC_JOB' "${T1_STATUS_FILE}"
-TIMEOUT=$(($(date +%s) + 120))
-while ! grep -q 'Task job script vacated by signal USR1' \
-            $SUITE_RUN_DIR/log/suite/log \
-        && (($TIMEOUT > $(date +%s)))
-do
-    sleep 1
-done
-TIMEOUT=$(($(date +%s) + 10))
-while ! sqlite3 $SUITE_RUN_DIR/cylc-suite.db \
-            'SELECT status FROM task_states WHERE name=="t1";' \
-            >"$TEST_NAME-db-t1" 2>/dev/null \
-        && (($TIMEOUT > $(date +%s)))
-do
-    sleep 1
-done
-grep_ok "^\(submitted\|running\)$" "$TEST_NAME-db-t1"
-# Start the job again and see what happens
-mkdir -p $SUITE_RUN_DIR/work/1/t1/
-touch $SUITE_RUN_DIR/work/1/t1/file # Allow t1 to complete
-$SUITE_RUN_DIR/log/job/1/t1/01/job </dev/null >/dev/null 2>&1 &
-# Wait for suite to complete
-TIMEOUT=$(($(date +%s) + 120))
-while [[ -f ~/.cylc/ports/$SUITE_NAME ]] && (($TIMEOUT > $(date +%s))); do
-    sleep 1
-done
-# Test t1 status in DB
-sqlite3 $SUITE_RUN_DIR/cylc-suite.db \
-    'SELECT status FROM task_states WHERE name=="t1";' >"$TEST_NAME-db-t1"
-cmp_ok "$TEST_NAME-db-t1" - <<<'succeeded'
-# Test reference
-TIMEOUT=$(($(date +%s) + 120))
-while ! grep -q 'DONE' $SUITE_RUN_DIR/log/suite/out \
-        && (($TIMEOUT > $(date +%s)))
-do
-    sleep 1
-done
-grep_ok 'SUITE REFERENCE TEST PASSED' $SUITE_RUN_DIR/log/suite/out
-#-------------------------------------------------------------------------------
-purge_suite $SUITE_NAME
-exit
+    poll '!' test -e "${T1_STATUS_FILE}"
+    poll '!' grep 'CYLC_JOB_PID=' "${T1_STATUS_FILE}"
+
+    # Kill the job and see what happens
+    T1_PID=$(awk -F= '$1=="CYLC_JOB_PID" {print $2}' "${T1_STATUS_FILE}")
+    kill -s USR1 $T1_PID
+    while ps $T1_PID 1>/dev/null 2>&1; do
+        sleep 1
+    done
+    run_fail "${T1_STATUS_FILE}" grep -q '^CYLC_JOB' "${T1_STATUS_FILE}"
+    TIMEOUT=$(($(date +%s) + 120))
+    while ! grep -q 'Task job script vacated by signal USR1' \
+                $SUITE_RUN_DIR/log/suite/log \
+            && (($TIMEOUT > $(date +%s)))
+    do
+        sleep 1
+    done
+    TIMEOUT=$(($(date +%s) + 10))
+    while ! sqlite3 $SUITE_RUN_DIR/cylc-suite.db \
+                'SELECT status FROM task_states WHERE name=="t1";' \
+                >"$TEST_NAME-db-t1" 2>/dev/null \
+            && (($TIMEOUT > $(date +%s)))
+    do
+        sleep 1
+    done
+    grep_ok "^\(submitted\|running\)$" "$TEST_NAME-db-t1"
+    # Start the job again and see what happens
+    mkdir -p $SUITE_RUN_DIR/work/1/t1/
+    touch $SUITE_RUN_DIR/work/1/t1/file # Allow t1 to complete
+    $SUITE_RUN_DIR/log/job/1/t1/01/job </dev/null >/dev/null 2>&1 &
+    # Wait for suite to complete
+    TIMEOUT=$(($(date +%s) + 120))
+    while [[ -f ~/.cylc/ports/$SUITE_NAME ]] && (($TIMEOUT > $(date +%s))); do
+        sleep 1
+    done
+    # Test t1 status in DB
+    sqlite3 $SUITE_RUN_DIR/cylc-suite.db \
+        'SELECT status FROM task_states WHERE name=="t1";' >"$TEST_NAME-db-t1"
+    cmp_ok "$TEST_NAME-db-t1" - <<<'succeeded'
+    # Test reference
+    TIMEOUT=$(($(date +%s) + 120))
+    while ! grep -q 'DONE' $SUITE_RUN_DIR/log/suite/out \
+            && (($TIMEOUT > $(date +%s)))
+    do
+        sleep 1
+    done
+    grep_ok 'SUITE REFERENCE TEST PASSED' $SUITE_RUN_DIR/log/suite/out
+    purge_suite $SUITE_NAME
+    exit
+}
+
+trap 'run_tests' 'SIGUSR1'
+kill -s 'SIGUSR1' "$$"
+sleep 1
+skip_all 'Program not receiving SIGUSR1'

--- a/tests/vacation/00-sigusr1.t
+++ b/tests/vacation/00-sigusr1.t
@@ -83,6 +83,9 @@ run_tests() {
     exit
 }
 
+# Programs running in some environment is unable to trap SIGUSR1. E.g.:
+# An environment documented in this comment:
+# https://github.com/cylc/cylc/pull/1648#issuecomment-149348410
 trap 'run_tests' 'SIGUSR1'
 kill -s 'SIGUSR1' "$$"
 sleep 1


### PR DESCRIPTION
Remove and rebuild `*.pyc` files only if directory is writable.
Skip mail related tests if `mail` command not available.