### PR TITLE
Don't repeatedly mark queued tasks as ready to run.

### DIFF
--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -498,10 +498,13 @@ class TaskProxy(object):
                 self.sub_try_state.is_delay_done(now))
 
     def ready_to_run(self):
-        """Is this task ready to run?"""
+        """Am I in a pre-run state but ready to run?
+
+        Queued tasks are not counted as they've already been deemed ready.
+
+        """
         ready = (
             (
-                self.state.is_currently('queued') or
                 (
                     self.state.is_currently('waiting') and
                     self.prerequisites_are_all_satisfied() and

--- a/tests/lib/bash/test_header
+++ b/tests/lib/bash/test_header
@@ -242,7 +242,7 @@ function count_ok() {
     local FILE=$2
     local COUNT=$3
     local TEST_NAME=$(basename "$FILE")-count-ok
-    NEW_COUNT=$(grep -e "$BRE" "$FILE" | wc -l)
+    NEW_COUNT=$(grep -c "$BRE" "$FILE")
     if (( NEW_COUNT == COUNT )); then
         ok $TEST_NAME
         return

--- a/tests/lib/bash/test_header
+++ b/tests/lib/bash/test_header
@@ -52,6 +52,8 @@
 #         (stdin if FILE_CONTROL is "-" or missing).
 #     grep_ok PATTERN FILE
 #         Run "grep -q PATTERN FILE".
+#     count_ok PATTERN FILE COUNT
+#         Test that PATTERN occurs in exactly COUNT lines of FILE.
 #     exists_ok FILE
 #         Test that FILE exists
 #     exists_fail FILE
@@ -230,6 +232,22 @@ function grep_ok() {
         return
     fi
     echo "Can't find $BRE in $FILE" > $TEST_NAME.stderr
+    mkdir -p $TEST_LOG_DIR
+    cp $TEST_NAME.stderr $TEST_LOG_DIR/$TEST_NAME.stderr
+    fail $TEST_NAME
+}
+
+function count_ok() {
+    local BRE=$1
+    local FILE=$2
+    local COUNT=$3
+    local TEST_NAME=$(basename "$FILE")-count-ok
+    NEW_COUNT=$(grep -e "$BRE" "$FILE" | wc -l)
+    if (( NEW_COUNT == COUNT )); then
+        ok $TEST_NAME
+        return
+    fi
+    echo "Found $NEW_COUNT (not $COUNT) of $BRE in $FILE" > $TEST_NAME.stderr
     mkdir -p $TEST_LOG_DIR
     cp $TEST_NAME.stderr $TEST_LOG_DIR/$TEST_NAME.stderr
     fail $TEST_NAME

--- a/tests/task-proc-loop/00-count.t
+++ b/tests/task-proc-loop/00-count.t
@@ -1,0 +1,36 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2015 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test that presence of queued tasks does not cause dependency matching etc. in
+# the absence of other activity - GitHub #1787. WARNING: this test is sensitive
+# to the number of times the task pool gets processed as the suite runs, in
+# response to task state changes.  It will need to be updated if that number
+# changes in the future.
+
+. $(dirname $0)/test_header
+
+set_test_number 3
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+run_ok "${TEST_NAME_BASE}" cylc run --debug "${SUITE_NAME}"
+
+SUITE_LOG_DIR="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/log/suite"
+count_ok "BEGIN TASK PROCESSING" $SUITE_LOG_DIR/log 6
+
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/task-proc-loop/00-count/suite.rc
+++ b/tests/task-proc-loop/00-count/suite.rc
@@ -4,13 +4,10 @@
         abort on timeout = True
 [scheduling]
     [[queues]]
-        [[[q1]]]
-            members = FAM
+        [[[default]]]
             limit = 1
     [[dependencies]]
-        graph = FAM
+        graph = m1 & m2
 [runtime]
-    [[FAM]]
-        script = sleep 10
     [[m1, m2]]
-        inherit = FAM
+        script = sleep 10

--- a/tests/task-proc-loop/00-count/suite.rc
+++ b/tests/task-proc-loop/00-count/suite.rc
@@ -1,0 +1,16 @@
+[cylc]
+    [[event hooks]]
+        timeout = PT1M
+        abort on timeout = True
+[scheduling]
+    [[queues]]
+        [[[q1]]]
+            members = FAM
+            limit = 1
+    [[dependencies]]
+        graph = FAM
+[runtime]
+    [[FAM]]
+        script = sleep 10
+    [[m1, m2]]
+        inherit = FAM

--- a/tests/task-proc-loop/test_header
+++ b/tests/task-proc-loop/test_header
@@ -1,0 +1,1 @@
+../lib/bash/test_header


### PR DESCRIPTION
Close #1787 

New logic explained by the new in-source comment.

Test battery passes here.

@matthewrmshin - please review/assign

(I can probably make a new test for this, that relies on counting logged iterations through the main scheduling loop in a suite with two tasks - one queued task and one running ... but that'll have to be tomorrow).