### PR TITLE
Add another known *atd not running* warning string

### DIFF
--- a/lib/cylc/batch_sys_handlers/at.py
+++ b/lib/cylc/batch_sys_handlers/at.py
@@ -37,7 +37,11 @@ class AtCommandHandler(object):
            command template = at teatime
     """
 
-    ERR_NO_ATD = "Can't open /var/run/atd.pid to signal atd. No atd running?"
+    # List of known error strings when atd is not running
+    ERR_NO_ATD_STRS = [
+        "Can't open /var/run/atd.pid to signal atd. No atd running?",
+        "Warning: at daemon not running",
+    ]
     CAN_KILL_PROC_GROUP = True
     # N.B. The perl command ensures that the job script is executed in its own
     # process group, which allows the job script and its child processes to be
@@ -78,7 +82,7 @@ class AtCommandHandler(object):
                     out += line
                 elif any([rec.match(line) for rec in self.REC_ERR_FILTERS]):
                     continue
-                elif line.strip() == self.ERR_NO_ATD:
+                elif line.strip() in self.ERR_NO_ATD_STRS:
                     raise OSError(
                         errno.ESRCH, os.strerror(errno.ESRCH), line)
                 else:


### PR DESCRIPTION
It seems like `at` can throw a different error string when `atd` is not running. This change handles another known case.