### PR TITLE
cylc task-message: unified message queue

### DIFF
--- a/bin/cylc-restart
+++ b/bin/cylc-restart
@@ -415,7 +415,8 @@ class restart(Scheduler):
                     get_point(point_string),
                     state,
                     submit_num=submit_num,
-                    is_reload=True
+                    is_reload=True,
+                    message_queue=self.pool.message_queue
                 )
             except TaskNotDefinedError, x:
                 print >> sys.stderr, str(x)

--- a/bin/cylc-run
+++ b/bin/cylc-run
@@ -135,7 +135,8 @@ class start(Scheduler):
                 continue
             try:
                 itask = get_task_proxy(
-                    name, self.start_point, 'waiting', is_startup=True)
+                    name, self.start_point, 'waiting', is_startup=True,
+                    message_queue=self.pool.message_queue)
             except TaskProxySequenceBoundsError as exc:
                 self.log.debug(str(exc))
                 continue

--- a/lib/cylc/network/task_msgqueue.py
+++ b/lib/cylc/network/task_msgqueue.py
@@ -30,10 +30,10 @@ class TaskMessageServer(PyroServer):
         super(TaskMessageServer, self).__init__()
         self.queue = Queue()
 
-    def put(self, priority, message):
+    def put(self, task_id, priority, message):
         check_access_priv(self, 'full-control')
         self.report('task_message')
-        self.queue.put((priority, message))
+        self.queue.put((task_id, priority, message))
         return (True, 'Message queued')
 
     def get_queue(self):
@@ -45,9 +45,11 @@ class TaskMessageClient(PyroClient):
 
     def __init__(self, suite, task_id, owner=USER,
                  host=get_hostname(), pyro_timeout=None, port=None):
-        self.target_server_object = task_id
+        self.target_server_object = "task_pool"
+        self.task_id = task_id
         super(TaskMessageClient, self).__init__(
             suite, owner, host, pyro_timeout, port)
 
     def put(self, *args):
+        args = [self.task_id] + list(args)
         self.call_server_func('put', *args)

--- a/lib/cylc/run.py
+++ b/lib/cylc/run.py
@@ -81,10 +81,12 @@ def main(name, start):
 
     try:
         server.configure()
+        if server.options.profile_mode:
+            import cProfile
+            import pstats
+            prof = cProfile.Profile()
+            prof.enable()
         server.run()
-        # For profiling (see Python docs for how to display the stats).
-        # import cProfile
-        # cProfile.runctx('server.run()', globals(), locals(), 'stats')
     except SchedulerStop, x:
         # deliberate stop
         print str(x)
@@ -124,3 +126,12 @@ def main(name, start):
     else:
         # main loop ends (not used?)
         server.shutdown()
+
+    if server.options.profile_mode:
+        prof.disable()
+        import StringIO
+        string_stream = StringIO.StringIO()
+        stats = pstats.Stats(prof, stream=string_stream)
+        stats.sort_stats('cumulative')
+        stats.print_stats()
+        print string_stream.getvalue()


### PR DESCRIPTION
Each task currently has its own individual message queue, which contains a relatively expensive `Queue.Queue` object. As we get more and more tasks in a suite, this becomes increasingly unwieldy to keep in memory and to keep checking for new messages.

This change rolls the queues up into a single task pool message queue. It saves around 20% of the per-task memory for the minimal tasks I've tested, which is around 10% of the total memory usage - a surprising amount. The CPU usage is reduced by a couple of percent for a 'super-busy' suite, largely just due to not calling `qsize` as much.

Due to the communication change, this will break daemon-task mismatched versions before and after this PR, so I've initially put this in the `soon` milestone.

I've also added a proper profiling behaviour on running with the `--profile` switch - it is kind of a pain to keep git stashing and stash applying this bit of code!

@hjoliver, @matthewrmshin please review.