### PR TITLE
gscan, gpanel: gscan.rc config file.

### DIFF
--- a/doc/cug.tex
+++ b/doc/cug.tex
@@ -7100,6 +7100,10 @@ testing of the script during development or debugging.
 
 \pagebreak
 
+\input{gscanrc.tex}
+
+\pagebreak
+
 
 \section{Command Reference}
 \label{CommandReference}

--- a/doc/gscanrc.tex
+++ b/doc/gscanrc.tex
@@ -1,0 +1,43 @@
+
+\section{Cylc Gscan Config File Reference}
+\label{GscanRCReference}
+
+\lstset{language=bash}
+
+This section defines all legal items and values for the gscan config
+file which should be located in
+\lstinline=$HOME/.cylc/gscan.rc=.
+
+\subsection{Top Level Items}
+
+
+\subsubsection{activate on startup}
+Set whether
+\lstinline=cylc gpanel=
+will activate automatically when the gui is loaded or not.
+
+\begin{myitemize}
+    \item {\em type:} boolean (True or False)
+\item {\em legal values:} ``True'', ``False''
+\item {\em default:} ``False''
+\item {\em example:} \lstinline@activate on startup = True@
+\end{myitemize}
+
+
+\subsubsection{columns}
+Set the data fields displayed initially when the
+\lstinline=cylc gscan=
+GUI starts. This
+can be changed later using the right click context menu.
+\newline
+Note that the order in
+which the fields are specified does not affect the order in which they are
+displayed.
+
+\begin{myitemize}
+\item {\em type:} string (a list of one or more view names)
+\item {\em legal values:} ``host'', ``status'', ``suite'',  ``title'',
+        ``updated''
+\item {\em default:} ``status'', ``suite''
+\item {\em example:} \lstinline@columns = suite, title, status@
+\end{myitemize}

--- a/lib/cylc/cfgspec/gscan.py
+++ b/lib/cylc/cfgspec/gscan.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2016 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+
+from parsec import ParsecError
+from parsec.validate import validator as vdr
+from parsec.config import config
+
+"""gscan config file format."""
+
+USER_FILE = os.path.join(os.environ['HOME'], '.cylc', 'gscan.rc')
+
+SPEC = {
+    'columns': vdr(vtype='string_list', default=['suite', 'status']),
+    'activate on startup': vdr(vtype='boolean', default=False)
+}
+
+
+class gscanconfig(config):
+
+    def check(self):
+        cfg = self.get(sparse=True)
+        if 'columns' in cfg:
+            for column in cfg['columns']:
+                if column not in ['host', 'suite', 'title', 'updated',
+                                  'status']:
+                    print >> sys.stderr, ("WARNING: illegal column name "
+                                          "'" + column + "'")
+                    cfg['columns'].remove(column)
+            if len(cfg['columns']) < 1:
+                print >> sys.stderr, ('WARNING: at least one column must be '
+                                      'specified, defaulting to "suite, '
+                                      'status"')
+                cfg['columns'] = ['suite', 'status']
+
+
+gsfg = None
+if not gsfg:
+    gsfg = gscanconfig(SPEC)
+    if os.access(USER_FILE, os.F_OK | os.R_OK):
+        try:
+            gsfg.loadcfg(USER_FILE, 'user config')
+        except ParsecError as exc:
+            sys.stderr.write('ERROR: bad gscan config %s:\n' % USER_FILE)
+            raise
+    gsfg.check()

--- a/lib/cylc/gui/gpanel.py
+++ b/lib/cylc/gui/gpanel.py
@@ -40,6 +40,7 @@ from cylc.gui.dot_maker import DotMaker
 from cylc.gui.util import get_icon, setup_icons
 from cylc.owner import USER
 from cylc.network.suite_state import extract_group_state
+from cylc.cfgspec.gscan import gsfg
 
 
 class ScanPanelApplet(object):
@@ -81,6 +82,8 @@ class ScanPanelApplet(object):
                                               owner=owner,
                                               poll_interval=poll_interval)
         self.top_hbox.connect("destroy", self.stop)
+        if gsfg.get(["activate on startup"]):
+            self.updater.start()
 
     def get_widget(self):
         """Return the topmost widget for embedding in the panel."""

--- a/lib/cylc/gui/gscan.py
+++ b/lib/cylc/gui/gscan.py
@@ -39,7 +39,7 @@ from cylc.network.port_scan import scan_all
 from cylc.owner import USER
 from cylc.version import CYLC_VERSION
 from cylc.task_state import TASK_STATUSES_ORDERED, TASK_STATUS_RUNAHEAD
-
+from cylc.cfgspec.gscan import gsfg
 
 PYRO_TIMEOUT = 2
 KEY_NAME = "name"
@@ -438,7 +438,7 @@ class ScanApp(object):
         host_name_column.set_cell_data_func(
             cell_text_host, self._set_cell_text_host)
         host_name_column.set_sort_column_id(0)
-        host_name_column.set_visible(False)
+        host_name_column.set_visible("host" in gsfg.get(["columns"]))
         host_name_column.set_resizable(True)
 
         # Construct the suite name column.
@@ -448,6 +448,7 @@ class ScanApp(object):
         suite_name_column.set_cell_data_func(
             cell_text_name, self._set_cell_text_name)
         suite_name_column.set_sort_column_id(1)
+        suite_name_column.set_visible("suite" in gsfg.get(["columns"]))
         suite_name_column.set_resizable(True)
 
         # Construct the suite title column.
@@ -457,7 +458,8 @@ class ScanApp(object):
         suite_title_column.set_cell_data_func(
             cell_text_title, self._set_cell_text_title)
         suite_title_column.set_sort_column_id(3)
-        suite_title_column.set_visible(False)
+        suite_title_column.set_visible("title" in gsfg.get(
+            ["columns"]))
         suite_title_column.set_resizable(True)
 
         # Construct the update time column.
@@ -467,7 +469,7 @@ class ScanApp(object):
         time_column.set_cell_data_func(
             cell_text_time, self._set_cell_text_time)
         time_column.set_sort_column_id(4)
-        time_column.set_visible(False)
+        time_column.set_visible("updated" in gsfg.get(["columns"]))
         time_column.set_resizable(True)
 
         self.suite_treeview.append_column(host_name_column)
@@ -478,6 +480,7 @@ class ScanApp(object):
         # Construct the status column.
         status_column = gtk.TreeViewColumn("Status")
         status_column.set_sort_column_id(5)
+        status_column.set_visible("status" in gsfg.get(["columns"]))
         status_column.set_resizable(True)
         status_column_info = 6
         cycle_column_info = 5


### PR DESCRIPTION
Closes #1830 
Closes #1834 

Added gscan.rc config file, currently it configures:
- The data columns for `cylc gscan`.
- Whether `cylc gpanel` activates on startup or not.

If you can think of any other behaviour that could be described by this file please comment.

@hjoliver Please Review
@benfitzpatrick Please Review