### PR TITLE
Fixed twice-packed Gtk box.

### DIFF
--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -1928,7 +1928,6 @@ shown here in the state they were in at the time of triggering.''')
 
         nodetach_group = controlled_option_group("No-detach", "--no-detach")
         nodetach_group.pack(hbox)
-        vbox.pack_start(hbox)
 
         noautoshutdown_group = controlled_option_group(
             "No-auto-shutdown", "--no-auto-shutdown")


### PR DESCRIPTION
Open gcylc for a stopped suite, first use of the Run dialog results in this warning message:
```
 /home/oliverh/cylc/cylc.git/lib/cylc/gui/app_gcylc.py:1936:
       GtkWarning: gtk_box_pack: assertion 'child->parent == NULL' failed
  vbox.pack_start(hbox)
```
A Gtk.HBox was being packed into the same container twice.  This fixes it.  @matthewrmshin - one review should be enough on this.