### PR TITLE
batch sys: at: poll exit, poll PID is alive or not

### DIFF
--- a/lib/cylc/batch_sys_handlers/at.py
+++ b/lib/cylc/batch_sys_handlers/at.py
@@ -42,8 +42,8 @@ class AtCommandHandler(object):
         "Can't open /var/run/atd.pid to signal atd. No atd running?",
         "Warning: at daemon not running",
     ]
-    CAN_KILL_PROC_GROUP = True
-    CAN_POLL_PROC_GROUP = True
+    SHOULD_KILL_PROC_GROUP = True
+    SHOULD_POLL_PROC_GROUP = True
     KILL_CMD_TMPL = "atrm '%(job_id)s'"
     POLL_CMD = "atq"
     POLL_CMD_TMPL = POLL_CMD

--- a/lib/cylc/batch_sys_handlers/at.py
+++ b/lib/cylc/batch_sys_handlers/at.py
@@ -43,9 +43,7 @@ class AtCommandHandler(object):
         "Warning: at daemon not running",
     ]
     CAN_KILL_PROC_GROUP = True
-    # N.B. The perl command ensures that the job script is executed in its own
-    # process group, which allows the job script and its child processes to be
-    # killed correctly.
+    CAN_POLL_PROC_GROUP = True
     KILL_CMD_TMPL = "atrm '%(job_id)s'"
     POLL_CMD = "atq"
     POLL_CMD_TMPL = POLL_CMD
@@ -53,6 +51,9 @@ class AtCommandHandler(object):
         re.compile("warning: commands will be executed using /bin/sh")]
     REC_ID_FROM_SUBMIT_ERR = re.compile(r"\Ajob\s(?P<id>\S+)\sat")
     SUBMIT_CMD_TMPL = "at now"
+    # N.B. The perl command ensures that the job script is executed in its own
+    # process group, which allows the job script and its child processes to be
+    # killed correctly.
     SUBMIT_CMD_STDIN_TMPL = (
         r"exec perl -e 'setpgrp(0,0);exec(@ARGV)'" +
         r" '%(job)s' 1>'%(job)s.out' 2>'%(job)s.err'")

--- a/lib/cylc/batch_sys_handlers/background.py
+++ b/lib/cylc/batch_sys_handlers/background.py
@@ -32,7 +32,7 @@ class BgCommandHandler(object):
 
     """
 
-    CAN_KILL_PROC_GROUP = True
+    SHOULD_KILL_PROC_GROUP = True
     POLL_CMD = "ps"
     POLL_CMD_TMPL = POLL_CMD + " '%(job_id)s'"
     REC_ID_FROM_SUBMIT_OUT = re.compile(r"""\A(?P<id>\d+)\Z""")

--- a/lib/cylc/batch_sys_manager.py
+++ b/lib/cylc/batch_sys_manager.py
@@ -71,11 +71,11 @@ batch_sys.submit(job_file_path) => ret_code, out, err
       beyond just running a system or shell command. See also
       "batch_sys.SUBMIT_CMD".
 
-batch_sys.CAN_KILL_PROC_GROUP
-    * A boolean to indicate whether it is possible to kill a job by sending
+batch_sys.SHOULD_KILL_PROC_GROUP
+    * A boolean to indicate whether it is necessary to kill a job by sending
       a signal to its Unix process group.
 
-batch_sys.CAN_POLL_PROC_GROUP
+batch_sys.SHOULD_POLL_PROC_GROUP
     * A boolean to indicate whether it is necessary to poll a job by its PID
       as well as the job ID.
 
@@ -380,7 +380,7 @@ class BatchSysManager(object):
         else:
             return (1, "Cannot determine batch system from 'job.status' file")
         st_file.seek(0, 0)  # rewind
-        if getattr(batch_sys, "CAN_KILL_PROC_GROUP", False):
+        if getattr(batch_sys, "SHOULD_KILL_PROC_GROUP", False):
             for line in st_file:
                 if line.startswith(self.CYLC_JOB_PID + "="):
                     pid = line.strip().split("=", 1)[1]
@@ -605,12 +605,11 @@ class BatchSysManager(object):
         exp_pids = []
         bad_pids = []
         items = [[self.get_inst(batch_sys_name), exp_job_ids, bad_job_ids]]
-        if getattr(items[0][0], "CAN_POLL_PROC_GROUP", False):
+        if getattr(items[0][0], "SHOULD_POLL_PROC_GROUP", False):
             exp_pids = [ctx.pid for ctx in my_ctx_list if ctx.pid is not None]
-            bad_pids = bad_pids.extend(exp_pids)
+            bad_pids.extend(exp_pids)
             items.append([self.get_inst("background"), exp_pids, bad_pids])
         for batch_sys, exp_ids, bad_ids in items:
-            batch_sys = self.get_inst(batch_sys_name)
             if hasattr(batch_sys, "get_poll_many_cmd"):
                 # Some poll commands may not be as simple
                 cmd = batch_sys.get_poll_many_cmd(exp_ids)


### PR DESCRIPTION
When polling "at" jobs, if a job appears to have exited "atq", check PID
of job to see if it is still alive. In some systems, the job may not be
on "atq" while it is still running as a normal Unix process.

Close #1661.