### PR TITLE
Fix link redirects (W3C Link Checker)

### DIFF
--- a/doc/cug.tex
+++ b/doc/cug.tex
@@ -382,15 +382,15 @@ previous section, emerges naturally at run time.
 
 \begin{myitemize}
     \item {\bf Cylc}, the version associated with this document is: \input{cylc-version.txt}. % generated each time by doc/process
-        \newline Cylc can be downloaded from from GitHub: \url{http://cylc.github.com/cylc}
+        \newline Cylc can be downloaded from from GitHub: \url{https://cylc.github.com/cylc}
     \item {\bf OS: A Linux or Unix variant (including, reportedly, Apple OS X).}
     \item {\bf The Python Language, version 2.6 or later, but not 3.x yet}.
-        \newline \url{http://python.org}
+        \newline \url{https://python.org}
     \item {\bf Pyro-3 (Python Remote Objects), version 3.10$+$, latest
         tested 3.16}; not Pyro4 as yet. Pyro is used
         for network communication between server processes (cylc suites)
         and client programs (running tasks, the gcylc GUI, user commands).
-        \newline \url{http://pypi.python.org/pypi/Pyro/}
+        \newline \url{https://pypi.python.org/pypi/Pyro/}
     \item {\bf sqlite (a server-less, zero-configuration, SQL database
         engine}). This is likely included in your Linux distribution
         already. Cylc generates an sqlite database for each suite as it
@@ -412,7 +412,7 @@ Jinja2 you will not be able to run many of the example suites}:
         (latest tested 1.1), a graph layout engine and a Python
         interface to it.
         \newline \url{http://www.graphviz.org}
-        \newline \url{http://networkx.lanl.gov/pygraphviz}
+        \newline \url{http://pygraphviz.github.io/}
     \item {\bf Jinja2}, a template processor for Python (latest tested:
         2.6). Jinja2 allows use of general programming constructs in
         suite definitions.
@@ -451,7 +451,7 @@ by installing the
 fast C-coded \lstinline=ordereddict= module by Anthon van der Neut:
 \begin{myitemize}
     \item {\bf ordereddict} (latest tested 0.4.5) \newline
-        \url{http://www.xs4all.nl/~anthon/Python/ordereddict}
+        \url{https://anthon.home.xs4all.nl/Python/ordereddict/}
 \end{myitemize}
 {\em This module is currently included with cylc} under
 \lstinline=$CYLC_DIR/ext=, and is built by the top level cylc Makefile.
@@ -534,7 +534,7 @@ Here's how to solve the problem:
 \subsection{Other Software Used Internally By Cylc}
 
 Cylc has incorporated a custom-modified version the {\em xdot} graph
-viewer (\url{http://code.google.com/p/jrfonseca/wiki/XDot}, LGPL license).
+viewer (\url{https://github.com/jrfonseca/xdot.py}, LGPL license).
 
 
 \section{Installation}


### PR DESCRIPTION
Trivial pull request. Some links in the documentation are generating HTTP redirects. This pull request uses the destination link, rather than the one being redirected. I believe the Google Code link is the only one that is going to the wrong place. No other broken links in the documentation :grinning: 