### PR TITLE
task job logs register retry delays

### DIFF
--- a/doc/siterc.tex
+++ b/doc/siterc.tex
@@ -538,6 +538,16 @@ to be copied from the suite daemon to a job.
 Global default for the~\ref{runtime-remote-retrieve-job-logs} setting for the
 specified host.
 
+\paragraph[retrieve job logs command]{[hosts] $\rightarrow$ [[HOST]] $\rightarrow$ retrieve job logs command}
+
+If \lstinline@rsync -a@ is unavailable or insufficient to retrieve job logs
+from a remote host, you can use this setting to specify a suitable command.
+
+\begin{myitemize}
+\item {\em type:} string
+\item {\em default:} rsync -a
+\end{myitemize}
+
 \paragraph[retrieve job logs max size]{[hosts] $\rightarrow$ [[HOST]] $\rightarrow$ retrieve job logs max size}
 
 Global default for the~\ref{runtime-remote-retrieve-job-logs-max-size} setting for the

--- a/doc/suiterc.tex
+++ b/doc/suiterc.tex
@@ -1570,6 +1570,23 @@ Equivalent to~\ref{runtime-event-hooks-submission-timeout}.
 
 Equivalent to~\ref{runtime-event-hooks-execution-timeout}.
 
+\subparagraph[register job logs retry delays]{[runtime] $\rightarrow$ [[\_\_NAME\_\_]] $\rightarrow$ [[[events]]] $\rightarrow$ register job logs retry delays}
+
+Some batch systems have considerable delays between the time when the job
+completes and when it writes the job logs in its normal location. Consequently,
+the suite may be unable to register the existence of some job log files in its
+runtime database until the job log files become available at their expected
+location. If this is the case, you can configure an initial delay and some
+retry delays between subsequent attempts. The default behaviour is to attempt
+once without any delay.
+
+\begin{myitemize}
+    \item {\em type:} Comma-separated list of ISO 8601 duration/interval
+        representations, optionally {\em preceded} by multipliers.
+    \item {\em example:} \lstinline@PT5S, PT1M, PT5M@
+    \item {\em default:} (none)
+\end{myitemize}
+
 \subparagraph[reset timer]{[runtime] $\rightarrow$ [[\_\_NAME\_\_]] $\rightarrow$ [[[events]]] $\rightarrow$ reset timer}
 
 Equivalent to~\ref{runtime-event-hooks-reset-timer}.

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -147,6 +147,8 @@ SPEC = {
             'copyable environment variables': vdr(
                 vtype='string_list', default=[]),
             'retrieve job logs': vdr(vtype='boolean', default=False),
+            'retrieve job logs command': vdr(
+                vtype='string', default='rsync -a'),
             'retrieve job logs max size': vdr(vtype='string'),
             'retrieve job logs retry delays': vdr(
                 vtype='interval_minutes_list', default=[]),
@@ -189,12 +191,13 @@ SPEC = {
             'global init-script': vdr(vtype='string'),
             'copyable environment variables': vdr(
                 vtype='string_list', default=[]),
-            'retrieve job logs': vdr(vtype='boolean', default=False),
+            'retrieve job logs': vdr(vtype='boolean'),
+            'retrieve job logs command': vdr(vtype='string'),
             'retrieve job logs max size': vdr(vtype='string'),
             'retrieve job logs retry delays': vdr(
-                vtype='interval_minutes_list', default=[]),
+                vtype='interval_minutes_list'),
             'task event handler retry delays': vdr(
-                vtype='interval_minutes_list', default=[]),
+                vtype='interval_minutes_list'),
             'local tail command template': vdr(vtype='string'),
             'remote tail command template': vdr(vtype='string'),
             'batch systems': {
@@ -218,6 +221,8 @@ SPEC = {
         'mail retry delays': vdr(vtype='interval_minutes_list', default=[]),
         'mail smtp': vdr(vtype='string'),
         'mail to': vdr(vtype='string'),
+        'register job logs retry delays': vdr(
+            vtype='interval_minutes_list', default=[]),
         'reset timer': vdr(vtype='boolean', default=False),
         'submission timeout': vdr(vtype='interval_minutes'),
     },

--- a/lib/cylc/cfgspec/suite.py
+++ b/lib/cylc/cfgspec/suite.py
@@ -384,6 +384,8 @@ SPEC = {
                 'mail retry delays': vdr(vtype='interval_minutes_list'),
                 'mail smtp': vdr(vtype='string'),
                 'mail to': vdr(vtype='string'),
+                'register job logs retry delays': vdr(
+                    vtype='interval_minutes_list'),
                 'reset timer': vdr(vtype='boolean'),
                 'submission timeout': vdr(vtype='interval_minutes'),
             },

--- a/lib/cylc/mp_pool.py
+++ b/lib/cylc/mp_pool.py
@@ -73,7 +73,14 @@ def _run_command(ctx):
         proc = Popen(
             ctx.cmd, stdin=stdin_file, stdout=PIPE, stderr=PIPE,
             env=ctx.cmd_kwargs.get('env'), shell=ctx.cmd_kwargs.get('shell'))
-    except (IOError, OSError) as exc:
+    except IOError as exc:
+        if cylc.flags.debug:
+            traceback.print_exc()
+        ctx.ret_code = 1
+        ctx.err = str(exc)
+    except OSError as exc:
+        if exc.filename is None:
+            exc.filename = ctx.cmd[0]
         if cylc.flags.debug:
             traceback.print_exc()
         ctx.ret_code = 1

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -840,7 +840,8 @@ class scheduler(object):
         for var, val in cenv.items():
             cenv[var] = os.path.expandvars(val)
         # path to suite bin directory for suite and task event handlers
-        cenv['PATH'] = self.suite_dir + '/bin:' + os.environ['PATH']
+        cenv['PATH'] = os.pathsep.join([
+            os.path.join(self.suite_dir, 'bin'), os.environ['PATH']])
 
         # Make [cylc][environment] available to task event handlers in worker
         # processes,

--- a/tests/cylc-get-config/00-simple/section2.stdout
+++ b/tests/cylc-get-config/00-simple/section2.stdout
@@ -41,6 +41,7 @@
       mail from = 
       execution timeout = 
       submission timeout = 
+      register job logs retry delays = 
       reset timer = 
    [[[environment]]]
    [[[directives]]]
@@ -123,6 +124,7 @@
       mail from = 
       execution timeout = 
       submission timeout = 
+      register job logs retry delays = 
       reset timer = 
    [[[environment]]]
    [[[directives]]]
@@ -204,6 +206,7 @@
       mail from = 
       execution timeout = 
       submission timeout = 
+      register job logs retry delays = 
       reset timer = 
    [[[environment]]]
    [[[directives]]]
@@ -286,6 +289,7 @@
       mail from = 
       execution timeout = 
       submission timeout = 
+      register job logs retry delays = 
       reset timer = 
    [[[environment]]]
    [[[directives]]]
@@ -368,6 +372,7 @@
       mail from = 
       execution timeout = 
       submission timeout = 
+      register job logs retry delays = 
       reset timer = 
    [[[environment]]]
    [[[directives]]]
@@ -435,6 +440,7 @@
       mail from = 
       execution timeout = 
       submission timeout = 
+      register job logs retry delays = 
       reset timer = 
    [[[event hooks]]]
       submission timeout handler = 
@@ -517,6 +523,7 @@
       mail from = 
       execution timeout = 
       submission timeout = 
+      register job logs retry delays = 
       reset timer = 
    [[[event hooks]]]
       submission timeout handler = 
@@ -599,6 +606,7 @@
       mail from = 
       execution timeout = 
       submission timeout = 
+      register job logs retry delays = 
       reset timer = 
    [[[event hooks]]]
       submission timeout handler = 
@@ -680,6 +688,7 @@
       mail from = 
       execution timeout = 
       submission timeout = 
+      register job logs retry delays = 
       reset timer = 
    [[[event hooks]]]
       submission timeout handler = 
@@ -762,6 +771,7 @@
       mail from = 
       execution timeout = 
       submission timeout = 
+      register job logs retry delays = 
       reset timer = 
    [[[event hooks]]]
       submission timeout handler = 
@@ -844,6 +854,7 @@
       mail from = 
       execution timeout = 
       submission timeout = 
+      register job logs retry delays = 
       reset timer = 
    [[[event hooks]]]
       submission timeout handler = 
@@ -925,6 +936,7 @@
       mail from = 
       execution timeout = 
       submission timeout = 
+      register job logs retry delays = 
       reset timer = 
    [[[event hooks]]]
       submission timeout handler = 
@@ -1007,6 +1019,7 @@
       mail from = 
       execution timeout = 
       submission timeout = 
+      register job logs retry delays = 
       reset timer = 
    [[[event hooks]]]
       submission timeout handler = 

--- a/tests/events/16-task-event-job-logs-register-globalcfg.t
+++ b/tests/events/16-task-event-job-logs-register-globalcfg.t
@@ -1,0 +1,63 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test remote job logs retrieval, requires compatible version of cylc on remote
+# job host.
+. "$(dirname "$0")/test_header"
+set_test_number 5
+
+mkdir 'conf'
+cat >'conf/global.rc' <<__GLOBALCFG__
+[task events]
+    register job logs retry delays = PT0S, PT15S
+__GLOBALCFG__
+export CYLC_CONF_PATH="${PWD}/conf"
+
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+suite_run_ok "${TEST_NAME_BASE}-run" \
+    cylc run --reference-test --debug "${SUITE_NAME}"
+
+SUITE_RUN_DIR="$(cylc get-global-config '--print-run-dir')/${SUITE_NAME}"
+sqlite3 "${SUITE_RUN_DIR}/cylc-suite.db" \
+    'select cycle,name,submit_num,filename,location from task_job_logs
+     ORDER BY cycle,name,submit_num,filename' >'select-task-job-logs.out'
+cmp_ok 'select-task-job-logs.out' <<'__OUT__'
+1|t1|1|job|1/t1/01/job
+1|t1|1|job-activity.log|1/t1/01/job-activity.log
+1|t1|1|job.err|1/t1/01/job.err
+1|t1|1|job.out|1/t1/01/job.out
+1|t1|1|job.out.keep|1/t1/01/job.out.keep
+1|t1|1|job.status|1/t1/01/job.status
+__OUT__
+
+sed "/'job-logs-register'/!d; s/^[^ ]* //" \
+    "${SUITE_RUN_DIR}/log/job/1/t1/01/job-activity.log" \
+    >'edited-activities.log'
+cmp_ok 'edited-activities.log' <<'__LOG__'
+[('job-logs-register', 1) ret_code] 0
+__LOG__
+
+grep -F 'failed, retrying in' "${SUITE_RUN_DIR}/log/suite/log" \
+    | cut -d' ' -f 4-10 | sort >"edited-log"
+    cmp_ok 'edited-log' <<'__LOG__'
+[t1.1] -('job-logs-register', 1) failed, retrying in PT15S
+__LOG__
+
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/events/16-task-event-job-logs-register-globalcfg/reference.log
+++ b/tests/events/16-task-event-job-logs-register-globalcfg/reference.log
@@ -1,0 +1,5 @@
+2015-06-19T14:47:30+01 INFO - Run mode: live
+2015-06-19T14:47:30+01 INFO - Initial point: 1
+2015-06-19T14:47:30+01 INFO - Final point: 1
+2015-06-19T14:47:30+01 INFO - Cold Start 1
+2015-06-19T14:47:30+01 INFO - [t1.1] -triggered off []

--- a/tests/events/16-task-event-job-logs-register-globalcfg/suite.rc
+++ b/tests/events/16-task-event-job-logs-register-globalcfg/suite.rc
@@ -1,0 +1,23 @@
+#!jinja2
+
+title=Task Event Job Log Retrieve
+
+[cylc]
+    [[reference test]]
+        live mode suite timeout=PT1M
+
+[scheduling]
+    [[dependencies]]
+        graph=t1
+
+[runtime]
+    [[t1]]
+        script="""
+wait "${CYLC_TASK_MESSAGE_STARTED_PID}" 2>/dev/null || true
+mv "$0.out" "$0.out.keep"
+cylc task message 'succeeded' >>"$0.out.keep"
+sleep 5
+cp -p "$0.out.keep" "$0.out"
+
+trap '' EXIT
+"""

--- a/tests/events/17-task-event-job-logs-retrieve-command
+++ b/tests/events/17-task-event-job-logs-retrieve-command
@@ -1,0 +1,1 @@
+10-task-event-job-logs-retrieve

--- a/tests/events/17-task-event-job-logs-retrieve-command.t
+++ b/tests/events/17-task-event-job-logs-retrieve-command.t
@@ -15,25 +15,25 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test general task event handler + retry.
+# Test remote job logs retrieval custom command, requires compatible version of
+# cylc on remote job host.
 . "$(dirname "$0")/test_header"
 HOST=$(cylc get-global-config -i '[test battery]remote host' 2>'/dev/null')
 if [[ -z "${HOST}" ]]; then
     skip_all '"[test battery]remote host": not defined'
 fi
-set_test_number 4
+set_test_number 3
 
 mkdir 'conf'
 cat >'conf/global.rc' <<__GLOBALCFG__
 [hosts]
     [[${HOST}]]
-        task event handler retry delays=3*PT1S
-[task events]
-    handlers=hello-event-handler '%(name)s' '%(event)s'
-    handler events=succeeded, failed
+        retrieve job logs = True
+        retrieve job logs command = my-rsync
 __GLOBALCFG__
-
 export CYLC_CONF_PATH="${PWD}/conf"
+OPT_SET='-s GLOBALCFG=True'
+
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 set -eu
 SSH='ssh -oBatchMode=yes -oConnectTimeout=5'
@@ -42,33 +42,34 @@ ${SSH} "${HOST}" \
     <"${TEST_DIR}/${SUITE_NAME}/passphrase"
 set +eu
 
+mkdir -p "${TEST_DIR}/${SUITE_NAME}/bin"
+cat >"${TEST_DIR}/${SUITE_NAME}/bin/my-rsync" <<'__BASH__'
+#!/bin/bash
+set -eu
+echo "$@" >>"${CYLC_SUITE_LOG_DIR}/my-rsync.log"
+exec rsync -a "$@"
+__BASH__
+chmod +x "${TEST_DIR}/${SUITE_NAME}/bin/my-rsync"
+
 run_ok "${TEST_NAME_BASE}-validate" \
-    cylc validate -s "HOST=${HOST}" -s 'GLOBALCFG=True' "${SUITE_NAME}"
+    cylc validate ${OPT_SET} -s "HOST=${HOST}" "${SUITE_NAME}"
 suite_run_ok "${TEST_NAME_BASE}-run" \
-    cylc run --reference-test --debug -s "HOST=${HOST}" -s 'GLOBALCFG=True' \
+    cylc run --reference-test --debug ${OPT_SET} -s "HOST=${HOST}" \
     "${SUITE_NAME}"
 
-SUITE_RUN_DIR="$(cylc get-global-config '--print-run-dir')/${SUITE_NAME}"
-LOG="${SUITE_RUN_DIR}/log/job/1/t1/NN/job-activity.log"
-sed "/(('event-handler-00', 'succeeded'), 1)/!d; s/^.* \[/[/" "${LOG}" \
-    >'edited-job-activity.log'
-cmp_ok 'edited-job-activity.log' <<'__LOG__'
-[(('event-handler-00', 'succeeded'), 1) cmd] hello-event-handler 't1' 'succeeded'
-[(('event-handler-00', 'succeeded'), 1) ret_code] 1
-[(('event-handler-00', 'succeeded'), 1) cmd] hello-event-handler 't1' 'succeeded'
-[(('event-handler-00', 'succeeded'), 1) ret_code] 1
-[(('event-handler-00', 'succeeded'), 1) cmd] hello-event-handler 't1' 'succeeded'
-[(('event-handler-00', 'succeeded'), 1) ret_code] 0
-[(('event-handler-00', 'succeeded'), 1) out] hello
+SUITE_LOG_D="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/log"
+sed 's/^.* -v //' "${SUITE_LOG_D}/suite/my-rsync.log" >'my-rsync.log.edited'
+
+OPT_HEAD='--include=/1 --include=/1/t1'
+OPT_TAIL='--exclude=/**'
+ARGS="${HOST}:\$HOME/cylc-run/${SUITE_NAME}/log/job/ ${SUITE_LOG_D}/job/"
+cmp_ok 'my-rsync.log.edited' <<__LOG__
+${OPT_HEAD} --include=/1/t1/01 --include=/1/t1/01/** ${OPT_TAIL} ${ARGS}
+${OPT_HEAD} --include=/1/t1/02 --include=/1/t1/02/** ${OPT_TAIL} ${ARGS}
+${OPT_HEAD} --include=/1/t1/03 --include=/1/t1/03/** ${OPT_TAIL} ${ARGS}
 __LOG__
 
-grep 'event-handler-00.*will run after' "${SUITE_RUN_DIR}/log/suite/log" \
-    | cut -d' ' -f 4-11 >'edited-log'
-cmp_ok 'edited-log' <<'__LOG__'
-[t1.1] -(('event-handler-00', 'succeeded'), 1) will run after PT1S
-[t2.1] -(('event-handler-00', 'succeeded'), 1) will run after P0Y
-__LOG__
-
-${SSH} "${HOST}" "rm -rf '.cylc/${SUITE_NAME}' 'cylc-run/${SUITE_NAME}'"
+${SSH} "${HOST}" \
+    "rm -rf '.cylc/${SUITE_NAME}' 'cylc-run/${SUITE_NAME}'"
 purge_suite "${SUITE_NAME}"
 exit

--- a/tests/lib/bash/test_header
+++ b/tests/lib/bash/test_header
@@ -189,9 +189,11 @@ function cmp_ok() {
     local FILE_CONTROL=${2:--}
     local TEST_NAME=$(basename $FILE_TEST)-cmp-ok
     local DIFF_CMD=${CYLC_TEST_DIFF_CMD:-'diff -u'}
-    if ${DIFF_CMD} "$FILE_TEST" "$FILE_CONTROL" 1>$TEST_NAME.stderr 2>&1; then
+    if ${DIFF_CMD} "$FILE_TEST" "$FILE_CONTROL" >"${TEST_NAME}.stderr" 2>&1;then
         ok $TEST_NAME
         return
+    else
+        cat "${TEST_NAME}.stderr" >&2
     fi
     mkdir -p $TEST_LOG_DIR
     cp $TEST_NAME.stderr $TEST_LOG_DIR/$TEST_NAME.stderr


### PR DESCRIPTION
Allow retry when adding items to the `task_job_logs` table. A missing
`job.out` or `job.err` normally indicates a failure. The logic is
already part of retrieve-job-logs for remote jobs.

Register `job`, `job-activity.log` etc on job submission.

Also:
* configurable retrieve remote job logs command
* fix multi task event mail and job logs retrival reporting logic

Close #1655.