### PR TITLE
cylc refresh: don't nuke passphrase on title change

### DIFF
--- a/bin/cylc-copy
+++ b/bin/cylc-copy
@@ -77,7 +77,7 @@ import shutil
 import cylc.flags
 from cylc.CylcOptionParsers import cop
 from cylc.mkdir_p import mkdir_p
-from cylc.registration import localdb, RegistrationError
+from cylc.registration import RegistrationDB, RegistrationError
 from cylc.regpath import RegPath
 
 
@@ -98,10 +98,10 @@ def main():
     arg_dir = args[2]
 
     if options.dbfrom:
-        dbfrom = localdb(file=options.dbfrom)
+        dbfrom = RegistrationDB(options.dbfrom)
     else:
-        dbfrom = localdb(file=options.db)
-    db = localdb(file=options.db)
+        dbfrom = RegistrationDB(options.db)
+    db = RegistrationDB(options.db)
 
     flist = dbfrom.get_list('^' + arg_from + r'\b')
     if len(flist) == 0:

--- a/bin/cylc-monitor
+++ b/bin/cylc-monitor
@@ -35,7 +35,6 @@ from time import sleep
 from parsec.OrderedDict import OrderedDict
 from cylc.CylcOptionParsers import cop
 from cylc.task_state import TaskState
-from cylc.registration import localdb
 from cylc.network.suite_state import (
     StateSummaryClient, SuiteStillInitialisingError)
 from cylc.wallclock import get_time_string_from_unix_time

--- a/bin/cylc-print
+++ b/bin/cylc-print
@@ -37,7 +37,7 @@ import re
 
 import cylc.flags
 from cylc.CylcOptionParsers import cop
-from cylc.registration import localdb
+from cylc.registration import RegistrationDB
 from cylc.print_tree import print_tree
 from cylc.regpath import RegPath
 
@@ -94,7 +94,7 @@ def main():
     else:
         parser.error("Wrong number of arguments.")
 
-    db = localdb(file=options.db)
+    db = RegistrationDB(options.db)
     allsuites = db.get_list(regfilter)
     if options.fail and len(allsuites) == 0:
         raise SystemExit('ERROR: no suites matched.')

--- a/bin/cylc-refresh
+++ b/bin/cylc-refresh
@@ -31,7 +31,7 @@ if remrun().execute():
 
 import cylc.flags
 from cylc.CylcOptionParsers import cop
-from cylc.registration import localdb, RegistrationError
+from cylc.registration import RegistrationDB, RegistrationError
 from cylc.config import SuiteConfigError
 from cylc.regpath import RegPath
 
@@ -47,7 +47,7 @@ def main():
 
     (options, args) = parser.parse_args()
 
-    db = localdb(file=options.db)
+    db = RegistrationDB(options.db)
 
     if len(args) == 0:
         pattern = '.*'

--- a/bin/cylc-register
+++ b/bin/cylc-register
@@ -56,7 +56,7 @@ if remrun().execute():
 import os
 
 from cylc.CylcOptionParsers import cop
-from cylc.registration import localdb
+from cylc.registration import RegistrationDB
 import cylc.flags
 
 
@@ -76,7 +76,7 @@ def main():
         rdir = args[1]
         suiterc = os.path.join(rdir, 'suite.rc')
 
-    db = localdb(file=options.db)
+    db = RegistrationDB(options.db)
     db.register(suite, rdir)
 
 

--- a/bin/cylc-reregister
+++ b/bin/cylc-reregister
@@ -28,7 +28,7 @@ if remrun().execute():
     sys.exit(0)
 
 from cylc.CylcOptionParsers import cop
-from cylc.registration import localdb
+from cylc.registration import RegistrationDB
 import cylc.flags
 
 
@@ -39,7 +39,7 @@ def main():
     arg_from = args[0]
     arg_to = args[1]
 
-    db = localdb(file=options.db)
+    db = RegistrationDB(options.db)
     db.reregister(arg_from, arg_to)
 
 

--- a/bin/cylc-restart
+++ b/bin/cylc-restart
@@ -46,7 +46,7 @@ from cylc.suite_state_dumping import SuiteStateDumper
 from cylc.task_state import TaskState
 from cylc.run import main
 from cylc.get_task_proxy import get_task_proxy
-from cylc.registration import localdb
+from cylc.registration import RegistrationDB
 from cylc.task_id import TaskID
 from cylc.cycling.loader import get_point, DefaultCycler, ISO8601_CYCLING_TYPE
 from cylc.wallclock import get_current_time_string
@@ -101,7 +101,7 @@ class restart(Scheduler):
     def parse_commandline(self):
         (self.options, self.args) = self.parser.parse_args()
         self.suite = self.args[0]
-        self.suiterc = localdb(self.options.db).get_suiterc(self.suite)
+        self.suiterc = RegistrationDB(self.options.db).get_suiterc(self.suite)
         self.suite_dir = os.path.dirname(self.suiterc)
 
         # For user-defined job submission methods:

--- a/bin/cylc-run
+++ b/bin/cylc-run
@@ -51,7 +51,7 @@ import cylc.flags
 from cylc.CylcOptionParsers import cop
 from cylc.scheduler import Scheduler
 from cylc.run import main
-from cylc.registration import localdb
+from cylc.registration import RegistrationDB
 from cylc.task_proxy import TaskProxySequenceBoundsError
 from cylc.get_task_proxy import get_task_proxy
 
@@ -101,7 +101,7 @@ class start(Scheduler):
     def parse_commandline(self):
         (self.options, self.args) = self.parser.parse_args()
         self.suite = self.args[0]
-        self.suiterc = localdb(self.options.db).get_suiterc(self.suite)
+        self.suiterc = RegistrationDB(self.options.db).get_suiterc(self.suite)
         self.suite_dir = os.path.dirname(self.suiterc)
 
         # For user-defined job submission methods:

--- a/bin/cylc-submit
+++ b/bin/cylc-submit
@@ -44,7 +44,7 @@ from cylc.execute import execute
 from cylc.job_file import JOB_FILE
 from cylc.config import SuiteConfig
 from cylc.CylcOptionParsers import cop
-from cylc.registration import localdb
+from cylc.registration import RegistrationDB
 from cylc.task_id import TaskID
 from cylc.get_task_proxy import get_task_proxy
 from cylc.cycling.loader import get_point
@@ -79,7 +79,7 @@ def main():
     if options.debug:
         cylc.flags.debug = True
     suite = args[0]
-    suiterc = localdb(options.db).get_suiterc(suite)
+    suiterc = RegistrationDB(options.db).get_suiterc(suite)
 
     owner = options.owner
     host = options.host

--- a/bin/cylc-unregister
+++ b/bin/cylc-unregister
@@ -33,7 +33,7 @@ if remrun().execute():
 import os
 from shutil import rmtree
 from cylc.CylcOptionParsers import cop
-from cylc.registration import localdb
+from cylc.registration import RegistrationDB
 import cylc.flags
 
 
@@ -54,7 +54,7 @@ def main():
 
     (options, args) = parser.parse_args()
 
-    db = localdb(file=options.db)
+    db = RegistrationDB(options.db)
 
     dirs = db.unregister(args[0])
 

--- a/bin/cylc-upgrade-db
+++ b/bin/cylc-upgrade-db
@@ -37,7 +37,7 @@ from optparse import OptionParser
 import pickle
 
 import cylc.flags
-from cylc.registration import localdb, RegistrationError
+from cylc.registration import RegistrationDB, RegistrationError
 
 
 def main():
@@ -65,7 +65,7 @@ def main():
     olditems = pickle.load(open(oldpath, 'r'))
 
     # new db
-    db = localdb(file=newpath)
+    db = RegistrationDB(newpath)
     for suite, (dir, title) in olditems.items():
         try:
             db.register(suite, dir)

--- a/lib/cylc/CylcOptionParsers.py
+++ b/lib/cylc/CylcOptionParsers.py
@@ -22,7 +22,7 @@ import os
 import re
 import cylc.flags
 from cylc.owner import user
-from cylc.registration import localdb, RegistrationError
+from cylc.registration import RegistrationDB, RegistrationError
 from cylc.regpath import IllegalRegPathError
 
 
@@ -337,7 +337,7 @@ Arguments:"""
         If arg is a file, suite name is the name of its container directory.
 
         """
-        reg_db = localdb(options.db)
+        reg_db = RegistrationDB(options.db)
         try:
             path = reg_db.get_suiterc(arg)
             name = arg

--- a/lib/cylc/gui/dbchooser.py
+++ b/lib/cylc/gui/dbchooser.py
@@ -35,7 +35,7 @@ else:
     PyroInstalled = True
     from cylc.network.port_scan import scan
 
-from cylc.registration import localdb
+from cylc.registration import RegistrationDB
 from cylc.regpath import RegPath
 from warning_dialog import warning_dialog, info_dialog, question_dialog
 from util import get_icon
@@ -421,7 +421,7 @@ class dbchooser(object):
         self.start_updater()
 
     def start_updater(self, filtr=None):
-        db = localdb(self.db)
+        db = RegistrationDB(self.db)
         # self.db_button.set_label("_Local/Central DB")
         if self.updater:
             self.updater.quit = True  # does this take effect?

--- a/lib/cylc/network/port_scan.py
+++ b/lib/cylc/network/port_scan.py
@@ -32,7 +32,7 @@ from cylc.network.connection_validator import ConnValidator, SCAN_HASH
 from cylc.network.suite_state import SuiteStillInitialisingError
 from cylc.owner import user
 from cylc.passphrase import passphrase, get_passphrase, PassphraseError
-from cylc.registration import localdb
+from cylc.registration import RegistrationDB
 from cylc.suite_host import get_hostname, is_remote_host
 
 passphrases = []
@@ -45,7 +45,7 @@ def load_passphrases(db):
         return passphrases
 
     # Find passphrases in all registered suite directories.
-    reg = localdb(db)
+    reg = RegistrationDB(db)
     reg_suites = reg.get_list()
     for item in reg_suites:
         rg = item[0]
@@ -157,7 +157,8 @@ def scan(host=get_hostname(), db=None, pyro_timeout=None):
                 # This suite keeps its state info private.
                 # Try again with the passphrase if I have it.
                 try:
-                    pphrase = get_passphrase(name, owner, host, localdb(db))
+                    pphrase = get_passphrase(
+                        name, owner, host, RegistrationDB(db))
                 except PassphraseError:
                     if cylc.flags.debug:
                         print '    (no passphrase)'

--- a/lib/cylc/network/pyro_base.py
+++ b/lib/cylc/network/pyro_base.py
@@ -35,7 +35,7 @@ from cylc.network.client_reporter import PyroClientReporter
 from cylc.network.connection_validator import ConnValidator
 from cylc.owner import is_remote_user, user, host, user_at_host
 from cylc.passphrase import get_passphrase, PassphraseError
-from cylc.registration import localdb
+from cylc.registration import RegistrationDB
 from cylc.suite_host import is_remote_host
 from cylc.network.connection_validator import ConnValidator, OK_HASHES
 
@@ -73,7 +73,8 @@ class PyroClient(object):
         if print_uuid:
             print >> sys.stderr, '%s' % self.my_uuid
         try:
-            self.pphrase = get_passphrase(suite, owner, host, localdb(db))
+            self.pphrase = get_passphrase(
+                suite, owner, host, RegistrationDB(db))
         except PassphraseError:
             # No passphrase: public access client.
             self.pphrase = None

--- a/lib/cylc/registration.py
+++ b/lib/cylc/registration.py
@@ -63,7 +63,7 @@ class RegistrationDB(object):
         return suites
 
     def register(self, name, path):
-        """Register a suite, its source patha nd its title."""
+        """Register a suite, its source path and its title."""
         name = RegPath(name).get()
         for suite in self.list_all_suites():
             if name == suite:

--- a/lib/cylc/registration.py
+++ b/lib/cylc/registration.py
@@ -15,53 +15,55 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Simple suite name registration database."""
 
 import os
 import sys
 import re
 import cylc.flags
+from cylc.mkdir_p import mkdir_p
 from cylc.regpath import RegPath
 from cylc.passphrase import passphrase
 from cylc.suite_host import get_hostname
 from cylc.owner import user
 
-"""Simple suite name registration database."""
-
-regdb_path = os.path.join(os.environ['HOME'], '.cylc', 'REGDB')
+REGDB_PATH = os.path.join(os.environ['HOME'], '.cylc', 'REGDB')
 
 
 class RegistrationError(Exception):
-    def __init__(self, msg):
-        self.msg = msg
-
-    def __str__(self):
-        return repr(self.msg)
+    """Raise on suite registration error."""
+    pass
 
 
-class localdb(object):
+class RegistrationDB(object):
     """Represents a simple suite name registration database."""
 
     Error = RegistrationError
 
-    def __init__(self, file=None):
-        dbpath = file  # (back compat)
-        global regdb_path
-        self.dbpath = dbpath or regdb_path
+    def __init__(self, dbpath=None):
+        self.dbpath = dbpath or REGDB_PATH
         # create initial database directory if necessary
         if not os.path.exists(self.dbpath):
             try:
-                os.makedirs(self.dbpath)
-            except Exception, x:
-                sys.exit(str(x))
+                mkdir_p(self.dbpath)
+            except OSError as exc:
+                sys.exit(str(exc))
+
+    def dump_suite_data(self, suite, data):
+        """Dump suite path and title in text file."""
+        with open(os.path.join(self.dbpath, suite), 'w') as handle:
+            handle.write('path=%(path)s\ntitle=%(title)s\n' % data)
 
     def list_all_suites(self):
+        """Return a list containing names of registered suites."""
         try:
             suites = os.listdir(self.dbpath)
-        except Exception, x:
-            sys.exit(str(x))
+        except OSError as exc:
+            sys.exit(str(exc))
         return suites
 
-    def register(self, name, dir):
+    def register(self, name, path):
+        """Register a suite, its source patha nd its title."""
         name = RegPath(name).get()
         for suite in self.list_all_suites():
             if name == suite:
@@ -74,31 +76,30 @@ class localdb(object):
                 # suite starts with, to some level, an existing suite name
                 raise RegistrationError(
                     "ERROR: " + suite + " is a registered suite.")
-        dir = dir.rstrip('/')  # strip trailing '/'
-        dir = re.sub('^\./', '', dir)  # strip leading './'
-        if not dir.startswith('/'):
-            # On AIX on GPFS os.path.abspath(dir) returns the path with
+        path = path.rstrip('/')  # strip trailing '/'
+        path = re.sub('^\./', '', path)  # strip leading './'
+        if not path.startswith('/'):
+            # On AIX on GPFS os.path.abspath(path) returns the path with
             # full 'fileset' prefix. Manual use of $PWD to absolutize a
             # relative path gives a cleaner result.
-            dir = os.path.join(os.environ['PWD'], dir)
-        title = self.get_suite_title(name, path=dir)
+            path = os.path.join(os.environ['PWD'], path)
+        title = self.get_suite_title(name, path=path)
         title = title.split('\n')[0]  # use the first of multiple lines
-        print 'REGISTER', name + ':', dir
-        with open(os.path.join(self.dbpath, name), 'w') as file:
-            file.write('path=' + dir + '\n')
-            file.write('title=' + title + '\n')
+        print 'REGISTER', name + ':', path
+        self.dump_suite_data(name, {'path': path, 'title': title})
 
         # create a new passphrase for the suite if necessary
-        passphrase(name, user, get_hostname()).generate(dir)
+        passphrase(name, user, get_hostname()).generate(path)
 
     def get_suite_data(self, suite):
+        """Return {"path": path, "title": title} a suite."""
         suite = RegPath(suite).get()
         fpath = os.path.join(self.dbpath, suite)
         if not os.path.isfile(fpath):
             raise RegistrationError("ERROR: Suite not found " + suite)
         data = {}
-        with open(fpath, 'r') as file:
-            lines = file.readlines()
+        with open(fpath, 'r') as handle:
+            lines = handle.readlines()
         count = 0
         for line in lines:
             count += 1
@@ -118,15 +119,17 @@ class localdb(object):
         return data
 
     def get_suitedir(self, reg):
+        """Return the registered directory path of a suite."""
         data = self.get_suite_data(reg)
         return data['path']
 
     def get_suiterc(self, reg):
+        """Return the suite.rc path of a suite."""
         data = self.get_suite_data(reg)
         return os.path.join(data['path'], 'suite.rc')
 
     def get_list(self, regfilter=None):
-        # Return a filtered list of valid suite registrations.
+        """Return a filtered list of valid suite registrations."""
         res = []
         for suite in self.list_all_suites():
             if regfilter:
@@ -141,11 +144,12 @@ class localdb(object):
             except RegistrationError as exc:
                 print >> sys.stderr, str(exc)
             else:
-                dir, title = data['path'], data['title']
-                res.append([suite, dir, title])
+                path, title = data['path'], data['title']
+                res.append([suite, path, title])
         return res
 
     def unregister(self, exp):
+        """Un-register a suite."""
         suitedirs = []
         for key in self.list_all_suites():
             if re.search(exp + '$', key):
@@ -154,20 +158,21 @@ class localdb(object):
                 except RegistrationError:
                     pass
                 else:
-                    dir = data['path']
-                    for f in ['passphrase', 'suite.rc.processed']:
+                    path = data['path']
+                    for base_name in ['passphrase', 'suite.rc.processed']:
                         try:
-                            os.unlink(os.path.join(dir, f))
+                            os.unlink(os.path.join(path, base_name))
                         except OSError:
                             pass
-                    if dir not in suitedirs:
+                    if path not in suitedirs:
                         # (could be multiple registrations of the same suite).
-                        suitedirs.append(dir)
+                        suitedirs.append(path)
                 print 'UNREGISTER', key
                 os.unlink(os.path.join(self.dbpath, key))
         return suitedirs
 
     def reregister(self, srce, targ):
+        """Rename a source."""
         targ = RegPath(targ).get()
         found = False
         for suite in self.list_all_suites():
@@ -175,14 +180,12 @@ class localdb(object):
                 # single suite
                 newsuite = targ
                 data = self.get_suite_data(suite)
-                dir, title = data['path'], data['title']
                 self.unregister(suite)
                 self.register(targ, data['path'])
                 found = True
             elif suite.startswith(srce + RegPath.delimiter):
                 # group of suites
                 data = self.get_suite_data(suite)
-                dir, title = data['path'], data['title']
                 newsuite = re.sub('^' + srce, targ, suite)
                 self.unregister(suite)
                 self.register(newsuite, data['path'])
@@ -191,6 +194,7 @@ class localdb(object):
             raise RegistrationError("ERROR, suite or group not found: " + srce)
 
     def get_invalid(self):
+        """Return a list containing suite names that are no longer valid."""
         invalid = []
         for reg in self.list_all_suites():
             try:
@@ -198,8 +202,7 @@ class localdb(object):
             except RegistrationError:
                 invalid.append(reg)
             else:
-                dir = data['path']
-                rcfile = os.path.join(dir, 'suite.rc')
+                rcfile = os.path.join(data['path'], 'suite.rc')
                 if not os.path.isfile(rcfile):
                     invalid.append(reg)
         return invalid
@@ -218,26 +221,26 @@ class localdb(object):
             if re.search('^\s*\[', line):
                 # abort: title comes before first [section]
                 break
-            m = re.match('^\s*title\s*=\s*(.*)\s*$', line)
-            if m:
-                line = m.groups()[0]
+            match = re.match('^\s*title\s*=\s*(.*)\s*$', line)
+            if match:
+                line = match.groups()[0]
                 title = line.strip('"\'')
 
         return title
 
     def refresh_suite_title(self, suite):
+        """Update suite title, if necessary."""
         data = self.get_suite_data(suite)
-        dir, title = data['path'], data['title']
         new_title = self.get_suite_title(suite)
-        if title == new_title:
+        if data['title'] == new_title:
             if cylc.flags.verbose:
                 print 'unchanged:', suite
             changed = False
         else:
             print 'RETITLED:', suite
-            print '   old title:', title
+            print '   old title:', data['title']
             print '   new title:', new_title
             changed = True
-            self.unregister(suite)
-            self.register(suite, dir)
+            data['title'] = new_title
+            self.dump_suite_data(suite, data)
         return changed

--- a/tests/cylc-refresh/00-title.t
+++ b/tests/cylc-refresh/00-title.t
@@ -15,7 +15,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test "cylc refresh" on a running suite, with a title change to "suite.rc".
+# Test "cylc refresh" on a running suite, with "title" changed in "suite.rc".
+# It used to nuke the passphrase before https://github.com/cylc/cylc/pull/1774
+# which would cause all subsequent clients (that require authentication) to
+# fail. This test ensures that the problem will not happen again.
 . "$(dirname "$0")/test_header"
 
 set_test_number 3

--- a/tests/cylc-refresh/00-title.t
+++ b/tests/cylc-refresh/00-title.t
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-
+#!/bin/bash
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
 # Copyright (C) 2008-2015 NIWA
 #
@@ -15,37 +14,20 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "cylc refresh" on a running suite, with a title change to "suite.rc".
+. "$(dirname "$0")/test_header"
 
-"""cylc [db] get-directory REG
+set_test_number 3
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
-Retrieve and print the directory location of suite REG.
-Here's an easy way to move to a suite directory:
-  $ cd $(cylc get-dir REG)."""
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+run_ok "${TEST_NAME_BASE}" cylc run --reference-test --debug "${SUITE_NAME}"
 
-import sys
-from cylc.CylcOptionParsers import cop
-from cylc.registration import RegistrationDB
-import cylc.flags
+cmp_ok "${HOME}/.cylc/REGDB/${SUITE_NAME}" <<__REG__
+path=${TEST_DIR}/${SUITE_NAME}
+title=Modified Title
+__REG__
 
-from cylc.remote import remrun
-if remrun().execute():
-    sys.exit(0)
-
-
-def main():
-    parser = cop(__doc__)
-
-    (options, args) = parser.parse_args()
-
-    reg = args[0]
-    db = RegistrationDB(options.db)
-    print db.get_suitedir(reg)
-
-
-if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(exc)
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/cylc-refresh/00-title/reference.log
+++ b/tests/cylc-refresh/00-title/reference.log
@@ -1,0 +1,5 @@
+2016-01-14T11:55:10Z INFO - Run mode: live
+2016-01-14T11:55:10Z INFO - Initial point: 1
+2016-01-14T11:55:10Z INFO - Final point: 1
+2016-01-14T11:55:10Z INFO - [refresher.1] -triggered off []
+2016-01-14T11:55:13Z INFO - [whatever.1] -triggered off ['refresher.1']

--- a/tests/cylc-refresh/00-title/suite.rc
+++ b/tests/cylc-refresh/00-title/suite.rc
@@ -1,0 +1,18 @@
+title = Original Title
+[cylc]
+   UTC mode = True
+   [[reference test]]
+       live mode suite timeout = PT30S
+       required run mode = live
+[scheduling]
+    [[dependencies]]
+        graph = """refresher => whatever"""
+[runtime]
+    [[refresher]]
+        script = """
+sed -i 's/^\(title = \).*$/\1Modified Title/' "${CYLC_SUITE_DEF_PATH}/suite.rc"
+cylc refresh "${CYLC_SUITE_NAME}"
+sleep 5
+"""
+    [[whatever]]
+        script = true

--- a/tests/cylc-refresh/test_header
+++ b/tests/cylc-refresh/test_header
@@ -1,0 +1,1 @@
+../lib/bash/test_header


### PR DESCRIPTION
It was nuking the passphrase by doing an unregister and a new register
on suite title change. This is not necessary, and on running suites,
will cause subsequent client commands to fail.

Also modified `cylc.registration` to improve its pylint score.

The new test would time out before this change, because the refresh
command would reset the passphrase, which would make it impossible for
subsequent task jobs to report progress back to the suite.

Related to metomi/rose#1846. @hjoliver @arjclark please review.