### PR TITLE
cylc.suite_host: improve logic

### DIFF
--- a/bin/cylc-scan
+++ b/bin/cylc-scan
@@ -47,15 +47,10 @@ if "--use-ssh" in sys.argv[1:]:
         sys.exit(0)
 
 import re
-from multiprocessing import cpu_count, Pool
-from time import sleep
-import traceback
 
-import cylc.flags
-from cylc.network.port_scan import scan
+from cylc.network.port_scan import scan_all
 from cylc.CylcOptionParsers import cop
 from cylc.cfgspec.globalcfg import GLOBAL_CFG
-from cylc.suite_host import is_remote_host
 from cylc.task_state import TaskState
 from cylc.owner import user
 
@@ -342,45 +337,6 @@ def get_point_state_count_lines(state_count_totals, state_count_cycles,
                 line += '%s:%d ' % (st, tot)
         yield (point_string, line.strip())
 
-
-def scan_all(hosts=None, reg_db_path=None, pyro_timeout=None):
-    """Scan all hosts."""
-    if not hosts:
-        hosts = GLOBAL_CFG.get(["suite host scanning", "hosts"])
-    # Ensure that it does "localhost" only once
-    hosts = set(hosts)
-    for host in list(hosts):
-        if not is_remote_host(host):
-            hosts.remove(host)
-            hosts.add("localhost")
-    proc_pool_size = GLOBAL_CFG.get(["process pool size"])
-    if proc_pool_size is None:
-        proc_pool_size = cpu_count()
-    if proc_pool_size > len(hosts):
-        proc_pool_size = len(hosts)
-    proc_pool = Pool(proc_pool_size)
-    async_results = {}
-    for host in hosts:
-        async_results[host] = proc_pool.apply_async(
-            scan, [host, reg_db_path, pyro_timeout])
-    proc_pool.close()
-    scan_results = []
-    hosts = []
-    while async_results:
-        sleep(0.05)
-        for host, async_result in async_results.items():
-            if async_result.ready():
-                async_results.pop(host)
-                try:
-                    res = async_result.get()
-                except:
-                    if cylc.flags.debug:
-                        traceback.print_exc()
-                else:
-                    scan_results.extend(res)
-                    hosts.extend([host] * len(res))
-    proc_pool.join()
-    return zip(hosts, scan_results)
 
 if __name__ == "__main__":
     main()

--- a/bin/cylc-scan
+++ b/bin/cylc-scan
@@ -91,7 +91,7 @@ def main():
         action="append", dest="patterns_name", default=[])
 
     parser.add_option(
-        "-o", "--owner",
+        "-o", "--suite-owner",
         metavar="PATTERN",
         help="List suites with owner matching PATTERN (regular expression). "
              "Defaults to just your own suites. Can be used multiple times.",

--- a/lib/cylc/gui/gscan.py
+++ b/lib/cylc/gui/gscan.py
@@ -46,7 +46,7 @@ KEY_STATES = "states"
 KEY_UPDATE_TIME = "update-time"
 
 
-def get_hosts_suites_info(hosts, timeout=None, owner=None):
+def get_hosts_suites_info(hosts, timeout=None, owner=user):
     """Return a dictionary of hosts, suites, and their properties."""
     host_suites_map = {}
     for host, port_results in scan_all(

--- a/lib/cylc/gui/gscan.py
+++ b/lib/cylc/gui/gscan.py
@@ -42,18 +42,21 @@ from cylc.task_state import TaskState
 
 PYRO_TIMEOUT = 2
 KEY_NAME = "name"
+KEY_OWNER = "owner"
 KEY_STATES = "states"
 KEY_UPDATE_TIME = "update-time"
 
 
-def get_hosts_suites_info(hosts, timeout=None, owner=user):
+def get_hosts_suites_info(hosts, timeout=None, owner=None):
     """Return a dictionary of hosts, suites, and their properties."""
     host_suites_map = {}
     for host, port_results in scan_all(
-            hosts=hosts, pyro_timeout=timeout, owner=owner):
+            hosts=hosts, pyro_timeout=timeout):
+        port, result = port_results
+        if owner and owner != result.get(KEY_OWNER):
+            continue
         if host not in host_suites_map:
             host_suites_map[host] = {}
-        port, result = port_results
         try:
             host_suites_map[host][result[KEY_NAME]] = {}
             props = host_suites_map[host][result[KEY_NAME]]

--- a/lib/cylc/gui/gscan.py
+++ b/lib/cylc/gui/gscan.py
@@ -767,7 +767,7 @@ class BaseScanUpdater(threading.Thread):
         while not self.quit:
             time_for_update = (
                 self.last_update_time is None or
-                time.time() < self.last_update_time + self.poll_interval
+                time.time() >= self.last_update_time + self.poll_interval
             )
             if not self._should_force_update and not time_for_update:
                 time.sleep(1)

--- a/lib/cylc/network/port_scan.py
+++ b/lib/cylc/network/port_scan.py
@@ -16,20 +16,23 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from multiprocessing import cpu_count, Pool
 import os
 import sys
+from time import sleep
+import traceback
+
 import Pyro.errors
 import Pyro.core
 
-import cylc.flags
-from cylc.owner import user
-from cylc.suite_host import get_hostname
-from cylc.registration import localdb
-from cylc.passphrase import passphrase, get_passphrase, PassphraseError
 from cylc.cfgspec.globalcfg import GLOBAL_CFG
+import cylc.flags
 from cylc.network import PYRO_SUITEID_OBJ_NAME, NO_PASSPHRASE
-from cylc.network.connection_validator import (
-    ConnValidator, OK_HASHES, SCAN_HASH)
+from cylc.network.connection_validator import ConnValidator, SCAN_HASH
+from cylc.owner import user
+from cylc.passphrase import passphrase, get_passphrase, PassphraseError
+from cylc.registration import localdb
+from cylc.suite_host import get_hostname, is_remote_host
 
 passphrases = []
 
@@ -78,7 +81,7 @@ def get_proxy(host, port, pyro_timeout):
     return proxy
 
 
-def scan(host=get_hostname(), db=None, pyro_timeout=None, owner=user):
+def scan(host=get_hostname(), db=None, pyro_timeout=None, owner=None):
     """Scan ports, return a list of suites found: [(port, suite.identify())].
 
     Note that we could easily scan for a given suite+owner and return its
@@ -90,6 +93,8 @@ def scan(host=get_hostname(), db=None, pyro_timeout=None, owner=user):
         pyro_timeout = float(pyro_timeout)
     else:
         pyro_timeout = None
+    if not owner:
+        owner = user
 
     results = []
     for port in range(base_port, last_port):
@@ -173,3 +178,43 @@ def scan(host=get_hostname(), db=None, pyro_timeout=None, owner=user):
                             print '    (got states with passphrase)'
         results.append(result)
     return results
+
+
+def scan_all(hosts=None, reg_db_path=None, pyro_timeout=None, owner=None):
+    """Scan all hosts."""
+    if not hosts:
+        hosts = GLOBAL_CFG.get(["suite host scanning", "hosts"])
+    # Ensure that it does "localhost" only once
+    hosts = set(hosts)
+    for host in list(hosts):
+        if not is_remote_host(host):
+            hosts.remove(host)
+            hosts.add("localhost")
+    proc_pool_size = GLOBAL_CFG.get(["process pool size"])
+    if proc_pool_size is None:
+        proc_pool_size = cpu_count()
+    if proc_pool_size > len(hosts):
+        proc_pool_size = len(hosts)
+    proc_pool = Pool(proc_pool_size)
+    async_results = {}
+    for host in hosts:
+        async_results[host] = proc_pool.apply_async(
+            scan, [host, reg_db_path, pyro_timeout, owner])
+    proc_pool.close()
+    scan_results = []
+    hosts = []
+    while async_results:
+        sleep(0.05)
+        for host, async_result in async_results.items():
+            if async_result.ready():
+                async_results.pop(host)
+                try:
+                    res = async_result.get()
+                except:
+                    if cylc.flags.debug:
+                        traceback.print_exc()
+                else:
+                    scan_results.extend(res)
+                    hosts.extend([host] * len(res))
+    proc_pool.join()
+    return zip(hosts, scan_results)

--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -25,7 +25,6 @@ from pipes import quote
 import Queue
 from random import randrange
 import re
-import socket
 import shlex
 from shutil import rmtree
 import time
@@ -1481,7 +1480,7 @@ class TaskProxy(object):
         logfiles.append(local_jobfile_path)
 
         if not self.job_conf['host']:
-            self.job_conf['host'] = socket.gethostname()
+            self.job_conf['host'] = 'localhost'
 
         if (is_remote_host(self.job_conf['host']) or
                 is_remote_user(self.job_conf['owner'])):


### PR DESCRIPTION
Memoize results of `is_remote_host` with a dict to prevent many network
related system calls, e.g. DNS lookups.

Functions in `cylc.suite_host` are now wrapped by a singleton object to improve
encapsulation and style.

Move `scan_all` from `bin/cylc-scan` to `cylc.network.port_scan`.

`cylc gscan` now uses the `scan_all` function in `cylc.network.port_scan` instead of subprocess calls to `cylc scan --raw`.
* Should benefit from the memoize logic in `cylc.suite_host` module.
* Now require no string parsing, only going down a data structure.

`cylc scan` fixes:
* `--owner=OWNER` did not work (but `-o OWNER` is fine) because `bin/cylc` modifies `--owner=OWNER` options to `--user=OWNER`. Option modified to `--suite-owner=OWNER` instead.

`cylc gscan` fixes:
* Typo that caused unnecessary `cylc cat-state` calls.
* Polling interval logic, which caused polling every second instead of every minute.

`cylc.port_scan` fixes:
* `scan` function no longer takes an `owner` argument, which was not used correctly.