### PR TITLE
Fix polling of jobs submitted to Loadleveler.

### DIFF
--- a/lib/cylc/batch_sys_manager.py
+++ b/lib/cylc/batch_sys_manager.py
@@ -635,7 +635,10 @@ class BatchSysManager(object):
             if hasattr(batch_sys, "filter_poll_many_output"):
                 # Allow custom filter
                 for id_ in batch_sys.filter_poll_many_output(out):
-                    bad_ids.remove(id_)
+                    try:
+                        bad_ids.remove(id_)
+                    except ValueError:
+                        pass
             else:
                 # Just about all poll commands return a table, with column 1
                 # being the job ID. The logic here should be sufficient to
@@ -646,7 +649,10 @@ class BatchSysManager(object):
                     except IndexError:
                         continue
                     if head in exp_ids:
-                        bad_ids.remove(head)
+                        try:
+                            bad_ids.remove(head)
+                        except ValueError:
+                            pass
 
         for ctx in my_ctx_list:
             ctx.batch_sys_exit_polled = int(

--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -194,6 +194,8 @@ class TaskProxy(object):
     TABLE_TASK_EVENTS = CylcSuiteDAO.TABLE_TASK_EVENTS
     TABLE_TASK_STATES = CylcSuiteDAO.TABLE_TASK_STATES
 
+    POLLED_INDICATOR = "(polled)"
+
     event_handler_env = {}
     stop_sim_mode_job_submission = False
 
@@ -1589,20 +1591,20 @@ class TaskProxy(object):
         the state backward in the natural order of events.
 
         """
-        # TODO - formalise state ordering, for: 'if new_state < old_state'
 
         # Log incoming messages with '>' to distinguish non-message log entries
-        self.log(
-            self.LOGGING_LVL_OF.get(priority, INFO),
-            '(current:' + self.state.get_status() + ')> ' + msg_in)
+        log_msg = '(current:%s)> %s' % (self.state.get_status(), msg_in)
+        if msg_was_polled:
+            log_msg += ' %s' % self.POLLED_INDICATOR
+        self.log(self.LOGGING_LVL_OF.get(priority, INFO), log_msg)
 
-        # Now strip the "at TIME" suffix.
+        # Strip the "at TIME" suffix.
         msg = self.MESSAGE_SUFFIX_RE.sub('', msg_in)
 
         # always update the suite state summary for latest message
         self.summary['latest_message'] = msg
         if msg_was_polled:
-            self.summary['latest_message'] += " (polled)"
+            self.summary['latest_message'] += " %s" % self.POLLED_INDICATOR
         flags.iflag = True
 
         if self.reject_if_failed(msg):


### PR DESCRIPTION
Loadleveler job poll failing in 6.8.1:
```
2016-03-16T10:55:52+13 ERROR - 2016-03-16T10:55:52+13 [jobs-poll cmd] cylc jobs-poll --host=wrh-1.hpcf.niwa.co.nz -- '$HOME/cylc-run/foo/log/job' 1/foo/01
2016-03-16T10:55:52+13 [jobs-poll ret_code] 1
2016-03-16T10:55:52+13 [jobs-poll err]

Traceback (most recent call last):
  File "/home/oliverh/cylc/cylc.git/bin/cylc-jobs-poll", line 43, in <module>
    main()
  File "/home/oliverh/cylc/cylc.git/bin/cylc-jobs-poll", line 37, in main
    BATCH_SYS_MANAGER.jobs_poll(args[0], args[1:])
  File "/gpfs_hpcf/filesets/hpcf/home/oliverh/cylc/cylc.git/lib/cylc/batch_sys_manager.py", line 321, in jobs_poll
    job_log_root, batch_sys_name, my_ctx_list)
  File "/gpfs_hpcf/filesets/hpcf/home/oliverh/cylc/cylc.git/lib/cylc/batch_sys_manager.py", line 638, in _jobs_poll_batch_sys
    bad_ids.remove(id_)
ValueError: list.remove(x): x not in list
ERROR: remote command terminated by signal 1
```