### PR TITLE
Use explicit string conversion in sys.exit(exc).

### DIFF
--- a/bin/cylc
+++ b/bin/cylc
@@ -40,7 +40,7 @@ except OSError as exc:
     # immediately below. We cannot just chdir to $HOME as gcylc does
     # because that would break relative directory path command arguments
     # (cylc reg SUITE PATH).
-    sys.exit(exc)
+    sys.exit(str(exc))
 
 # Import cylc to initialise CYLC_DIR and the path for python (__init__.py).
 import cylc

--- a/bin/cylc-broadcast
+++ b/bin/cylc-broadcast
@@ -281,4 +281,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-cat-state
+++ b/bin/cylc-cat-state
@@ -64,4 +64,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-check-versions
+++ b/bin/cylc-check-versions
@@ -133,4 +133,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-copy
+++ b/bin/cylc-copy
@@ -128,4 +128,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-cycle-point
+++ b/bin/cylc-cycle-point
@@ -271,4 +271,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-diff
+++ b/bin/cylc-diff
@@ -182,4 +182,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-documentation
+++ b/bin/cylc-documentation
@@ -167,4 +167,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-dump
+++ b/bin/cylc-dump
@@ -83,10 +83,10 @@ def main():
             print_uuid=options.print_uuid)
         # get state summary, task names, cycle points
         glbl, states, fam_states = pclient.get_suite_state_summary()
-    except Exception, x:
+    except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(x)
+        sys.exit(str(exc))
 
     if display_global:
         for item in glbl:
@@ -102,4 +102,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-edit
+++ b/bin/cylc-edit
@@ -212,4 +212,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-ext-trigger
+++ b/bin/cylc-ext-trigger
@@ -83,4 +83,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-get-directory
+++ b/bin/cylc-get-directory
@@ -48,4 +48,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-get-gui-config
+++ b/bin/cylc-get-gui-config
@@ -73,4 +73,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-get-site-config
+++ b/bin/cylc-get-site-config
@@ -92,4 +92,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-get-suite-config
+++ b/bin/cylc-get-suite-config
@@ -143,4 +143,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-get-suite-version
+++ b/bin/cylc-get-suite-version
@@ -55,4 +55,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-graph
+++ b/bin/cylc-graph
@@ -287,4 +287,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-gui
+++ b/bin/cylc-gui
@@ -107,4 +107,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-hold
+++ b/bin/cylc-hold
@@ -81,4 +81,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-insert
+++ b/bin/cylc-insert
@@ -92,4 +92,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-kill
+++ b/bin/cylc-kill
@@ -66,4 +66,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-list
+++ b/bin/cylc-list
@@ -157,4 +157,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-nudge
+++ b/bin/cylc-nudge
@@ -65,4 +65,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-ping
+++ b/bin/cylc-ping
@@ -83,4 +83,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-poll
+++ b/bin/cylc-poll
@@ -74,4 +74,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-print
+++ b/bin/cylc-print
@@ -162,4 +162,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-random
+++ b/bin/cylc-random
@@ -51,4 +51,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-refresh
+++ b/bin/cylc-refresh
@@ -101,4 +101,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-register
+++ b/bin/cylc-register
@@ -86,4 +86,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-release
+++ b/bin/cylc-release
@@ -69,4 +69,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-reload
+++ b/bin/cylc-reload
@@ -71,4 +71,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-remove
+++ b/bin/cylc-remove
@@ -67,4 +67,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-reregister
+++ b/bin/cylc-reregister
@@ -49,4 +49,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-reset
+++ b/bin/cylc-reset
@@ -75,4 +75,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-restart
+++ b/bin/cylc-restart
@@ -509,4 +509,4 @@ if __name__ == '__main__':
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-run
+++ b/bin/cylc-run
@@ -152,4 +152,4 @@ if __name__ == '__main__':
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-set-runahead
+++ b/bin/cylc-set-runahead
@@ -73,4 +73,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-set-verbosity
+++ b/bin/cylc-set-verbosity
@@ -79,4 +79,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-show
+++ b/bin/cylc-show
@@ -115,4 +115,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-stop
+++ b/bin/cylc-stop
@@ -170,4 +170,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-submit
+++ b/bin/cylc-submit
@@ -196,4 +196,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-suite-state
+++ b/bin/cylc-suite-state
@@ -271,4 +271,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-trigger
+++ b/bin/cylc-trigger
@@ -204,4 +204,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-unregister
+++ b/bin/cylc-unregister
@@ -107,4 +107,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-upgrade-db
+++ b/bin/cylc-upgrade-db
@@ -79,4 +79,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-upgrade-run-dir
+++ b/bin/cylc-upgrade-run-dir
@@ -157,4 +157,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-validate
+++ b/bin/cylc-validate
@@ -126,4 +126,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-version
+++ b/bin/cylc-version
@@ -50,4 +50,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-view
+++ b/bin/cylc-view
@@ -182,4 +182,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/bin/cylc-warranty
+++ b/bin/cylc-warranty
@@ -53,4 +53,4 @@ if __name__ == "__main__":
     except Exception as exc:
         if cylc.flags.debug:
             raise
-        sys.exit(exc)
+        sys.exit(str(exc))

--- a/tests/validate/53-zero-interval.t
+++ b/tests/validate/53-zero-interval.t
@@ -1,0 +1,41 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2016 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test validatation error message on zero-width date-time interval.
+# See issue cylc/cylc#1800.
+. "$(dirname "$0")/test_header"
+set_test_number 2
+
+cat >'suite.rc' <<'__SUITE_RC__'
+[cylc]
+    UTC mode = True
+[scheduling]
+    initial cycle point = 2010
+    [[dependencies]]
+        [[[P0M]]]   # OOPS! zero-width interval
+            graph = foo
+[runtime]
+    [[foo]]
+        script = true
+__SUITE_RC__
+
+run_fail "${TEST_NAME_BASE}" cylc validate 'suite.rc'
+cmp_ok "${TEST_NAME_BASE}.stderr" <<'__ERR__'
+Sequence R/20100101T0000Z/P0Y, point format CCYYMMDDThhmmZ: equal adjacent points: 20100101T0000Z => 20100101T0000Z.
+__ERR__
+
+exit


### PR DESCRIPTION
Close #1800 

Just to be sure, use `sys.exit(str(exc))` in all commands, even though this shouldn't be necessary.

@benfitzpatrick - can you review this? - the exception classes in `lib/cylc/cycling/__init__.py` may need fixing, in which case the changes in this PR may be unnecessary.

The reason `sys.exit(exc)` doesn't print anything for the validation example in #1800, is that the `__str__()` method in `SequenceDegenerateError` is generating a hidden `AttributeError: 'SequenceDegenerateError' object has no attribute 'code'`.  This can be avoided with explicit string conversion of the incoming arguments.