### PR TITLE
Fix validation error when graphviz is not available

### DIFF
--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -686,7 +686,7 @@ class SuiteConfig(object):
                 cfg['URL'] = re.sub(RE_TASK_NAME_VAR, name, cfg['URL'])
                 cfg['URL'] = re.sub(RE_SUITE_NAME_VAR, self.suite, cfg['URL'])
 
-        if self.validation:
+        if self.validation and not graphing_disabled:
             # Detect cyclic dependence.
             # (ignore suicide triggers as they look like cyclic dependence:
             #    "foo:fail => bar => !foo" looks like "foo => bar => foo").
@@ -709,6 +709,11 @@ class SuiteConfig(object):
                     print >> sys.stderr, '  %s => %s' % e
                 raise SuiteConfigError('ERROR: cyclic dependence detected '
                                        '(graph the suite to see back-edges).')
+        elif graphing_disabled:
+            print >> sys.stderr, (
+                "WARNING: skipping cyclic dependence check"
+                "  (importing graphviz library failed)")
+
         self.mem_log("config.py: end init config")
  
     def is_graph_defined(self, dependency_map):

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -686,33 +686,34 @@ class SuiteConfig(object):
                 cfg['URL'] = re.sub(RE_TASK_NAME_VAR, name, cfg['URL'])
                 cfg['URL'] = re.sub(RE_SUITE_NAME_VAR, self.suite, cfg['URL'])
 
-        if self.validation and not graphing_disabled:
-            # Detect cyclic dependence.
-            # (ignore suicide triggers as they look like cyclic dependence:
-            #    "foo:fail => bar => !foo" looks like "foo => bar => foo").
-            graph = self.get_graph(ungroup_all=True, ignore_suicide=True)
-            # Original edges.
-            o_edges = graph.edges()
-            # Reverse any back edges using graphviz 'acyclic'.
-            # (Note: use of acyclic(copy=True) reveals our CGraph class init
-            # should have the same arg list as its parent, pygraphviz.AGraph).
-            graph.acyclic()
-            # Look for reversed edges (note this does not detect self-edges).
-            n_edges = graph.edges()
-            back_edges = []
-            for e in o_edges:
-                if e not in n_edges:
-                    back_edges.append(e)
-            if len(back_edges) > 0:
-                print >> sys.stderr, "Back-edges:"
-                for e in back_edges:
-                    print >> sys.stderr, '  %s => %s' % e
-                raise SuiteConfigError('ERROR: cyclic dependence detected '
-                                       '(graph the suite to see back-edges).')
-        elif graphing_disabled:
-            print >> sys.stderr, (
-                "WARNING: skipping cyclic dependence check"
-                "  (importing graphviz library failed)")
+        if self.validation:
+            if graphing_disabled:
+                print >> sys.stderr, (
+                    "WARNING: skipping cyclic dependence check"
+                    "  (could not import graphviz library)")
+            else:
+                # Detect cyclic dependence.
+                # (ignore suicide triggers as they look like cyclic dependence:
+                #    "foo:fail => bar => !foo" looks like "foo => bar => foo").
+                graph = self.get_graph(ungroup_all=True, ignore_suicide=True)
+                # Original edges.
+                o_edges = graph.edges()
+                # Reverse any back edges using graphviz 'acyclic'.
+                # (Note: use of acyclic(copy=True) reveals our CGraph class init
+                # should have the same arg list as its parent, pygraphviz.AGraph).
+                graph.acyclic()
+                # Look for reversed edges (note this does not detect self-edges).
+                n_edges = graph.edges()
+                back_edges = []
+                for e in o_edges:
+                    if e not in n_edges:
+                        back_edges.append(e)
+                if len(back_edges) > 0:
+                    print >> sys.stderr, "Back-edges:"
+                    for e in back_edges:
+                        print >> sys.stderr, '  %s => %s' % e
+                    raise SuiteConfigError('ERROR: cyclic dependence detected '
+                                           '(graph the suite to see back-edges).')
 
         self.mem_log("config.py: end init config")
  


### PR DESCRIPTION
Issue #1463 added the capability to fail cyclic dependencies when
validating a suite.  However, if the graphviz library is not available
the graphing_disabled flag is set, but not checked for the cyclic
dependency generation.  This results either an error with traceback
(for cylc 6.6.1) or a cryptic "global name 'graphing' is not defined'
error in 6.7.1 but the validation always fails.

This updates the cyclic dependence check to run only if the graphing
module was imported successfully.  If the graphing module is not
available, a warning message is printed out (even if the suite is
otherwise valid).