### PR TITLE
task_proxy: cache prereq status for speed

### DIFF
--- a/lib/cylc/prerequisite.py
+++ b/lib/cylc/prerequisite.py
@@ -130,7 +130,7 @@ class Prerequisite(object):
         try:
             return self.all_satisfied
         except AttributeError:
-            # No cached value, or not possible to cache (conditional).
+            # No cached value.
             if not self.satisfied:
                 # No prerequisites left after pre-initial simplification.
                 return True

--- a/lib/cylc/prerequisite.py
+++ b/lib/cylc/prerequisite.py
@@ -136,8 +136,9 @@ class Prerequisite(object):
                 return True
             if self.conditional_expression:
                 # Trigger expression with at least one '|': use eval.
-                return self._conditional_is_satisfied()
-            self.all_satisfied = all(self.satisfied.values())
+                self.all_satisfied = self._conditional_is_satisfied()
+            else:
+                self.all_satisfied = all(self.satisfied.values())
             return self.all_satisfied
 
     def _conditional_is_satisfied(self):
@@ -172,6 +173,8 @@ class Prerequisite(object):
                     self.satisfied_by[label] = outputs[msg]  # owner_id
             if self.conditional_expression is None:
                 self.all_satisfied = all(self.satisfied.values())
+            else:
+                self.all_satisfied = self._conditional_is_satisfied()
         return relevant_msgs
 
     def dump(self):
@@ -195,12 +198,16 @@ class Prerequisite(object):
             self.satisfied[label] = True
         if self.conditional_expression is None:
             self.all_satisfied = True
+        else:
+            self.all_satisfied = self._conditional_is_satisfied()
 
     def set_not_satisfied(self):
         for label in self.messages:
             self.satisfied[label] = False
         if self.conditional_expression is None:
             self.all_satisfied = False
+        else:
+            self.all_satisfied = self._conditional_is_satisfied()
 
     def get_target_points(self):
         """Return a list of cycle points target by each prerequisite,

--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -247,6 +247,9 @@ class TaskProxy(object):
                 self.point, self.tdef.intercycle_offsets)
             self.identity = TaskID.get(self.tdef.name, self.point)
 
+        self._recalc_satisfied = True
+        self._is_satisfied = False
+        self._suicide_is_satisfied = False
         self.prerequisites = []
         self.suicide_prerequisites = []
         self._add_prerequisites(self.point)
@@ -371,6 +374,7 @@ class TaskProxy(object):
         # self.triggers[sequence] = [triggers for sequence]
         # Triggers for sequence_i only used if my cycle point is a
         # valid member of sequence_i's sequence of cycle points.
+        self._recalc_satisfied = True
 
         for sequence, exps in self.tdef.triggers.items():
             for ctrig, exp in exps:
@@ -618,18 +622,26 @@ class TaskProxy(object):
                 preq.is_satisfied()
 
     def prerequisites_are_all_satisfied(self):
-        return all(preq.is_satisfied() for preq in self.prerequisites)
+        if self._recalc_satisfied:
+            self._is_satisfied = all(
+                preq.is_satisfied() for preq in self.prerequisites)
+        return self._is_satisfied
 
     def suicide_prerequisites_are_all_satisfied(self):
-        return all(preq.is_satisfied() for preq in self.suicide_prerequisites)
+        if self._recalc_satisfied:
+            self._suicide_is_satisfied = all(
+                preq.is_satisfied() for preq in self.suicide_prerequisites)
+        return self._suicide_is_satisfied
 
     def set_prerequisites_all_satisfied(self):
         for prereq in self.prerequisites:
             prereq.set_satisfied()
+        self._recalc_satisfied = True
 
     def set_prerequisites_not_satisfied(self):
         for prereq in self.prerequisites:
             prereq.set_not_satisfied()
+        self._recalc_satisfied = True
 
     def reset_state_ready(self):
         """Reset state to "ready"."""
@@ -1821,14 +1833,18 @@ class TaskProxy(object):
 
     def not_fully_satisfied(self):
         """Return True if prerequisites are not fully satisfied."""
-        return (not self.prerequisites_are_all_satisfied() or
-                not self.suicide_prerequisites_are_all_satisfied())
+        if self._recalc_satisfied:
+            return (not self.prerequisites_are_all_satisfied() or
+                    not self.suicide_prerequisites_are_all_satisfied())
+        return (not self._is_satisfied or not self._suicide_is_satisfied)
 
     def satisfy_me(self, task_output_msgs, task_outputs):
         """Attempt to get my prerequisites satisfied."""
+        self._recalc_satisfied = False
         for preqs in [self.prerequisites, self.suicide_prerequisites]:
             for preq in preqs:
-                preq.satisfy_me(task_output_msgs, task_outputs)
+                if preq.satisfy_me(task_output_msgs, task_outputs):
+                    self._recalc_satisfied = True
 
     def next_point(self):
         """Return the next cycle point."""


### PR DESCRIPTION
This adds some caching to speed up task proxy `ready_to_run`.

(By the way, all these speed up PRs are coming from a single branch I've been working on for a few weeks. I've decided to split it up into related pieces.)

If a task doesn't have conditional prerequisites, then we can simply cache the 'am I satisfied' result instead of rechecking it every loop. We only normally need to recheck it once one or more relevant outputs have been found in `satisfy_me`.

I've moved the conditional expression checking into its own method for neatness and ease of future profiling - I wonder how much it costs if we have lots of 'OR' dependent tasks!

This reduces the cost of calling `ready_to_run` (another dominant cost in a modified `busy` suite with lots of waiting tasks) by around two thirds.

@hjoliver, @kaday please review.