### PR TITLE
Re-enable view menu for viewing pre-reqs.

### DIFF
--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -1246,9 +1246,6 @@ been defined for this suite""").inform()
             view_item.set_submenu(view_menu)
             items.append(view_item)
 
-            view_item.set_sensitive(
-                t_state in self.STATES_VIEW_LOGS or submit_num > 0)
-
             # NOTE: we have to respond to 'button-press-event' rather than
             # 'activate' in order for sub-menus to work in the graph-view.
 
@@ -1265,6 +1262,8 @@ been defined for this suite""").inform()
                 item.connect(
                     'button-press-event', self.view_task_info, task_id,
                     filename)
+                item.set_sensitive(
+                    t_state in self.STATES_VIEW_LOGS or submit_num > 0)
 
             info_item = gtk.ImageMenuItem('prereq\'s & outputs')
             img = gtk.image_new_from_stock(


### PR DESCRIPTION
Slight oversight from #1709.

This re-enables the view menu to allow viewing of pre-requisites for tasks that haven't run yet and instead disables job err/out/log etc. if it hasn't been run.

@matthewrmshin - please review 1
@hjoliver - please review 2