### PR TITLE
gcylc right-click menu specificity

### DIFF
--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -528,9 +528,10 @@ Main Control GUI that displays one or more views or interfaces to the suite.
 
     STATES_POLLABLE = [
         'submitted',
-        'running'
+        'running',
+        'succeeded',
+        'failed'
     ]
-
 
     def __init__(self, suite, db, owner, host, port, pyro_timeout,
                  template_vars, template_vars_file, restricted_display):
@@ -1206,14 +1207,16 @@ been defined for this suite""").inform()
         url_item.connect('activate', self.browse, "-t", name, self.cfg.suite)
         menu.append(url_item)
 
-        menu_items = self._get_right_click_menu_items(task_id, t_state, task_is_family)
+        menu_items = self._get_right_click_menu_items(
+            task_id, t_state, task_is_family)
         for item in menu_items:
             menu.append(item)
 
         menu.show_all()
         return menu
 
-    def _get_right_click_menu_items(self, task_id, t_state, task_is_family=False):
+    def _get_right_click_menu_items(
+            self, task_id, t_state, task_is_family=False):
         # Return the default menu items for a task
         name, point_string = TaskID.split(task_id)
 
@@ -1297,7 +1300,7 @@ been defined for this suite""").inform()
             items.append(trigger_edit_item)
             trigger_edit_item.connect(
                 'activate', self.trigger_task_edit_run, task_id)
-
+            trigger_edit_item.set_sensitive(t_state in self.STATES_TRIGGERABLE)
         items.append(gtk.SeparatorMenuItem())
 
         # TODO - grey out poll and kill if the task is not active.

--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -509,6 +509,29 @@ Main Control GUI that displays one or more views or interfaces to the suite.
         VIEWS["graph"] = ControlGraph
         VIEWS_ORDERED.append("graph")
 
+    STATES_TRIGGERABLE = [
+        'waiting',
+        'held',
+        'queued',
+        'ready',
+        'expired',
+        'submit-failed',
+        'succeeded',
+        'failed',
+        'runahead'
+    ]
+
+    STATES_KILLABLE = [
+        'submitted',
+        'running'
+    ]
+
+    STATES_POLLABLE = [
+        'submitted',
+        'running'
+    ]
+
+
     def __init__(self, suite, db, owner, host, port, pyro_timeout,
                  template_vars, template_vars_file, restricted_display):
 
@@ -1168,7 +1191,7 @@ been defined for this suite""").inform()
 
         return False
 
-    def get_right_click_menu(self, task_id, task_is_family=False):
+    def get_right_click_menu(self, task_id, t_state, task_is_family=False):
         """Return the default menu for a task."""
         menu = gtk.Menu()
         menu_root = gtk.MenuItem(task_id)
@@ -1183,14 +1206,14 @@ been defined for this suite""").inform()
         url_item.connect('activate', self.browse, "-t", name, self.cfg.suite)
         menu.append(url_item)
 
-        menu_items = self._get_right_click_menu_items(task_id, task_is_family)
+        menu_items = self._get_right_click_menu_items(task_id, t_state, task_is_family)
         for item in menu_items:
             menu.append(item)
 
         menu.show_all()
         return menu
 
-    def _get_right_click_menu_items(self, task_id, task_is_family=False):
+    def _get_right_click_menu_items(self, task_id, t_state, task_is_family=False):
         # Return the default menu items for a task
         name, point_string = TaskID.split(task_id)
 
@@ -1264,6 +1287,7 @@ been defined for this suite""").inform()
         items.append(trigger_now_item)
         trigger_now_item.connect(
             'activate', self.trigger_task_now, task_id, task_is_family)
+        trigger_now_item.set_sensitive(t_state in self.STATES_TRIGGERABLE)
 
         if not task_is_family:
             trigger_edit_item = gtk.ImageMenuItem('Trigger (edit run)')
@@ -1282,6 +1306,7 @@ been defined for this suite""").inform()
         poll_item.set_image(img)
         items.append(poll_item)
         poll_item.connect('activate', self.poll_task, task_id, task_is_family)
+        poll_item.set_sensitive(t_state in self.STATES_POLLABLE)
 
         items.append(gtk.SeparatorMenuItem())
 
@@ -1290,6 +1315,7 @@ been defined for this suite""").inform()
         kill_item.set_image(img)
         items.append(kill_item)
         kill_item.connect('activate', self.kill_task, task_id, task_is_family)
+        kill_item.set_sensitive(t_state in self.STATES_KILLABLE)
 
         items.append(gtk.SeparatorMenuItem())
 

--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -533,6 +533,13 @@ Main Control GUI that displays one or more views or interfaces to the suite.
         'failed'
     ]
 
+    STATES_VIEW_LOGS = [
+        'running',
+        'succeeded',
+        'failed',
+        'retrying',
+    ]
+
     def __init__(self, suite, db, owner, host, port, pyro_timeout,
                  template_vars, template_vars_file, restricted_display):
 
@@ -1192,7 +1199,8 @@ been defined for this suite""").inform()
 
         return False
 
-    def get_right_click_menu(self, task_id, t_state, task_is_family=False):
+    def get_right_click_menu(
+            self, task_id, t_state, task_is_family=False, submit_num=None):
         """Return the default menu for a task."""
         menu = gtk.Menu()
         menu_root = gtk.MenuItem(task_id)
@@ -1208,7 +1216,7 @@ been defined for this suite""").inform()
         menu.append(url_item)
 
         menu_items = self._get_right_click_menu_items(
-            task_id, t_state, task_is_family)
+            task_id, t_state, task_is_family, submit_num)
         for item in menu_items:
             menu.append(item)
 
@@ -1216,7 +1224,7 @@ been defined for this suite""").inform()
         return menu
 
     def _get_right_click_menu_items(
-            self, task_id, t_state, task_is_family=False):
+            self, task_id, t_state, task_is_family=False, submit_num=None):
         # Return the default menu items for a task
         name, point_string = TaskID.split(task_id)
 
@@ -1240,6 +1248,9 @@ been defined for this suite""").inform()
             view_item.set_image(img)
             view_item.set_submenu(view_menu)
             items.append(view_item)
+
+            view_item.set_sensitive(
+                t_state in self.STATES_VIEW_LOGS or submit_num > 0)
 
             # NOTE: we have to respond to 'button-press-event' rather than
             # 'activate' in order for sub-menus to work in the graph-view.

--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -528,16 +528,14 @@ Main Control GUI that displays one or more views or interfaces to the suite.
 
     STATES_POLLABLE = [
         'submitted',
-        'running',
-        'succeeded',
-        'failed'
+        'running'
     ]
 
     STATES_VIEW_LOGS = [
         'running',
         'succeeded',
         'failed',
-        'retrying',
+        'retrying'
     ]
 
     def __init__(self, suite, db, owner, host, port, pyro_timeout,

--- a/lib/cylc/gui/view_dot.py
+++ b/lib/cylc/gui/view_dot.py
@@ -102,7 +102,10 @@ LED suite control interface.
 
         is_fam = (name in self.t.descendants)
 
-        menu = self.get_right_click_menu(task_id, task_is_family=is_fam)
+        task_state = treemodel.get_value(iter,2)
+
+        menu = self.get_right_click_menu(
+                        task_id, t_state=task_state, task_is_family=is_fam)
 
         sep = gtk.SeparatorMenuItem()
         sep.show()

--- a/lib/cylc/gui/view_dot.py
+++ b/lib/cylc/gui/view_dot.py
@@ -102,7 +102,10 @@ LED suite control interface.
 
         is_fam = (name in self.t.descendants)
 
-        task_state = treemodel.get_value(iter,2)
+        if is_fam:
+            task_state = self.t.fam_state_summary[task_id]['state']
+        else:
+            task_state = self.t.state_summary[task_id]['state']
 
         menu = self.get_right_click_menu(
                         task_id, t_state=task_state, task_is_family=is_fam)

--- a/lib/cylc/gui/view_dot.py
+++ b/lib/cylc/gui/view_dot.py
@@ -108,7 +108,7 @@ LED suite control interface.
             task_state = self.t.state_summary[task_id]['state']
 
         menu = self.get_right_click_menu(
-                        task_id, t_state=task_state, task_is_family=is_fam)
+            task_id, t_state=task_state, task_is_family=is_fam)
 
         sep = gtk.SeparatorMenuItem()
         sep.show()

--- a/lib/cylc/gui/view_dot.py
+++ b/lib/cylc/gui/view_dot.py
@@ -104,11 +104,14 @@ LED suite control interface.
 
         if is_fam:
             task_state = self.t.fam_state_summary[task_id]['state']
+            submit_num = None
         else:
             task_state = self.t.state_summary[task_id]['state']
+            submit_num = self.t.state_summary[task_id]['submit_num']
 
         menu = self.get_right_click_menu(
-            task_id, t_state=task_state, task_is_family=is_fam)
+            task_id, t_state=task_state,
+            task_is_family=is_fam, submit_num=submit_num)
 
         sep = gtk.SeparatorMenuItem()
         sep.show()

--- a/lib/cylc/gui/view_graph.py
+++ b/lib/cylc/gui/view_graph.py
@@ -188,10 +188,12 @@ Dependency graph suite control interface.
             is_fam = (name in self.t.descendants)
             if is_fam:
                 t_state = self.t.fam_state_summary[task_id]['state']
+                submit_num = None
             else:
                 t_state = self.t.state_summary[task_id]['state']
+                submit_num = self.t.state_summary[task_id]['submit_num']
             default_menu = self.get_right_click_menu(
-                task_id, t_state, task_is_family=is_fam)
+                task_id, t_state, task_is_family=is_fam, submit_num=submit_num)
             dm_kids = default_menu.get_children()
             for item in reversed(dm_kids[:2]):
                 # Put task name and URL at the top.

--- a/lib/cylc/gui/view_graph.py
+++ b/lib/cylc/gui/view_graph.py
@@ -185,8 +185,12 @@ Dependency graph suite control interface.
         menu.append(ungroup_rec_item)
 
         if type == 'live task':
-            t_state = self.t.state_summary[task_id]['state']
             is_fam = (name in self.t.descendants)
+            if is_fam:
+                t_state = self.t.fam_state_summary[task_id]['state']
+            else:
+                t_state = self.t.state_summary[task_id]['state']
+            
             default_menu = self.get_right_click_menu(
                 task_id, t_state, task_is_family=is_fam)
             dm_kids = default_menu.get_children()

--- a/lib/cylc/gui/view_graph.py
+++ b/lib/cylc/gui/view_graph.py
@@ -190,7 +190,6 @@ Dependency graph suite control interface.
                 t_state = self.t.fam_state_summary[task_id]['state']
             else:
                 t_state = self.t.state_summary[task_id]['state']
-            
             default_menu = self.get_right_click_menu(
                 task_id, t_state, task_is_family=is_fam)
             dm_kids = default_menu.get_children()

--- a/lib/cylc/gui/view_graph.py
+++ b/lib/cylc/gui/view_graph.py
@@ -185,9 +185,10 @@ Dependency graph suite control interface.
         menu.append(ungroup_rec_item)
 
         if type == 'live task':
+            t_state = self.t.state_summary[task_id]['state']
             is_fam = (name in self.t.descendants)
             default_menu = self.get_right_click_menu(
-                task_id, task_is_family=is_fam)
+                task_id, t_state, task_is_family=is_fam)
             dm_kids = default_menu.get_children()
             for item in reversed(dm_kids[:2]):
                 # Put task name and URL at the top.

--- a/lib/cylc/gui/view_tree.py
+++ b/lib/cylc/gui/view_tree.py
@@ -180,7 +180,7 @@ class ControlTree(object):
             task_state = self.t.state_summary[task_id]['state']
 
         menu = self.get_right_click_menu(
-                        task_id, t_state=task_state, task_is_family=is_fam)
+            task_id, t_state=task_state, task_is_family=is_fam)
 
         sep = gtk.SeparatorMenuItem()
         sep.show()

--- a/lib/cylc/gui/view_tree.py
+++ b/lib/cylc/gui/view_tree.py
@@ -174,7 +174,10 @@ class ControlTree(object):
 
         is_fam = (name in self.t.descendants)
 
-        task_state = treemodel.get_value(iter,2)
+        if is_fam:
+            task_state = self.t.fam_state_summary[task_id]['state']
+        else:
+            task_state = self.t.state_summary[task_id]['state']
 
         menu = self.get_right_click_menu(
                         task_id, t_state=task_state, task_is_family=is_fam)

--- a/lib/cylc/gui/view_tree.py
+++ b/lib/cylc/gui/view_tree.py
@@ -174,7 +174,10 @@ class ControlTree(object):
 
         is_fam = (name in self.t.descendants)
 
-        menu = self.get_right_click_menu(task_id, task_is_family=is_fam)
+        task_state = treemodel.get_value(iter,2)
+
+        menu = self.get_right_click_menu(
+                        task_id, t_state=task_state, task_is_family=is_fam)
 
         sep = gtk.SeparatorMenuItem()
         sep.show()

--- a/lib/cylc/gui/view_tree.py
+++ b/lib/cylc/gui/view_tree.py
@@ -176,11 +176,14 @@ class ControlTree(object):
 
         if is_fam:
             task_state = self.t.fam_state_summary[task_id]['state']
+            submit_num = None
         else:
             task_state = self.t.state_summary[task_id]['state']
+            submit_num = self.t.state_summary[task_id]['submit_num']
 
         menu = self.get_right_click_menu(
-            task_id, t_state=task_state, task_is_family=is_fam)
+            task_id, t_state=task_state,
+            task_is_family=is_fam, submit_num=submit_num)
 
         sep = gtk.SeparatorMenuItem()
         sep.show()


### PR DESCRIPTION
Addresses #1321 

Trigger (now and edit), poll and kill right-click menu options are now enabled/disabled based on the task state.

@hjoliver - please review 1
@kaday - please review 2

I've played around with a running suite to check things are working but you'll probably want to do some manual testing yourselves. Please also double-check I've covered the right states for these actions.