### PR TITLE
Insert an entry of task_jobs at earliest

### DIFF
--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -1292,8 +1292,13 @@ class TaskProxy(object):
         self.log(DEBUG, "incrementing submit number")
         self.submit_num += 1
         self.summary['submit_num'] = self.submit_num
-        self._db_events_insert(event="incrementing submit number")
         self.job_file_written = False
+        self._db_events_insert(event="incrementing submit number")
+        self.db_inserts_map[self.TABLE_TASK_JOBS].append({
+            "is_manual_submit": self.is_manual_submit,
+            "try_num": self.run_try_state.num + 1,
+            "time_submit": get_current_time_string(),
+        })
 
         local_job_log_dir, common_job_log_path = self._create_job_log_path(
             new_mode=True)
@@ -1391,10 +1396,7 @@ class TaskProxy(object):
                 'post-script': postcommand,
             }.items()
         )
-        self.db_inserts_map[self.TABLE_TASK_JOBS].append({
-            "is_manual_submit": self.is_manual_submit,
-            "try_num": self.run_try_state.num + 1,
-            "time_submit": get_current_time_string(),
+        self.db_updates_map[self.TABLE_TASK_JOBS].append({
             "user_at_host": self.user_at_host,
             "batch_sys_name": self.batch_sys_name,
         })

--- a/tests/job-submission/11-garbage-host-command.t
+++ b/tests/job-submission/11-garbage-host-command.t
@@ -1,0 +1,36 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2016 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test job submission rundb task_jobs entry with garbage host command.
+. "$(dirname "$0")/test_header"
+
+set_test_number 3
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+suite_run_ok "${TEST_NAME_BASE}-run" \
+    cylc run --debug --reference-test "${SUITE_NAME}"
+sqlite3 \
+    "$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/cylc-suite.db" \
+    'SELECT submit_num,submit_status FROM task_jobs WHERE name=="t1"' \
+    >'sqlite3.out'
+cmp_ok 'sqlite3.out' <<'__OUT__'
+1|1
+2|0
+__OUT__
+#-------------------------------------------------------------------------------
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/job-submission/11-garbage-host-command/reference.log
+++ b/tests/job-submission/11-garbage-host-command/reference.log
@@ -1,0 +1,7 @@
+2015-05-05T10:33:27+01 INFO - Run mode: live
+2015-05-05T10:33:27+01 INFO - Initial point: 1
+2015-05-05T10:33:27+01 INFO - Final point: 1
+2015-05-05T10:33:27+01 INFO - Cold Start 1
+2015-05-05T10:33:27+01 INFO - [t1.1] -triggered off []
+2015-05-05T10:33:28+01 INFO - [t2.1] -triggered off ['t1.1']
+2015-05-05T10:33:27+01 INFO - [t1.1] -triggered off []

--- a/tests/job-submission/11-garbage-host-command/suite.rc
+++ b/tests/job-submission/11-garbage-host-command/suite.rc
@@ -1,0 +1,20 @@
+[cylc]
+   [[reference test]]
+       expected task failures = t1.1
+       required run mode = live
+       live mode suite timeout = PT30S
+
+[scheduling]
+    [[dependencies]]
+        graph = """t1:submit-fail => t2"""
+
+[runtime]
+    [[t1]]
+        script = true
+        [[[remote]]]
+            host = $(cat 'rubbish.txt')
+    [[t2]]
+        script = """
+cylc broadcast "${CYLC_SUITE_NAME}" -n 't1' -p '1' -s '[remote]host=localhost'
+cylc trigger "${CYLC_SUITE_NAME}" 't1.1'
+"""


### PR DESCRIPTION
Otherwise, a job entry will be missing from the task_jobs table in the
runtime database if, e.g. a host select command fails.

@hjoliver @arjclark please review.