### PR TITLE
Improve robustness on write to NN/job-activity.log

### DIFF
--- a/lib/cylc/batch_sys_manager.py
+++ b/lib/cylc/batch_sys_manager.py
@@ -513,12 +513,17 @@ class BatchSysManager(object):
 
         """
         job_file_dir = os.path.dirname(job_file_path)
+        source = os.path.basename(job_file_dir)
         nn_path = os.path.join(os.path.dirname(job_file_dir), "NN")
         try:
-            os.unlink(nn_path)
+            old_source = os.readlink(nn_path)
         except OSError:
-            pass
-        os.symlink(os.path.basename(job_file_dir), nn_path)
+            old_source = None
+        if old_source is not None and old_source != source:
+            os.unlink(nn_path)
+            old_source = None
+        if old_source is None:
+            os.symlink(source, nn_path)
 
     def _filter_submit_output(self, st_file_path, batch_sys, out, err):
         """Filter submit command output, if relevant."""

--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -466,8 +466,11 @@ class TaskProxy(object):
         job_log_dir = self.get_job_log_dir(
             self.tdef.name, self.point, submit_num, self.suite_name)
         job_activity_log = os.path.join(job_log_dir, "job-activity.log")
-        with open(job_activity_log, "ab") as handle:
-            handle.write(ctx_str)
+        try:
+            with open(job_activity_log, "ab") as handle:
+                handle.write(ctx_str)
+        except IOError:
+            pass
         if ctx.cmd and ctx.ret_code:
             self.log(ERROR, ctx_str)
         elif ctx.cmd:
@@ -856,10 +859,13 @@ class TaskProxy(object):
         job_log_dir = self.get_job_log_dir(
             self.tdef.name, self.point, "NN", self.suite_name)
         job_activity_log = os.path.join(job_log_dir, "job-activity.log")
-        with open(job_activity_log, "ab") as handle:
-            if not line.endswith("\n"):
-                line += "\n"
-            handle.write(line)
+        try:
+            with open(job_activity_log, "ab") as handle:
+                if not line.endswith("\n"):
+                    line += "\n"
+                handle.write(line)
+        except IOError:
+            pass
 
     def setup_event_handlers(
             self, event, message, db_update=True, db_event=None, db_msg=None):

--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -469,8 +469,8 @@ class TaskProxy(object):
         try:
             with open(job_activity_log, "ab") as handle:
                 handle.write(ctx_str)
-        except IOError:
-            pass
+        except IOError as exc:
+            self.log(WARNING, "%s: write failed\n%s" % (job_activity_log, exc))
         if ctx.cmd and ctx.ret_code:
             self.log(ERROR, ctx_str)
         elif ctx.cmd:
@@ -864,8 +864,8 @@ class TaskProxy(object):
                 if not line.endswith("\n"):
                     line += "\n"
                 handle.write(line)
-        except IOError:
-            pass
+        except IOError as exc:
+            self.log(WARNING, "%s: write failed\n%s" % (job_activity_log, exc))
 
     def setup_event_handlers(
             self, event, message, db_update=True, db_event=None, db_msg=None):


### PR DESCRIPTION
On a very slow share file system, suite daemon may be writing to the job
activity log while the NN link is being recreated by job submission.
This could bring down a suite. This chnage makes this less likely:
* NN link is now only recreated if necessary.
* Failing to write to the `job-activity.log` will no longer bring down
  the suite.