### PR TITLE
Make local and remote port file exception messages consistent.

### DIFF
--- a/lib/cylc/network/port_file.py
+++ b/lib/cylc/network/port_file.py
@@ -115,7 +115,7 @@ class PortRetriever(object):
         if err:
             print >> sys.stderr, err.rstrip('\n')
         if res != 0:
-            raise PortFileError("ERROR, remote port file not found")
+            raise PortFileError("Port file not found - suite not running?.")
         return str_port
 
     def get(self):


### PR DESCRIPTION
Address #1697 (whether or not we should close the issue remains to be seen...)

I'll merge this un-reviewed for today's release as it only changes a single error message string, and thus can't possibly have any deleterious effects!
