### PR TITLE
cylc gui: fix updater poll schd on stopped suite

### DIFF
--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -2830,7 +2830,7 @@ This is what my suite does:..."""
     def reset_connection_polling(self, bt):
         # Force the polling schedule to go back to short intervals so
         # that the GUI can immediately connect to the started suite.
-        self.updater.poll_schd.t_init = None
+        self.updater.poll_schd.stop()
 
     def construct_command_menu(self, menu):
         cat_menu = gtk.Menu()


### PR DESCRIPTION
The gui was not using the poll schd delay scheme when started on stopped
suites, (i.e. if we launched the gui on a stopped suite, it would continue to poll every second).

This fixes the problem. (I have also improved the diagnostic for debug mode, and improved the pylint score for the cylc.gui.updater module.)

@hjoliver @benfitzpatrick please review.