### PR TITLE
cylc ping: use 'scan hash' for communications

### DIFF
--- a/bin/cylc-ping
+++ b/bin/cylc-ping
@@ -59,6 +59,7 @@ def main():
         suite, options.owner, options.host, options.pyro_timeout,
         options.port, options.db, my_uuid=options.set_uuid,
         print_uuid=options.print_uuid)
+    pclient.set_use_scan_hash()
 
     # cylc ping SUITE
     pclient.get_info('ping_suite')  # (no need to check the result)

--- a/doc/siterc.tex
+++ b/doc/siterc.tex
@@ -873,10 +873,10 @@ susceptible to hash collision weakness, so both algorithms are more secure for
 HMAC use than in the general case.
 
 Clients will attempt to establish a connection using the algorithms from first
-to last. The exception is scanning, which will use the algorithm configured in
-the [authentication] $\rightarrow$ scan hash setting below. If you have lots
-of suites running with e.g. MD5 hashes, you will want to include 'md5' in your
-list of hashes and set it as the default scan hash.
+to last. The exceptions are scanning and pinging, which will use the algorithm
+configured in the [authentication] $\rightarrow$ scan hash setting below. If
+you have lots of suites running with e.g. MD5 hashes, you will want to include
+'md5' in your list of hashes and set it as the default scan hash.
 
 See \url{https://docs.python.org/2/library/hmac.html} and
 \url{https://docs.python.org/2/library/hashlib.html} for discussion of hash
@@ -902,7 +902,7 @@ algorithms.
 See [authentication] $\rightarrow$ hashes.
 
 Configure which of the specified hash algorithms in [authentication]
-$\rightarrow$ hashes is used for scanning.
+$\rightarrow$ hashes is used for scanning and pinging (cylc scan, cylc ping).
 
 The default hash algorithm for scans is MD5, for backwards compatibility
 reasons. You can override it by specifying a different value for this setting

--- a/lib/cylc/network/suite_info.py
+++ b/lib/cylc/network/suite_info.py
@@ -22,6 +22,7 @@ import cylc.flags
 from cylc.network import PYRO_INFO_OBJ_NAME
 from cylc.network.pyro_base import PyroClient, PyroServer
 from cylc.network import check_access_priv
+from cylc.network.connection_validator import SCAN_HASH
 
 
 # Back-compat for older suite daemons <= 6.4.1.
@@ -74,3 +75,12 @@ class SuiteInfoClient(PyroClient):
             command = back_compat[args[0]]
             args = tuple([command]) + args[1:]
             return self.call_server_func("get", *args)
+
+    def set_use_scan_hash(self):
+        """Use the configured scan hash for backwards compatibility."""
+        self._hash_name = SCAN_HASH
+
+    def _get_proxy(self, hash_name=None):
+        if hash_name is None and hasattr(self, "_hash_name"):
+            hash_name = self._hash_name
+        return super(SuiteInfoClient, self)._get_proxy(hash_name=hash_name)


### PR DESCRIPTION
This is a follow on to #1700. The `scan hash` configuration is used for `cylc scan` for
better backwards compatibility with older daemons, and it needs to be used for `cylc ping`
for the same reasons. This avoids having a spurious connection denied warning in the suite
err log.

@hjoliver and @arjclark please review.