### PR TITLE
Sort task names in the text-based monitor.

### DIFF
--- a/bin/cylc-monitor
+++ b/bin/cylc-monitor
@@ -67,6 +67,11 @@ A terminal-based live suite monitor.  Exit with 'Ctrl-C'.""",
             action="store_true", default=False, dest="once")
 
         self.parser.add_option(
+            "-s", "--sort",
+            help="Sort task names under each cycle point.",
+            action="store_true", default=False, dest="sort_columns")
+
+        self.parser.add_option(
             "-u", "--runahead",
             help="Display task proxies in the runahead pool (off by default).",
             action="store_true", default=False, dest="display_runahead")
@@ -205,6 +210,10 @@ A terminal-based live suite monitor.  Exit with 'Ctrl-C'.""",
                                 line += " %s" % val[name]
                             else:
                                 line += " %s" % (' ' * len(name))
+                    elif options.sort_columns:
+                        for name in sorted(name_list):
+                            if name in val:
+                                line += " %s" % val[name]
                     else:
                         for name, info in val.items():
                             line += " %s" % info

--- a/bin/cylc-monitor
+++ b/bin/cylc-monitor
@@ -67,11 +67,6 @@ A terminal-based live suite monitor.  Exit with 'Ctrl-C'.""",
             action="store_true", default=False, dest="once")
 
         self.parser.add_option(
-            "-s", "--sort",
-            help="Sort task names under each cycle point.",
-            action="store_true", default=False, dest="sort_columns")
-
-        self.parser.add_option(
             "-u", "--runahead",
             help="Display task proxies in the runahead pool (off by default).",
             action="store_true", default=False, dest="display_runahead")
@@ -204,19 +199,14 @@ A terminal-based live suite monitor.  Exit with 'Ctrl-C'.""",
                     indx = point_str
                     line = "%s%s%s" % (
                         '\033[1;34m', point_str, task_state.ctrl_end)
-                    if options.align_columns:
-                        for name in sorted(name_list):
-                            if name in val:
-                                line += " %s" % val[name]
-                            else:
+
+                    for name in sorted(name_list):
+                        try:
+                            line += " %s" % val[name]
+                        except KeyError:
+                            if options.align_columns:
                                 line += " %s" % (' ' * len(name))
-                    elif options.sort_columns:
-                        for name in sorted(name_list):
-                            if name in val:
-                                line += " %s" % val[name]
-                    else:
-                        for name, info in val.items():
-                            line += " %s" % info
+
                     blitlines[indx] = line
 
                 if not options.once:


### PR DESCRIPTION
The current align-column option is only useful for small suites, but for
larger suites using the monitor the current list of tasks is presented in
a non-intuitive order.  This changeset allows a command-line option to
sort the names of the task proxies (using standard Python string sort order)
before displaying in the text-based `cylc monitor`.

I'd really like it if the normal behavior was to have the sort turned on, but my goal with this initial PR is to create as minimal a change as required to test the functionality and get it merged.  There will be no arguments from me if the developers want to have this enabled by default!

It looks like the documentation gets automatically updated based on the help string, but please let me know if this change needs to be propagated elsewhere.