### PR TITLE
Fix host specific task event handler retry delays

### DIFF
--- a/doc/siterc.tex
+++ b/doc/siterc.tex
@@ -548,6 +548,11 @@ specified host.
 Global default for the~\ref{runtime-remote-retrieve-job-logs-retry-delays}
 setting for the specified host.
 
+\paragraph[task event handler retry delays]{[hosts] $\rightarrow$ HOSTS $\rightarrow$ task event handler retry delays}
+
+Host specific default for the~\ref{runtime-events-handler-retry-delays}
+setting.
+
 \paragraph[batch systems $\rightarrow$ JOB SUBMISSION METHOD $\rightarrow$ err tailer]{[hosts] $\rightarrow$ HOSTS $\rightarrow$ batch systems $\rightarrow$ JOB SUBMISSION METHOD $\rightarrow$ err tailer}
 
 A command template (with \lstinline=%(job_id)s= substitution) that can be used

--- a/doc/suiterc.tex
+++ b/doc/suiterc.tex
@@ -1497,6 +1497,7 @@ Specify the events for which the general task event handlers should be invoked.
 \end{myitemize}
 
 \subparagraph[handler retry delays]{[runtime] $\rightarrow$ [[\_\_NAME\_\_]] $\rightarrow$ [[[events]]] $\rightarrow$ handler retry delays}
+\label{runtime-events-handler-retry-delays}
 
 Specify an initial delay before running an event handler command and any retry
 delays in case the command returns a non-zero code. The default behaviour is to

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -165,7 +165,7 @@ SPEC = {
         'execution timeout': vdr(vtype='interval_minutes'),
         'handlers': vdr(vtype='string_list', default=[]),
         'handler events': vdr(vtype='string_list', default=[]),
-        'handler retry delays': vdr(vtype='interval_minutes_list', default=[]),
+        'handler retry delays': vdr(vtype='interval_minutes_list'),
         'mail events': vdr(vtype='string_list', default=[]),
         'mail from': vdr(vtype='string'),
         'mail retry delays': vdr(vtype='interval_minutes_list', default=[]),

--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -910,7 +910,9 @@ class TaskProxy(object):
         elif (self._get_events_conf('handlers', []) and
                 event in self._get_events_conf('handler events', [])):
             handlers = self._get_events_conf('handlers', [])
-        retry_delays = self._get_events_conf('handler retry delays', [])
+        retry_delays = self._get_events_conf(
+            'handler retry delays',
+            self._get_host_conf("task event handler retry delays", []))
         env = None
         for i, handler in enumerate(handlers):
             key1 = (

--- a/tests/events/08-task-event-handler-retry/suite.rc
+++ b/tests/events/08-task-event-handler-retry/suite.rc
@@ -13,6 +13,10 @@ title=Task Event Handler Retry
 [runtime]
     [[t1]]
         script=true
+{% if HOST is defined %}
+        [[[remote]]]
+            host = {{HOST}}
+{% endif %}
 {% if GLOBALCFG is not defined %}
         [[[events]]]
             handlers=hello-event-handler '%(name)s' '%(event)s'

--- a/tests/events/15-host-task-event-handler-retry-globalcfg
+++ b/tests/events/15-host-task-event-handler-retry-globalcfg
@@ -1,0 +1,1 @@
+08-task-event-handler-retry

--- a/tests/events/15-host-task-event-handler-retry-globalcfg.t
+++ b/tests/events/15-host-task-event-handler-retry-globalcfg.t
@@ -1,0 +1,75 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test general task event handler + retry.
+. "$(dirname "$0")/test_header"
+HOST=$(cylc get-global-config -i '[test battery]remote host' 2>'/dev/null')
+if [[ -z "${HOST}" ]]; then
+    skip_all '[test battery]remote host: not defined'
+fi
+set_test_number 4
+
+mkdir 'conf'
+cat >'conf/global.rc' <<__GLOBALCFG__
+[hosts]
+    [[${HOST}]]
+        task event handler retry delays=3*PT1S
+[task events]
+    handlers=hello-event-handler '%(name)s' '%(event)s'
+    handler events=succeeded, failed
+__GLOBALCFG__
+
+export CYLC_CONF_PATH="${PWD}/conf"
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+set -eu
+SSH='ssh -oBatchMode=yes -oConnectTimeout=5'
+${SSH} "${HOST}" \
+    "mkdir -p .cylc/${SUITE_NAME}/ && cat >.cylc/${SUITE_NAME}/passphrase" \
+    <"${TEST_DIR}/${SUITE_NAME}/passphrase"
+set +eu
+
+run_ok "${TEST_NAME_BASE}-validate" \
+    cylc validate -s "HOST=${HOST}" -s 'GLOBALCFG=True' "${SUITE_NAME}"
+suite_run_ok "${TEST_NAME_BASE}-run" \
+    cylc run --reference-test --debug -s "HOST=${HOST}" -s 'GLOBALCFG=True' \
+    "${SUITE_NAME}"
+
+SUITE_RUN_DIR="$(cylc get-global-config '--print-run-dir')/${SUITE_NAME}"
+LOG="${SUITE_RUN_DIR}/log/job/1/t1/NN/job-activity.log"
+sed "/(('event-handler-00', 'succeeded'), 1)/!d; s/^.* \[/[/" "${LOG}" \
+    >'edited-job-activity.log'
+cmp_ok 'edited-job-activity.log' <<'__LOG__'
+[(('event-handler-00', 'succeeded'), 1) cmd] hello-event-handler 't1' 'succeeded'
+[(('event-handler-00', 'succeeded'), 1) ret_code] 1
+[(('event-handler-00', 'succeeded'), 1) cmd] hello-event-handler 't1' 'succeeded'
+[(('event-handler-00', 'succeeded'), 1) ret_code] 1
+[(('event-handler-00', 'succeeded'), 1) cmd] hello-event-handler 't1' 'succeeded'
+[(('event-handler-00', 'succeeded'), 1) ret_code] 0
+[(('event-handler-00', 'succeeded'), 1) out] hello
+__LOG__
+
+grep -F 'will run after' "${SUITE_RUN_DIR}/log/suite/log" \
+    | cut -d' ' -f 4-11 >'edited-log'
+cmp_ok 'edited-log' <<'__LOG__'
+[t1.1] -(('event-handler-00', 'succeeded'), 1) will run after PT1S
+[t2.1] -(('event-handler-00', 'succeeded'), 1) will run after P0Y
+__LOG__
+
+
+${SSH} "${HOST}" "rm -rf '.cylc/${SUITE_NAME}' 'cylc-run/${SUITE_NAME}'"
+purge_suite "${SUITE_NAME}"
+exit


### PR DESCRIPTION
Per-host task event handler retry delays was not enabled. This change
fixes it.

@hjoliver @arjclark please review.