### PR TITLE
cylc.rundb: improve retry and diagnostics

### DIFF
--- a/lib/cylc/rundb.py
+++ b/lib/cylc/rundb.py
@@ -336,7 +336,6 @@ class CylcSuiteDAO(object):
                     table.update_queues.pop(stmt)
             if self.conn is not None:
                 self.conn.commit()
-            will_retry = False
         except sqlite3.Error:
             if not self.is_public:
                 raise
@@ -345,7 +344,6 @@ class CylcSuiteDAO(object):
                 traceback.print_exc()
                 sys.stderr.write(
                     "WARNING: %s: db write failed\n" % self.db_file_name)
-            will_retry = True
             self.n_tries += 1
             logger = getLogger("main")
             logger.log(


### PR DESCRIPTION
The current logic continues with the next query on any failure. In rare occasions, this may cause queries to be issued in the wrong order - causing the public database to be out of sync with the private one. This PR changes the logic to break out as soon as there is a failure. This should be safer on retry, as it will ensure that queries after the previous failure are issued in the correct order.