### PR TITLE
Do a final state summary update before shutdown.

### DIFF
--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -1067,6 +1067,7 @@ class scheduler(object):
 
             if ((self.shut_down_cleanly or auto_stop) and
                     self.pool.no_active_tasks()):
+                self.update_state_summary()
                 proc_pool.close()
                 self.shut_down_now = True
 
@@ -1075,6 +1076,7 @@ class scheduler(object):
                     if not self.pool.no_active_tasks():
                         self.log.warning(
                             'some tasks were not killable at shutdown')
+                    self.update_state_summary()
                     proc_pool.close()
                     self.shut_down_now = True
                 else:


### PR DESCRIPTION
This should allow gcylc to detect normal shutdowns.

Close #1697.

@kaday @arjclark - please review.

It might still be *possible* for a suite to shut down before the GUI can read the final status update from the daemon, but I haven't seen that happen while testing this change - so I hope we can avoid having to read the suite logs to to detect a clean shutdown.  
