### PR TITLE
Improve style to pass PEP8 1.7.0

### DIFF
--- a/bin/cylc
+++ b/bin/cylc
@@ -169,7 +169,7 @@ def pretty_print(incom, choose_dict, indent=True, numbered=False, sort=False):
             else:
                 digit = str(count)
             print digit + '/',
-        print (
+        print(
             label[item],
             '.' * (longest - len(label[item])) + '...',
             incom[item])

--- a/bin/cylc-refresh
+++ b/bin/cylc-refresh
@@ -81,16 +81,16 @@ def main():
             print >> sys.stderr, x
             readerror.append(suite)
     if len(invalid) > 0:
-        print ("ERROR, %d invalid registrations "
-               "(no suite.rc file):" % len(invalid))
+        print("ERROR, %d invalid registrations "
+              "(no suite.rc file):" % len(invalid))
         for i in invalid:
             if options.unregister:
                 db.unregister(i)
             else:
                 print ' -', i
     if len(readerror) > 0:
-        print ("ERROR, %d title parse failures "
-               "(bad suite.rc file):" % len(readerror))
+        print("ERROR, %d title parse failures "
+              "(bad suite.rc file):" % len(readerror))
         for i in readerror:
             print ' -', i
 

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -2146,8 +2146,8 @@ class SuiteConfig(object):
             total_graph_text = "\n".join(
                 back_comp_initial_section_graphs[section])
             if self.validation:
-                print ("# REPLACING START-UP/ASYNC DEPENDENCIES " +
-                       "WITH AN R1* SECTION")
+                print("# REPLACING START-UP/ASYNC DEPENDENCIES " +
+                      "WITH AN R1* SECTION")
                 print "# (VARYING INITIAL CYCLE POINT MAY AFFECT VALIDITY)"
                 print "        [[[" + section + "]]]"
                 print "            " + 'graph = """'

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -1005,10 +1005,10 @@ To see if %(suite)s is running on '%(host)s:%(port)s':
                 while not proc_pool.is_dead():
                     proc_pool.handle_results_async()
                     if not warned:
-                        print ("Waiting for the command process " +
-                               "pool to empty for shutdown")
-                        print ("(you can \"stop now\" to shut " +
-                               "down immediately if you like).")
+                        print("Waiting for the command process " +
+                              "pool to empty for shutdown")
+                        print("(you can \"stop now\" to shut " +
+                              "down immediately if you like).")
                         warned = True
                     self.process_command_queue()
                     time.sleep(0.5)


### PR DESCRIPTION
Allow `cylc test battery` to pass on Ubuntu 16.04LTS.

@hjoliver please review (and please feel free to reassign milestone to next-release).