### PR TITLE
Fix typo in docs

### DIFF
--- a/doc/cug.tex
+++ b/doc/cug.tex
@@ -2071,7 +2071,7 @@ title = "A Jinja2 Hello World! suite"
 \vspace{3mm}
 
 Tasks can be configured to retry a number of times if they fail.
-An environment variable \lstinline=$CYLC_TASK_TRY_NUBMER= increments
+An environment variable \lstinline=$CYLC_TASK_TRY_NUMBER= increments
 from $1$ on each successive try, and is passed to the task to allow
 different behaviour on the retry:
 \lstset{language=suiterc}


### PR DESCRIPTION
Corrects a typo of:
```
$CYLC_TASK_TRY_NUBMER
```
to:
```
$CYLC_TASK_TRY_NUMBER
```
@hjoliver - please review.