### PR TITLE
Fix.state summary update

### DIFF
--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -239,7 +239,8 @@ class Scheduler(object):
 
         self.pool = TaskPool(
             self.suite, self.pri_dao, self.pub_dao, self.final_point,
-            self.pyro, self.log, self.run_mode)
+            self.pyro, self.log, self.run_mode,
+            self._update_state_summary_callback)
         self.state_dumper.pool = self.pool
         self.request_handler = PyroRequestHandler(self.pyro)
         self.request_handler.start()
@@ -328,6 +329,9 @@ class Scheduler(object):
                 if name in self.proc_cmds:
                     self.do_process_tasks = True
             queue.task_done()
+
+    def _update_state_summary_callback(self):
+        self.do_update_state_summary = True
 
     def _task_type_exists(self, name_or_id):
         # does a task name or id match a known task type in this suite?

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -121,7 +121,7 @@ class Scheduler(object):
         self.suite_contact_env = {}
 
         self.do_process_tasks = False
-        self.do_update_state_summary = False
+        self.do_update_state_summary = True
 
         # initialize some items in case of early shutdown
         # (required in the shutdown() method)

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -72,7 +72,7 @@ class TaskPool(object):
     JOBS_SUBMIT = "jobs-submit"
 
     def __init__(self, suite, pri_dao, pub_dao, stop_point, pyro, log,
-                 run_mode):
+                 run_mode, update_state_summary_callback):
         self.suite_name = suite
         self.pyro = pyro
         self.run_mode = run_mode
@@ -81,6 +81,7 @@ class TaskPool(object):
         self.reconfiguring = False
         self.pri_dao = pri_dao
         self.pub_dao = pub_dao
+        self.update_state_summary_callback = update_state_summary_callback
 
         config = SuiteConfig.get_inst()
         self.custom_runahead_limit = config.get_custom_runahead_limit()
@@ -778,6 +779,8 @@ class TaskPool(object):
         else:
             self.log.info("Reload completed.")
             self.reload_warned = False
+            # The GUI detects end of a reload via the suite state summary.
+            self.update_state_summary_callback()
 
         self.reconfiguring = found
 

--- a/tests/reload/17-state-summary.t
+++ b/tests/reload/17-state-summary.t
@@ -1,0 +1,41 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test that the state summary updates immediately when a reload finishes.
+# See https://github.com/cylc/cylc/pull/1756
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 2
+#-------------------------------------------------------------------------------
+install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-validate
+run_ok $TEST_NAME cylc validate $SUITE_NAME
+#-------------------------------------------------------------------------------
+# Suite runs and shuts down with a failed task.
+cylc run --no-detach $SUITE_NAME > /dev/null 2>&1
+# Restart with a failed task and a succeeded task (so reload finishes
+# immediately).
+cylc restart $SUITE_NAME
+sleep 5
+cylc dump $SUITE_NAME > dump.out
+TEST_NAME=$TEST_NAME_BASE-grep
+# State summary should not say "reloading = True"
+grep_ok "reloading = False" dump.out
+#-------------------------------------------------------------------------------
+cylc stop --max-polls=10 --interval=2 $SUITE_NAME
+purge_suite $SUITE_NAME

--- a/tests/reload/17-state-summary/suite.rc
+++ b/tests/reload/17-state-summary/suite.rc
@@ -1,0 +1,9 @@
+[scheduling]
+    [[dependencies]]
+        graph = """foo
+            foo:fail => stopper"""
+[runtime]
+    [[foo]]
+        script = false
+    [[stopper]]
+        script = cylc stop $CYLC_SUITE_NAME

--- a/tests/startup/02-state-summary.t
+++ b/tests/startup/02-state-summary.t
@@ -1,0 +1,40 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test that the state summary updates immediately on start-up.
+# See https://github.com/cylc/cylc/pull/1756
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 2
+#-------------------------------------------------------------------------------
+install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-validate
+run_ok $TEST_NAME cylc validate $SUITE_NAME
+#-------------------------------------------------------------------------------
+# Suite runs and shuts down with a failed task.
+cylc run --no-detach $SUITE_NAME > /dev/null 2>&1
+# Restart with a failed task and a succeeded task.
+cylc restart $SUITE_NAME
+sleep 5
+cylc dump $SUITE_NAME > dump.out
+TEST_NAME=$TEST_NAME_BASE-grep
+# State summary should not just say "Initializing..."
+grep_ok "state totals = {'failed': 1, 'succeeded': 1}" dump.out
+#-------------------------------------------------------------------------------
+cylc stop --max-polls=10 --interval=2 $SUITE_NAME
+purge_suite $SUITE_NAME

--- a/tests/startup/02-state-summary/suite.rc
+++ b/tests/startup/02-state-summary/suite.rc
@@ -1,0 +1,9 @@
+[scheduling]
+    [[dependencies]]
+        graph = """foo
+            foo:fail => stopper"""
+[runtime]
+    [[foo]]
+        script = false
+    [[stopper]]
+        script = cylc stop $CYLC_SUITE_NAME


### PR DESCRIPTION
Follow-up to #1745, which it turns out was a little bit overzealous.  The state summary is not being updated at start-up until the first task state change (so a suite with no immediate active tasks stays in "initializing...", with no state to display, until a task triggers) or when a reload completes (so the GUI keeps reporting "reloading..." until a task triggers).

@benfitzpatrick, @matthewrmshin - please review.

Note my fix for the second problem is a bit ugly!  Alternative suggestions welcome, but we need to get this fix out pretty quickly.   For efficiency, in future we might want to separate this sort of simple global information from the task state summary updates, which might be time consuming in large suites.