### PR TITLE
Don't delay reload of active tasks.

### DIFF
--- a/bin/cylc-restart
+++ b/bin/cylc-restart
@@ -426,7 +426,7 @@ class restart(Scheduler):
                     state,
                     has_spawned,
                     submit_num=submit_num,
-                    is_reload=True,
+                    is_reload_or_restart=True,
                     message_queue=self.pool.message_queue
                 )
             except TaskNotDefinedError, x:

--- a/tests/reload/16-waiting/suite.rc
+++ b/tests/reload/16-waiting/suite.rc
@@ -26,7 +26,7 @@ done
     [[reloader]]
         script = """
 cylc reload "${CYLC_SUITE_NAME}"
-while ! grep -q 'RELOADING TASK DEFINITION FOR waiter\.1' \
+while ! grep -q '\[waiter\.1\] -reloaded task definition' \
     "${CYLC_SUITE_LOG_DIR}/log"
 do
     sleep 1


### PR DESCRIPTION
Close #1818 - simplify reload logic by not delaying reload of active tasks. Instead just log a warning that the job is already active under the old settings.

Now preserves task outputs across the reload, so there's no need for the delayed reload any more even if task outputs are changed in the reloaded suite definition.
