### PR TITLE
Modify retrieve job logs OK condition

### DIFF
--- a/doc/cug.tex
+++ b/doc/cug.tex
@@ -1405,7 +1405,7 @@ ssh -oBatchMode=yes -oConnectTimeout=10 wrh-1.niwa.co.nz\
 ' "/opt/cylc/bin/cylc" '"'"'job-submit'"'"\
 ' --remote-mode "/home/oliverh/cylc-run/tut.oneoff.remote/log/job/1/hello/01/job"'
 \end{lstlisting}
-(Don't be intimated by this - it is really quite straightforward and would
+(Don't be intimidated by this - it is really quite straightforward and would
 appear much simpler if the job log path was shorter!). Remote task job logs are
 saved to the suite run directory on the task host, not on the suite host,
 although they can be retrieved by right-clicking on the task in the GUI. If you
@@ -1460,6 +1460,20 @@ be anything that is accepted by the \lstinline@--max-size=SIZE@ option of the
             # Don't get anything bigger than 10MB
             retrieve job logs max size = 10M
 \end{lstlisting}
+
+It is worth noting that cylc uses the existence of a job's \lstinline=job.out=
+or \lstinline=job.err= in the local file system to indicate a successful job
+log retrieval. If \lstinline=retrieve job logs max size=SIZE= is set and both
+\lstinline=job.out= and \lstinline=job.err= are bigger than \lstinline=SIZE=
+then cylc will consider the retrieval as failed. If retry delays are specified,
+this will trigger some useless (but harmless) retries. If this occurs
+regularly, you should try the following:
+
+\begin{myitemize}
+\item Reduce the verbosity of STDOUT or STDERR from the task.
+\item Redirect the verbosity from STDOUT or STDERR to an alternate log file.
+\item Adjust the size limit with tolerance to the expected size of STDOUT or STDERR.
+\end{myitemize}
 
 \begin{myitemize}
 \item For more on remote tasks see~\ref{RunningTasksOnARemoteHost}

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -1147,7 +1147,7 @@ class TaskPool(object):
                 itask = tasks[(point, name)]
                 try_states = itask.event_handler_try_states
                 filenames = itask.register_job_logs(submit_num)
-                if "job.out" in filenames and "job.err" in filenames:
+                if "job.out" in filenames or "job.err" in filenames:
                     log_ctx = SuiteProcContext((key1, submit_num), None)
                     log_ctx.ret_code = 0
                     itask.command_log(log_ctx)
@@ -1208,7 +1208,7 @@ class TaskPool(object):
                 filenames = []
                 if ctx.ret_code == 0:
                     filenames = itask.register_job_logs(submit_num)
-                if "job.out" in filenames and "job.err" in filenames:
+                if "job.out" in filenames or "job.err" in filenames:
                     log_ctx = SuiteProcContext((key1, submit_num), None)
                     log_ctx.ret_code = 0
                     itask.command_log(log_ctx)

--- a/tests/events/16-task-event-job-logs-register-globalcfg.t
+++ b/tests/events/16-task-event-job-logs-register-globalcfg.t
@@ -38,6 +38,7 @@ cmp_ok 'select-task-job-logs.out' <<'__OUT__'
 1|t1|1|job|1/t1/01/job
 1|t1|1|job-activity.log|1/t1/01/job-activity.log
 1|t1|1|job.err|1/t1/01/job.err
+1|t1|1|job.err.keep|1/t1/01/job.err.keep
 1|t1|1|job.out|1/t1/01/job.out
 1|t1|1|job.out.keep|1/t1/01/job.out.keep
 1|t1|1|job.status|1/t1/01/job.status

--- a/tests/events/16-task-event-job-logs-register-globalcfg/suite.rc
+++ b/tests/events/16-task-event-job-logs-register-globalcfg/suite.rc
@@ -15,9 +15,11 @@ title=Task Event Job Log Retrieve
         script="""
 wait "${CYLC_TASK_MESSAGE_STARTED_PID}" 2>/dev/null || true
 mv "$0.out" "$0.out.keep"
+mv "$0.err" "$0.err.keep"
 cylc task message 'succeeded' >>"$0.out.keep"
 sleep 5
 cp -p "$0.out.keep" "$0.out"
+cp -p "$0.err.keep" "$0.err"
 
 trap '' EXIT
 """


### PR DESCRIPTION
Previously, both `job.out` and `job.err` must exist to give an OK
condition. This is now relaxed to the existence of either `job.out` or
`job.err`.

@hjoliver @benfitzpatrick please review.