### PR TITLE
Fix and improve suite find info in run/restart stdout.

### DIFF
--- a/lib/cylc/daemonize.py
+++ b/lib/cylc/daemonize.py
@@ -32,12 +32,9 @@ Suite Info:
  + Logs: %(logd)s/{log,out,err}
 
 To see if this suite is still running:
- * cylc scan
- * cylc ping -v %(suite)s
- * ssh %(host)s pgrep -fu $USER 'cylc-r .* \<%(suite)s\>'
-
-To run in non-daemon mode use --no-detach or --debug.
-For more information see 'cylc --help' and the User Guide.
+ * cylc scan -n '\b%(suite)s\b' %(host)s
+ * cylc ping -v --host=%(host)s %(suite)s
+ * ssh %(host)s "pgrep -a -P 1 -fu $USER 'cylc-r.* \b%(suite)s\b'"
 
 """
 

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -579,15 +579,15 @@ class Scheduler(object):
         else:
             sys.stderr.write(
                 (
-                    r"""
-Is suite already running on '%(host)s:%(port)s'?
-If not, kill off any left over processes and delete the port file at:
- * %(port_file)s
+                    r"""ERROR: port file exists: %(port_file)s
+ 
+If %(suite)s is not running, delete the port file and try again.  If it is
+running but not responsive, kill any left over suite processes too.
 
-To see if a suite of the same name is still running, try:
- * cylc scan, or
- * cylc ping -v %(suite)s, or
- * ssh %(host)s pgrep -fu $USER 'cylc-r .* \<%(suite)s\>'
+To see if %(suite)s is running on '%(host)s:%(port)s':
+ * cylc scan -n '\b%(suite)s\b' %(host)s
+ * cylc ping -v --host=%(host)s %(suite)s
+ * ssh %(host)s "pgrep -a -P 1 -fu $USER 'cylc-r.* \b%(suite)s\b'"
 
 """
                 ) % {

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -580,7 +580,7 @@ class Scheduler(object):
             sys.stderr.write(
                 (
                     r"""ERROR: port file exists: %(port_file)s
- 
+
 If %(suite)s is not running, delete the port file and try again.  If it is
 running but not responsive, kill any left over suite processes too.
 


### PR DESCRIPTION
The pgrep command suggested for detecting running suites was broken.  This fixes it, and makes it print full info for just the parent process (instead of just PID for parent and all sub-processes), and also suggests `scan` and `ping` commands that work from other hosts.

Example output:
```
ERROR: port file exists: /home/oliverh/.cylc/ports/foo
 
If foo is not running, delete the port file and try again.  If it is
running but not responsive, kill any left over suite processes too.

To see if foo is running on 'niwa-34403.niwa.local:7766':
 * cylc scan -n '\bfoo\b' niwa-34403.niwa.local
 * cylc ping -v --host=niwa-34403.niwa.local foo
 * ssh niwa-34403.niwa.local "pgrep -a -P 1 -fu $USER 'cylc-r.* \bfoo\b'"

'ERROR, port file exists: /home/oliverh/.cylc/ports/foo'
```

And for the suggested commands:
```
[oliverh@wrh-1 ~]$ cylc scan -n '\bfoo\b' niwa-34403.niwa.local
foo oliverh@niwa-34403.niwa.local:7766

[oliverh@wrh-1 ~]$ cylc ping -v --host=niwa-34403.niwa.local foo
Generated suite passphrase: /home/oliverh/.cylc/passphrases/oliverh@niwa-34403.niwa.local/foo/passphrase
Running on niwa-34403.niwa.local:7766

[oliverh@wrh-1 ~]$ ssh niwa-34403.niwa.local "pgrep -a -P 1 -fu $USER 'cylc-r.* \bfoo\b'"
25383 python /home/oliverh/cylc/cylc.git/bin/cylc-run foo
[oliverh@wrh-1 ~]$ 
```

@matthewrmshin - please review (one review is probably enough). 
