### PR TITLE
Graph viewer option to start ungrouped.

### DIFF
--- a/bin/cylc-graph
+++ b/bin/cylc-graph
@@ -156,6 +156,11 @@ def main():
              '(default: initial + 3 points)')])
 
     parser.add_option(
+        "-u", "--ungrouped",
+        help="Start with task families ungrouped (the default is grouped).",
+        action="store_true", default=False, dest="start_ungrouped")
+
+    parser.add_option(
         "-n", "--namespaces",
         help="Plot the suite namespace inheritance hierarchy "
              "(task run time properties).",
@@ -237,6 +242,9 @@ def main():
                              options.templatevars_file,
                              should_hide=should_hide_gtk_window,
                              ignore_suicide=hide_suicide)
+
+    if options.start_ungrouped:
+        window.ungroup_all(None)
 
     window.widget.connect('clicked', on_url_clicked, window)
     if options.filter_patterns:

--- a/lib/cylc/gui/graph.py
+++ b/lib/cylc/gui/graph.py
@@ -72,7 +72,7 @@ def graph_suite_popup(reg, cmd_help, defstartc, defstopc, graph_opts,
         tmpdir, template_opts, parent_window))
 
     help_button = gtk.Button("_Help")
-    help_button.connect("clicked", cmd_help, 'prep', 'graph')
+    help_button.connect("clicked", cmd_help, '', 'graph')
 
     hbox = gtk.HBox()
     hbox.pack_start(ok_button, False)

--- a/tests/graphing/08-ungrouped.t
+++ b/tests/graphing/08-ungrouped.t
@@ -1,0 +1,35 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test that ungrouped graphing works without having to use the viewer GUI.
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 3
+#-------------------------------------------------------------------------------
+install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-validate
+run_ok $TEST_NAME cylc validate "$SUITE_NAME"
+#-------------------------------------------------------------------------------
+graph_suite $SUITE_NAME graph.plain
+cmp_ok graph.plain $TEST_SOURCE_DIR/$TEST_NAME_BASE/graph.plain.ref
+#-------------------------------------------------------------------------------
+graph_suite $SUITE_NAME graph.plain.suicide --ungrouped
+cmp_ok graph.plain.suicide \
+    $TEST_SOURCE_DIR/$TEST_NAME_BASE/graph.plain.ungrouped.ref
+#-------------------------------------------------------------------------------
+purge_suite $SUITE_NAME

--- a/tests/graphing/08-ungrouped/graph.plain.ref
+++ b/tests/graphing/08-ungrouped/graph.plain.ref
@@ -1,0 +1,5 @@
+edge "foo.1" "BAR.1" solid
+graph
+node "BAR.1" "BAR\n1" unfilled doubleoctagon black
+node "foo.1" "foo\n1" unfilled box black
+stop

--- a/tests/graphing/08-ungrouped/graph.plain.ungrouped.ref
+++ b/tests/graphing/08-ungrouped/graph.plain.ungrouped.ref
@@ -1,0 +1,9 @@
+edge "foo.1" "bar1.1" solid
+edge "foo.1" "bar2.1" solid
+edge "foo.1" "bar3.1" solid
+graph
+node "bar1.1" "bar1\n1" unfilled box black
+node "bar2.1" "bar2\n1" unfilled box black
+node "bar3.1" "bar3\n1" unfilled box black
+node "foo.1" "foo\n1" unfilled box black
+stop

--- a/tests/graphing/08-ungrouped/suite.rc
+++ b/tests/graphing/08-ungrouped/suite.rc
@@ -1,0 +1,8 @@
+[scheduling]
+    [[dependencies]]
+        graph = foo => BAR
+[runtime]
+    [[foo]]
+    [[BAR]]
+    [[bar1, bar2, bar3]]
+        inherit = BAR


### PR DESCRIPTION
Currently we can't print an ungrouped graph with `cylc graph -O foo-graph.png foo` if suite `foo` has any task families (although we can do it via the GUI, of course). This provides an option to start with the graph ungrouped.