### PR TITLE
Fix constant state dumps for queued tasks

### DIFF
--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -966,14 +966,16 @@ To see if a suite of the same name is still running, try:
                     self.log.debug("BEGIN TASK PROCESSING")
                     main_loop_start_time = time.time()
 
+                changes = 0
                 self.pool.match_dependencies()
                 if not self.shut_down_cleanly:
-                    self.pool.submit_tasks()
-                self.pool.spawn_tasks()
-                self.pool.remove_spent_tasks()
-                self.pool.remove_suiciding_tasks()
+                    changes += self.pool.submit_tasks()
+                changes += self.pool.spawn_tasks()
+                changes += self.pool.remove_spent_tasks()
+                changes += self.pool.remove_suiciding_tasks()
 
-                self.do_update_state_summary = True
+                if changes:
+                    self.do_update_state_summary = True
 
                 BroadcastServer.get_inst().expire(self.pool.get_min_point())
 

--- a/tests/state-dump/03-queued-no-repeats.t
+++ b/tests/state-dump/03-queued-no-repeats.t
@@ -1,0 +1,38 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test that we don't get lots of redundant state dumps with queued tasks.
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 4
+install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-validate
+run_ok $TEST_NAME cylc validate $SUITE_NAME
+SUITE_DIR=$(cylc get-global-config --print-run-dir)/$SUITE_NAME
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-run
+suite_run_ok $TEST_NAME cylc run --reference-test --debug $SUITE_NAME
+run_ok $TEST_NAME-n-dumps test $(find $SUITE_DIR/state -type f -name "state*" | wc -l) -eq 7
+grep 'person' $SUITE_DIR/state/state >$TEST_NAME.state
+cmp_ok $TEST_NAME.state <<'__STATE__'
+person_a.1 : status=succeeded, spawned=true
+person_b.1 : status=succeeded, spawned=true
+__STATE__
+#-------------------------------------------------------------------------------
+purge_suite $SUITE_NAME
+exit

--- a/tests/state-dump/03-queued-no-repeats/reference.log
+++ b/tests/state-dump/03-queued-no-repeats/reference.log
@@ -1,0 +1,17 @@
+2016-03-01T11:45:10Z INFO - Run mode: live
+2016-03-01T11:45:10Z INFO - Initial point: 1
+2016-03-01T11:45:10Z INFO - Final point: 1
+2016-03-01T11:45:10Z INFO - Cold Start 1
+2016-03-01T11:45:10Z INFO - [person_a.1] -triggered off []
+2016-03-01T11:45:12Z INFO - [person_a.1] -submit_method_id=2150
+2016-03-01T11:45:12Z INFO - [person_a.1] -submission succeeded
+2016-03-01T11:45:12Z INFO - [person_a.1] -(current:submitted)> person_a.1 started at 2016-03-01T11:45:11Z
+2016-03-01T11:45:22Z INFO - [person_a.1] -(current:running)> person_a.1 succeeded at 2016-03-01T11:45:21Z
+2016-03-01T11:45:22Z INFO - [person_a.1] -('job-logs-register', 1) will run after P0Y (after 2016-03-01T11:45:22Z)
+2016-03-01T11:45:23Z INFO - [person_b.1] -triggered off []
+2016-03-01T11:45:24Z INFO - [person_b.1] -submit_method_id=2256
+2016-03-01T11:45:24Z INFO - [person_b.1] -submission succeeded
+2016-03-01T11:45:24Z INFO - [person_b.1] -(current:submitted)> person_b.1 started at 2016-03-01T11:45:23Z
+2016-03-01T11:45:34Z INFO - [person_b.1] -(current:running)> person_b.1 succeeded at 2016-03-01T11:45:33Z
+2016-03-01T11:45:34Z INFO - [person_b.1] -('job-logs-register', 1) will run after P0Y (after 2016-03-01T11:45:34Z)
+2016-03-01T11:45:35Z INFO - Suite shutting down at 2016-03-01T11:45:35Z

--- a/tests/state-dump/03-queued-no-repeats/suite.rc
+++ b/tests/state-dump/03-queued-no-repeats/suite.rc
@@ -1,0 +1,12 @@
+[scheduling]
+    [[queues]]
+        [[[people_queue]]]
+            limit = 1
+            members = person_a, person_b
+    [[dependencies]]
+        graph = """
+            person_a & person_b
+        """
+[runtime]
+    [[person_a,person_b]]
+        script = sleep 10


### PR DESCRIPTION
This fixes #1744 where the state file is continually dumped
if the task pool contains a queued task.

This is due to the ready_to_run check in process_tasks in scheduler.py
returning True if any task is queued and has reached its start time.

The fix is to only update the state summary if we really think
something has changed. This is a good thing to be doing anyway.

@hjoliver, @matthewrmshin please review.