### PR TITLE
cylc monitor - sort by alphanumeric or definition order.

### DIFF
--- a/bin/cylc-monitor
+++ b/bin/cylc-monitor
@@ -39,6 +39,7 @@ from cylc.registration import localdb
 from cylc.network.suite_state import (
     StateSummaryClient, SuiteStillInitialisingError)
 from cylc.wallclock import get_time_string_from_unix_time
+from cylc.cfgspec.globalcfg import GLOBAL_CFG
 
 
 class SuiteMonitor(object):
@@ -62,12 +63,20 @@ A terminal-based live suite monitor.  Exit with 'Ctrl-C'.""",
             "line still represents all task proxies.",
             action="store_true", default=False, dest="restricted")
 
+        if GLOBAL_CFG.get(["monitor", "sort by definition order"]):
+            self.default_sort = "definition"
+            self.other_sort = "alphanumeric"
+        else:
+            self.default_sort = "alphanumeric"
+            self.other_sort = "definition"
+
         self.parser.add_option(
             "-s", "--sort",
-            help="Sort tasks into alphanumeric order. The default is "
-            "definition order (i.e. the order tasks are defined under "
-            "[runtime] in the suite definition.",
-            action="store_true", default=False, dest="sort_alphanumeric")
+            help="Sort tasks into " + self.other_sort + " order. "
+            "The default is " + self.default_sort + " order, as specified by "
+            "global config. (Definition order is the order that tasks appear "
+            "under [runtime] in the suite definition).",
+            action="store_true", default=False, dest="alt_sort")
 
         self.parser.add_option(
             "-o", "--once",
@@ -155,11 +164,17 @@ A terminal-based live suite monitor.  Exit with 'Ctrl-C'.""",
                     task_info[point_string][name] = "%s%s%s" % (
                         task_state.ctrl[state], name, task_state.ctrl_end)
 
-                # Put each cycle point's tasks in alphanumeric order.
-                if options.sort_alphanumeric:
+                # Sort the tasks in each cycle point.
+                if options.alt_sort:
+                    sort_order = self.other_sort
+                else:
+                    sort_order = self.default_sort
+
+                if sort_order == "alphanumeric":
                     sorted_name_list = sorted(name_list)
                 else:
                     sorted_name_list = ns_defn_order
+
                 sorted_task_info = {}
                 for point_str, info in task_info.items():
                     sorted_task_info[point_str] = OrderedDict()

--- a/bin/cylc-monitor
+++ b/bin/cylc-monitor
@@ -63,20 +63,15 @@ A terminal-based live suite monitor.  Exit with 'Ctrl-C'.""",
             "line still represents all task proxies.",
             action="store_true", default=False, dest="restricted")
 
-        if GLOBAL_CFG.get(["monitor", "sort by definition order"]):
-            self.default_sort = "definition"
-            self.other_sort = "alphanumeric"
-        else:
-            self.default_sort = "alphanumeric"
-            self.other_sort = "definition"
+        def_sort_order = GLOBAL_CFG.get(["monitor", "sort order"])
 
         self.parser.add_option(
-            "-s", "--sort",
-            help="Sort tasks into " + self.other_sort + " order. "
-            "The default is " + self.default_sort + " order, as specified by "
+            "-s", "--sort", metavar="ORDER",
+            help="Task sort order: \"definition\" or \"alphanumeric\"."
+            "The default is " + def_sort_order + " order, as determined by "
             "global config. (Definition order is the order that tasks appear "
             "under [runtime] in the suite definition).",
-            action="store_true", default=False, dest="alt_sort")
+            action="store", default=def_sort_order, dest="sort_order")
 
         self.parser.add_option(
             "-o", "--once",
@@ -165,12 +160,7 @@ A terminal-based live suite monitor.  Exit with 'Ctrl-C'.""",
                         task_state.ctrl[state], name, task_state.ctrl_end)
 
                 # Sort the tasks in each cycle point.
-                if options.alt_sort:
-                    sort_order = self.other_sort
-                else:
-                    sort_order = self.default_sort
-
-                if sort_order == "alphanumeric":
+                if options.sort_order == "alphanumeric":
                     sorted_name_list = sorted(name_list)
                 else:
                     sorted_name_list = ns_defn_order

--- a/bin/cylc-monitor
+++ b/bin/cylc-monitor
@@ -32,6 +32,7 @@ import os
 import re
 from time import sleep
 
+from parsec.OrderedDict import OrderedDict
 from cylc.CylcOptionParsers import cop
 from cylc.task_state import task_state
 from cylc.registration import localdb
@@ -60,6 +61,13 @@ A terminal-based live suite monitor.  Exit with 'Ctrl-C'.""",
             "This may be needed for very large suites. The state summary "
             "line still represents all task proxies.",
             action="store_true", default=False, dest="restricted")
+
+        self.parser.add_option(
+            "-s", "--sort",
+            help="Sort tasks into alphanumeric order. The default is "
+            "definition order (i.e. the order tasks are defined under "
+            "[runtime] in the suite definition.",
+            action="store_true", default=False, dest="sort_alphanumeric")
 
         self.parser.add_option(
             "-o", "--once",
@@ -132,6 +140,7 @@ A terminal-based live suite monitor.  Exit with 'Ctrl-C'.""",
                 stopping = glbl['stopping']
                 will_pause_at = glbl['will_pause_at']
                 will_stop_at = glbl['will_stop_at']
+                ns_defn_order = glbl['namespace definition order']
 
                 task_info = {}
                 name_list = set()
@@ -145,6 +154,19 @@ A terminal-based live suite monitor.  Exit with 'Ctrl-C'.""",
                         task_info[point_string] = {}
                     task_info[point_string][name] = "%s%s%s" % (
                         task_state.ctrl[state], name, task_state.ctrl_end)
+
+                # Put each cycle point's tasks in alphanumeric order.
+                if options.sort_alphanumeric:
+                    sorted_name_list = sorted(name_list)
+                else:
+                    sorted_name_list = ns_defn_order
+                sorted_task_info = {}
+                for point_str, info in task_info.items():
+                    sorted_task_info[point_str] = OrderedDict()
+                    for name in sorted_name_list:
+                        if name in name_list:
+                            # (Defn order includes family names.).
+                            sorted_task_info[point_str][name] = info.get(name)
 
                 # Construct lines to blit to the screen.
                 blit = []
@@ -195,18 +217,15 @@ A terminal-based live suite monitor.  Exit with 'Ctrl-C'.""",
                 blit.append(divider_str)
 
                 blitlines = {}
-                for point_str, val in task_info.items():
+                for point_str, val in sorted_task_info.items():
                     indx = point_str
                     line = "%s%s%s" % (
                         '\033[1;34m', point_str, task_state.ctrl_end)
-
-                    for name in sorted(name_list):
-                        try:
-                            line += " %s" % val[name]
-                        except KeyError:
-                            if options.align_columns:
-                                line += " %s" % (' ' * len(name))
-
+                    for name, info in val.items():
+                        if info is not None:
+                            line += " %s" % info
+                        elif options.align_columns:
+                            line += " %s" % (' ' * len(name))
                     blitlines[indx] = line
 
                 if not options.once:

--- a/doc/siterc.tex
+++ b/doc/siterc.tex
@@ -373,16 +373,18 @@ Each suite stores its port number, by suite name, under this directory.
 
 Configurable settings for the command line \lstinline=cylc monitor= tool.
 
-\subsubsection[monitor]{[monitor] $\rightarrow$ sort by definition order}
+\subsubsection[monitor]{[monitor] $\rightarrow$ sort order}
 
-If True, display tasks in definition order by default, i.e.\ the order in which
-they appear under \lstinline=[runtime]= in the suite definition.  Otherwise,
-the default is alphanumeric sort.  The monitor has a command line option to
-switch to the non-default sort order.
-
+The sort order for tasks in the monitor view.
 \begin{myitemize}
-\item {\em type:} boolean
-\item {\em default:} True
+\item {\em type:} string
+\item {\em options:}
+    \begin{myitemize}
+    \item {\bf alphanumeric}
+    \item {\bf definition} -  the order that tasks appear under
+	    \lstinline=[runtime]= in the suite definition.
+  \end{myitemize}
+\item {\em default:} definition
 \end{myitemize}
 
 \subsection{[hosts]}

--- a/doc/siterc.tex
+++ b/doc/siterc.tex
@@ -369,6 +369,22 @@ Each suite stores its port number, by suite name, under this directory.
 \item {\em default:} \lstinline@$HOME/.cylc/ports/@
 \end{myitemize}
 
+\subsection{[monitor]}
+
+Configurable settings for the command line \lstinline=cylc monitor= tool.
+
+\subsubsection[monitor]{[monitor] $\rightarrow$ sort by definition order}
+
+If True, display tasks in definition order by default, i.e.\ the order in which
+they appear under \lstinline=[runtime]= in the suite definition.  Otherwise,
+the default is alphanumeric sort.  The monitor has a command line option to
+switch to the non-default sort order.
+
+\begin{myitemize}
+\item {\em type:} boolean
+\item {\em default:} True
+\end{myitemize}
+
 \subsection{[hosts]}
 
 The [hosts] section configures some important host-specific settings for

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -129,7 +129,9 @@ SPEC = {
     },
 
     'monitor': {
-        'sort by definition order': vdr(vtype='boolean', default=True),
+        'sort order': vdr(vtype='string',
+                          options=["alphanumeric", "definition"],
+                          default="definition"),
     },
 
     'hosts': {

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -128,6 +128,10 @@ SPEC = {
         'ports directory': vdr(vtype='string', default="$HOME/.cylc/ports/"),
     },
 
+    'monitor': {
+        'sort by definition order': vdr(vtype='boolean', default=True),
+    },
+
     'hosts': {
         'localhost': {
             'run directory': vdr(vtype='string', default="$HOME/cylc-run"),


### PR DESCRIPTION
Sort by `[runtime]` definition order by default, alphanumeric by option.  Works with aligned and non-aligned display.

Follow up on #1676; close #1677.

@trwhitcomb - note definition order is the default to be consistent with the GUI. I suppose if you don't like this we could make the default sorting site/user configurable...