### PR TITLE
gcylc updater: change title bar by idle_add.

### DIFF
--- a/lib/cylc/gui/updater.py
+++ b/lib/cylc/gui/updater.py
@@ -223,8 +223,8 @@ class Updater(threading.Thread):
 
         gobject.idle_add(
             self.app_window.set_title, "%s - %s:%s" % (
-            self.cfg.suite, self.suite_info_client.host,
-            self.suite_info_client.port))
+                self.cfg.suite, self.suite_info_client.host,
+                self.suite_info_client.port))
         if cylc.flags.debug:
             print >> sys.stderr, "succeeded"
         # Connected.

--- a/lib/cylc/gui/updater.py
+++ b/lib/cylc/gui/updater.py
@@ -221,9 +221,9 @@ class Updater(threading.Thread):
                     gobject.idle_add(self.warn, str(exc))
             return
 
-        self.app_window.set_title("%s - %s:%s" % (
-            self.cfg.suite,
-            self.suite_info_client.host,
+        gobject.idle_add(
+            self.app_window.set_title, "%s - %s:%s" % (
+            self.cfg.suite, self.suite_info_client.host,
             self.suite_info_client.port))
         if cylc.flags.debug:
             print >> sys.stderr, "succeeded"
@@ -367,10 +367,12 @@ class Updater(threading.Thread):
             client.port = None
 
         if self.cfg.host:
-            self.app_window.set_title(
-                "%s - %s" % (self.cfg.suite, self.cfg.host))
+            gobject.idle_add(
+                self.app_window.set_title, "%s - %s" % (
+                    self.cfg.suite, self.cfg.host))
         else:
-            self.app_window.set_title(str(self.cfg.suite))
+            gobject.idle_add(
+                self.app_window.set_title, str(self.cfg.suite))
 
     def set_status(self, status=None):
         """Update status bar."""


### PR DESCRIPTION
Close #1750.

Turns out this "idle" speculation was correct: https://github.com/cylc/cylc/issues/1750#issuecomment-192091119

`git blame` suggests the problem was introduced first in Dec 2015, by f3e65f4

@matthewrmshin - please review/assign.

I'd like to get this out quickly in the next minor release as it has been a somewhat maddening problem!