### PR TITLE
Speed up dependency matching

### DIFF
--- a/lib/cylc/broker.py
+++ b/lib/cylc/broker.py
@@ -34,6 +34,7 @@ class broker(object):
     def __init__(self):
         self.log = logging.getLogger('main')
         self.all_outputs = {}   # all_outputs[ message ] = taskid
+        self.all_output_msgs = set()
 
     def register(self, tasks):
 
@@ -42,10 +43,12 @@ class broker(object):
             # TODO - SHOULD WE CHECK FOR SYSTEM-WIDE DUPLICATE OUTPUTS?
             # (note that successive tasks of the same type can register
             # identical outputs if they write staggered restart files).
+        self.all_output_msgs = set(self.all_outputs)
 
     def reset(self):
         # throw away all messages
         self.all_outputs = {}
+        self.all_output_msgs = set()
 
     def dump(self):
         # for debugging
@@ -55,4 +58,4 @@ class broker(object):
 
     def negotiate(self, task):
         # can my outputs satisfy any of task's prerequisites
-        task.satisfy_me(self.all_outputs)
+        task.satisfy_me(self.all_output_msgs, self.all_outputs)

--- a/lib/cylc/prerequisite.py
+++ b/lib/cylc/prerequisite.py
@@ -141,7 +141,16 @@ class Prerequisite(object):
             return res
 
     def satisfy_me(self, output_msgs, outputs):
-        # Can any completed outputs satisfy any of my prequisites?
+        """Can any completed outputs satisfy any of my prequisites?
+
+        This needs to be fast as it's called for all unsatisfied tasks
+        whenever there's a change.
+
+        At the moment, this uses set intersections to filter out
+        irrelevant outputs - using for loops and if matching is very
+        slow.
+
+        """
         relevant_msgs = output_msgs & self.messages_set
         for msg in relevant_msgs:
             for label in self.satisfied:

--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -1824,11 +1824,11 @@ class TaskProxy(object):
         return (not self.prerequisites_are_all_satisfied() or
                 not self.suicide_prerequisites_are_all_satisfied())
 
-    def satisfy_me(self, task_outputs):
+    def satisfy_me(self, task_output_msgs, task_outputs):
         """Attempt to get my prerequisites satisfied."""
         for preqs in [self.prerequisites, self.suicide_prerequisites]:
             for preq in preqs:
-                preq.satisfy_me(task_outputs)
+                preq.satisfy_me(task_output_msgs, task_outputs)
 
     def next_point(self):
         """Return the next cycle point."""


### PR DESCRIPTION
This partially satisfies #1688.

It filters down the amount of `for` looping and comparisons by doing a set intersection on
known dependencies and outputs beforehand. It speeds up our 1000-tasks-per-cycle `dev/suites/busy`
suite by 50x!

@hjoliver, @matthewrmshin please review.

