### PR TITLE
task proxy: reduce unnecessary rtconfig deepcopy on submit

### DIFF
--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -1310,8 +1310,11 @@ class TaskProxy(object):
         local_jobfile_path = os.path.join(
             local_job_log_dir, common_job_log_path)
 
-        rtconfig = pdeepcopy(self.tdef.rtconfig)
-        poverride(rtconfig, overrides)
+        if overrides:
+            rtconfig = pdeepcopy(self.tdef.rtconfig)
+            poverride(rtconfig, overrides)
+        else:
+            rtconfig = self.tdef.rtconfig
 
         self.set_from_rtconfig(rtconfig)
 


### PR DESCRIPTION
This change reduces the time taken to submit a minimal task by around 40% in a modified 'busy' suite (would be more for larger tasks?) on a fast filesystem. (When the filesystem is slow, more of the time will be taken in writing the job script file).

For extremely active suites (100s of 1 second tasks active at once) the pdeepcopy and poverride here can be one of the dominant costs. I find it amazing how much time it takes just to move or re-organise data structures!

The rtconfig is chucked away in the `set_from_rtconfig` method that follows, so I don't think this saves memory in the long run.

The speedup won't apply if there are broadcast overrides, so some of our larger suites that use broadcasts of reservation ids for each task, etc, won't benefit.

@arjclark, @matthewrmshin please review.