### PR TITLE
cylc.task_pool: speed up queued db ops

### DIFF
--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -1224,6 +1224,9 @@ class TaskPool(object):
         """Handle queued db operations for each task proxy."""
         for itask in self.get_all_tasks():
             # (runahead pool tasks too, to get new state recorders).
+            if not (any(itask.db_inserts_map.values()) or
+                    any(itask.db_updates_map.values())):
+                continue
             for table_name, db_inserts in sorted(itask.db_inserts_map.items()):
                 while db_inserts:
                     db_insert = db_inserts.pop(0)

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -1224,32 +1224,35 @@ class TaskPool(object):
         """Handle queued db operations for each task proxy."""
         for itask in self.get_all_tasks():
             # (runahead pool tasks too, to get new state recorders).
-            if not (any(itask.db_inserts_map.values()) or
-                    any(itask.db_updates_map.values())):
-                continue
-            for table_name, db_inserts in sorted(itask.db_inserts_map.items()):
-                while db_inserts:
-                    db_insert = db_inserts.pop(0)
-                    db_insert.update({
-                        "name": itask.tdef.name,
-                        "cycle": str(itask.point),
-                    })
-                    if "submit_num" not in db_insert:
-                        db_insert["submit_num"] = itask.submit_num
-                    self.pri_dao.add_insert_item(table_name, db_insert)
-                    self.pub_dao.add_insert_item(table_name, db_insert)
+            if any(itask.db_inserts_map.values()):
+                for table_name, db_inserts in sorted(
+                        itask.db_inserts_map.items()):
+                    while db_inserts:
+                        db_insert = db_inserts.pop(0)
+                        db_insert.update({
+                            "name": itask.tdef.name,
+                            "cycle": str(itask.point),
+                        })
+                        if "submit_num" not in db_insert:
+                            db_insert["submit_num"] = itask.submit_num
+                        self.pri_dao.add_insert_item(table_name, db_insert)
+                        self.pub_dao.add_insert_item(table_name, db_insert)
 
-            for table_name, db_updates in sorted(itask.db_updates_map.items()):
-                while db_updates:
-                    set_args = db_updates.pop(0)
-                    where_args = {
-                        "cycle": str(itask.point), "name": itask.tdef.name}
-                    if "submit_num" not in set_args:
-                        where_args["submit_num"] = itask.submit_num
-                    self.pri_dao.add_update_item(
-                        table_name, set_args, where_args)
-                    self.pub_dao.add_update_item(
-                        table_name, set_args, where_args)
+            if any(itask.db_updates_map.values()):
+                for table_name, db_updates in sorted(
+                        itask.db_updates_map.items()):
+                    while db_updates:
+                        set_args = db_updates.pop(0)
+                        where_args = {
+                            "cycle": str(itask.point),
+                            "name": itask.tdef.name
+                        }
+                        if "submit_num" not in set_args:
+                            where_args["submit_num"] = itask.submit_num
+                        self.pri_dao.add_update_item(
+                            table_name, set_args, where_args)
+                        self.pub_dao.add_update_item(
+                            table_name, set_args, where_args)
 
         # record any broadcast settings to be dumped out
         bcast = BroadcastServer.get_inst()


### PR DESCRIPTION
This speeds up the `process_queued_db_ops` method by around 40% (for the modified busy suite on a fast filesystem). The for loop and the calls to `sorted` and `items` cost a fair bit (according to the profiler) in the null dictionary case.

@arjclark, @hjoliver please review.