### PR TITLE
Improve message cycle offset placeholder pattern

### DIFF
--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -1699,7 +1699,7 @@ class SuiteConfig(object):
                 for lbl, msg in self.cfg['runtime'][name]['outputs'].items():
                     outp = output(msg, base_interval)
                     # Check for a cycle offset placeholder.
-                    if not re.match('\[.*\]', msg):
+                    if not re.search(r'\[[^\]]*\]', msg):
                         print >> sys.stderr, (
                             "Message outputs require an "
                             "offset placeholder (e.g. '[]' or '[-P2M]'):")


### PR DESCRIPTION
Need to do an `re.search` instead of an `re.match`.
(Fix message trigger related tests broken by #1695.)
Improve pattern to match a single pair of square braces.

@hjoliver please review.