### PR TITLE
Fix reload-alteration of a reload-removed then reload-added task

### DIFF
--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -528,6 +528,8 @@ class Scheduler(object):
         # update state SuiteStateDumper state
         self.state_dumper.set_cts(self.initial_point, self.final_point)
 
+        self.do_update_state_summary = True
+
     def command_set_runahead(self, *args):
         self.pool.set_runahead(*args)
 

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -690,6 +690,9 @@ class TaskPool(object):
         for name in old_task_name_list:
             if name not in self.task_name_list:
                 self.orphans.append(name)
+        for name in self.task_name_list:
+            if name in self.orphans:
+                self.orphans.remove(name)
         # adjust the new suite config to handle the orphans
         config.adopt_orphans(self.orphans)
 

--- a/tests/reload/18-remove-add-alter-task.t
+++ b/tests/reload/18-remove-add-alter-task.t
@@ -1,0 +1,31 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2016 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test that removing, adding, then altering a task in the graph works OK.
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 2
+#-------------------------------------------------------------------------------
+install_suite $TEST_NAME_BASE remove-add-alter-task
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-validate
+run_ok $TEST_NAME cylc validate $SUITE_NAME
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-run
+suite_run_ok $TEST_NAME cylc run --debug --reference-test $SUITE_NAME
+#-------------------------------------------------------------------------------
+purge_suite $SUITE_NAME

--- a/tests/reload/remove-add-alter-task/reference.log
+++ b/tests/reload/remove-add-alter-task/reference.log
@@ -1,0 +1,30 @@
+2016-05-03T09:57:39Z INFO - Suite starting on shire:7772
+2016-05-03T09:57:39Z INFO - Run mode: live
+2016-05-03T09:57:39Z INFO - Initial point: 1
+2016-05-03T09:57:39Z INFO - Final point: 1
+2016-05-03T09:57:39Z INFO - Cold Start 1
+2016-05-03T09:57:39Z INFO - [reloader.1] -triggered off []
+2016-05-03T09:57:40Z INFO - [reloader.1] -submit_method_id=13374
+2016-05-03T09:57:40Z INFO - [reloader.1] -submission succeeded
+2016-05-03T09:57:40Z INFO - [client-command] reload_suite baggins@shire:cylc-reload 637d8b64-d542-4283-b334-3fd6b64e117c
+2016-05-03T09:57:41Z INFO - [reloader.1] -(current:submitted)> started at 2016-05-03T09:57:40Z
+2016-05-03T09:57:41Z INFO - Command succeeded: reload_suite()
+2016-05-03T09:57:42Z WARNING - Reload will complete once active tasks have finished.
+2016-05-03T09:57:51Z INFO - [client-command] reload_suite baggins@shire:cylc-reload 23ccbafd-0fd1-445e-8327-dceef38437dd
+2016-05-03T09:57:51Z INFO - Command succeeded: reload_suite()
+2016-05-03T09:58:01Z INFO - [client-command] insert_task baggins@shire:cylc-insert 0d229903-9abc-4c28-9b16-2d19e6aaa960
+2016-05-03T09:58:02Z INFO - Command succeeded: insert_task(['remove_add_alter_me.1'],None,None,None)
+2016-05-03T09:58:12Z INFO - [client-command] reload_suite baggins@shire:cylc-reload 56ed5ddf-2453-4311-90f3-8bcb85c9e638
+2016-05-03T09:58:13Z INFO - Command succeeded: reload_suite()
+2016-05-03T09:58:14Z INFO - RELOADING TASK DEFINITION FOR remove_add_alter_me.1
+2016-05-03T09:58:23Z INFO - [reloader.1] -(current:running)> succeeded at 2016-05-03T09:58:22Z
+2016-05-03T09:58:23Z INFO - [reloader.1] -('job-logs-register', 1) will run after P0Y (after 2016-05-03T09:58:23Z)
+2016-05-03T09:58:24Z INFO - RELOADING TASK DEFINITION FOR reloader.1
+2016-05-03T09:58:24Z INFO - Reload completed.
+2016-05-03T09:58:24Z INFO - [remove_add_alter_me.1] -triggered off ['reloader.1']
+2016-05-03T09:58:25Z INFO - [remove_add_alter_me.1] -submit_method_id=29648
+2016-05-03T09:58:25Z INFO - [remove_add_alter_me.1] -submission succeeded
+2016-05-03T09:58:25Z INFO - [remove_add_alter_me.1] -(current:submitted)> started at 2016-05-03T09:58:25Z
+2016-05-03T09:58:26Z INFO - [remove_add_alter_me.1] -(current:running)> succeeded at 2016-05-03T09:58:25Z
+2016-05-03T09:58:26Z INFO - [remove_add_alter_me.1] -('job-logs-register', 1) will run after P0Y (after 2016-05-03T09:58:26Z)
+2016-05-03T09:58:27Z INFO - Suite shutting down at 2016-05-03T09:58:27Z

--- a/tests/reload/remove-add-alter-task/suite.rc
+++ b/tests/reload/remove-add-alter-task/suite.rc
@@ -1,0 +1,33 @@
+title = "Test reloading of a task removed then added by a reload."
+# Don't run this suite in-place: it modifies itself.
+
+[cylc]
+    UTC mode = True
+    [[reference test]]
+        required run mode = live
+        live mode suite timeout = PT60S
+
+[scheduling]
+    [[dependencies]]
+        graph = reloader => remove_add_alter_me
+
+[runtime]
+   [[remove_add_alter_me]]
+      script = false
+   [[reloader]]
+      script = """
+sed -i "12s/\(graph = reloader\).*/\1/" $CYLC_SUITE_DEF_PATH/suite.rc
+cylc reload $CYLC_SUITE_NAME
+sleep 5
+sed -i "12s/\(graph = reloader\)/\1 => remove_add_alter_me/" $CYLC_SUITE_DEF_PATH/suite.rc
+cylc reload $CYLC_SUITE_NAME
+sleep 5
+cylc insert $CYLC_SUITE_NAME remove_add_alter_me.1
+sleep 5
+cat >>$CYLC_SUITE_DEF_PATH/suite.rc <<'__RUNTIME__'
+[[remove_add_alter_me]]
+    script = true
+__RUNTIME__
+cylc reload $CYLC_SUITE_NAME
+sleep 5
+        """


### PR DESCRIPTION
This closes #1759. A task that became a reload orphan always stayed an orphan in future reloads and couldn't be changed via reload.

It also fixes a small issue I found when debugging - reload in itself doesn't trigger a state summary update. This isn't always necessary (e.g. when just altering the runtime) but seems like a good idea.

@arjclark, @hjoliver please review.