### PR TITLE
gcylc - reloading is not a status.

### DIFF
--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -3082,7 +3082,6 @@ For more Stop options use the Control menu.""")
          * running to 2015-08-08T01:00:00+12:00
          * running to hold at 20150601T0000Z
          * held
-         * reloading
          * stopping
          * stopped
          * stopped with 'succeeded'
@@ -3095,7 +3094,6 @@ For more Stop options use the Control menu.""")
         run_ok = "stopped" in new_status
         # Pause: avoid "stopped with 'running'".
         pause_ok = (
-            new_status == "reloading" or
             "running" in new_status and "stopped" not in new_status)
         unpause_ok = "held" == new_status
         stop_ok = ("stopped" not in new_status and

--- a/lib/cylc/gui/updater.py
+++ b/lib/cylc/gui/updater.py
@@ -143,6 +143,7 @@ class Updater(threading.Thread):
         self.dt = "waiting..."
         self.dt_date = None
         self.status = None
+        self.is_reloading =False
         self.connected = False
         self._no_update_event = threading.Event()
         self.poll_schd = PollSchd()
@@ -331,19 +332,15 @@ class Updater(threading.Thread):
             self.status = 'running to ' + glbl['will_stop_at']
         else:
             self.status = 'running'
-
         # 2. Override with temporary held status.
         if glbl['paused']:
             self.status = 'held'
 
-        # 3. Override running or held with reloading.
-        if not self.status == 'stopping':
-            try:
-                if glbl['reloading']:
-                    self.status = 'reloading'
-            except KeyError:
-                # Back compat.
-                pass
+        try:
+            self.is_reloading = glbl['reloading']
+        except KeyError:
+            # Back compat.
+            pass
 
     def set_stopped(self):
         """Reset data and clients when suite is stopped."""
@@ -445,13 +442,13 @@ class Updater(threading.Thread):
                     self.info_bar.prog_bar_can_start()):
                 gobject.idle_add(
                     self.info_bar.prog_bar_start, "suite stopping...")
-            if (self.status == "reloading" and
+            if (self.is_reloading and
                     self.info_bar.prog_bar_can_start()):
                 gobject.idle_add(
                     self.info_bar.prog_bar_start, "suite reloading...")
             if (self.info_bar.prog_bar_active() and
-                    self.status not in
-                    ["stopping", "initialising", "reloading"]):
+                    not self.is_reloading and
+                    self.status not in ["stopping", "initialising"]):
                 gobject.idle_add(self.info_bar.prog_bar_stop)
             if summaries_changed or err_log_changed:
                 return True

--- a/lib/cylc/gui/updater.py
+++ b/lib/cylc/gui/updater.py
@@ -143,7 +143,7 @@ class Updater(threading.Thread):
         self.dt = "waiting..."
         self.dt_date = None
         self.status = None
-        self.is_reloading =False
+        self.is_reloading = False
         self.connected = False
         self._no_update_event = threading.Event()
         self.poll_schd = PollSchd()


### PR DESCRIPTION
Close #1760 

The problem here was that treating "reloading" as a suite status (represented by a single string) hides the underlying status of running, held, etc., which is also used to determine the state of the run/pause button etc.

@matthewrmshin - please review and/or assign.  