### PR TITLE
cylc auth: allow hash choice, SHA256 by default

### DIFF
--- a/doc/siterc.tex
+++ b/doc/siterc.tex
@@ -853,3 +853,73 @@ required.
     \end{myitemize}
 \item {\em default:} state-totals
 \end{myitemize}
+
+\subsubsection{[authentication] $\rightarrow$ hashes}
+
+This sets the hash algorithms used for Pyro HMAC. SHA-256 and SHA-512 are
+the most secure. The first item is used as the default hash. Subsequent items
+(if any) are used as fallback hashes (e.g. for backwards compatibility should
+the hash change).
+
+The default value is SHA256 followed by MD5. You may want to exclude MD5 for
+security reasons - e.g. for FIPS compliance.
+
+MD5 is popularly used for HMAC, but is the least secure. SHA-1 is slightly
+better. Note that HMAC use is not as susceptible to hash collision weakness,
+so both algorithms are more secure for HMAC use than in the general case.
+
+Clients will attempt to establish a connection using the algorithms from first
+to last. The exception is scanning, which will use the algorithm configured in
+the [authentication] $\rightarrow$ scan hash setting below. If you have lots
+of suites running with e.g. MD5 hashes, you will want to include 'md5' in your
+list of hashes and set it as the default scan hash.
+
+If you are running cylc on a client with an old Python version (< 2.5) then
+you will need to include MD5 or preferably SHA-1 in your hash choices.
+
+See \url{https://docs.python.org/2/library/hmac.html} and
+\url{https://docs.python.org/2/library/hashlib.html} for discussion of hash
+algorithms.
+
+\begin{myitemize}
+\item {\em type:} comma-separated list of hash names (must each be one of the
+    following options)
+\item {\em options:}
+    \begin{myitemize}
+        \item {\em sha256} - SHA-256 (recommended, default)
+        \item {\em sha512} - SHA-512 (most secure, but slowest)
+        \item {\em sha1} - SHA-1 (may be the best option on legacy systems)
+        \item {\em md5} - MD5 (old default, usually used for HMAC, but the
+            least secure)
+    \end{myitemize}
+\item {\em default:} sha256,md5
+\end{myitemize}
+
+
+\subsubsection{[authentication] $\rightarrow$ scan hash}
+
+See [authentication] $\rightarrow$ hashes.
+
+Configure which of the specified hash algorithms in [authentication]
+$\rightarrow$ hashes is used for scanning.
+
+The default hash algorithm for scans is MD5, for backwards compatibility
+reasons. You can override it by specifying a different value for this setting
+(e.g. for FIPS compliance).
+
+The default will become SHA-256 sometime in 2016, when it is unlikely that any
+MD5 suites are still around.
+
+\begin{myitemize}
+\item {\em type:} hash name (must be one of the following options)
+\item {\em options:}
+    \begin{myitemize}
+        \item {\em sha256} - SHA-256 (recommended, future default)
+        \item {\em sha512} - SHA-512 (most secure, but slowest)
+        \item {\em sha1} - SHA-1 (may be the best option on legacy systems)
+        \item {\em md5} - MD5 (default, good for backwards compatibility, but
+            the least secure)
+    \end{myitemize}
+\item {\em default:} md5
+\end{myitemize}
+

--- a/doc/siterc.tex
+++ b/doc/siterc.tex
@@ -861,7 +861,7 @@ the most secure. The first item is used as the default hash. Subsequent items
 (if any) are used as fallback hashes (e.g. for backwards compatibility should
 the hash change).
 
-The default value is SHA256 followed by MD5. You may want to exclude MD5 for
+The default hashes are SHA-256 followed by MD5. You may want to exclude MD5 for
 security reasons - e.g. for FIPS compliance. Older cylc versions use MD5.
 
 MD5 is popularly used for HMAC, but is the least secure. SHA-1 is slightly

--- a/doc/siterc.tex
+++ b/doc/siterc.tex
@@ -856,17 +856,21 @@ required.
 
 \subsubsection{[authentication] $\rightarrow$ hashes}
 
-This sets the hash algorithms used for Pyro HMAC. SHA-256 and SHA-512 are
-the most secure. The first item is used as the default hash. Subsequent items
-(if any) are used as fallback hashes (e.g. for backwards compatibility should
-the hash change).
+This sets the hash algorithms used for Pyro HMAC, which are used to
+authenticate a client (e.g. gcylc) to the suite daemon. The first item is used
+as the default hash. Subsequent items (if any) are used as fallback hashes
+(e.g. for backwards compatibility with older suite daemons that are still
+running with an alternative hash).
 
 The default hashes are SHA-256 followed by MD5. You may want to exclude MD5 for
-security reasons - e.g. for FIPS compliance. Older cylc versions use MD5.
+security reasons - e.g. for FIPS
+(\url{https://en.wikipedia.org/wiki/FIPS_140-2}) compliance. Older cylc
+versions use MD5.
 
-MD5 is popularly used for HMAC, but is the least secure. SHA-1 is slightly
-better. Note that HMAC use is not as susceptible to hash collision weakness,
-so both algorithms are more secure for HMAC use than in the general case.
+SHA-256 and SHA-512 are the most secure. MD5 is popularly used for HMAC, but is
+the least secure. SHA-1 is slightly better. Note that HMAC use is not as
+susceptible to hash collision weakness, so both algorithms are more secure for
+HMAC use than in the general case.
 
 Clients will attempt to establish a connection using the algorithms from first
 to last. The exception is scanning, which will use the algorithm configured in

--- a/doc/siterc.tex
+++ b/doc/siterc.tex
@@ -862,7 +862,7 @@ the most secure. The first item is used as the default hash. Subsequent items
 the hash change).
 
 The default value is SHA256 followed by MD5. You may want to exclude MD5 for
-security reasons - e.g. for FIPS compliance.
+security reasons - e.g. for FIPS compliance. Older cylc versions use MD5.
 
 MD5 is popularly used for HMAC, but is the least secure. SHA-1 is slightly
 better. Note that HMAC use is not as susceptible to hash collision weakness,
@@ -873,9 +873,6 @@ to last. The exception is scanning, which will use the algorithm configured in
 the [authentication] $\rightarrow$ scan hash setting below. If you have lots
 of suites running with e.g. MD5 hashes, you will want to include 'md5' in your
 list of hashes and set it as the default scan hash.
-
-If you are running cylc on a client with an old Python version (< 2.5) then
-you will need to include MD5 or preferably SHA-1 in your hash choices.
 
 See \url{https://docs.python.org/2/library/hmac.html} and
 \url{https://docs.python.org/2/library/hashlib.html} for discussion of hash
@@ -908,7 +905,7 @@ reasons. You can override it by specifying a different value for this setting
 (e.g. for FIPS compliance).
 
 The default will become SHA-256 sometime in 2016, when it is unlikely that any
-MD5 suites are still around.
+old MD5 suites are still around.
 
 \begin{myitemize}
 \item {\em type:} hash name (must be one of the following options)

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -265,7 +265,14 @@ SPEC = {
         'public': vdr(
             vtype='string',
             options=PRIVILEGE_LEVELS[:PRIVILEGE_LEVELS.index('shutdown') + 1],
-            default="state-totals")
+            default="state-totals"),
+        'hashes': vdr(
+            vtype='string_list',
+            default=['sha256', 'md5']),
+        'scan hash': vdr(
+            vtype='string',
+            options=['md5', 'sha1', 'sha256', 'sha512'],
+            default='md5'),
     },
 }
 

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -268,6 +268,7 @@ SPEC = {
             default="state-totals"),
         'hashes': vdr(
             vtype='string_list',
+            options=['md5', 'sha1', 'sha256', 'sha512'],
             default=['sha256', 'md5']),
         'scan hash': vdr(
             vtype='string',

--- a/lib/cylc/network/connection_validator.py
+++ b/lib/cylc/network/connection_validator.py
@@ -28,13 +28,8 @@ from Pyro.protocol import DefaultConnValidator
 import Pyro.constants
 import Pyro.errors
 import hmac
-try:
-    import hashlib
-    md5 = hashlib.md5
-except ImportError:
-    import md5
-    md5 = md5.md5
 
+from cylc.cfgspec.globalcfg import GLOBAL_CFG
 from cylc.network import NO_PASSPHRASE, PRIVILEGE_LEVELS
 from cylc.config import SuiteConfig
 from cylc.suite_host import is_remote_host
@@ -43,7 +38,19 @@ from cylc.owner import user, host
 
 # Access for users without the suite passphrase: encrypting the "no passphrase"
 # passphrase is unnecessary, but doing so allows common passphrase handling.
-NO_PASSPHRASE_MD5 = md5(NO_PASSPHRASE).hexdigest()
+
+OK_HASHES = GLOBAL_CFG.get()['authentication']['hashes']
+SCAN_HASH = GLOBAL_CFG.get()['authentication']['scan hash']
+if SCAN_HASH not in OK_HASHES:
+    OK_HASHES.append(SCAN_HASH)
+
+try:
+    import hashlib
+except ImportError:
+    # We can only use MD5 or SHA1 here.
+    for hash_name in list(OK_HASHES):
+        if hash_name not in ("md5", "sha1"):
+            OK_HASHES.remove(hash_name)
 
 CONNECT_DENIED_TMPL = "[client-connect] DENIED %s@%s:%s %s"
 CONNECT_ALLOWED_TMPL = "[client-connect] %s@%s:%s privilege='%s' %s"
@@ -52,9 +59,22 @@ CONNECT_ALLOWED_TMPL = "[client-connect] %s@%s:%s privilege='%s' %s"
 class ConnValidator(DefaultConnValidator):
     """Custom Pyro connection validator for user authentication."""
 
+    HASHES = {}
+    LENGTH_HASH_DIGESTS = {}
+    NO_PASSPHRASE_HASHES = {}
+
     def set_pphrase(self, pphrase):
         """Store encrypted suite passphrase (called by the server)."""
-        self.pphrase = md5(pphrase).hexdigest()
+        self.pphrase_hashes = {}
+        for hash_name in OK_HASHES:
+            hash_ = self._get_hash(hash_name)
+            self.pphrase_hashes[hash_name] = hash_(pphrase).hexdigest()
+
+    def set_default_hash(self, hash_name):
+        """Configure a hash to use as the default."""
+        self._default_hash_name = hash_name
+        if None in self.HASHES:
+            self.HASHES.pop(None)  # Pop default setting.
 
     def acceptIdentification(self, daemon, connection, token, challenge):
         """Authorize client login."""
@@ -64,7 +84,7 @@ class ConnValidator(DefaultConnValidator):
         # Processes the token returned by createAuthToken.
         try:
             user, host, uuid, prog_name, proc_passwd = token.split(':', 4)
-        except ValueError as exc:
+        except ValueError:
             # Back compat for old suite client (passphrase only)
             # (Allows old scan to see new suites.)
             proc_passwd = token
@@ -74,16 +94,32 @@ class ConnValidator(DefaultConnValidator):
             uuid = "(uuid)"
             prog_name = "(OLD_CLIENT)"
 
+        hash_name = self._get_hash_name_from_digest_length(proc_passwd)
+
+        if hash_name not in OK_HASHES:
+            return (0, Pyro.constants.DENIED_SECURITY)
+
+        hash_ = self._get_hash(hash_name)
+
+        # Access for users without the suite passphrase: encrypting the
+        # no-passphrase is unnecessary, but doing so allows common handling.
+        no_passphrase_hash = self._get_no_passphrase_hash(hash_name)
+
         # Check username and password, and set privilege level accordingly.
         # The auth token has a binary hash that needs conversion to ASCII.
-        if hmac.new(challenge,
-                    self.pphrase.decode("hex")).digest() == proc_passwd:
+        if self._compare_hmacs(
+                hmac.new(challenge,
+                         self.pphrase_hashes[hash_name].decode("hex"),
+                         hash_).digest(),
+                proc_passwd):
             # The client has the suite passphrase.
             # Access granted at highest privilege level.
             priv_level = PRIVILEGE_LEVELS[-1]
-        elif (hmac.new(
-                challenge,
-                NO_PASSPHRASE_MD5.decode("hex")).digest() == proc_passwd):
+        elif not is_old_client and self._compare_hmacs(
+                hmac.new(challenge,
+                         no_passphrase_hash.decode("hex"),
+                         hash_).digest(),
+                proc_passwd):
             # The client does not have the suite passphrase.
             # Public access granted at level determined by global/suite config.
             config = SuiteConfig.get_inst()
@@ -113,8 +149,11 @@ class ConnValidator(DefaultConnValidator):
         Argument authid is what's returned by mungeIdent().
 
         """
+        hash_ = self._get_hash()
         return ":".join(
-            list(authid[:4]) + [hmac.new(challenge, authid[4]).digest()])
+            list(authid[:4]) +
+            [hmac.new(challenge, authid[4], hash_).digest()]
+        )
 
     def mungeIdent(self, ident):
         """Receive (uuid, passphrase) from client. Encrypt the passphrase.
@@ -123,8 +162,66 @@ class ConnValidator(DefaultConnValidator):
         (user, host, prog name).
 
         """
+        hash_ = self._get_hash()
         uuid, passphrase = ident
         prog_name = os.path.basename(sys.argv[0])
         if passphrase is None:
             passphrase = NO_PASSPHRASE
-        return (user, host, str(uuid), prog_name, md5(passphrase).digest())
+        return (user, host, str(uuid), prog_name, hash_(passphrase).digest())
+
+    def _compare_hmacs(self, hmac1, hmac2):
+        """Compare hmacs as securely as possible."""
+        try:
+            return hmac.compare_hmacs(hmac1, hmac2)
+        except AttributeError:
+            # < Python 2.7.7.
+            return (hmac1 == hmac2)
+
+    def _get_default_hash_name(self):
+        if hasattr(self, "_default_hash_name"):
+            return self._default_hash_name
+        return GLOBAL_CFG.get()['authentication']['hashes'][0]
+
+    def _get_hash(self, hash_name=None):
+        try:
+            return self.HASHES[hash_name]
+        except KeyError:
+            pass
+
+        hash_name_dest = hash_name
+        if hash_name is None:
+            hash_name = self._get_default_hash_name()
+
+        try:
+            import hashlib
+            self.HASHES[hash_name_dest] = getattr(hashlib, hash_name)
+        except ImportError:
+            # < Python 2.5
+            if hash_name == 'sha1':
+                import sha
+                self.HASHES[hash_name_dest] = sha.sha
+            elif hash_name == 'md5':
+                import md5
+                self.HASHES[hash_name_dest] = md5.md5
+            else:
+                raise
+        return self.HASHES[hash_name_dest]
+
+    def _get_hash_name_from_digest_length(self, digest):
+        if len(digest) in self.LENGTH_HASH_DIGESTS:
+            return self.LENGTH_HASH_DIGESTS[len(digest)]
+        for hash_name in OK_HASHES:
+            hash_ = self._get_hash(hash_name)
+            len_hash = len(hash_("foo").digest())
+            self.LENGTH_HASH_DIGESTS[len_hash] = hash_name
+            if len_hash == len(digest):
+                return hash_name
+
+    def _get_no_passphrase_hash(self, hash_name=None):
+        try:
+            return self.NO_PASSPHRASE_HASHES[hash_name]
+        except KeyError:
+            hash_ = self._get_hash(hash_name)
+            self.NO_PASSPHRASE_HASHES[hash_name] = (
+                hash_(NO_PASSPHRASE).hexdigest())
+        return self.NO_PASSPHRASE_HASHES[hash_name]

--- a/lib/cylc/network/connection_validator.py
+++ b/lib/cylc/network/connection_validator.py
@@ -20,6 +20,7 @@ try:
     import Pyro.core
 except ImportError, x:
     raise SystemExit("ERROR: Pyro is not installed")
+import hashlib
 import logging
 import os
 import sys
@@ -44,13 +45,6 @@ SCAN_HASH = GLOBAL_CFG.get()['authentication']['scan hash']
 if SCAN_HASH not in OK_HASHES:
     OK_HASHES.append(SCAN_HASH)
 
-try:
-    import hashlib
-except ImportError:
-    # We can only use MD5 or SHA1 here.
-    for hash_name in list(OK_HASHES):
-        if hash_name not in ("md5", "sha1"):
-            OK_HASHES.remove(hash_name)
 
 CONNECT_DENIED_TMPL = "[client-connect] DENIED %s@%s:%s %s"
 CONNECT_ALLOWED_TMPL = "[client-connect] %s@%s:%s privilege='%s' %s"
@@ -192,19 +186,7 @@ class ConnValidator(DefaultConnValidator):
         if hash_name is None:
             hash_name = self._get_default_hash_name()
 
-        try:
-            import hashlib
-            self.HASHES[hash_name_dest] = getattr(hashlib, hash_name)
-        except ImportError:
-            # < Python 2.5
-            if hash_name == 'sha1':
-                import sha
-                self.HASHES[hash_name_dest] = sha.sha
-            elif hash_name == 'md5':
-                import md5
-                self.HASHES[hash_name_dest] = md5.md5
-            else:
-                raise
+        self.HASHES[hash_name_dest] = getattr(hashlib, hash_name)
         return self.HASHES[hash_name_dest]
 
     def _get_hash_name_from_digest_length(self, digest):

--- a/lib/cylc/network/port_scan.py
+++ b/lib/cylc/network/port_scan.py
@@ -28,7 +28,8 @@ from cylc.registration import localdb
 from cylc.passphrase import passphrase, get_passphrase, PassphraseError
 from cylc.cfgspec.globalcfg import GLOBAL_CFG
 from cylc.network import PYRO_SUITEID_OBJ_NAME, NO_PASSPHRASE
-from cylc.network.connection_validator import ConnValidator
+from cylc.network.connection_validator import (
+    ConnValidator, OK_HASHES, SCAN_HASH)
 
 passphrases = []
 
@@ -94,7 +95,9 @@ def scan(host=get_hostname(), db=None, pyro_timeout=None, owner=user):
     for port in range(base_port, last_port):
         try:
             proxy = get_proxy(host, port, pyro_timeout)
-            proxy._setNewConnectionValidator(ConnValidator())
+            conn_val = ConnValidator()
+            conn_val.set_default_hash(SCAN_HASH)
+            proxy._setNewConnectionValidator(conn_val)
             proxy._setIdentification((user, NO_PASSPHRASE))
             result = (port, proxy.identify())
         except Pyro.errors.ConnectionDeniedError as exc:
@@ -156,7 +159,9 @@ def scan(host=get_hostname(), db=None, pyro_timeout=None, owner=user):
                 else:
                     try:
                         proxy = get_proxy(host, port, pyro_timeout)
-                        proxy._setNewConnectionValidator(ConnValidator())
+                        conn_val = ConnValidator()
+                        conn_val.set_default_hash(SCAN_HASH)
+                        proxy._setNewConnectionValidator(conn_val)
                         proxy._setIdentification((user, pphrase))
                         result = (port, proxy.identify())
                     except Exception:

--- a/lib/parsec/util.py
+++ b/lib/parsec/util.py
@@ -213,8 +213,8 @@ def itemstr( parents=[], item=None, value=None ):
         # last parent is the item
         item = keys[-1]
         keys.remove(item)
-    if parents:
-        s = '[' + ']['.join(parents) + ']'
+    if keys:
+        s = '[' + ']['.join(keys) + ']'
     else:
         s = ''
     if item:

--- a/lib/parsec/validate.py
+++ b/lib/parsec/validate.py
@@ -320,6 +320,11 @@ class validator(object):
         value = self.coercer( value, keys, self.args )
         # handle option lists centrally here
         if self.args['options']:
-            if value not in self.args['options']:
-                raise IllegalValueError( 'option', keys, value )
+            if isinstance(value, list):
+                for val in value:
+                    if val not in self.args['options']:
+                        raise IllegalValueError( 'option', keys, val )
+            else:
+                if value not in self.args['options']:
+                    raise IllegalValueError( 'option', keys, value )
         return value

--- a/tests/authentication/07-back-compat.t
+++ b/tests/authentication/07-back-compat.t
@@ -18,9 +18,16 @@
 # Test authentication - ignore old client denials, report bad new clients.
 
 . $(dirname $0)/test_header
-set_test_number 13
+set_test_number 23
 
 # Set things up and run the suite.
+# Choose the default global.rc hash settings, for reference.
+cat > global.rc << __END__
+[authentication]
+    hashes = sha256,md5
+    scan hash = md5
+__END__
+export CYLC_CONF_PATH="${PWD}"
 install_suite "${TEST_NAME_BASE}" basic
 TEST_NAME="${TEST_NAME_BASE}-validate"
 run_ok "${TEST_NAME}" cylc validate "${SUITE_NAME}"
@@ -80,7 +87,7 @@ class MyConnValidator(Pyro.protocol.DefaultConnValidator):
     """Create an incorrect but plausible auth token."""
 
     def createAuthToken(self, authid, challenge, peeraddr, URI, daemon):
-        return "colonel_mustard:drawing_room:dagger:mystery:57abbed"
+        return "colonel_mustard:drawing_room:dagger:mystery:decea5ede57abbed"
 
 uri = "PYROLOC://localhost:" + sys.argv[1] + "/cylcid"
 proxy = Pyro.core.getProxyForURI(uri)
@@ -92,13 +99,82 @@ grep_ok "ConnectionDeniedError" "${TEST_NAME}.stderr"
 # Check that the new client connection failure is logged (it is suspicious).
 TEST_NAME="${TEST_NAME_BASE}-log-new-client"
 # Get any new lines added to the error file.
-comm -13 err-before-scan "${ERR_PATH}" >"${TEST_NAME_BASE}-new-client-err-diff"
+comm -13 err-before-scan "${ERR_PATH}" >"${TEST_NAME}-new-client-err-diff"
 # Check the new lines for a connection denied report.
 grep_ok "WARNING - \[client-connect\] DENIED colonel_mustard@drawing_room:mystery dagger$" \
-    "${TEST_NAME_BASE}-new-client-err-diff"
+    "${TEST_NAME}-new-client-err-diff"
 
-# Shutdown and purge.
+# Simulate a client with the wrong hash.
+TEST_NAME="${TEST_NAME_BASE}-new-wrong-hash-client-snapshot-err"
+run_ok "${TEST_NAME}" cp "${ERR_PATH}" err-before-scan
+cat > global.rc << __END__
+[authentication]
+    hashes = sha1
+    scan hash = sha1
+__END__
+export CYLC_CONF_PATH="${PWD}"
+run_ok "${TEST_NAME}" cylc scan -fb -n "${SUITE_NAME}" 'localhost'
+comm -13 err-before-scan "${ERR_PATH}" >"${TEST_NAME}-diff"
+# Wrong hash usage should not be logged as the hash choice may change.
+cat "${TEST_NAME}-diff" >/dev/tty
+diff "${TEST_NAME}-diff" - </dev/null >/dev/tty
+cmp_ok "${TEST_NAME}-diff" </dev/null
+
+# Run a scan using SHA256 hashing (default is MD5).
+TEST_NAME="${TEST_NAME_BASE}-scan-sha256"
+cat > global.rc << __END__
+[authentication]
+    scan hash = sha256
+__END__
+export CYLC_CONF_PATH="${PWD}"
+run_ok "${TEST_NAME}" cylc scan -fb -n "${SUITE_NAME}" 'localhost'
+grep_ok "${SUITE_NAME} ${USER}@localhost:${PORT}" "${TEST_NAME}.stdout"
+export CYLC_CONF_PATH=
+rm global.rc
+
+# Shutdown.
 TEST_NAME="${TEST_NAME_BASE}-stop"
 run_ok "${TEST_NAME}" cylc stop --max-polls=10 --interval=1 "${SUITE_NAME}"
+
+# Now run an MD5 suite and see if we can trigger with a different
+# default hash (SHA256), falling back to MD5.
+
+# Set things up and run the suite.
+cat > global.rc << __END__
+[authentication]
+    hashes = md5
+__END__
+export CYLC_CONF_PATH="${PWD}"
+install_suite "${TEST_NAME_BASE}" basic
+TEST_NAME="${TEST_NAME_BASE}-validate-md5"
+run_ok "${TEST_NAME}" cylc validate "${SUITE_NAME}"
+cylc run "${SUITE_NAME}"
+
+# Scan to grab the suite's port.
+sleep 5  # Wait for the suite to initialize.
+TEST_NAME="${TEST_NAME_BASE}-new-scan-md5"
+PORT=$(cylc scan -b -n $SUITE_NAME 'localhost' 2>'/dev/null' \
+    | sed -e 's/.*@localhost://')
+
+# Connect using SHA256 hash.
+cat > global.rc << __END__
+[authentication]
+    hashes = sha256,md5
+__END__
+
+# Connect using SHA256 hash.
+TEST_NAME="${TEST_NAME_BASE}-new-scan-md5-sha256"
+run_ok "${TEST_NAME}" cylc trigger "${SUITE_NAME}" bar 1
+grep_ok "INFO - \[client-command\] trigger_task" "$(cylc cat-log -l $SUITE_NAME)"
+
+# Shutdown using SHA256.
+TEST_NAME="${TEST_NAME_BASE}-stop-md5-sha256"
+run_ok "${TEST_NAME}" cylc stop --max-polls=10 --interval=1 "${SUITE_NAME}"
+
+# Double check shutdown.
+TEST_NAME="${TEST_NAME_BASE}-stop-md5"
+run_fail "${TEST_NAME}" cylc stop --max-polls=10 --interval=1 "${SUITE_NAME}"
+
+# Purge.
 purge_suite "${SUITE_NAME}"
 exit

--- a/tests/authentication/07-back-compat.t
+++ b/tests/authentication/07-back-compat.t
@@ -139,6 +139,7 @@ run_ok "${TEST_NAME}" cylc stop --max-polls=10 --interval=1 "${SUITE_NAME}"
 # Now run an MD5 suite and see if we can trigger with a different
 # default hash (SHA256), falling back to MD5.
 
+purge_suite "${SUITE_NAME}" basic
 # Set things up and run the suite.
 cat > global.rc << __END__
 [authentication]

--- a/tests/validate/50-fail-authentication-hashes.t
+++ b/tests/validate/50-fail-authentication-hashes.t
@@ -22,18 +22,18 @@ set_test_number 4
 #-------------------------------------------------------------------------------
 cat >global.rc <<'__CONF__'
 [authentication]
-    hashes = md6
+    hashes = sha1048576
 __CONF__
 export CYLC_CONF_PATH=$PWD
-TEST_NAME="$TEST_NAME_BASE-md6-get-global-config"
+TEST_NAME="$TEST_NAME_BASE-hashes-get-global-config"
 run_fail $TEST_NAME cylc get-global-config
-grep_ok "hashes = md6" "$TEST_NAME.stderr"
+grep_ok "\[authentication\]hashes = sha1048576" "$TEST_NAME.stderr"
 #-------------------------------------------------------------------------------
 cat >global.rc <<'__CONF__'
 [authentication]
     scan hash = sha1048576
 __CONF__
-TEST_NAME="$TEST_NAME_BASE-sha-lots-get-global-config"
+TEST_NAME="$TEST_NAME_BASE-scan-hash-get-global-config"
 run_fail $TEST_NAME cylc get-global-config
-grep_ok "scan hash = sha1048576" "$TEST_NAME.stderr"
+grep_ok "\[authentication\]scan hash = sha1048576" "$TEST_NAME.stderr"
 exit

--- a/tests/validate/50-fail-authentication-hashes.t
+++ b/tests/validate/50-fail-authentication-hashes.t
@@ -1,0 +1,39 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test fail validation of bad vis node attributes.
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 4
+#-------------------------------------------------------------------------------
+cat >global.rc <<'__CONF__'
+[authentication]
+    hashes = md6
+__CONF__
+export CYLC_CONF_PATH=$PWD
+TEST_NAME="$TEST_NAME_BASE-md6-get-global-config"
+run_fail $TEST_NAME cylc get-global-config
+grep_ok "hashes = md6" "$TEST_NAME.stderr"
+#-------------------------------------------------------------------------------
+cat >global.rc <<'__CONF__'
+[authentication]
+    scan hash = sha1048576
+__CONF__
+TEST_NAME="$TEST_NAME_BASE-sha-lots-get-global-config"
+run_fail $TEST_NAME cylc get-global-config
+grep_ok "scan hash = sha1048576" "$TEST_NAME.stderr"
+exit


### PR DESCRIPTION
This change allows a site or user configuration of the hashing
algorithm used in Pyro communication. MD5 is not really recommended for
HMAC use, and is actually disabled on some POSIX systems.

Multiple hash algorithms are now allowed for both client and daemon.
The daemon can accept authentication in any of the configured hash
algorithms, and the client will work through any of the configured hash
algorithms until one works.

The default is SHA256 followed by MD5 as a fallback and for scanning.
This allows MD5 (old) suites to work - it preserves
old-client/new-daemon and new-scan-client/old-daemons.

Closes #1629.