### PR TITLE
cylc gcylc/graph: hide suicide triggers as default

### DIFF
--- a/bin/cylc-graph
+++ b/bin/cylc-graph
@@ -180,8 +180,8 @@ def main():
 
     parser.add_option(
         "--show-suicide",
-        help="Show the suicide triggers, default is to not display the graph "
-             "and with the suicide triggers.",
+        help="Show suicide triggers.  They are not shown by default, unless "
+             "toggled on with the tool bar button.",
         action="store_true", default=False, dest="show_suicide")
 
     (options, args) = parser.parse_args()

--- a/bin/cylc-graph
+++ b/bin/cylc-graph
@@ -178,6 +178,11 @@ def main():
              "If not given, assume --output-file=-.",
         action="store_true", default=False, dest="reference")
 
+    parser.add_option(
+        "--show-graph",
+        help="Show the graph, default is to not display the graph.",
+        action="store_true", default=False, dest="show_graph")
+
     (options, args) = parser.parse_args()
 
     # import modules that require gtk now, so that a display is not needed
@@ -221,6 +226,12 @@ def main():
         window = MyDotWindow2(suite, suiterc, options.templatevars,
                               options.templatevars_file,
                               should_hide=should_hide_gtk_window)
+    elif options.show_graph:
+        window = MyDotWindow(suite, suiterc, start_point_string,
+                             stop_point_string, options.templatevars,
+                             options.templatevars_file,
+                             should_hide=should_hide_gtk_window,
+                             ignore_suicide=False)
     else:
         window = MyDotWindow(suite, suiterc, start_point_string,
                              stop_point_string, options.templatevars,

--- a/bin/cylc-graph
+++ b/bin/cylc-graph
@@ -179,9 +179,10 @@ def main():
         action="store_true", default=False, dest="reference")
 
     parser.add_option(
-        "--show-graph",
-        help="Show the graph, default is to not display the graph.",
-        action="store_true", default=False, dest="show_graph")
+        "--show-suicide",
+        help="Show the suicide triggers, default is to not display the graph "
+             "and with the suicide triggers.",
+        action="store_true", default=False, dest="show_suicide")
 
     (options, args) = parser.parse_args()
 
@@ -226,17 +227,13 @@ def main():
         window = MyDotWindow2(suite, suiterc, options.templatevars,
                               options.templatevars_file,
                               should_hide=should_hide_gtk_window)
-    elif options.show_graph:
+    else:
+        hide_suicide = not options.show_suicide
         window = MyDotWindow(suite, suiterc, start_point_string,
                              stop_point_string, options.templatevars,
                              options.templatevars_file,
                              should_hide=should_hide_gtk_window,
-                             ignore_suicide=False)
-    else:
-        window = MyDotWindow(suite, suiterc, start_point_string,
-                             stop_point_string, options.templatevars,
-                             options.templatevars_file,
-                             should_hide=should_hide_gtk_window)
+                             ignore_suicide=hide_suicide)
 
     window.widget.connect('clicked', on_url_clicked, window)
     if options.filter_patterns:

--- a/doc/cug.tex
+++ b/doc/cug.tex
@@ -3447,9 +3447,7 @@ that trigger if they're needed but otherwise remove themselves from the
 suite (you can run the {\em AutoRecover.async} example suite to see how
 this works).  The dashed graph edges ending in solid dots indicate
 suicide triggers, and the open arrowheads indicate conditional triggers
-as usual. Note as default the suicide triggers are ignored in the graphing. 
-Under {\em View}, {\em Options} you can select to toggle 
-{\em Ignore Suicide Triggers}.
+as usual. Suicide triggers are ignored by default in the graph view, unless you toggle them on with {\em View} -> {\em Options} -> {\em Ignore Suicide Triggers}. 
 
 \begin{figure}
 \begin{minipage}[b]{0.5\textwidth}

--- a/doc/cug.tex
+++ b/doc/cug.tex
@@ -3447,7 +3447,9 @@ that trigger if they're needed but otherwise remove themselves from the
 suite (you can run the {\em AutoRecover.async} example suite to see how
 this works).  The dashed graph edges ending in solid dots indicate
 suicide triggers, and the open arrowheads indicate conditional triggers
-as usual.
+as usual. Note as default the suicide triggers are ignored in the graphing. 
+Under {\em View}, {\em Options} you can select to toggle 
+{\em Ignore Suicide Triggers}.
 
 \begin{figure}
 \begin{minipage}[b]{0.5\textwidth}

--- a/lib/cylc/cylc_xdot.py
+++ b/lib/cylc/cylc_xdot.py
@@ -265,7 +265,7 @@ class MyDotWindow( CylcDotViewerCommon ):
     '''
     def __init__(self, suite, suiterc, start_point_string, stop_point_string,
             template_vars, template_vars_file, orientation="TB",
-            subgraphs_on=False, should_hide=False):
+            subgraphs_on=False, ignore_suicide=True, should_hide=False):
         self.outfile = None
         self.disable_output_image = False
         self.suite = suite
@@ -275,7 +275,7 @@ class MyDotWindow( CylcDotViewerCommon ):
         self.subgraphs_on = subgraphs_on
         self.template_vars = template_vars
         self.template_vars_file = template_vars_file
-        self.ignore_suicide = False
+        self.ignore_suicide = ignore_suicide
         self.start_point_string = start_point_string
         self.stop_point_string = stop_point_string
         self.filter_recs = []
@@ -359,6 +359,10 @@ class MyDotWindow( CylcDotViewerCommon ):
             '/ToolBar/Subgraphs')
         subgraphs_toolitem.set_active(self.subgraphs_on)
 
+        igsui_toolitem = uimanager.get_widget(
+            '/ToolBar/IgnoreSuicide')
+        igsui_toolitem.set_active(self.ignore_suicide)
+
         # Create a Toolbar
 
         toolbar = uimanager.get_widget('/ToolBar')
@@ -384,6 +388,8 @@ class MyDotWindow( CylcDotViewerCommon ):
 
     def get_graph( self, group_nodes=[], ungroup_nodes=[],
             ungroup_recursive=False, ungroup_all=False, group_all=False ):
+        if not self.suiterc:
+            return
         family_nodes = self.suiterc.get_first_parent_descendants().keys()
         graphed_family_nodes = self.suiterc.triggering_families
         suite_polling_tasks = self.suiterc.suite_polling_tasks

--- a/lib/cylc/gui/updater_graph.py
+++ b/lib/cylc/gui/updater_graph.py
@@ -60,7 +60,7 @@ class GraphUpdater(threading.Thread):
 
         self.quit = False
         self.cleared = False
-        self.ignore_suicide = False
+        self.ignore_suicide = True
         self.focus_start_point_string = None
         self.focus_stop_point_string = None
         self.xdot = xdot

--- a/tests/graphing/05-suicide-family.t
+++ b/tests/graphing/05-suicide-family.t
@@ -18,7 +18,7 @@
 # Test that a suicide-triggered family plots as a collapsed family node (#1526).
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
-set_test_number 2
+set_test_number 3
 #-------------------------------------------------------------------------------
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
@@ -27,5 +27,8 @@ run_ok $TEST_NAME cylc validate "$SUITE_NAME"
 #-------------------------------------------------------------------------------
 graph_suite $SUITE_NAME graph.plain
 cmp_ok graph.plain $TEST_SOURCE_DIR/$TEST_NAME_BASE/graph.plain.ref
+#-------------------------------------------------------------------------------
+graph_suite $SUITE_NAME graph.plain.suicide --show-suicide
+cmp_ok graph.plain.suicide $TEST_SOURCE_DIR/$TEST_NAME_BASE/graph.plain.suicide.ref
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/graphing/05-suicide-family/graph.plain.ref
+++ b/tests/graphing/05-suicide-family/graph.plain.ref
@@ -1,5 +1,2 @@
-edge "foo.1" "BAR.1" dashed
 graph
-node "BAR.1" "BAR\n1" unfilled doubleoctagon black
-node "foo.1" "foo\n1" unfilled box black
 stop

--- a/tests/graphing/05-suicide-family/graph.plain.suicide.ref
+++ b/tests/graphing/05-suicide-family/graph.plain.suicide.ref
@@ -1,0 +1,5 @@
+edge "foo.1" "BAR.1" dashed
+graph
+node "BAR.1" "BAR\n1" unfilled doubleoctagon black
+node "foo.1" "foo\n1" unfilled box black
+stop


### PR DESCRIPTION
Hides the suicide triggers with cylc gcylc and cylc graph.
Option --show-graph for cylc graph so that it opens with the graph displaying.