### PR TITLE
cylc.network.suite_state: speed up updating

### DIFF
--- a/lib/cylc/network/suite_state.py
+++ b/lib/cylc/network/suite_state.py
@@ -200,7 +200,6 @@ class StateSummaryServer(PyroServer):
             ts = task.get_state_summary()
             task_summary[task.identity] = ts
             name, point_string = TaskID.split(task.identity)
-            point_string = str(point_string)
             task_states.setdefault(point_string, {})
             task_states[point_string][name] = ts['state']
 
@@ -209,7 +208,6 @@ class StateSummaryServer(PyroServer):
             ts['state'] = 'runahead'
             task_summary[task.identity] = ts
             name, point_string = TaskID.split(task.identity)
-            point_string = str(point_string)
             task_states.setdefault(point_string, {})
             task_states[point_string][name] = 'runahead'
 


### PR DESCRIPTION
This change roughly halves the cost of updating of suite state summaries, which is our old expensive friend, and (still) usually the dominant cost in an active suite. 

Some of the expensive stuff has been moved to a new method, purely for profiling reasons and for later speed ups.

The speed up mostly comes from doing fewer, more targeted loops and from avoiding as many `.items()` calls, which the profiler alleges to be expensive (may just be profiler overhead - not sure).

@matthewrmshin, @kaday please review.
