### PR TITLE
Implement suite stalled handler.

### DIFF
--- a/conf/cylc.lang
+++ b/conf/cylc.lang
@@ -86,99 +86,121 @@
       <!-- To regenerate this keyword list, create a minimal suite.rc file and run something like:
         cylc get-config my-minimal-suite | sed "/^[^=]*$/d; s/=.*//g; s/^ *//g; s/ *$//g" | sort -r | uniq | sed "s/\(.*\)/<keyword>\1<\/keyword>/g"
         -->
-      <keyword>work sub-directory</keyword>
-      <keyword>warning handler</keyword>
-      <keyword>verbose mode</keyword>
-      <keyword>UTC mode</keyword>
-      <keyword>user</keyword>
-      <keyword>use node color for labels</keyword>
-      <keyword>use node color for edges</keyword>
-      <keyword>title</keyword>
-      <keyword>timeout handler</keyword>
-      <keyword>timeout</keyword>
-      <keyword>suite shutdown event handler</keyword>
-      <keyword>suite definition directory</keyword>
-      <keyword>succeeded handler</keyword>
-      <keyword>submitted handler</keyword>
-      <keyword>submission timeout handler</keyword>
-      <keyword>submission timeout</keyword>
-      <keyword>submission retry handler</keyword>
-      <keyword>submission polling intervals</keyword>
-      <keyword>submission failed handler</keyword>
-      <keyword>startup handler</keyword>
-      <keyword>start-up</keyword>
-      <keyword>started handler</keyword>
-      <keyword>simulation mode suite timeout</keyword>
-      <keyword>simulate failure</keyword>
-      <keyword>shutdown handler</keyword>
-      <keyword>shell</keyword>
-      <keyword>sequential</keyword>
-      <keyword>script</keyword>
-      <keyword>run time range</keyword>
-      <keyword>run-dir</keyword>
-      <keyword>template</keyword>
-      <keyword>runahead limit</keyword>
-      <keyword>root</keyword>
-      <keyword>retry handler</keyword>
-      <keyword>retry delays</keyword>
-      <keyword>reset timer</keyword>
-      <keyword>required run mode</keyword>
-      <keyword>pre-script</keyword>
-      <keyword>post-script</keyword>
-      <keyword>owner</keyword>
-      <keyword>number of cycle points</keyword>
-      <keyword>method</keyword>
-      <keyword>members</keyword>
-      <keyword>max-polls</keyword>
-      <keyword>max active cycle points</keyword>
-      <keyword>log resolved dependencies</keyword>
-      <keyword>live mode suite timeout</keyword>
-      <keyword>limit</keyword>
-      <keyword>interval</keyword>
-      <keyword>init-script</keyword>
-      <keyword>initial cycle point constraints</keyword>
-      <keyword>initial cycle point</keyword>
-      <keyword>inherit</keyword>
-      <keyword>include at start-up</keyword>
-      <keyword>include</keyword>
-      <keyword>host</keyword>
-      <keyword>graph</keyword>
-      <keyword>force run mode</keyword>
-      <keyword>final cycle point constraints</keyword>
-      <keyword>final cycle point</keyword>
-      <keyword>failed handler</keyword>
-      <keyword>extra log files</keyword>
-      <keyword>expected task failures</keyword>
-      <keyword>execution timeout handler</keyword>
-      <keyword>execution timeout</keyword>
-      <keyword>execution polling intervals</keyword>
-      <keyword>exclude at start-up</keyword>
-      <keyword>exclude</keyword>
-      <keyword>env-script</keyword>
-      <keyword>enable resurrection</keyword>
-      <keyword>dummy mode suite timeout</keyword>
-      <keyword>disable task event hooks</keyword>
-      <keyword>disable suite event hooks</keyword>
-      <keyword>disable retries</keyword>
-      <keyword>disable pre-script</keyword>
-      <keyword>disable post-script</keyword>
-      <keyword>description</keyword>
-      <keyword>default node attributes</keyword>
-      <keyword>default edge attributes</keyword>
-      <keyword>cycling mode</keyword>
-      <keyword>cycle point time zone</keyword>
-      <keyword>cycle point num expanded year digits</keyword>
-      <keyword>cycle point format</keyword>
-      <keyword>command template</keyword>
-      <keyword>collapsed families</keyword>
-      <keyword>cold-start</keyword>
-      <keyword>clock-triggered</keyword>
-      <keyword>allow task failures</keyword>
-      <keyword>abort on timeout</keyword>
-      <keyword>abort if timeout handler fails</keyword>
-      <keyword>abort if startup handler fails</keyword>
-      <keyword>abort if shutdown handler fails</keyword>
-      <keyword>abort if any task fails</keyword>
+        <keyword>work sub-directory</keyword>
+        <keyword>warning handler</keyword>
+        <keyword>verbose mode</keyword>
+        <keyword>user</keyword>
+        <keyword>use node color for labels</keyword>
+        <keyword>use node color for edges</keyword>
+        <keyword>title</keyword>
+        <keyword>timeout handler</keyword>
+        <keyword>timeout</keyword>
+        <keyword>template</keyword>
+        <keyword>suite shutdown event handler</keyword>
+        <keyword>suite definition directory</keyword>
+        <keyword>succeeded handler</keyword>
+        <keyword>submitted handler</keyword>
+        <keyword>submission timeout handler</keyword>
+        <keyword>submission timeout</keyword>
+        <keyword>submission retry handler</keyword>
+        <keyword>submission polling intervals</keyword>
+        <keyword>submission failed handler</keyword>
+        <keyword>startup handler</keyword>
+        <keyword>started handler</keyword>
+        <keyword>start-up</keyword>
+        <keyword>stalled handler</keyword>
+        <keyword>simulation mode suite timeout</keyword>
+        <keyword>simulate failure</keyword>
+        <keyword>shutdown handler</keyword>
+        <keyword>shell</keyword>
+        <keyword>sequential</keyword>
+        <keyword>script</keyword>
+        <keyword>runahead limit</keyword>
+        <keyword>run-dir</keyword>
+        <keyword>run time range</keyword>
+        <keyword>root</keyword>
+        <keyword>retry handler</keyword>
+        <keyword>retry delays</keyword>
+        <keyword>retrieve job logs retry delays</keyword>
+        <keyword>retrieve job logs max size</keyword>
+        <keyword>retrieve job logs</keyword>
+        <keyword>reset timer</keyword>
+        <keyword>required run mode</keyword>
+        <keyword>register job logs retry delays</keyword>
+        <keyword>public</keyword>
+        <keyword>pre-script</keyword>
+        <keyword>post-script</keyword>
+        <keyword>owner</keyword>
+        <keyword>number of cycle points</keyword>
+        <keyword>method</keyword>
+        <keyword>members</keyword>
+        <keyword>max-polls</keyword>
+        <keyword>max active cycle points</keyword>
+        <keyword>mail to</keyword>
+        <keyword>mail smtp</keyword>
+        <keyword>mail retry delays</keyword>
+        <keyword>mail from</keyword>
+        <keyword>mail events</keyword>
+        <keyword>log resolved dependencies</keyword>
+        <keyword>live mode suite timeout</keyword>
+        <keyword>limit</keyword>
+        <keyword>interval</keyword>
+        <keyword>initial cycle point constraints</keyword>
+        <keyword>initial cycle point</keyword>
+        <keyword>init-script</keyword>
+        <keyword>inherit</keyword>
+        <keyword>include at start-up</keyword>
+        <keyword>include</keyword>
+        <keyword>host</keyword>
+        <keyword>hold after point</keyword>
+        <keyword>handlers</keyword>
+        <keyword>handler retry delays</keyword>
+        <keyword>handler events</keyword>
+        <keyword>graph</keyword>
+        <keyword>force run mode</keyword>
+        <keyword>final cycle point constraints</keyword>
+        <keyword>final cycle point</keyword>
+        <keyword>failed handler</keyword>
+        <keyword>extra log files</keyword>
+        <keyword>external-trigger</keyword>
+        <keyword>expired handler</keyword>
+        <keyword>expected task failures</keyword>
+        <keyword>execution timeout handler</keyword>
+        <keyword>execution timeout</keyword>
+        <keyword>execution polling intervals</keyword>
+        <keyword>exclude at start-up</keyword>
+        <keyword>exclude</keyword>
+        <keyword>env-script</keyword>
+        <keyword>enable resurrection</keyword>
+        <keyword>dummy mode suite timeout</keyword>
+        <keyword>disable task event hooks</keyword>
+        <keyword>disable suite event hooks</keyword>
+        <keyword>disable retries</keyword>
+        <keyword>disable pre-script</keyword>
+        <keyword>disable post-script</keyword>
+        <keyword>disable automatic shutdown</keyword>
+        <keyword>description</keyword>
+        <keyword>default node attributes</keyword>
+        <keyword>default edge attributes</keyword>
+        <keyword>cycling mode</keyword>
+        <keyword>cycle point time zone</keyword>
+        <keyword>cycle point num expanded year digits</keyword>
+        <keyword>cycle point format</keyword>
+        <keyword>command template</keyword>
+        <keyword>collapsed families</keyword>
+        <keyword>cold-start</keyword>
+        <keyword>clock-trigger</keyword>
+        <keyword>clock-expire</keyword>
+        <keyword>allow task failures</keyword>
+        <keyword>abort on timeout</keyword>
+        <keyword>abort on stalled</keyword>
+        <keyword>abort if timeout handler fails</keyword>
+        <keyword>abort if startup handler fails</keyword>
+        <keyword>abort if stalled handler fails</keyword>
+        <keyword>abort if shutdown handler fails</keyword>
+        <keyword>abort if any task fails</keyword>
+        <keyword>UTC mode</keyword>
+        <keyword>URL</keyword>
     </context>
     <context id="cylc-subshell" style-ref="string">
       <match>"""</match>

--- a/conf/cylc.xml
+++ b/conf/cylc.xml
@@ -15,13 +15,13 @@
         <RegExpr attribute='Keyword' String=' work sub-directory '/>
         <RegExpr attribute='Keyword' String=' warning handler '/>
         <RegExpr attribute='Keyword' String=' verbose mode '/>
-        <RegExpr attribute='Keyword' String=' UTC mode '/>
         <RegExpr attribute='Keyword' String=' user '/>
         <RegExpr attribute='Keyword' String=' use node color for labels '/>
         <RegExpr attribute='Keyword' String=' use node color for edges '/>
         <RegExpr attribute='Keyword' String=' title '/>
         <RegExpr attribute='Keyword' String=' timeout handler '/>
         <RegExpr attribute='Keyword' String=' timeout '/>
+        <RegExpr attribute='Keyword' String=' template '/>
         <RegExpr attribute='Keyword' String=' suite shutdown event handler '/>
         <RegExpr attribute='Keyword' String=' suite definition directory '/>
         <RegExpr attribute='Keyword' String=' succeeded handler '/>
@@ -32,23 +32,28 @@
         <RegExpr attribute='Keyword' String=' submission polling intervals '/>
         <RegExpr attribute='Keyword' String=' submission failed handler '/>
         <RegExpr attribute='Keyword' String=' startup handler '/>
-        <RegExpr attribute='Keyword' String=' start-up '/>
         <RegExpr attribute='Keyword' String=' started handler '/>
+        <RegExpr attribute='Keyword' String=' start-up '/>
+        <RegExpr attribute='Keyword' String=' stalled handler '/>
         <RegExpr attribute='Keyword' String=' simulation mode suite timeout '/>
         <RegExpr attribute='Keyword' String=' simulate failure '/>
         <RegExpr attribute='Keyword' String=' shutdown handler '/>
         <RegExpr attribute='Keyword' String=' shell '/>
         <RegExpr attribute='Keyword' String=' sequential '/>
         <RegExpr attribute='Keyword' String=' script '/>
-        <RegExpr attribute='Keyword' String=' run time range '/>
-        <RegExpr attribute='Keyword' String=' run-dir '/>
-        <RegExpr attribute='Keyword' String=' template '/>
         <RegExpr attribute='Keyword' String=' runahead limit '/>
+        <RegExpr attribute='Keyword' String=' run-dir '/>
+        <RegExpr attribute='Keyword' String=' run time range '/>
         <RegExpr attribute='Keyword' String=' root '/>
         <RegExpr attribute='Keyword' String=' retry handler '/>
         <RegExpr attribute='Keyword' String=' retry delays '/>
+        <RegExpr attribute='Keyword' String=' retrieve job logs retry delays '/>
+        <RegExpr attribute='Keyword' String=' retrieve job logs max size '/>
+        <RegExpr attribute='Keyword' String=' retrieve job logs '/>
         <RegExpr attribute='Keyword' String=' reset timer '/>
         <RegExpr attribute='Keyword' String=' required run mode '/>
+        <RegExpr attribute='Keyword' String=' register job logs retry delays '/>
+        <RegExpr attribute='Keyword' String=' public '/>
         <RegExpr attribute='Keyword' String=' pre-script '/>
         <RegExpr attribute='Keyword' String=' post-script '/>
         <RegExpr attribute='Keyword' String=' owner '/>
@@ -57,23 +62,34 @@
         <RegExpr attribute='Keyword' String=' members '/>
         <RegExpr attribute='Keyword' String=' max-polls '/>
         <RegExpr attribute='Keyword' String=' max active cycle points '/>
+        <RegExpr attribute='Keyword' String=' mail to '/>
+        <RegExpr attribute='Keyword' String=' mail smtp '/>
+        <RegExpr attribute='Keyword' String=' mail retry delays '/>
+        <RegExpr attribute='Keyword' String=' mail from '/>
+        <RegExpr attribute='Keyword' String=' mail events '/>
         <RegExpr attribute='Keyword' String=' log resolved dependencies '/>
         <RegExpr attribute='Keyword' String=' live mode suite timeout '/>
         <RegExpr attribute='Keyword' String=' limit '/>
         <RegExpr attribute='Keyword' String=' interval '/>
-        <RegExpr attribute='Keyword' String=' init-script '/>
         <RegExpr attribute='Keyword' String=' initial cycle point constraints '/>
         <RegExpr attribute='Keyword' String=' initial cycle point '/>
+        <RegExpr attribute='Keyword' String=' init-script '/>
         <RegExpr attribute='Keyword' String=' inherit '/>
         <RegExpr attribute='Keyword' String=' include at start-up '/>
         <RegExpr attribute='Keyword' String=' include '/>
         <RegExpr attribute='Keyword' String=' host '/>
+        <RegExpr attribute='Keyword' String=' hold after point '/>
+        <RegExpr attribute='Keyword' String=' handlers '/>
+        <RegExpr attribute='Keyword' String=' handler retry delays '/>
+        <RegExpr attribute='Keyword' String=' handler events '/>
         <RegExpr attribute='Keyword' String=' graph '/>
         <RegExpr attribute='Keyword' String=' force run mode '/>
         <RegExpr attribute='Keyword' String=' final cycle point constraints '/>
         <RegExpr attribute='Keyword' String=' final cycle point '/>
         <RegExpr attribute='Keyword' String=' failed handler '/>
         <RegExpr attribute='Keyword' String=' extra log files '/>
+        <RegExpr attribute='Keyword' String=' external-trigger '/>
+        <RegExpr attribute='Keyword' String=' expired handler '/>
         <RegExpr attribute='Keyword' String=' expected task failures '/>
         <RegExpr attribute='Keyword' String=' execution timeout handler '/>
         <RegExpr attribute='Keyword' String=' execution timeout '/>
@@ -88,6 +104,7 @@
         <RegExpr attribute='Keyword' String=' disable retries '/>
         <RegExpr attribute='Keyword' String=' disable pre-script '/>
         <RegExpr attribute='Keyword' String=' disable post-script '/>
+        <RegExpr attribute='Keyword' String=' disable automatic shutdown '/>
         <RegExpr attribute='Keyword' String=' description '/>
         <RegExpr attribute='Keyword' String=' default node attributes '/>
         <RegExpr attribute='Keyword' String=' default edge attributes '/>
@@ -98,13 +115,18 @@
         <RegExpr attribute='Keyword' String=' command template '/>
         <RegExpr attribute='Keyword' String=' collapsed families '/>
         <RegExpr attribute='Keyword' String=' cold-start '/>
-        <RegExpr attribute='Keyword' String=' clock-triggered '/>
+        <RegExpr attribute='Keyword' String=' clock-trigger '/>
+        <RegExpr attribute='Keyword' String=' clock-expire '/>
         <RegExpr attribute='Keyword' String=' allow task failures '/>
         <RegExpr attribute='Keyword' String=' abort on timeout '/>
+        <RegExpr attribute='Keyword' String=' abort on stalled '/>
         <RegExpr attribute='Keyword' String=' abort if timeout handler fails '/>
         <RegExpr attribute='Keyword' String=' abort if startup handler fails '/>
+        <RegExpr attribute='Keyword' String=' abort if stalled handler fails '/>
         <RegExpr attribute='Keyword' String=' abort if shutdown handler fails '/>
         <RegExpr attribute='Keyword' String=' abort if any task fails '/>
+        <RegExpr attribute='Keyword' String=' UTC mode '/>
+        <RegExpr attribute='Keyword' String=' URL '/>
         <!-- Non-keyword syntax -->
         <RegExpr attribute="Section" String="^ *\[.*\] *$" />
         <RegExpr attribute='Assignment' String='=&gt;'/>

--- a/doc/siterc.tex
+++ b/doc/siterc.tex
@@ -858,9 +858,9 @@ of which can be found under ~\ref{SuiteEventHandling}:
 
 \subparagraph[abort on timeout]{[cylc] \textrightarrow [[event hooks]] \textrightarrow abort on timeout}
 
-\subparagraph[startup handler]{[cylc] \textrightarrow [[event hooks]] \textrightarrow stalled handler}
+\subparagraph[stalled handler]{[cylc] \textrightarrow [[event hooks]] \textrightarrow stalled handler}
 
-\subparagraph[abort on timeout]{[cylc] \textrightarrow [[event hooks]] \textrightarrow abort on stalled}
+\subparagraph[abort on stalled]{[cylc] \textrightarrow [[event hooks]] \textrightarrow abort on stalled}
 
 \subsection{[authentication]}
 \label{GlobalAuth}

--- a/doc/siterc.tex
+++ b/doc/siterc.tex
@@ -858,6 +858,10 @@ of which can be found under ~\ref{SuiteEventHandling}:
 
 \subparagraph[abort on timeout]{[cylc] \textrightarrow [[event hooks]] \textrightarrow abort on timeout}
 
+\subparagraph[startup handler]{[cylc] \textrightarrow [[event hooks]] \textrightarrow stalled handler}
+
+\subparagraph[abort on timeout]{[cylc] \textrightarrow [[event hooks]] \textrightarrow abort on stalled}
+
 \subsection{[authentication]}
 \label{GlobalAuth}
 

--- a/doc/suiterc.tex
+++ b/doc/suiterc.tex
@@ -342,10 +342,10 @@ time.
 
 \paragraph[abort on stalled]{[cylc] \textrightarrow [[event hooks]] \textrightarrow abort on stalled}
 
-If a this is set is set to True this will cause the suite to abort with
-error status if the suite stalls. A suite is considered "stalled" if there are
-no active, queued or submitting tasks or tasks waiting for clock triggers to
-be met. It is possible to set a default for this at the site level
+If a this is set to True this will cause the suite to abort with error status
+if the suite stalls. A suite is considered "stalled" if there are no active,
+queued or submitting tasks or tasks waiting for clock triggers to be met. It is
+possible to set a default for this at the site level
 (see ~\ref{SiteCylcHooks}).
 
 \begin{myitemize}

--- a/doc/suiterc.tex
+++ b/doc/suiterc.tex
@@ -240,6 +240,7 @@ following EVENTs occurs:
     \item {\bf startup}  - the suite has started running
     \item {\bf shutdown} - the suite is shutting down
     \item {\bf timeout}  - the suite has timed out
+    \item {\bf stalled} - the suite has stalled
 \end{myitemize}
 
 Default values for these can be set at the site level via the siterc file
@@ -337,6 +338,19 @@ time.
 \begin{myitemize}
     \item {\em type:} boolean
     \item {\em default:} True
+\end{myitemize}
+
+\paragraph[abort on stalled]{[cylc] \textrightarrow [[event hooks]] \textrightarrow abort on stalled}
+
+If a this is set is set to True this will cause the suite to abort with
+error status if the suite stalls. A suite is considered "stalled" if there are
+no active, queued or submitting tasks or tasks waiting for clock triggers to
+be met. It is possible to set a default for this at the site level
+(see ~\ref{SiteCylcHooks}).
+
+\begin{myitemize}
+    \item {\em type:} boolean
+    \item {\em default:} False, unless set at the site level.
 \end{myitemize}
 
 \paragraph[abort on timeout]{[cylc] \textrightarrow [[event hooks]] \textrightarrow abort on timeout}

--- a/doc/suiterc.tex
+++ b/doc/suiterc.tex
@@ -342,8 +342,8 @@ time.
 
 \paragraph[abort on stalled]{[cylc] \textrightarrow [[event hooks]] \textrightarrow abort on stalled}
 
-If a this is set to True this will cause the suite to abort with error status
-if the suite stalls. A suite is considered "stalled" if there are no active,
+If this is set to True it will cause the suite to abort with error status
+if it stalls. A suite is considered "stalled" if there are no active,
 queued or submitting tasks or tasks waiting for clock triggers to be met. It is
 possible to set a default for this at the site level
 (see ~\ref{SiteCylcHooks}).

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -87,7 +87,7 @@ SPEC = {
             'startup handler': vdr(vtype='string_list', default=[]),
             'timeout handler': vdr(vtype='string_list', default=[]),
             'shutdown handler': vdr(vtype='string_list', default=[]),
-            'stalled handler' : vdr(vtype='string_list', default=[]),
+            'stalled handler': vdr(vtype='string_list', default=[]),
             'timeout': vdr(vtype='interval_minutes'),
             'abort on timeout': vdr(vtype='boolean', default=False),
             'abort on stalled': vdr(vtype='boolean', default=False),

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -87,8 +87,10 @@ SPEC = {
             'startup handler': vdr(vtype='string_list', default=[]),
             'timeout handler': vdr(vtype='string_list', default=[]),
             'shutdown handler': vdr(vtype='string_list', default=[]),
+            'stalled handler' : vdr(vtype='string_list', default=[]),
             'timeout': vdr(vtype='interval_minutes'),
             'abort on timeout': vdr(vtype='boolean', default=False),
+            'abort on stalled': vdr(vtype='boolean', default=False),
         },
     },
 

--- a/lib/cylc/cfgspec/suite.py
+++ b/lib/cylc/cfgspec/suite.py
@@ -205,6 +205,7 @@ SPEC = {
             'startup handler': vdr(vtype='string_list'),
             'timeout handler': vdr(vtype='string_list'),
             'shutdown handler': vdr(vtype='string_list'),
+            'stalled handler': vdr(vtype='string_list'),
             'timeout': vdr(vtype='interval_minutes'),
             'reset timer': vdr(vtype='boolean', default=True),
             'abort if startup handler fails': vdr(
@@ -213,6 +214,9 @@ SPEC = {
                 vtype='boolean', default=False),
             'abort if timeout handler fails': vdr(
                 vtype='boolean', default=False),
+            'abort if stalled handler fails': vdr(
+                vtype='boolean', default=False),
+            'abort on stalled': vdr(vtype='boolean'),
             'abort on timeout': vdr(vtype='boolean'),
             'mail events': vdr(vtype='string_list'),
             'mail from': vdr(vtype='string'),

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -761,7 +761,7 @@ class TaskPool(object):
         for itask in self.get_tasks():
             if (itask.state.status in [TASK_STATUS_QUEUED,
                                        TASK_STATUS_READY] or
-               itask.state.status in TASK_STATUSES_ACTIVE):
+                    itask.state.status in TASK_STATUSES_ACTIVE):
                 return False
             if (not itask.start_time_reached() and
                 itask.state.status not in [TASK_STATUS_SUCCEEDED,

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -756,6 +756,20 @@ class TaskPool(object):
                     return False
         return True
 
+    def pool_is_stalled(self):
+        """Return True if no active, queued or clock trigger awaiting tasks"""
+        for itask in self.get_tasks():
+            if (itask.state.status in [TASK_STATUS_QUEUED,
+                                       TASK_STATUS_READY] or
+               itask.state.status in TASK_STATUSES_ACTIVE):
+                return False
+            if (not itask.start_time_reached() and
+                itask.state.status not in [TASK_STATUS_SUCCEEDED,
+                                           TASK_STATUS_FAILED,
+                                           TASK_STATUS_SUBMIT_FAILED]):
+                return False
+        return True
+
     def poll_task_jobs(self, items=None, compat=None):
         """Poll jobs of active tasks.
 

--- a/tests/events/23-suite-stalled-handler.t
+++ b/tests/events/23-suite-stalled-handler.t
@@ -1,0 +1,29 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2016 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test suite event handler, flexible interface
+. "$(dirname "$0")/test_header"
+set_test_number 2
+
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+run_ok "${TEST_NAME_BASE}-validate" \
+    cylc validate "${SUITE_NAME}"
+suite_run_ok "${TEST_NAME_BASE}-run" \
+    cylc run --reference-test --debug "${SUITE_NAME}"
+
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/events/23-suite-stalled-handler/reference.log
+++ b/tests/events/23-suite-stalled-handler/reference.log
@@ -1,0 +1,31 @@
+2016-05-20T10:22:52Z INFO - Suite starting
+2016-05-20T10:22:52Z INFO - Run mode: live
+2016-05-20T10:22:52Z INFO - Initial point: 1
+2016-05-20T10:22:52Z INFO - Final point: 1
+2016-05-20T10:22:52Z INFO - Cold Start 1
+2016-05-20T10:22:52Z INFO - [foo.1] -triggered off []
+2016-05-20T10:22:53Z INFO - [foo.1] -submit_method_id=1942
+2016-05-20T10:22:53Z INFO - [foo.1] -submission succeeded
+2016-05-20T10:22:53Z INFO - [foo.1] -(current:submitted)> started at 2016-05-20T10:22:53Z
+2016-05-20T10:22:54Z INFO - [foo.1] -(current:running)> succeeded at 2016-05-20T10:22:53Z
+2016-05-20T10:22:54Z INFO - [foo.1] -('job-logs-register', 1) will run after P0Y (after 2016-05-20T10:22:54Z)
+2016-05-20T10:22:55Z INFO - [bar.1] -triggered off ['foo.1']
+2016-05-20T10:22:56Z INFO - [bar.1] -submit_method_id=2039
+2016-05-20T10:22:56Z INFO - [bar.1] -submission succeeded
+2016-05-20T10:22:56Z INFO - [bar.1] -(current:submitted)> started at 2016-05-20T10:22:56Z
+2016-05-20T10:22:57Z CRITICAL - [bar.1] -(current:running)> Task job script received signal ERR at 2016-05-20T10:22:56Z
+2016-05-20T10:22:57Z CRITICAL - [bar.1] -(current:running)> failed at 2016-05-20T10:22:56Z
+2016-05-20T10:22:57Z INFO - [bar.1] -('job-logs-register', 1) will run after P0Y (after 2016-05-20T10:22:57Z)
+2016-05-20T10:22:59Z WARNING - suite stalled
+2016-05-20T10:23:00Z INFO - 2016-05-20T11:23:00+01 [('suite-event-handler-00', 'stalled') cmd] cylc reset test bar -s succeeded
+2016-05-20T11:23:00+01 [('suite-event-handler-00', 'stalled') ret_code] 0
+
+2016-05-20T10:23:00Z INFO - [bar.1] -resetting state to succeeded
+2016-05-20T10:23:00Z INFO - Command succeeded: reset_task_state(['bar'],None,succeeded)
+2016-05-20T10:23:01Z INFO - [baz.1] -triggered off ['bar.1']
+2016-05-20T10:23:02Z INFO - [baz.1] -submit_method_id=2148
+2016-05-20T10:23:02Z INFO - [baz.1] -submission succeeded
+2016-05-20T10:23:02Z INFO - [baz.1] -(current:submitted)> started at 2016-05-20T10:23:02Z
+2016-05-20T10:23:03Z INFO - [baz.1] -(current:running)> succeeded at 2016-05-20T10:23:02Z
+2016-05-20T10:23:03Z INFO - [baz.1] -('job-logs-register', 1) will run after P0Y (after 2016-05-20T10:23:03Z)
+2016-05-20T10:23:04Z INFO - Suite shutting down at 2016-05-20T10:23:04Z

--- a/tests/events/23-suite-stalled-handler/suite.rc
+++ b/tests/events/23-suite-stalled-handler/suite.rc
@@ -1,0 +1,16 @@
+[cylc]
+    UTC mode = True # Ignore DST
+    [[event hooks]]
+        stalled handler = cylc reset %(suite)s bar -s succeeded
+    [[reference test]]
+        allow task failures = true
+        live mode suite timeout=PT1M
+[scheduling]
+    [[dependencies]]
+        graph = foo => bar => baz
+
+[runtime]
+    [[foo,baz]]
+        script = true
+    [[bar]]
+        script = false

--- a/tests/events/24-abort-on-stalled.t
+++ b/tests/events/24-abort-on-stalled.t
@@ -15,15 +15,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test suite event handler, flexible interface with stalled handler
+# Test suite event handler, abort on stalled setting
 . "$(dirname "$0")/test_header"
-set_test_number 2
+set_test_number 3
 
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 run_ok "${TEST_NAME_BASE}-validate" \
     cylc validate "${SUITE_NAME}"
-suite_run_ok "${TEST_NAME_BASE}-run" \
+suite_run_fail "${TEST_NAME_BASE}-run" \
     cylc run --reference-test --debug "${SUITE_NAME}"
+grep_ok "Abort on suite stalled is set" "${TEST_NAME_BASE}-run.stderr"
 
 purge_suite "${SUITE_NAME}"
 exit

--- a/tests/events/24-abort-on-stalled/reference.log
+++ b/tests/events/24-abort-on-stalled/reference.log
@@ -1,0 +1,85 @@
+2016-05-23T12:58:33Z INFO - Suite starting on eld170.desktop.frd.metoffice.com:7766
+2016-05-23T12:58:33Z INFO - Run mode: live
+2016-05-23T12:58:33Z INFO - Initial point: 1
+2016-05-23T12:58:33Z INFO - Final point: 1
+2016-05-23T12:58:33Z DEBUG - request handling thread starting
+2016-05-23T12:58:33Z INFO - Cold Start 1
+2016-05-23T12:58:33Z DEBUG - [baz.1] -released to the task pool
+2016-05-23T12:58:33Z DEBUG - [foo.1] -released to the task pool
+2016-05-23T12:58:33Z DEBUG - [bar.1] -released to the task pool
+2016-05-23T12:58:33Z DEBUG - BEGIN TASK PROCESSING
+2016-05-23T12:58:33Z DEBUG - [foo.1] -(setting: queued)
+2016-05-23T12:58:33Z DEBUG - 1 task(s) de-queued
+2016-05-23T12:58:33Z INFO - [foo.1] -triggered off []
+2016-05-23T12:58:33Z DEBUG - [foo.1] -incrementing submit number
+2016-05-23T12:58:33Z DEBUG - [foo.1] -(setting: ready)
+2016-05-23T12:58:33Z DEBUG - END TASK PROCESSING (took 0.0159630775452 sec)
+2016-05-23T12:58:34Z DEBUG - [client-connect] aclark@eld170.desktop.frd.metoffice.com:cylc-message privilege='full-control' b90eef6f-1dc1-482e-8321-ca7970d982e1
+2016-05-23T12:58:34Z INFO - [client-command] task_message aclark@eld170.desktop.frd.metoffice.com:cylc-message b90eef6f-1dc1-482e-8321-ca7970d982e1
+2016-05-23T12:58:34Z DEBUG - 2016-05-23T13:58:33+01 [jobs-submit cmd] cylc jobs-submit --debug -- /home/h06/aclark/cylc-run/test/log/job 1/foo/01
+2016-05-23T13:58:33+01 [jobs-submit ret_code] 0
+2016-05-23T13:58:33+01 [jobs-submit out]
+
+[TASK JOB SUMMARY]2016-05-23T13:58:33+01|1/foo/01|0|5606
+[TASK JOB COMMAND]2016-05-23T13:58:33+01|1/foo/01|[STDOUT] 5606
+
+
+2016-05-23T12:58:34Z INFO - [foo.1] -submit_method_id=5606
+2016-05-23T12:58:34Z INFO - [foo.1] -submission succeeded
+2016-05-23T12:58:34Z DEBUG - [foo.1] -(setting: submitted)
+2016-05-23T12:58:34Z DEBUG - BEGIN TASK PROCESSING
+2016-05-23T12:58:34Z DEBUG - 0 task(s) de-queued
+2016-05-23T12:58:34Z DEBUG - [foo.1] -forced spawning
+2016-05-23T12:58:34Z DEBUG - END TASK PROCESSING (took 0.00137901306152 sec)
+2016-05-23T12:58:34Z INFO - [foo.1] -(current:submitted)> started at 2016-05-23T12:58:34Z
+2016-05-23T12:58:34Z DEBUG - [foo.1] -(setting: running)
+2016-05-23T12:58:34Z DEBUG - [client-connect] aclark@eld170.desktop.frd.metoffice.com:cylc-message privilege='full-control' 91c26233-0e25-4826-ab0d-aec75b3fe56d
+2016-05-23T12:58:34Z INFO - [client-command] task_message aclark@eld170.desktop.frd.metoffice.com:cylc-message 91c26233-0e25-4826-ab0d-aec75b3fe56d
+2016-05-23T12:58:35Z DEBUG - BEGIN TASK PROCESSING
+2016-05-23T12:58:35Z DEBUG - 0 task(s) de-queued
+2016-05-23T12:58:35Z DEBUG - END TASK PROCESSING (took 0.000829935073853 sec)
+2016-05-23T12:58:35Z INFO - [foo.1] -(current:running)> succeeded at 2016-05-23T12:58:34Z
+2016-05-23T12:58:35Z DEBUG - [foo.1] -(setting: succeeded)
+2016-05-23T12:58:35Z INFO - [foo.1] -('job-logs-register', 1) will run after P0Y (after 2016-05-23T12:58:35Z)
+2016-05-23T12:58:36Z DEBUG - BEGIN TASK PROCESSING
+2016-05-23T12:58:36Z DEBUG - [bar.1] -(setting: queued)
+2016-05-23T12:58:36Z DEBUG - 1 task(s) de-queued
+2016-05-23T12:58:36Z INFO - [bar.1] -triggered off ['foo.1']
+2016-05-23T12:58:36Z DEBUG - [bar.1] -incrementing submit number
+2016-05-23T12:58:36Z DEBUG - [bar.1] -(setting: ready)
+2016-05-23T12:58:36Z DEBUG - END TASK PROCESSING (took 0.0199220180511 sec)
+2016-05-23T12:58:37Z DEBUG - [client-connect] aclark@eld170.desktop.frd.metoffice.com:cylc-message privilege='full-control' 8135b32c-4801-4efa-8782-ec993b2034cc
+2016-05-23T12:58:37Z INFO - [client-command] task_message aclark@eld170.desktop.frd.metoffice.com:cylc-message 8135b32c-4801-4efa-8782-ec993b2034cc
+2016-05-23T12:58:37Z DEBUG - 2016-05-23T13:58:36+01 [jobs-submit cmd] cylc jobs-submit --debug -- /home/h06/aclark/cylc-run/test/log/job 1/bar/01
+2016-05-23T13:58:36+01 [jobs-submit ret_code] 0
+2016-05-23T13:58:36+01 [jobs-submit out]
+
+[TASK JOB SUMMARY]2016-05-23T13:58:36+01|1/bar/01|0|5702
+[TASK JOB COMMAND]2016-05-23T13:58:36+01|1/bar/01|[STDOUT] 5702
+
+
+2016-05-23T12:58:37Z INFO - [bar.1] -submit_method_id=5702
+2016-05-23T12:58:37Z INFO - [bar.1] -submission succeeded
+2016-05-23T12:58:37Z DEBUG - [bar.1] -(setting: submitted)
+2016-05-23T12:58:37Z DEBUG - BEGIN TASK PROCESSING
+2016-05-23T12:58:37Z DEBUG - 0 task(s) de-queued
+2016-05-23T12:58:37Z DEBUG - [bar.1] -forced spawning
+2016-05-23T12:58:37Z DEBUG - END TASK PROCESSING (took 0.00132513046265 sec)
+2016-05-23T12:58:37Z INFO - [bar.1] -(current:submitted)> started at 2016-05-23T12:58:37Z
+2016-05-23T12:58:37Z DEBUG - [bar.1] -(setting: running)
+2016-05-23T12:58:37Z DEBUG - [client-connect] aclark@eld170.desktop.frd.metoffice.com:cylc-message privilege='full-control' 1dde2401-18bb-4606-afb0-9c26b541b7c9
+2016-05-23T12:58:37Z INFO - [client-command] task_message aclark@eld170.desktop.frd.metoffice.com:cylc-message 1dde2401-18bb-4606-afb0-9c26b541b7c9
+2016-05-23T12:58:37Z DEBUG - [client-connect] aclark@eld170.desktop.frd.metoffice.com:cylc-message privilege='full-control' 1dde2401-18bb-4606-afb0-9c26b541b7c9
+2016-05-23T12:58:37Z INFO - [client-command] task_message aclark@eld170.desktop.frd.metoffice.com:cylc-message 1dde2401-18bb-4606-afb0-9c26b541b7c9
+2016-05-23T12:58:38Z DEBUG - BEGIN TASK PROCESSING
+2016-05-23T12:58:38Z DEBUG - 0 task(s) de-queued
+2016-05-23T12:58:38Z DEBUG - END TASK PROCESSING (took 0.00465202331543 sec)
+2016-05-23T12:58:38Z CRITICAL - [bar.1] -(current:running)> Task job script received signal ERR at 2016-05-23T12:58:37Z
+2016-05-23T12:58:38Z CRITICAL - [bar.1] -(current:running)> failed at 2016-05-23T12:58:37Z
+2016-05-23T12:58:38Z DEBUG - [bar.1] -(setting: failed)
+2016-05-23T12:58:38Z INFO - [bar.1] -('job-logs-register', 1) will run after P0Y (after 2016-05-23T12:58:38Z)
+2016-05-23T12:58:39Z DEBUG - BEGIN TASK PROCESSING
+2016-05-23T12:58:39Z DEBUG - 0 task(s) de-queued
+2016-05-23T12:58:39Z DEBUG - END TASK PROCESSING (took 0.000736951828003 sec)
+2016-05-23T12:58:40Z WARNING - suite stalled
+2016-05-23T12:58:40Z INFO - Suite shutting down at 2016-05-23T12:58:40Z

--- a/tests/events/24-abort-on-stalled/suite.rc
+++ b/tests/events/24-abort-on-stalled/suite.rc
@@ -1,0 +1,16 @@
+[cylc]
+    UTC mode = True # Ignore DST
+    [[event hooks]]
+        abort on stalled = true
+    [[reference test]]
+        allow task failures = true
+        live mode suite timeout=PT1M
+[scheduling]
+    [[dependencies]]
+        graph = foo => bar => baz
+
+[runtime]
+    [[foo,baz]]
+        script = true
+    [[bar]]
+        script = false


### PR DESCRIPTION
Close #1286 

First pass attempt at implementing a suite stalled handler.

This takes a look at the current task pool and if no tasks are active, submitting (ready), queued or awaiting a clock trigger then the suite is deemed to have stalled. Given the way the scheduler loop runs, the "am I stalled" check needs to indicate a stalled state for two consecutive loops in order to fire off the stalled handler/abort on stalled. This captures where a state has updated to succeeded/failed but the follow on task has yet to trigger (happening in the next scheduler loop).

@hjoliver - can you take an initial look through and see if you think I've missed anything? If you're happy then I'll start writing tests, documenting etc.