### PR TITLE
Test battery: fix ref test log analyser args order.

### DIFF
--- a/bin/cylc-check-triggering
+++ b/bin/cylc-check-triggering
@@ -71,7 +71,7 @@ new_log = os.path.join(log_dir, 'log')
 ref_log = os.path.join(suite_dir, 'reference.log')
 
 try:
-    lanal = LogAnalyser(ref_log, new_log)
+    lanal = LogAnalyser(new_log, ref_log)
     lanal.verify_triggering()
 except Exception, x:
     print >> sys.stderr, x

--- a/tests/broadcast/08-space/suite.rc
+++ b/tests/broadcast/08-space/suite.rc
@@ -2,6 +2,7 @@ title=broadcast section-space-key
 description=Test broadcast set section-space-key syntax
 [cylc]
     abort if any task fails = True
+    UTC mode = True
     [[event hooks]]
         abort on timeout = True
         timeout=PT1M


### PR DESCRIPTION
This error has no consequence, except if a reference test run submits no jobs at all due to starting beyond the final cycle point, then it reports that the wrong log (new vs reference) had no triggering info in it.

Also fixes https://github.com/cylc/cylc/pull/1684#issuecomment-163004073, which revealed this problem (sets UTC mode for the test).

@matthewrmshin - one review should be enough for this.