### PR TITLE
cylc unregister: skip suites with port files

### DIFF
--- a/bin/cylc-unregister
+++ b/bin/cylc-unregister
@@ -56,50 +56,28 @@ def main():
 
     db = RegistrationDB(options.db)
 
-    dirs = db.unregister(args[0])
+    unregistered_set, skipped_set = db.unregister(args[0])
 
-    n = len(dirs)
-    if n == 0:
-        print 'No suites unregistered.'
-        sys.exit(0)
+    print '%d suite(s) unregistered.' % len(unregistered_set)
+    if not unregistered_set or not options.obliterate:
+        sys.exit(bool(skipped_set))
 
-    print len(dirs), 'suites unregistered.'
-
-    if options.obliterate and len(dirs) > 0:
-        for dir in dirs:
-            print 'DELETE ', dir
-
-        really_obliterate = False
-        if options.force:
-            really_obliterate = True
-        else:
-            if len(dirs) == 1:
-                words = "THIS SUITE DEFINITION"
-            else:
-                words = "THESE SUITE DEFINITIONS"
-            response = raw_input(
-                "DO YOU REALLY WANT TO DELETE " + words + "? (y/n) ")
-            if response == 'y':
-                really_obliterate = True
-        if really_obliterate and len(dirs) > 0:
-            for dir in dirs:
-                try:
-                    rmtree(dir)
-                except OSError as exc:
-                    print >> sys.stderr, (
-                        "ERROR, could not remove directory: " + dir)
-                    print >> sys.stderr, str(exc)
-                    continue
-                # recursively remove empty superdirs
-                tmp = dir
-                while True:
-                    tmp = os.path.split(tmp)[0]
-                    try:
-                        os.rmdir(tmp)
-                    except OSError:
-                        break
-                    else:
-                        print 'Removed empty directory:', tmp
+    for _, path in sorted(unregistered_set):
+        if not options.force:
+            response = raw_input('REALLY DELETE "%s"? (y/n/a) ' % (path))
+            if response == 'a':
+                options.force = True
+            elif response != 'y':
+                continue
+        print 'DELETE "%s"' % (path)
+        try:
+            rmtree(path)
+        except OSError as exc:
+            print >> sys.stderr, (
+                "ERROR, could not remove directory: " + path)
+            print >> sys.stderr, str(exc)
+            continue
+    sys.exit(bool(skipped_set))
 
 if __name__ == "__main__":
     try:

--- a/tests/registration/03-skip-run.t
+++ b/tests/registration/03-skip-run.t
@@ -1,0 +1,74 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2016 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#------------------------------------------------------------------------------
+# Test skip unregister if suite has a port file.
+
+. "$(dirname "$0")/test_header"
+set_test_number 6
+
+CYLC_RUND="$(cylc get-global-config --print-run-dir)"
+
+SUITED_1="$(mktemp -d --tmpdir="${CYLC_RUND}" 'ctb-registration-03-1XXXXXXXX')"
+SUITED_2="$(mktemp -d --tmpdir="${CYLC_RUND}" 'ctb-registration-03-2XXXXXXXX')"
+SUITED_R="$(mktemp -d --tmpdir="${CYLC_RUND}" 'ctb-registration-03-RXXXXXXXX')"
+
+for SUITED in "${SUITED_1}" "${SUITED_2}" "${SUITED_R}"; do
+    cat >"${SUITED}/suite.rc" <<'__SUITERC__'
+[cylc]
+    [[event hooks]]
+        timeout = PT1M
+        abort on timeout = True
+[scheduling]
+    [[dependencies]]
+        graph = foo
+[runtime]
+    [[foo]]
+        script = false
+__SUITERC__
+    cylc register "$(basename "${SUITED}")" "${SUITED}" 1>'/dev/null'
+done
+
+cylc run "$(basename "${SUITED_R}")" 1>'/dev/null'
+sleep 1
+
+# Unregister on its own
+run_fail "${TEST_NAME_BASE}-1" cylc unregister "$(basename "${SUITED_R}")"
+cmp_ok "${TEST_NAME_BASE}-1.stdout" <<'__OUT__'
+0 suite(s) unregistered.
+__OUT__
+cmp_ok "${TEST_NAME_BASE}-1.stderr" <<__ERR__
+SKIP UNREGISTER $(basename "${SUITED_R}"): port file exists
+__ERR__
+# Unregister with regular expression
+run_fail "${TEST_NAME_BASE}-A" cylc unregister 'ctb-registration-03-.*'
+cmp_ok "${TEST_NAME_BASE}-A.stdout" <<__OUT__
+UNREGISTER $(basename "${SUITED_1}"):${SUITED_1}
+UNREGISTER $(basename "${SUITED_2}"):${SUITED_2}
+2 suite(s) unregistered.
+__OUT__
+cmp_ok "${TEST_NAME_BASE}-A.stderr" <<__ERR__
+SKIP UNREGISTER $(basename "${SUITED_R}"): port file exists
+__ERR__
+
+cylc shutdown --now --max-polls=30 --interval=2 "$(basename "${SUITED_R}")" \
+    1>'/dev/null'
+
+rm -fr "${SUITED_1}"
+rm -fr "${SUITED_2}"
+purge_suite "$(basename "${SUITED_R}")"
+
+exit

--- a/tests/registration/04-pattern.t
+++ b/tests/registration/04-pattern.t
@@ -1,0 +1,54 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2016 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#------------------------------------------------------------------------------
+# Test unregister suite with similar names.
+
+. "$(dirname "$0")/test_header"
+set_test_number 24
+
+mkdir 'foo' 'bar' 'foobar' 'barfoo'
+UUID="$(uuidgen)"
+for NAME in 'foo' 'bar' 'foobar' 'barfoo'; do
+    cat >"${NAME}/suite.rc" <<'__SUITERC__'
+[scheduling]
+    [[dependencies]]
+        graph = t1
+[runtime]
+    [[t1]]
+        script = true
+__SUITERC__
+    cylc register "${UUID}-${NAME}" "${PWD}/${NAME}" 1>'/dev/null'
+    cylc register "${NAME}-${UUID}" "${PWD}/${NAME}" 1>'/dev/null'
+done
+
+for NAME in 'foo' 'bar' 'foobar' 'barfoo'; do
+    run_ok "${TEST_NAME_BASE}-${UUID}-${NAME}" cylc unregister "${UUID}-${NAME}"
+    cmp_ok "${TEST_NAME_BASE}-${UUID}-${NAME}.stdout" <<__OUT__
+UNREGISTER ${UUID}-${NAME}:${PWD}/${NAME}
+1 suite(s) unregistered.
+__OUT__
+    cmp_ok "${TEST_NAME_BASE}-${UUID}-${NAME}.stderr" <'/dev/null'
+
+    run_ok "${TEST_NAME_BASE}-${NAME}-${UUID}" cylc unregister "${NAME}-${UUID}"
+    cmp_ok "${TEST_NAME_BASE}-${NAME}-${UUID}.stdout" <<__OUT__
+UNREGISTER ${NAME}-${UUID}:${PWD}/${NAME}
+1 suite(s) unregistered.
+__OUT__
+    cmp_ok "${TEST_NAME_BASE}-${NAME}-${UUID}.stderr" <'/dev/null'
+done
+
+exit

--- a/tests/registration/05-unregister-delete.t
+++ b/tests/registration/05-unregister-delete.t
@@ -1,0 +1,124 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2016 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#------------------------------------------------------------------------------
+# Test unregister --delete.
+
+. "$(dirname "$0")/test_header"
+set_test_number 13
+
+UUID="$(uuidgen)"
+
+create_and_register_name() {
+    local NAME="$1"
+    mkdir "${NAME}"
+    cat >"${NAME}/suite.rc" <<'__SUITERC__'
+[scheduling]
+    [[dependencies]]
+        graph = t1
+[runtime]
+    [[t1]]
+        script = true
+__SUITERC__
+    cylc register "${UUID}-${NAME}" "${PWD}/${NAME}" 1>'/dev/null'
+}
+
+for NAME in 'foo' 'bar' 'baz' 'qux'; do
+    create_and_register_name "${NAME}"
+done
+
+run_ok "${TEST_NAME_BASE}-force" cylc unregister --delete --force "${UUID}-.*"
+cmp_ok "${TEST_NAME_BASE}-force.stdout" <<__OUT__
+UNREGISTER ${UUID}-bar:${PWD}/bar
+UNREGISTER ${UUID}-baz:${PWD}/baz
+UNREGISTER ${UUID}-foo:${PWD}/foo
+UNREGISTER ${UUID}-qux:${PWD}/qux
+4 suite(s) unregistered.
+DELETE "${PWD}/bar"
+DELETE "${PWD}/baz"
+DELETE "${PWD}/foo"
+DELETE "${PWD}/qux"
+__OUT__
+cmp_ok "${TEST_NAME_BASE}-force.stderr" <'/dev/null'
+
+for NAME in 'foo' 'bar' 'baz' 'qux'; do
+    create_and_register_name "${NAME}"
+done
+
+run_ok "${TEST_NAME_BASE}-all" \
+    cylc unregister --delete "${UUID}-.*" <<<'a'
+cmp_ok "${TEST_NAME_BASE}-all.stdout" <<__OUT__
+UNREGISTER ${UUID}-bar:${PWD}/bar
+UNREGISTER ${UUID}-baz:${PWD}/baz
+UNREGISTER ${UUID}-foo:${PWD}/foo
+UNREGISTER ${UUID}-qux:${PWD}/qux
+4 suite(s) unregistered.
+REALLY DELETE "${PWD}/bar"? (y/n/a) DELETE "${PWD}/bar"
+DELETE "${PWD}/baz"
+DELETE "${PWD}/foo"
+DELETE "${PWD}/qux"
+__OUT__
+cmp_ok "${TEST_NAME_BASE}-all.stderr" <'/dev/null'
+
+for NAME in 'foo' 'bar' 'baz' 'qux'; do
+    create_and_register_name "${NAME}"
+done
+
+run_ok "${TEST_NAME_BASE}-yes-4" \
+    cylc unregister --delete "${UUID}-.*" <<'__YES__'
+y
+y
+y
+y
+__YES__
+cmp_ok "${TEST_NAME_BASE}-yes-4.stdout" <<__OUT__
+UNREGISTER ${UUID}-bar:${PWD}/bar
+UNREGISTER ${UUID}-baz:${PWD}/baz
+UNREGISTER ${UUID}-foo:${PWD}/foo
+UNREGISTER ${UUID}-qux:${PWD}/qux
+4 suite(s) unregistered.
+REALLY DELETE "${PWD}/bar"? (y/n/a) DELETE "${PWD}/bar"
+REALLY DELETE "${PWD}/baz"? (y/n/a) DELETE "${PWD}/baz"
+REALLY DELETE "${PWD}/foo"? (y/n/a) DELETE "${PWD}/foo"
+REALLY DELETE "${PWD}/qux"? (y/n/a) DELETE "${PWD}/qux"
+__OUT__
+cmp_ok "${TEST_NAME_BASE}-yes-4.stderr" <'/dev/null'
+
+for NAME in 'foo' 'bar' 'baz' 'qux'; do
+    create_and_register_name "${NAME}"
+done
+
+run_ok "${TEST_NAME_BASE}-yes-3" \
+    cylc unregister --delete "${UUID}-.*" <<'__YES__'
+y
+y
+n
+y
+__YES__
+cmp_ok "${TEST_NAME_BASE}-yes-3.stdout" <<__OUT__
+UNREGISTER ${UUID}-bar:${PWD}/bar
+UNREGISTER ${UUID}-baz:${PWD}/baz
+UNREGISTER ${UUID}-foo:${PWD}/foo
+UNREGISTER ${UUID}-qux:${PWD}/qux
+4 suite(s) unregistered.
+REALLY DELETE "${PWD}/bar"? (y/n/a) DELETE "${PWD}/bar"
+REALLY DELETE "${PWD}/baz"? (y/n/a) DELETE "${PWD}/baz"
+REALLY DELETE "${PWD}/foo"? (y/n/a) REALLY DELETE "${PWD}/qux"? (y/n/a) DELETE "${PWD}/qux"
+__OUT__
+cmp_ok "${TEST_NAME_BASE}-yes-3.stderr" <'/dev/null'
+exists_ok "${PWD}/foo"
+
+exit


### PR DESCRIPTION
Also ensure that `cylc unregister bar` does not unregister a suite
called `foobar`.

Close #1796.