### PR TITLE
Fixed format of 'cylc help' command summaries.

### DIFF
--- a/bin/cylc
+++ b/bin/cylc
@@ -169,7 +169,7 @@ def pretty_print(incom, choose_dict, indent=True, numbered=False, sort=False):
             else:
                 digit = str(count)
             print digit + '/',
-        print(
+        print "%s %s %s" % (
             label[item],
             '.' * (longest - len(label[item])) + '...',
             incom[item])


### PR DESCRIPTION
I just noticed that since f81ee558  (cylc-6.7.3 Nov 2015) "cylc help" is printing command summaries as tuples, e.g.:
```
$ cylc help prep
CATEGORY: preparation - Suite editing, validation, visualization, etc.

HELP: cylc [preparation] COMMAND help,--help
  You can abbreviate preparation and COMMAND.
  The category preparation may be omitted.

COMMANDS:
  ('5to6', '...........', 'Improve the cylc 6 compatibility of a cylc 5 suite file')
  ('diff|compare', '...', 'Compare two suite definitions and print differences')
  ('edit', '...........', 'Edit suite definitions, optionally inlined')
  ('graph', '..........', 'Plot suite dependency graphs and runtime hierarchies')
  ('graph-diff', '.....', 'Compare two suite dependencies or runtime hierarchies')
  ('jobscript', '......', 'Generate a task job script and print it to stdout')
  ('list|ls', '........', 'List suite tasks and family namespaces')
  ('search|grep', '....', 'Search in suite definitions')
  ('validate', '.......', 'Parse and validate suite definitions')
  ('view', '...........', 'View suite definitions, inlined and Jinja2 processed')
```
This PR restores it to the intended:
```
$ cylc help prep
CATEGORY: preparation - Suite editing, validation, visualization, etc.

HELP: cylc [preparation] COMMAND help,--help
  You can abbreviate preparation and COMMAND.
  The category preparation may be omitted.

COMMANDS:
  5to6 ........... Improve the cylc 6 compatibility of a cylc 5 suite file
  diff|compare ... Compare two suite definitions and print differences
  edit ........... Edit suite definitions, optionally inlined
  graph .......... Plot suite dependency graphs and runtime hierarchies
  graph-diff ..... Compare two suite dependencies or runtime hierarchies
  jobscript ...... Generate a task job script and print it to stdout
  list|ls ........ List suite tasks and family namespaces
  search|grep .... Search in suite definitions
  validate ....... Parse and validate suite definitions
  view ........... View suite definitions, inlined and Jinja2 processed
```

@matthewrmshin - please review or assign (one review should do for this trivial change).