### PR TITLE
tests: improve messages

### DIFF
--- a/tests/authentication/00-identity.t
+++ b/tests/authentication/00-identity.t
@@ -42,7 +42,7 @@ mv "${TEST_DIR}/${SUITE_NAME}/passphrase" \
 
 # Check scan output.
 PORT=$(cylc ping -v "${SUITE_NAME}" | awk '{print $4}')
-cylc scan -fb -n "${SUITE_NAME}" localhost > scan.out
+cylc scan -fb -n "${SUITE_NAME}" 'localhost' >'scan.out' 2>'/dev/null'
 cmp_ok scan.out << __END__
 ${SUITE_NAME} ${USER}@localhost:${PORT}
    (description and state totals withheld)

--- a/tests/authentication/01-description.t
+++ b/tests/authentication/01-description.t
@@ -42,7 +42,7 @@ mv "${TEST_DIR}/${SUITE_NAME}/passphrase" \
 
 # Check scan output.
 PORT=$(cylc ping -v "${SUITE_NAME}" | awk '{print $4}')
-cylc scan -fb -n "${SUITE_NAME}" localhost > scan.out
+cylc scan -fb -n "${SUITE_NAME}" 'localhost' >'scan.out' 2>'/dev/null'
 cmp_ok scan.out << __END__
 ${SUITE_NAME} ${USER}@localhost:${PORT}
    Title:

--- a/tests/authentication/02-state-totals.t
+++ b/tests/authentication/02-state-totals.t
@@ -42,7 +42,7 @@ mv "${TEST_DIR}/${SUITE_NAME}/passphrase" \
 
 # Check scan output.
 PORT=$(cylc ping -v "${SUITE_NAME}" | awk '{print $4}')
-cylc scan -fb -n "${SUITE_NAME}" localhost > scan.out
+cylc scan -fb -n "${SUITE_NAME}" 'localhost' >'scan.out' 2>'/dev/null'
 cmp_ok scan.out << __END__
 ${SUITE_NAME} ${USER}@localhost:${PORT}
    Title:

--- a/tests/authentication/03-full-read.t
+++ b/tests/authentication/03-full-read.t
@@ -42,7 +42,7 @@ mv "${TEST_DIR}/${SUITE_NAME}/passphrase" \
 
 # Check scan output.
 PORT=$(cylc ping -v "${SUITE_NAME}" | awk '{print $4}')
-cylc scan -fb -n "${SUITE_NAME}" localhost > scan.out
+cylc scan -fb -n "${SUITE_NAME}" 'localhost' >'scan.out' 2>'/dev/null'
 cmp_ok scan.out << __END__
 ${SUITE_NAME} ${USER}@localhost:${PORT}
    Title:

--- a/tests/authentication/04-shutdown.t
+++ b/tests/authentication/04-shutdown.t
@@ -40,7 +40,7 @@ mv "${TEST_DIR}/${SUITE_NAME}/passphrase" \
     "${TEST_DIR}/${SUITE_NAME}/passphrase.DIS"
 
 PORT=$(cylc ping -v "${SUITE_NAME}" | awk '{print $4}')
-cylc scan -fb -n "${SUITE_NAME}" localhost > scan.out
+cylc scan -fb -n "${SUITE_NAME}" 'localhost' >'scan.out' 2>'/dev/null'
 cmp_ok scan.out << __END__
 ${SUITE_NAME} ${USER}@localhost:${PORT}
    Title:

--- a/tests/authentication/05-full-control.t
+++ b/tests/authentication/05-full-control.t
@@ -39,7 +39,7 @@ cylc suite-state "${SUITE_NAME}" --task=foo --status=failed --cycle=1 \
 
 # Check scan output.
 PORT=$(cylc ping -v "${SUITE_NAME}" | awk '{print $4}')
-cylc scan -fb -n "${SUITE_NAME}" localhost > scan.out
+cylc scan -fb -n "${SUITE_NAME}" 'localhost' >'scan.out' 2>'/dev/null'
 cmp_ok scan.out << __END__
 ${SUITE_NAME} ${USER}@localhost:${PORT}
    Title:

--- a/tests/authentication/06-suite-override.t
+++ b/tests/authentication/06-suite-override.t
@@ -41,7 +41,7 @@ mv "${TEST_DIR}/${SUITE_NAME}/passphrase" \
     "${TEST_DIR}/${SUITE_NAME}/passphrase.DIS"
 
 PORT=$(cylc ping -v "${SUITE_NAME}" | awk '{print $4}')
-cylc scan -fb -n "${SUITE_NAME}" localhost > scan.out
+cylc scan -fb -n "${SUITE_NAME}" 'localhost' >'scan.out' 2>'/dev/null'
 cmp_ok scan.out << __END__
 ${SUITE_NAME} ${USER}@localhost:${PORT}
    Title:

--- a/tests/authentication/07-back-compat.t
+++ b/tests/authentication/07-back-compat.t
@@ -29,7 +29,8 @@ cylc run "${SUITE_NAME}"
 # Scan to grab the suite's port.
 sleep 5  # Wait for the suite to initialize.
 TEST_NAME="${TEST_NAME_BASE}-new-scan"
-PORT=$(cylc scan -b -n $SUITE_NAME localhost | sed -e 's/.*@localhost://')
+PORT=$(cylc scan -b -n $SUITE_NAME 'localhost' 2>'/dev/null' \
+    | sed -e 's/.*@localhost://')
 
 # Simulate an old client with the wrong passphrase.
 ERR_PATH="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/log/suite/err"

--- a/tests/cylc-cat-log/01-remote.t
+++ b/tests/cylc-cat-log/01-remote.t
@@ -21,7 +21,7 @@
 RC_ITEM='[test battery]remote host'
 export CYLC_TEST_HOST=$(cylc get-global-config -i "${RC_ITEM}" 2>'/dev/null')
 if [[ -z $CYLC_TEST_HOST ]]; then
-    skip_all '[test battery]remote host: not defined'
+    skip_all '"[test battery]remote host": not defined'
 fi
 set_test_number 14
 export CYLC_CONF_PATH=

--- a/tests/cylc-cat-log/02-remote-custom-runtime-viewer-pbs.t
+++ b/tests/cylc-cat-log/02-remote-custom-runtime-viewer-pbs.t
@@ -22,12 +22,12 @@ RC_PREF='[test battery][batch systems][pbs]'
 export CYLC_TEST_HOST="$( \
     cylc get-global-config -i "${RC_PREF}host" 2>'/dev/null')"
 if [[ -z "${CYLC_TEST_HOST}" ]]; then
-    skip_all '[test battery][batch systems][pbs]host: not defined'
+    skip_all '"[test battery][batch systems][pbs]host": not defined'
 fi
 ERR_VIEWER="$(cylc get-global-config -i "${RC_PREF}err viewer" 2>'/dev/null')"
 OUT_VIEWER="$(cylc get-global-config -i "${RC_PREF}out viewer" 2>'/dev/null')"
 if [[ -z "${ERR_VIEWER}" || -z "${OUT_VIEWER}" ]]; then
-    skip_all "[test battery][pbs]* viewer: not defined"
+    skip_all '"[test battery][pbs]* viewer": not defined'
 fi
 export CYLC_TEST_DIRECTIVES="$( \
     cylc get-global-config -i "${RC_PREF}[directives]" 2>'/dev/null')"

--- a/tests/cylc-cat-log/05-remote-tail.t
+++ b/tests/cylc-cat-log/05-remote-tail.t
@@ -21,7 +21,7 @@
 CYLC_TEST_HOST="$( \
     cylc get-global-config -i '[test battery]remote host' 2>'/dev/null')"
 if [[ -z "${CYLC_TEST_HOST}" ]]; then
-    skip_all '[test battery]remote host: not defined'
+    skip_all '"[test battery]remote host": not defined'
 fi
 export CYLC_TEST_HOST
 set_test_number 4

--- a/tests/cylc-kill/00-kill-multi-hosts.t
+++ b/tests/cylc-kill/00-kill-multi-hosts.t
@@ -20,7 +20,7 @@
 export CYLC_TEST_HOST=$(
     cylc get-global-config -i '[test battery]remote host' 2>'/dev/null')
 if [[ -z "${CYLC_TEST_HOST}" ]]; then
-    skip_all '[test battery]remote host: not defined'
+    skip_all '"[test battery]remote host": not defined'
 fi
 
 set_test_number 3

--- a/tests/cylc-message/00-ssh.t
+++ b/tests/cylc-message/00-ssh.t
@@ -22,7 +22,7 @@
 CYLC_TEST_HOST="$( \
     cylc get-global-config -i '[test battery]remote host' 2>'/dev/null')"
 if [[ -z "${CYLC_TEST_HOST}" ]]; then
-    skip_all '[test battery]remote host: not defined'
+    skip_all '"[test battery]remote host": not defined'
 fi
 set_test_number 3
 

--- a/tests/cylc-poll/04-poll-multi-hosts.t
+++ b/tests/cylc-poll/04-poll-multi-hosts.t
@@ -20,7 +20,7 @@
 export CYLC_TEST_HOST=$( \
     cylc get-global-config -i '[test battery]remote host' 2>'/dev/null')
 if [[ -z "${CYLC_TEST_HOST}" ]]; then
-    skip_all '[test battery]remote host: not defined'
+    skip_all '"[test battery]remote host": not defined'
 fi
 
 set_test_number 3

--- a/tests/cylc-submit/00-bg.t
+++ b/tests/cylc-submit/00-bg.t
@@ -27,7 +27,7 @@ if [[ "${TEST_NAME_BASE}" == *remote* ]]; then
     RC_ITEM="[test battery]${CONF_KEY}"
     HOST="$(cylc get-global-config "--item=${RC_ITEM}" 2>'/dev/null')"
     if [[ -z "${HOST}" ]]; then
-        skip_all "[test battery]${CONF_KEY} not set"
+        skip_all "\"[test battery]${CONF_KEY}\" not set"
     fi
     CYLC_TEST_HOST="${HOST}"
 fi
@@ -48,7 +48,7 @@ if [[ -n "${CONFIGURED_SYS_NAME}" ]]; then
     CYLC_TEST_HOST="$( \
         cylc get-global-config "--item=${ITEM_KEY}" 2>'/dev/null')"
     if [[ -z "${CYLC_TEST_HOST}" ]]; then
-        skip_all "${ITEM_KEY} not set"
+        skip_all "\"${ITEM_KEY}\" not set"
     fi
     ITEM_KEY="[test battery][batch systems][$CONFIGURED_SYS_NAME][directives]"
     CYLC_TEST_DIRECTIVES="$( \

--- a/tests/database/03-remote.t
+++ b/tests/database/03-remote.t
@@ -20,7 +20,7 @@
 export CYLC_TEST_HOST=$( \
     cylc get-global-config -i '[test battery]remote host' 2>'/dev/null')
 if [[ -z "${CYLC_TEST_HOST}" ]]; then
-    skip_all '[test battery]remote host: not defined'
+    skip_all '"[test battery]remote host": not defined'
 fi
 set_test_number 3
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"

--- a/tests/directives/00-loadleveler.t
+++ b/tests/directives/00-loadleveler.t
@@ -31,12 +31,12 @@ export CYLC_TEST_BATCH_SITE_DIRECTIVES=$( \
     cylc get-global-config -i "${RC_PREF}[directives]" 2>'/dev/null')
 if [[ -z "${CYLC_TEST_BATCH_TASK_HOST}" || "${CYLC_TEST_BATCH_TASK_HOST}" == None ]]
 then
-    skip_all "[directive tests]$BATCH_SYS_NAME host not defined"
+    skip_all "\"[test battery][batch systems][$BATCH_SYS_NAME]host\" not defined"
 fi
 # check the host is reachable
 if ! ssh -n ${SSH_OPTS} "${CYLC_TEST_BATCH_TASK_HOST}" true 1>/dev/null 2>&1
 then
-    skip_all "Host "$CYLC_TEST_BATCH_TASK_HOST" unreachable"
+    skip_all "Host \"$CYLC_TEST_BATCH_TASK_HOST\" unreachable"
 fi
 
 set_test_number 2

--- a/tests/documentation/00-make.t
+++ b/tests/documentation/00-make.t
@@ -19,7 +19,7 @@
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 if [[ ! -w $CYLC_DIR/doc ]]; then
-    skip_all '$CYLC_DIR/doc: not writable'
+    skip_all '"$CYLC_DIR/doc": not writable'
 fi
 #-------------------------------------------------------------------------------
 set_test_number 1

--- a/tests/events/10-task-event-job-logs-retrieve.t
+++ b/tests/events/10-task-event-job-logs-retrieve.t
@@ -20,7 +20,7 @@
 . "$(dirname "$0")/test_header"
 HOST=$(cylc get-global-config -i '[test battery]remote host' 2>'/dev/null')
 if [[ -z "${HOST}" ]]; then
-    skip_all '[test battery]remote host: not defined'
+    skip_all '"[test battery]remote host": not defined'
 fi
 set_test_number 5
 OPT_SET=

--- a/tests/events/11-cycle-task-event-job-logs-retrieve.t
+++ b/tests/events/11-cycle-task-event-job-logs-retrieve.t
@@ -20,7 +20,7 @@
 . "$(dirname "$0")/test_header"
 HOST=$(cylc get-global-config -i '[test battery]remote host' 2>'/dev/null')
 if [[ -z "${HOST}" ]]; then
-    skip_all '[test battery]remote host: not defined'
+    skip_all '"[test battery]remote host": not defined'
 fi
 set_test_number 4
 export CYLC_CONF_PATH=

--- a/tests/events/15-host-task-event-handler-retry-globalcfg.t
+++ b/tests/events/15-host-task-event-handler-retry-globalcfg.t
@@ -19,7 +19,7 @@
 . "$(dirname "$0")/test_header"
 HOST=$(cylc get-global-config -i '[test battery]remote host' 2>'/dev/null')
 if [[ -z "${HOST}" ]]; then
-    skip_all '[test battery]remote host: not defined'
+    skip_all '"[test battery]remote host": not defined'
 fi
 set_test_number 4
 

--- a/tests/job-kill/01-remote.t
+++ b/tests/job-kill/01-remote.t
@@ -21,7 +21,7 @@
 export CYLC_TEST_HOST=$( \
     cylc get-global-config -i '[test battery]remote host' 2>'/dev/null')
 if [[ -z $CYLC_TEST_HOST ]]; then
-    skip_all '[test battery]remote host: not defined'
+    skip_all '"[test battery]remote host": not defined'
 fi
 N_TESTS=3
 set_test_number $N_TESTS

--- a/tests/job-kill/02-loadleveler.t
+++ b/tests/job-kill/02-loadleveler.t
@@ -31,7 +31,7 @@ fi
 # check the host is reachable
 if ! ssh -n ${SSH_OPTS} "${CYLC_TEST_BATCH_TASK_HOST}" true 1>/dev/null 2>&1
 then
-    skip_all "Host "$CYLC_TEST_BATCH_TASK_HOST" unreachable"
+    skip_all "Host \"$CYLC_TEST_BATCH_TASK_HOST\" unreachable"
 fi
 set_test_number 2
 

--- a/tests/job-submission/02-job-nn-remote-host.t
+++ b/tests/job-submission/02-job-nn-remote-host.t
@@ -21,7 +21,7 @@
 export CYLC_TEST_HOST=$( \
     cylc get-global-config -i '[test battery]remote host' 2>'/dev/null')
 if [[ -z "$CYLC_TEST_HOST" ]]; then
-    skip_all '[test battery]remote host: not defined'
+    skip_all '"[test battery]remote host": not defined'
 fi
 set_test_number 2
 #-------------------------------------------------------------------------------

--- a/tests/job-submission/03-job-nn-remote-host-with-shared-fs.t
+++ b/tests/job-submission/03-job-nn-remote-host-with-shared-fs.t
@@ -22,7 +22,7 @@ export CYLC_TEST_HOST=$( \
     cylc get-global-config -i '[test battery]remote host with shared fs' \
     2>'/dev/null')
 if [[ -z "$CYLC_TEST_HOST" ]]; then
-    skip_all '[test battery]remote host with shared fs: not defined'
+    skip_all '"[test battery]remote host with shared fs": not defined'
 fi
 set_test_number 2
 #-------------------------------------------------------------------------------

--- a/tests/job-submission/07-multi.t
+++ b/tests/job-submission/07-multi.t
@@ -20,7 +20,7 @@
 CYLC_TEST_HOST="$( \
     cylc get-global-config -i '[test battery]remote host' 2>'/dev/null')"
 if [[ -z "${CYLC_TEST_HOST}" ]]; then
-    skip_all '[test battery]remote host: not defined'
+    skip_all '"[test battery]remote host": not defined'
 fi
 set_test_number 3
 

--- a/tests/restart/13-bad-job-host.t
+++ b/tests/restart/13-bad-job-host.t
@@ -21,7 +21,7 @@
 export CYLC_TEST_HOST=$( \
     cylc get-global-config -i '[test battery]remote host' 2>'/dev/null')
 if [[ -z "${CYLC_TEST_HOST}" ]]; then
-    skip_all '[test battery]remote host: not defined'
+    skip_all '"[test battery]remote host": not defined'
 fi
 set_test_number 3
 install_suite "${TEST_NAME_BASE}" bad-job-host

--- a/tests/vacation/01-loadleveler.t
+++ b/tests/vacation/01-loadleveler.t
@@ -25,7 +25,7 @@ RC_PREV="[test battery][batch systems][loadleveler]"
 export CYLC_TEST_HOST=$( \
     cylc get-global-config -i "${RC_PREV}host" 2>'/dev/null')
 if [[ -z $CYLC_TEST_HOST ]]; then
-    skip_all '[test battery][batch systems][loadleveler]host: not defined'
+    skip_all '"[test battery][batch systems][loadleveler]host": not defined'
 fi
 set_test_number 6
 export CYLC_TEST_DIRECTIVES=$( \


### PR DESCRIPTION
Use quotes consistently around configuration settings for skip-all messages.
Remove random "Suite initializing..." messages.

@hjoliver please review. (2nd review not necessary?)