### PR TITLE
cylc.job_host: more diagnostics on init failure

### DIFF
--- a/doc/cug.tex
+++ b/doc/cug.tex
@@ -1361,6 +1361,10 @@ For remote task hosting to work several requirements must be satisfied:
 \item Passwordless ssh must be enabled from the suite host account to
 the task host account, for task job submission.
 
+\item Your shell initialization (.profile, .bashrc, .cshrc, etc) on the remote
+host must not produce any standard output as it may confuse commands such as
+scp. See \url{http://www.openssh.com/faq.html#2.9} for more information.
+
 \item Networking settings must allow communication {\em back} from
 the task host to the suite host, either by network ports (Pyro) or ssh,
 unless the last-resort one way {\em task polling} communication method
@@ -4343,6 +4347,12 @@ For this to work,
 \begin{myitemize}
     \item passwordless ssh must be configured between the suite and task
     host accounts.
+
+    \item Your shell initialization (.profile, .bashrc, .cshrc, etc) on the
+    remote host must not produce any standard output as it may confuse commands
+    such as scp. See \url{http://www.openssh.com/faq.html#2.9} for more
+    information.
+
     \item cylc must be installed on task hosts so that remote tasks can
     use cylc messaging and poll or kill commands.
     \begin{myitemize}

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -279,7 +279,7 @@ class scheduler(object):
                 RemoteJobHostManager.get_inst().init_suite_run_dir(
                     self.suite, user_at_host)
             except RemoteJobHostInitError as exc:
-                self.log.warning(str(exc))
+                self.log.error(str(exc))
 
         self.already_timed_out = False
         if self.config.cfg['cylc']['event hooks']['timeout']:

--- a/tests/restart/bad-job-host/suite.rc
+++ b/tests/restart/bad-job-host/suite.rc
@@ -33,6 +33,6 @@ rm -f "${CYLC_SUITE_WORK_DIR}/${CYLC_TASK_CYCLE_POINT}/t-remote/file"
             host = {{environ['CYLC_TEST_HOST']}}
     [[t-check-log]]
         script = """
-timeout 30 grep -q 'ERROR - garbage: initialisation did not complete' \
+grep -q 'ERROR - garbage: initialisation did not complete' \
     "${CYLC_SUITE_LOG_DIR}/log"
 """

--- a/tests/restart/bad-job-host/suite.rc
+++ b/tests/restart/bad-job-host/suite.rc
@@ -1,4 +1,8 @@
 #!jinja2
+[cylc]
+    [[event hooks]]
+        timeout = PT2M
+        abort on timeout = True
 [scheduling]
     [[dependencies]]
             graph = """
@@ -29,6 +33,6 @@ rm -f "${CYLC_SUITE_WORK_DIR}/${CYLC_TASK_CYCLE_POINT}/t-remote/file"
             host = {{environ['CYLC_TEST_HOST']}}
     [[t-check-log]]
         script = """
-grep -q 'WARNING - garbage: initialisation did not complete' \
+timeout 30 grep -q 'ERROR - garbage: initialisation did not complete' \
     "${CYLC_SUITE_LOG_DIR}/log"
 """


### PR DESCRIPTION
~~Address~~ Close #1669. On failure to initialise the suite run directory of remote a job host, it should now print out the failed command, its return code, and its standard output/error.