### PR TITLE
Fix a test - site directives not used.

### DIFF
--- a/tests/cylc-submit/00-bg.t
+++ b/tests/cylc-submit/00-bg.t
@@ -51,7 +51,7 @@ if [[ -n "${CONFIGURED_SYS_NAME}" ]]; then
         skip_all "\"${ITEM_KEY}\" not set"
     fi
     ITEM_KEY="[test battery][batch systems][$CONFIGURED_SYS_NAME][directives]"
-    CYLC_TEST_DIRECTIVES="$( \
+    export CYLC_TEST_DIRECTIVES="$( \
         cylc get-global-config "--item=${ITEM_KEY}" 2>'/dev/null')"
     CYLC_TEST_BATCH_SYS_NAME=$CONFIGURED_SYS_NAME
 fi

--- a/tests/cylc-submit/00-bg/suite.rc
+++ b/tests/cylc-submit/00-bg/suite.rc
@@ -14,9 +14,11 @@
             method = {{CYLC_TEST_BATCH_SYS_NAME}}
 {% if CYLC_TEST_BATCH_SYS_NAME == "loadleveler" %}
         [[[directives]]]
-            class = serial
             job_type = serial
             notification = never
             wall_clock_limit = 120,60
+{% if "CYLC_TEST_DIRECTIVES" in environ and environ["CYLC_TEST_DIRECTIVES"] %}
+    {{environ["CYLC_TEST_DIRECTIVES"]}}
+{% endif %}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
@matthewrmshin - this fixes a test that was passing for the wrong reasons here.  Site directives were not being used.  In the suite.rc the site directives are only used for loadleveler jobs, which seems odd (you might want to briefly consider how that affects your site?).