### PR TITLE
Clarify cylc suite-state only works off states.

### DIFF
--- a/bin/cylc-suite-state
+++ b/bin/cylc-suite-state
@@ -27,6 +27,9 @@ it (consider max-polls*interval as an overall timeout).
 
 Note for non-cycling tasks --point=1 must be provided.
 
+Important: cylc suite-state only works with task states and does not work with
+task messages.
+
 For your own suites the database location is determined by your
 site/user config. For other suites, e.g. those owned by others, or
 mirrored suite databases, use --run-dir=DIR to specify the location.

--- a/doc/cug.tex
+++ b/doc/cug.tex
@@ -6445,7 +6445,7 @@ you wish:
 \end{lstlisting}
 
 
-\subsection{Inter-suite Dependence: Triggering Off Tasks In Other Suites}
+\subsection{Inter-suite Dependence: Triggering Off Task States In Other Suites}
 \label{SuiteStatePolling}
 
 The \lstinline=cylc suite-state= command interrogates suite run databases. It
@@ -6453,7 +6453,9 @@ has a polling mode that waits for a given task in the target suite to achieve a
 given state. This can be used to make task scripting wait for a remote task
 to succeed (for example). The suite graph notation also provides a way to
 define automatic suite-state polling tasks, which use the same polling command
-under the hood.
+under the hood. Note that cylc suite-state can only trigger off task
+{\em states} in remote suites and does not support triggering off tasks
+messages.
 
 Here's how to trigger a task \lstinline=bar= off a task \lstinline=foo= in
 a remote suite called \lstinline=other.suite=:

--- a/doc/cug.tex
+++ b/doc/cug.tex
@@ -6454,7 +6454,7 @@ given state. This can be used to make task scripting wait for a remote task
 to succeed (for example). The suite graph notation also provides a way to
 define automatic suite-state polling tasks, which use the same polling command
 under the hood. Note that cylc suite-state can only trigger off task
-{\em states} in remote suites and does not support triggering off tasks
+{\em states} in remote suites and does not support triggering off task
 messages.
 
 Here's how to trigger a task \lstinline=bar= off a task \lstinline=foo= in


### PR DESCRIPTION
Closes #1682 

Adds clarification that cylc suite-state doesn't support triggering off task messages to CLI and main manual documentation.

@hjoliver - please review. I don't think this needs a review 2 but feel free to assign a second reviewer if you think its appropriate.