### PR TITLE
cylc validate: improve family name validate

### DIFF
--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -1398,12 +1398,7 @@ class SuiteConfig(object):
             # backslashed re markers like \b from being interpreted as
             # normal escapeded characters.
 
-            fam_in_line = re.search(
-                r"(?<!%(name_char_re)s)%(fam)s(?!%(name_char_re)s)" % {
-                    "name_char_re": TaskID.NAME_CHAR_RE, "fam": fam
-                },
-                line)
-            if not fam_in_line:
+            if fam not in re.findall(TaskID.NAME_RE, line):
                 continue
 
             # Replace family triggers with member triggers

--- a/lib/cylc/task_id.py
+++ b/lib/cylc/task_id.py
@@ -26,8 +26,7 @@ class TaskID(object):
 
     DELIM = '.'
     DELIM2 = '/'
-    NAME_CHAR_RE = r"[\w\-+%@]"
-    NAME_RE = r"\w" + NAME_CHAR_RE + r"*"
+    NAME_RE = r"\w[\w\-+%@]*"
     NAME_REC = re.compile(r"\A" + NAME_RE + r"\Z")
     POINT_RE = r"\S+"
     POINT_REC = re.compile(r"\A" + POINT_RE + r"\Z")


### PR DESCRIPTION
It was attempted in #1779 but the fix had a speed issue. This attempt
improves the speed and reduces the complexity of the original fix.

@arjclark @hjoliver please review.