### PR TITLE
new suite status string - back compat both ways

### DIFF
--- a/lib/cylc/dump.py
+++ b/lib/cylc/dump.py
@@ -82,8 +82,7 @@ def get_stop_state_summary(suite, owner=None, hostname=None, lines=None):
             global_summary["last_updated"] = time.time()
 
     # Skip initial and final cycle points.
-    _ = lines.pop(0)
-    _ = lines.pop(0)
+    lines[0:2] = []
     global_summary["status_string"] = SUITE_STATUS_STOPPED
     while lines:
         line = lines.pop(0)

--- a/lib/cylc/network/suite_state.py
+++ b/lib/cylc/network/suite_state.py
@@ -50,6 +50,12 @@ SUITE_STATUS_STOPPED_WITH = "stopped with '%s'"
 
 
 def get_suite_status_string(paused, stopping, will_pause_at, will_stop_at):
+    """Construct a suite status summary string for clients programs.
+
+    This is in a function for re-use in monitor and GUI back-compat code
+    (clients at cylc version <= 6.9.1 construct their own status string).
+
+    """
     if paused:
         return SUITE_STATUS_HELD
     elif stopping:
@@ -180,8 +186,18 @@ class StateSummaryServer(PyroServer):
         global_summary['namespace definition order'] = ns_defn_order
         global_summary['reloading'] = reloading
         global_summary['state totals'] = state_count_totals
+
+        # Construct a suite status string for use by monitoring clients.
         global_summary['status_string'] = get_suite_status_string(
             paused, stopping, will_pause_at, will_stop_at)
+
+        # TODO - delete this block post back-compat concerns (<= 6.9.1):
+        #  Report separate status string components for older clients that
+        # construct their own suite status strings.
+        global_summary['paused'] = paused
+        global_summary['stopping'] = stopping
+        global_summary['will_pause_at'] = will_pause_at
+        global_summary['will_stop_at'] = will_stop_at
 
         self._summary_update_time = time.time()
 

--- a/lib/cylc/network/suite_state.py
+++ b/lib/cylc/network/suite_state.py
@@ -50,7 +50,7 @@ SUITE_STATUS_STOPPED_WITH = "stopped with '%s'"
 
 
 def get_suite_status_string(paused, stopping, will_pause_at, will_stop_at):
-    """Construct a suite status summary string for clients programs.
+    """Construct a suite status summary string for client programs.
 
     This is in a function for re-use in monitor and GUI back-compat code
     (clients at cylc version <= 6.9.1 construct their own status string).


### PR DESCRIPTION
Follow up #1815, which follows up #1806 

This restores the individual components of the suite status string to the summary dict, so that the change now works for both old client + new daemon and new client + old daemon.

It also addresses two earlier feedback comments: https://github.com/cylc/cylc/pull/1806#discussion_r60707128 and https://github.com/cylc/cylc/pull/1815#discussion_r61218720

@matthewrmshin - please review and/or assign.