### PR TITLE
Fix cylc-graph right-click menu (missing gtk import).

### DIFF
--- a/bin/cylc-graph
+++ b/bin/cylc-graph
@@ -69,6 +69,16 @@ import cylc.flags
 from cylc.remote import remrun
 from cylc.task_id import TaskID
 
+try:
+    import gtk
+    import gobject
+    from xdot import DotWindow
+    from cylc.cylc_xdot import (
+        MyDotWindow, MyDotWindow2, get_reference_from_plain_format)
+except ImportError as exc:
+    # Allow command help generation without a graphical environment.
+    print >> sys.stderr, 'WARNING: no X environment? %s' % exc
+
 if remrun().execute():
     sys.exit(0)
 
@@ -185,15 +195,6 @@ def main():
         action="store_true", default=False, dest="show_suicide")
 
     (options, args) = parser.parse_args()
-
-    # import modules that require gtk now, so that a display is not needed
-    # just to get command help (e.g. when running make on a post-commit hook
-    # on a remote repository).
-    import gtk
-    import gobject
-    from xdot import DotWindow
-    from cylc.cylc_xdot import (
-        MyDotWindow, MyDotWindow2, get_reference_from_plain_format)
 
     if options.filename:
         if len(args) != 0:


### PR DESCRIPTION
I stupidly broke the graph viewer right-click menu with #1646.  This restores it.

@matthewrmshin - please review 1.  Let me know if you think there's a better way to handle this problem, which is: we need to be able to generate command help even if gtk is not available (e.g. for 'make' in non-GUI environments).  The way I've done it here results in the following error if you try to view a graph without gtk etc. installed:
```
 cylc graph foo
WARNING: no X environment? No module named gtk
global name 'MyDotWindow' is not defined
```