### PR TITLE
validation: Reduce O(N**2) edge comparison to O(N)

### DIFF
--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -737,11 +737,9 @@ class SuiteConfig(object):
                 graph.acyclic()
                 # Look for reversed edges (note this does not detect
                 # self-edges).
-                n_edges = graph.edges()
-                back_edges = []
-                for e in o_edges:
-                    if e not in n_edges:
-                        back_edges.append(e)
+                n_edges = set(graph.edges())
+
+                back_edges = [x for x in o_edges if x not in n_edges]
                 if len(back_edges) > 0:
                     print >> sys.stderr, "Back-edges:"
                     for e in back_edges:


### PR DESCRIPTION
The current edge comparison routine under validation used to check for cyclic dependencies is inefficient. For suites with very large numbers of inter task dependencies e.g. LARGE_FAM1:succeed-all => LARGE_FAM2 the current calculation means the suite is effectively un-validatable. Solves point 2 of #1776

This dramatically speeds up the comparison by reducing it to (effectively) order N from order ~N**2

In the case of the real user suite it gets the calculation down from 2.5+ hours (estimate based on the chunk I ran before giving up and assuming it can be read into memory) to 1 second.

@matthewrmshin - please review1
@hjoliver - please review2