### PR TITLE
Support for local lib/python dir.

### DIFF
--- a/doc/cug.tex
+++ b/doc/cug.tex
@@ -2338,9 +2338,8 @@ A cylc {\em suite definition directory} contains:
             \item And any include-files used in it (see below; may be
                 kept in sub-directories).
         \end{myitemize}
-    \item {\bf A \lstinline=bin/= sub-directory}.
+    \item {\bf A \lstinline=bin/= sub-directory} (optional)
         \begin{myitemize}
-            \item {\em Optional.}
             \item For scripts and executables that implement, or are
                 used by, suite tasks.
             \item Automatically added to \lstinline=$PATH= in task
@@ -2349,19 +2348,16 @@ A cylc {\em suite definition directory} contains:
                 commands, scripts, or programs; or they can be scripted
                 entirely within the suite.rc file.
         \end{myitemize}
-    \item {\bf A \lstinline=python/= sub-directory}.
+    \item {\bf A \lstinline=lib/python/= sub-directory} (optional)
         \begin{myitemize}
-            \item {\em Optional.}
-            \item For user-defined job-submission methods, if needed
-                (see~\ref{TaskJobSubmission}).
-            \item Alternatively, new job submission methods can be
-                installed into the cylc source tree, or in any directory
-                in your \lstinline=$PYTHONPATH=.
+            \item For custom job submission modules
+                (see~\ref{CustomJobSubmissionMethods})
+                and local Python modules imported by custom Jinja2 filters
+                (see~\ref{CustomJinja2Filters}).
         \end{myitemize}
     \item {\bf Any other sub-directories and files} - documentation,
-        control files, etc.
+        control files, etc. (optional)
         \begin{myitemize}
-            \item {\em Optional.}
             \item Holding everything in one place makes proper suite
                 revision control possible.
             \item Portable access to files here, for running tasks, is
@@ -4579,6 +4575,7 @@ host at the time the suite definition is parsed} - it is not, for
 instance, read at task run time on the task host.
 
 \subsubsection{Custom Jinja2 Filters}
+\label{CustomJinja2Filters}
 
 Jinja2 variable values can be modified by ``filters'', using pipe
 notation. For example, the built-in \lstinline=trim= filter strips
@@ -5014,7 +5011,7 @@ how cylc wraps and runs your tasks.
 \label{AvailableMethods}
 
 Cylc supports a number of commonly used job submission methods. 
-See~\ref{DefiningNewJobSubmissionMethods} for how to add new job
+See~\ref{CustomJobSubmissionMethods} for how to add new job
 submission methods.
 
 \subsubsection{background}
@@ -5323,14 +5320,13 @@ to its job submission method.
 Tasks can be killed on demand by right-clicking on them in gcylc or using the
 \lstinline=cylc kill= command.
 
-\subsection{Defining New Job Submission Methods}
-\label{DefiningNewJobSubmissionMethods}
+\subsection{Custom Job Submission Methods}
+\label{CustomJobSubmissionMethods}
 
-Defining a new handler for a new job submission method requires a little Python
-programming. You can derive (in the sense of object oriented programming
-inheritance) new classes from one of the existing ones, or simply write a new
-one using the existing ones as examples. Full reference can be found in the
-header \lstinline=cylc.batch_sys_manager= module.
+Defining a new job submission method requires a little Python programming.  You
+can use one of the built-in methods as an example, and read the documentation
+in the header of the \lstinline=cylc.batch_sys_manager= module.
+
 \lstset{language=Python}
 
 \subsubsection{An Example}
@@ -5377,7 +5373,7 @@ and generate a job script to see the resulting directives:
 \lstset{language=transcript}
 \begin{lstlisting}
 shell$ cylc db reg test $HOME/test
-shell$ cylc jobscript test a | grep QSUB
+shell$ cylc jobscript test a.1 | grep QSUB
 #QSUB -e /home/hilary/cylc-run/my.suite/log/job/1/a/01/job.err
 #QSUB -l nodes=1
 #QSUB -l walltime=00:01:00
@@ -5395,18 +5391,12 @@ in any of the following locations, depending on how generally useful
 the new method is and whether or not you have write-access to the cylc
 source tree:
 \begin{myitemize}
-    \item a \lstinline=python= sub-directory of your suite definition
+    \item a \lstinline=lib/python= sub-directory of your suite definition
         directory.
-    \item any directory in, or added to, your \lstinline=PYTHONPATH=
-        environment variable.
-    \item in the \lstinline=lib/cylc/job_sys_handlers= directory of
+    \item any directory in your \lstinline=$PYTHONPATH=.
+    \item in the \lstinline=lib/cylc/batch_sys_handlers= directory of
         the cylc source tree.
 \end{myitemize}
-Note that the form of the import statement at the top of the new
-user-defined Python module differs depending on whether or not
-the file is installed in the cylc source tree (see the comment
-at the top of the example file above).
-
 
 %\pagebreak
 

--- a/lib/cylc/batch_sys_manager.py
+++ b/lib/cylc/batch_sys_manager.py
@@ -199,7 +199,7 @@ class BatchSysManager(object):
     @classmethod
     def configure_suite_run_dir(cls, suite_run_dir):
         """Add local python module paths if not already done."""
-        for sub_dir in [ "python", os.path.join("lib", "python")]:
+        for sub_dir in ["python", os.path.join("lib", "python")]:
             # TODO - eventually drop the deprecated "python" sub-dir.
             suite_py = os.path.join(suite_run_dir, sub_dir)
             if os.path.isdir(suite_py) and suite_py not in sys.path:

--- a/lib/cylc/batch_sys_manager.py
+++ b/lib/cylc/batch_sys_manager.py
@@ -198,10 +198,12 @@ class BatchSysManager(object):
 
     @classmethod
     def configure_suite_run_dir(cls, suite_run_dir):
-        """Add "suite_run_dir"/python to sys.path if not already done."""
-        suite_py = os.path.join(suite_run_dir, "python")
-        if os.path.isdir(suite_py) and suite_py not in sys.path:
-            sys.path.append(suite_py)
+        """Add local python module paths if not already done."""
+        for sub_dir in [ "python", os.path.join("lib", "python")]:
+            # TODO - eventually drop the deprecated "python" sub-dir.
+            suite_py = os.path.join(suite_run_dir, sub_dir)
+            if os.path.isdir(suite_py) and suite_py not in sys.path:
+                sys.path.append(suite_py)
 
     def get_inst(self, batch_sys_name):
         """Return an instance of the class for "batch_sys_name"."""

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -264,11 +264,12 @@ class scheduler(object):
         f.close()
 
         # Copy local python modules from source to run directory.
-        for sub_dir in [ "python", os.path.join("lib", "python")]:
+        for sub_dir in ["python", os.path.join("lib", "python")]:
             # TODO - eventually drop the deprecated "python" sub-dir.
             suite_py = os.path.join(self.suite_dir, sub_dir)
             if (os.path.realpath(self.suite_dir) !=
-                    os.path.realpath(suite_run_dir) and os.path.isdir(suite_py)):
+                    os.path.realpath(suite_run_dir) and
+                    os.path.isdir(suite_py)):
                 suite_run_py = os.path.join(suite_run_dir, sub_dir)
                 try:
                     rmtree(suite_run_py)

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -263,15 +263,18 @@ class scheduler(object):
             f.write("%s=%s\n" % (key, value))
         f.close()
 
-        suite_py = os.path.join(self.suite_dir, "python")
-        if (os.path.realpath(self.suite_dir) !=
-                os.path.realpath(suite_run_dir) and os.path.isdir(suite_py)):
-            suite_run_py = os.path.join(suite_run_dir, "python")
-            try:
-                rmtree(suite_run_py)
-            except OSError:
-                pass
-            copytree(suite_py, suite_run_py)
+        # Copy local python modules from source to run directory.
+        for sub_dir in [ "python", os.path.join("lib", "python")]:
+            # TODO - eventually drop the deprecated "python" sub-dir.
+            suite_py = os.path.join(self.suite_dir, sub_dir)
+            if (os.path.realpath(self.suite_dir) !=
+                    os.path.realpath(suite_run_dir) and os.path.isdir(suite_py)):
+                suite_run_py = os.path.join(suite_run_dir, sub_dir)
+                try:
+                    rmtree(suite_run_py)
+                except OSError:
+                    pass
+                copytree(suite_py, suite_run_py)
 
         # 2) restart only: copy to other accounts with still-running tasks
         for user_at_host in self.old_user_at_host_set:

--- a/lib/parsec/fileparse.py
+++ b/lib/parsec/fileparse.py
@@ -229,14 +229,19 @@ def read_and_proc( fpath, template_vars=[], template_vars_file=None, viewcfg=Non
     if not os.path.isfile( fpath ):
         raise FileNotFoundError, 'File not found: ' + fpath
 
+    fdir = os.path.dirname(fpath)
+
+    # Allow Python modules in lib/python/ (e.g. for use by Jinja2 filters).
+    suite_lib_python = os.path.join(fdir, "lib", "python")
+    if os.path.isdir(suite_lib_python) and suite_lib_python not in sys.path:
+        sys.path.append(suite_lib_python)
+
     if cylc.flags.verbose:
         print "Reading file", fpath
 
     # read the file into a list, stripping newlines
     with open( fpath ) as f:
         flines = [ line.rstrip('\n') for line in f ]
-
-    fdir = os.path.dirname(fpath)
 
     do_inline = True
     do_jinja2 = True

--- a/tests/jinja2/08-local-lib-python.t
+++ b/tests/jinja2/08-local-lib-python.t
@@ -1,0 +1,32 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test that a custom Jinja2 filter can load a local python module in lib/python.
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 2
+#-------------------------------------------------------------------------------
+install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-validate
+run_ok $TEST_NAME cylc validate $SUITE_NAME
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-check-expansion
+cmp_ok $TEST_DIR/$SUITE_NAME/suite.rc.processed \
+    $TEST_SOURCE_DIR/$TEST_NAME_BASE/suite.rc.jproc
+#-------------------------------------------------------------------------------
+purge_suite $SUITE_NAME

--- a/tests/jinja2/08-local-lib-python/Jinja2Filters/qualify.py
+++ b/tests/jinja2/08-local-lib-python/Jinja2Filters/qualify.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+
+#import os, sys
+#sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'lib', 'python'))
+
+import local_lookup
+
+def qualify(arg):
+    return local_lookup.lookup(arg)

--- a/tests/jinja2/08-local-lib-python/lib/python/local_lookup.py
+++ b/tests/jinja2/08-local-lib-python/lib/python/local_lookup.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+
+lookup_table = {
+    'foo' : 'fooble',
+    'bar' : 'barble'}
+
+def lookup(arg):
+    return lookup_table[arg]

--- a/tests/jinja2/08-local-lib-python/suite.rc
+++ b/tests/jinja2/08-local-lib-python/suite.rc
@@ -1,0 +1,5 @@
+#!Jinja2
+
+[scheduling]
+    [[dependencies]]
+        graph = {{"foo" | qualify}} => {{"bar" | qualify}}

--- a/tests/jinja2/08-local-lib-python/suite.rc.jproc
+++ b/tests/jinja2/08-local-lib-python/suite.rc.jproc
@@ -1,0 +1,3 @@
+[scheduling]
+    [[dependencies]]
+        graph = fooble => barble

--- a/tests/job-submission/00-user/lib/python/my_background2.py
+++ b/tests/job-submission/00-user/lib/python/my_background2.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from cylc.batch_sys_handlers.background import BgCommandHandler
+
+
+class MyBgCommandHandler(BgCommandHandler):
+    pass
+
+
+BATCH_SYS_HANDLER = MyBgCommandHandler()

--- a/tests/job-submission/00-user/reference.log
+++ b/tests/job-submission/00-user/reference.log
@@ -1,21 +1,19 @@
-2014/02/04 16:27:40 INFO - Thread-2 start (Event Handlers)
-2014/02/04 16:27:40 INFO - Thread-3 start (Poll & Kill Commands)
-2014/02/04 16:27:40 INFO - port:7766
-2014/02/04 16:27:40 INFO - Suite starting at 2014-02-04 16:27:40.360630
-2014/02/04 16:27:40 INFO - Log event clock: real time
-2014/02/04 16:27:40 INFO - Run mode: live
-2014/02/04 16:27:40 INFO - Initial point: 1
-2014/02/04 16:27:40 INFO - Final point: 1
-2014/02/04 16:27:40 INFO - Thread-4 start (Job Submission)
-2014/02/04 16:27:40 INFO - Thread-5 start (Request Handling)
-2014/02/04 16:27:40 INFO - [foo.1] -triggered off []
-2014/02/04 16:27:41 INFO - [foo.1] -(current:ready)> foo.1 submitting now
-2014/02/04 16:27:43 INFO - [foo.1] -(current:ready)> foo.1 started at 2014-02-04T16:27:43
-2014/02/04 16:27:45 INFO - [foo.1] -(current:running)> foo.1 succeeded at 2014-02-04T16:27:44
-2014/02/04 16:27:45 WARNING - [foo.1] -Assuming non-reported outputs were completed:
-foo.1 submitted
-2014/02/04 16:27:45 INFO - Stopping: 
-  + all non-cycling tasks have succeeded
-2014/02/04 16:27:45 INFO - Thread-4 exit (Job Submission)
-2014/02/04 16:27:46 INFO - Thread-2 exit (Event Handlers)
-2014/02/04 16:27:46 INFO - Thread-3 exit (Poll & Kill Commands)
+2015-12-17T16:00:01+13 INFO - port:7766
+2015-12-17T16:00:01+13 INFO - Suite starting at 2015-12-17T16:00:01+13
+2015-12-17T16:00:01+13 INFO - Run mode: live
+2015-12-17T16:00:01+13 INFO - Initial point: 1
+2015-12-17T16:00:01+13 INFO - Final point: 1
+2015-12-17T16:00:01+13 INFO - Cold Start 1
+2015-12-17T16:00:01+13 INFO - [bar.1] -triggered off []
+2015-12-17T16:00:01+13 INFO - [foo.1] -triggered off []
+2015-12-17T16:00:02+13 INFO - [bar.1] -submit_method_id=17719
+2015-12-17T16:00:02+13 INFO - [bar.1] -submission succeeded
+2015-12-17T16:00:02+13 INFO - [foo.1] -submit_method_id=17720
+2015-12-17T16:00:02+13 INFO - [foo.1] -submission succeeded
+2015-12-17T16:00:02+13 INFO - [bar.1] -(current:submitted)> bar.1 started at 2015-12-17T16:00:01+13
+2015-12-17T16:00:02+13 INFO - [bar.1] -(current:running)> bar.1 succeeded at 2015-12-17T16:00:01+13
+2015-12-17T16:00:02+13 INFO - [foo.1] -(current:submitted)> foo.1 started at 2015-12-17T16:00:01+13
+2015-12-17T16:00:02+13 INFO - [foo.1] -(current:running)> foo.1 succeeded at 2015-12-17T16:00:01+13
+2015-12-17T16:00:02+13 INFO - [bar.1] -('job-logs-register', 1) will run after P0Y (after 2015-12-17T16:00:02+13)
+2015-12-17T16:00:02+13 INFO - [foo.1] -('job-logs-register', 1) will run after P0Y (after 2015-12-17T16:00:02+13)
+2015-12-17T16:00:04+13 INFO - Suite shutting down at 2015-12-17T16:00:04+13

--- a/tests/job-submission/00-user/suite.rc
+++ b/tests/job-submission/00-user/suite.rc
@@ -1,15 +1,22 @@
+# Test job submission modules in lib/python/ and python/ (deprecated).
+
 [cylc]
    [[reference test]]
        required run mode = live
-       live mode suite timeout = 0.5 # minutes
+       live mode suite timeout = PT30S
 
 [scheduling]
     [[dependencies]]
-        graph = foo
+        graph = foo & bar
 
 [runtime]
-    [[foo]]
+    [[root]]
         script = true # quick
+    [[foo]]
         [[[job submission]]]
-            # use python/my_background.py:my_background
+            # python/my_background.py  (deprecated location)
             method = my_background
+    [[bar]]
+        [[[job submission]]]
+            # lib/python/my_background2.py
+            method = my_background2


### PR DESCRIPTION
Close #1675,

Local `lib/python` directory is appended to `sys.path` before the suite is parsed, to allow Jinja2 filters to use local python modules; and again for job submission processes, to allow custom job submission methods.  In the later case the deprecated `python` directory (no `lib/`) is still supported too.

@matthewrmshin - please assign reviews.