### PR TITLE
Use string constants for suite status.

### DIFF
--- a/bin/cylc-monitor
+++ b/bin/cylc-monitor
@@ -29,19 +29,19 @@ if '--use-ssh' in sys.argv[1:]:
     sys.exit("No '--use-ssh': this command requires a local terminal.")
 
 import os
-import re
 from time import sleep
 
 from parsec.OrderedDict import OrderedDict
 from cylc.CylcOptionParsers import cop
 from cylc.task_state import TaskState
 from cylc.network.suite_state import (
-    StateSummaryClient, SuiteStillInitialisingError)
+    SUITE_STATUS_SPLIT_REC, StateSummaryClient, SuiteStillInitialisingError)
 from cylc.wallclock import get_time_string_from_unix_time
 from cylc.cfgspec.globalcfg import GLOBAL_CFG
 
 
 class SuiteMonitor(object):
+
     def __init__(self):
         self.parser = cop(
             """cylc [info] monitor [OPTIONS] ARGS
@@ -139,11 +139,8 @@ A terminal-based live suite monitor.  Exit with 'Ctrl-C'.""",
                     updated_at = glbl['last_updated'].isoformat()
 
                 run_mode = glbl['run_mode']
-                paused = glbl['paused']
-                stopping = glbl['stopping']
-                will_pause_at = glbl['will_pause_at']
-                will_stop_at = glbl['will_stop_at']
                 ns_defn_order = glbl['namespace definition order']
+                status_string = glbl['status_string']
 
                 task_info = {}
                 name_list = set()
@@ -205,16 +202,14 @@ A terminal-based live suite monitor.  Exit with 'Ctrl-C'.""",
                         TaskState.ctrl[state], tot, TaskState.ctrl_end)
                 blit.append(summary)
 
-                if stopping:
-                    suffix = 'S_T_O_P_P_I_N_G'
-                elif paused:
-                    suffix = 'P_A_U_S_E_D'
-                elif will_pause_at:
-                    suffix = 'P_A_U_S_I_N_G__A_T__' + will_pause_at
-                elif will_stop_at:
-                    suffix = 'S_T_O_P_P_I_N_G__A_T__' + will_stop_at
-                else:
-                    suffix = 'R_U_N_N_I_N_G'
+                # Print a divider line containing the suite status string.
+                try:
+                    status1, status2 = (
+                        SUITE_STATUS_SPLIT_REC.match(status_string)).groups()
+                except AttributeError:
+                    status1 = status_string
+                    status2 = ''
+                suffix = '_'.join(list(status1.replace(' ', '_'))) + status2
                 divider_str = '_' * len_header
                 divider_str = "\033[1;31m%s%s%s" % (
                     divider_str[:-len(suffix)], suffix, TaskState.ctrl_end)

--- a/lib/cylc/dump.py
+++ b/lib/cylc/dump.py
@@ -21,6 +21,7 @@ import sys
 import subprocess
 import time
 from cylc.task_id import TaskID
+from cylc.network.suite_state import SUITE_STATUS_STOPPED
 
 
 def get_stop_state(suite, owner=None, host=None):
@@ -80,10 +81,10 @@ def get_stop_state_summary(suite, owner=None, hostname=None, lines=None):
             # back compat pre cylc-6
             global_summary["last_updated"] = time.time()
 
-    start = lines.pop(0).rstrip().rsplit(None, 1)[-1]
-    stop = lines.pop(0).rstrip().rsplit(None, 1)[-1]
-    if stop != "(none)":
-        global_summary["will_stop_at"] = stop
+    # Skip initial and final cycle points.
+    _ = lines.pop(0)
+    _ = lines.pop(0)
+    global_summary["status_string"] = SUITE_STATUS_STOPPED
     while lines:
         line = lines.pop(0)
         if line.startswith("class") or line.startswith("Begin task"):
@@ -107,8 +108,6 @@ def get_stop_state_summary(suite, owner=None, hostname=None, lines=None):
         task_summary[task_id].update({"state": state})
         task_summary[task_id].update({"spawned": items.get("spawned")})
     global_summary["run_mode"] = "dead"
-    for key in ["paused", "stopping", "will_pause_at", "will_stop_at"]:
-        global_summary.setdefault(key, "")
     return global_summary, task_summary, family_summary
 
 

--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -3082,7 +3082,6 @@ For more Stop options use the Control menu.""")
          * running to 2015-08-08T01:00:00+12:00
          * running to hold at 20150601T0000Z
          * held
-         * reloading
          * stopping
          * stopped
          * stopped with 'succeeded'
@@ -3095,7 +3094,6 @@ For more Stop options use the Control menu.""")
         run_ok = "stopped" in new_status
         # Pause: avoid "stopped with 'running'".
         pause_ok = (
-            new_status == "reloading" or
             "running" in new_status and "stopped" not in new_status)
         unpause_ok = "held" == new_status
         stop_ok = ("stopped" not in new_status and

--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -53,7 +53,8 @@ from cylc.gui.updater import Updater
 from cylc.gui.util import (
     get_icon, get_image_dir, get_logo, EntryTempText,
     EntryDialog, setup_icons, set_exception_hook_dialog)
-from cylc.network.suite_state import extract_group_state
+from cylc.network.suite_state import (
+    extract_group_state, SUITE_STATUS_STOPPED_WITH)
 from cylc.task_id import TaskID
 from cylc.version import CYLC_VERSION
 from cylc.gui.option_group import controlled_option_group
@@ -399,9 +400,6 @@ Class to create an information bar.
 
     def set_stop_summary(self, summary_maps):
         """Set various summary info."""
-        # new string format() introduced in Python 2.6
-        # o>summary = "stopped with '{0}'"
-        summary = "stopped with '%s'"
         glob, task, fam = summary_maps
         states = [t["state"] for t in task.values() if "state" in t]
 
@@ -409,14 +407,12 @@ Class to create an information bar.
         suite_state = "?"
         if states:
             suite_state = extract_group_state(states, is_stopped=True)
-        # o>summary = summary.format(suite_state)
-        summary = summary % suite_state
+        summary = SUITE_STATUS_STOPPED_WITH % suite_state
         num_failed = 0
         for task_id in task:
             if task[task_id].get("state") == "failed":
                 num_failed += 1
         if num_failed:
-            # o> summary += ": {0} failed tasks".format(num_failed)
             summary += ": %s failed tasks" % num_failed
         self.set_status(summary)
         dt = glob["last_updated"]
@@ -3072,21 +3068,7 @@ For more Stop options use the Control menu.""")
         self.tool_bar_box.pack2(self.tool_bars[1], resize=True, shrink=True)
 
     def _alter_status_toolbar_menu(self, new_status):
-        """Handle changes in status for some toolbar/menuitems.
-
-       Example status strings:
-         * connected
-         * initialising
-         * running
-         * running to 20150601T0000Z
-         * running to 2015-08-08T01:00:00+12:00
-         * running to hold at 20150601T0000Z
-         * held
-         * stopping
-         * stopped
-         * stopped with 'succeeded'
-         * stopped with 'running'
-        """
+        """Handle changes in suite status for some toolbar/menuitems."""
         if new_status == self._prev_status:
             return False
         self.info_bar.prog_bar_disabled = False

--- a/lib/cylc/gui/updater.py
+++ b/lib/cylc/gui/updater.py
@@ -145,7 +145,7 @@ class Updater(threading.Thread):
         self.dt = "waiting..."
         self.dt_date = None
         self.status = SUITE_STATUS_NOT_CONNECTED
-        self.is_reloading =False
+        self.is_reloading = False
         self.connected = False
         self._no_update_event = threading.Event()
         self.poll_schd = PollSchd()
@@ -402,8 +402,8 @@ class Updater(threading.Thread):
                         "  daemon <= 6.4.0, suite initializing ...")
                 self.set_status(SUITE_STATUS_INITIALISING)
                 if self.info_bar.prog_bar_can_start():
-                    gobject.idle_add(
-                        self.info_bar.prog_bar_start, SUITE_STATUS_INITIALISING)
+                    gobject.idle_add(self.info_bar.prog_bar_start,
+                                     SUITE_STATUS_INITIALISING)
                     self.info_bar.set_state([])
                 # Reconnect till we get the suite state object.
                 self.reconnect()

--- a/lib/cylc/gui/updater.py
+++ b/lib/cylc/gui/updater.py
@@ -143,6 +143,7 @@ class Updater(threading.Thread):
         self.dt = "waiting..."
         self.dt_date = None
         self.status = None
+        self.is_reloading =False
         self.connected = False
         self._no_update_event = threading.Event()
         self.poll_schd = PollSchd()
@@ -331,19 +332,15 @@ class Updater(threading.Thread):
             self.status = 'running to ' + glbl['will_stop_at']
         else:
             self.status = 'running'
-
         # 2. Override with temporary held status.
         if glbl['paused']:
             self.status = 'held'
 
-        # 3. Override running or held with reloading.
-        if not self.status == 'stopping':
-            try:
-                if glbl['reloading']:
-                    self.status = 'reloading'
-            except KeyError:
-                # Back compat.
-                pass
+        try:
+            self.is_reloading = glbl['reloading']
+        except KeyError:
+            # Back compat.
+            pass
 
     def set_stopped(self):
         """Reset data and clients when suite is stopped."""
@@ -445,13 +442,13 @@ class Updater(threading.Thread):
                     self.info_bar.prog_bar_can_start()):
                 gobject.idle_add(
                     self.info_bar.prog_bar_start, "suite stopping...")
-            if (self.status == "reloading" and
+            if (self.is_reloading and
                     self.info_bar.prog_bar_can_start()):
                 gobject.idle_add(
                     self.info_bar.prog_bar_start, "suite reloading...")
             if (self.info_bar.prog_bar_active() and
-                    self.status not in
-                    ["stopping", "initialising", "reloading"]):
+                    not self.is_reloading and
+                    self.status not in ["stopping", "initialising"]):
                 gobject.idle_add(self.info_bar.prog_bar_stop)
             if summaries_changed or err_log_changed:
                 return True


### PR DESCRIPTION
A minor refactor to give suite status the same treatment as task status in #1775.

@matthewrmshin - please review and/or assign.  Note that this branch includes the (small) changes in #1805.  It was meant to be a second commit on that PR, but I forgot to push the change up before you reviewed it.  If you like, leave this till 1805 is merged then I'll rebase this.