### PR TITLE
gcylc CPU load fix: unset updater action flags

### DIFF
--- a/lib/cylc/gui/updater_dot.py
+++ b/lib/cylc/gui/updater_dot.py
@@ -304,6 +304,7 @@ class DotUpdater(threading.Thread):
         return True
 
     def update_gui(self):
+        self.action_required = False
         new_data = {}
         state_summary = {}
         state_summary.update(self.state_summary)
@@ -377,7 +378,6 @@ class DotUpdater(threading.Thread):
         while not self.quit:
             if self.update() or self.action_required:
                 gobject.idle_add(self.update_gui)
-                self.action_required = False
             sleep(0.2)
         else:
             pass

--- a/lib/cylc/gui/updater_graph.py
+++ b/lib/cylc/gui/updater_graph.py
@@ -272,6 +272,8 @@ class GraphUpdater(threading.Thread):
     def update_graph(self):
         # TODO - check edges against resolved ones
         # (adding new ones, and nodes, if necessary)
+
+        self.action_required = False
         try:
             self.oldest_point_string = (
                 self.global_summary['oldest cycle point string'])
@@ -443,7 +445,6 @@ class GraphUpdater(threading.Thread):
             self.set_live_node_attr(node, id)
 
         self.graphw.graph_attr['rankdir'] = self.orientation
-        self.action_required = False
 
         if self.write_dot_frames:
             arg = os.path.join(

--- a/lib/cylc/gui/updater_tree.py
+++ b/lib/cylc/gui/updater_tree.py
@@ -184,6 +184,8 @@ class TreeUpdater(threading.Thread):
         and expand those as well.
 
         """
+        self.action_required = False
+
         # We've a view -> sort model -> filter model -> base model hierarchy.
         model = self.ttreeview.get_model()
 


### PR DESCRIPTION
Close #1840. 

I've checked that this change restores normal CPU loading, and keeps the right-click menu fix of #1781 (note I found an easier way to reveal that bug: https://github.com/cylc/cylc/issues/1781#issuecomment-219217889).

@matthewrmshin - please review/assign