### PR TITLE
Use class __slots__ to reduce daemon memory use

### DIFF
--- a/lib/cylc/graphnode.py
+++ b/lib/cylc/graphnode.py
@@ -91,6 +91,11 @@ class GraphNodeError(Exception):
 class graphnode(object):
     """A node in the cycle suite.rc dependency graph."""
 
+    # Memory optimization - constrain possible attributes to this list.
+    __slots__ = ["offset_is_from_ict", "offset_is_irregular",
+                 "is_absolute", "special_output", "output",
+                 "name", "intercycle", "offset_string"]
+
     def __init__(self, node, base_interval=None):
         node_in = node
         # Get task name and properties from a graph node name.

--- a/lib/cylc/poll_timer.py
+++ b/lib/cylc/poll_timer.py
@@ -19,7 +19,6 @@
 
 import time
 from copy import copy
-from collections import deque
 from logging import WARNING, INFO
 
 from cylc.cfgspec.globalcfg import GLOBAL_CFG
@@ -28,9 +27,15 @@ from cylc.cfgspec.globalcfg import GLOBAL_CFG
 class PollTimer(object):
     """Timer for polling task job submission and execution."""
 
+    # Memory optimization - constrain possible attributes to this list.
+    __slots__ = ["intervals", "default_intervals", "name", "log",
+                 "current_interval", "timeout"]
+
     def __init__(self, intervals, defaults, name, log):
-        self.intervals = copy(deque(intervals))
-        self.default_intervals = deque(defaults)
+        self.intervals = copy(intervals)
+        self.default_intervals = copy(defaults)
+        self.intervals.reverse()
+        self.default_intervals.reverse()
         self.name = name
         self.log = log
         self.current_interval = None
@@ -57,7 +62,7 @@ class PollTimer(object):
     def set_timer(self):
         """Set the timer."""
         try:
-            self.current_interval = self.intervals.popleft()  # seconds
+            self.current_interval = self.intervals.pop()  # seconds
         except IndexError:
             # no more intervals, keep the last one
             pass

--- a/lib/cylc/prerequisite.py
+++ b/lib/cylc/prerequisite.py
@@ -40,6 +40,13 @@ class TriggerExpressionError(Exception):
 
 class Prerequisite(object):
 
+    # Memory optimization - constrain possible attributes to this list.
+    __slots__ = ["CYCLE_POINT_RE", "owner_id", "labels", "messages",
+                 "messages_set", "satisfied", "satisfied_by",
+                 "target_point_strings", "start_point",
+                 "pre_initial_messages", "conditional_expression",
+                 "raw_conditional_expression"]
+
     # Extracts T from "foo.T succeeded" etc.
     CYCLE_POINT_RE = re.compile('^\w+\.(\S+) .*$')
 

--- a/lib/cylc/prerequisite.py
+++ b/lib/cylc/prerequisite.py
@@ -42,7 +42,7 @@ class Prerequisite(object):
 
     # Memory optimization - constrain possible attributes to this list.
     __slots__ = ["CYCLE_POINT_RE", "owner_id", "labels", "messages",
-                 "messages_set", "satisfied", "satisfied_by",
+                 "messages_set", "satisfied", "all_satisfied", "satisfied_by",
                  "target_point_strings", "start_point",
                  "pre_initial_messages", "conditional_expression",
                  "raw_conditional_expression"]

--- a/lib/cylc/task_outputs.py
+++ b/lib/cylc/task_outputs.py
@@ -23,6 +23,10 @@ import sys
 
 
 class TaskOutputs(object):
+
+    # Memory optimization - constrain possible attributes to this list.
+    __slots__ = ["owner_id", "completed", "not_completed"]
+
     def __init__(self, owner_id):
 
         self.owner_id = owner_id

--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -89,6 +89,9 @@ TaskJobLogsRetrieveContext = namedtuple(
 class TryState(object):
     """Represent the current state of a (re)try."""
 
+    # Memory optimization - constrain possible attributes to this list.
+    __slots__ = ["ctx", "delays", "num", "delay", "timeout", "is_waiting"]
+
     def __init__(self, ctx=None, delays=None):
         self.ctx = ctx
         if delays:

--- a/lib/cylc/task_trigger.py
+++ b/lib/cylc/task_trigger.py
@@ -83,6 +83,10 @@ A task trigger is a prerequisite in the abstract, defined by the suite graph.
 It generates a concrete prerequisite string given a task's cycle point value.
     """
 
+    # Memory optimization - constrain possible attributes to this list.
+    __slots__ = ["task_name", "suicide", "graph_offset_string", "cycle_point",
+                 "message", "message_offset", "builtin"]
+
     def __init__(
             self, task_name, qualifier=None, graph_offset_string=None,
             cycle_point=None, suicide=False, outputs={}, base_interval=None):

--- a/lib/cylc/taskdef.py
+++ b/lib/cylc/taskdef.py
@@ -36,6 +36,16 @@ class TaskDefError(Exception):
 class TaskDef(object):
     """Task definition."""
 
+    # Memory optimization - constrain possible attributes to this list.
+    __slots__ = ["run_mode", "rtconfig", "start_point", "sequences",
+                 "implicit_sequences", "used_in_offset_trigger",
+                 "max_future_prereq_offset", "intercycle_offsets",
+                 "sequential", "is_coldstart", "suite_polling_cfg",
+                 "clocktrigger_offset", "expiration_offset",
+                 "namespace_hierarchy", "triggers", "outputs",
+                 "external_triggers", "name", "elapsed_times",
+                 "mean_total_elapsed_time"]
+
     def __init__(self, name, rtcfg, run_mode, start_point):
         if not TaskID.is_valid_name(name):
             raise TaskDefError("Illegal task name: %s" % name)


### PR DESCRIPTION
These things are great. We freeze the possible attributes of a class (fine, since we nearly always declare everything in the init method anyway) and in return, the memory penalty from our thousands of instances of smallish classes drops to practically nothing.

This change reduces the daemon memory usage by a third in my 10000 tasks/cycle busy suite.

https://docs.python.org/2/reference/datamodel.html#slots
http://stackoverflow.com/questions/472000/python-slots

I thought about adding `__slots__` for the task proxy class itself - maybe later. I think there could be scope for doing this for our `OrderedDictWithDefaults` parsec class, but that depends on the ancestor classes having slots set (not sure that's true for the `collections` `OrderedDict`).

I also moved the `PollTimer` class away from the use of `deque`, which appears to be a high memory item in itself.

@matthewrmshin, @hjoliver please review.