### PR TITLE
gcylc.rc enhancements

### DIFF
--- a/doc/gcylcrc.tex
+++ b/doc/gcylcrc.tex
@@ -152,6 +152,32 @@ be sorted using ascending or descending order.
     \item {\em example:} \lstinline@sort column ascending = False@
 \end{myitemize}
 
+\subsubsection{transpose graph}
+
+Transposes the content in graph view so that it displays from left to right
+rather than from top to bottom. Can be changed later using the options submenu
+avaliable via the view menu.
+
+\begin{myitemize}
+    \item {\em type:} boolean
+    \item {\em legal values:} ``True'' (left-to-right), ``False'' (top-to-bottom)
+    \item {\em default:} ``False''
+    \item {\em example:} \lstinline@transpose graph = True@
+\end{myitemize}
+
+\subsubsection{transpose dot}
+
+Transposes the content in dot view so that it displays from left to right rather
+than from top to bottom. Can be changed later using the options submenu
+avaliable via the view menu.
+
+\begin{myitemize}
+    \item {\em type:} boolean
+    \item {\em legal values:} ``True'' (left-to-right), ``False'' (top-to-bottom)
+    \item {\em default:} ``False''
+    \item {\em example:} \lstinline@transpose dot = True@
+\end{myitemize}
+
 \subsection{[themes]}
 
 This section may contain task state color theme definitions.

--- a/doc/gcylcrc.tex
+++ b/doc/gcylcrc.tex
@@ -114,6 +114,17 @@ are required to prevent the hex code being interpreted as a comment).
     \item {\em default:} \lstinline=PowderBlue=
 \end{myitemize}
 
+\subsubsection{window size}
+
+Sets the size of the cylc gui at startup.
+
+\begin{myitemize}
+    \item {\em type:} integer list (x, y)
+\item {\em legal values:} positive integers
+\item {\em default:} 800, 500
+\item {\em example:} \lstinline@window size = 1000, 700@
+\end{myitemize}
+
 \subsection{[themes]}
 
 This section may contain task state color theme definitions.

--- a/doc/gcylcrc.tex
+++ b/doc/gcylcrc.tex
@@ -125,6 +125,33 @@ Sets the size of the cylc gui at startup.
 \item {\em example:} \lstinline@window size = 1000, 700@
 \end{myitemize}
 
+\subsubsection{sort column}
+
+If ``text'' is in \lstinline@initial views@ then \lstinline@sort column@ sets
+the column that will be sorted initially when the gui launches. Sorting can be
+changed later by clicking on the column headers.
+
+\begin{myitemize}
+    \item {\em type:} string
+    \item {\em legal values:} ``task'', ``state'', ``host'', ``job system'',
+        ``job ID'', ``T-submit'', ``T-start'', ``T-finish'', ``dT-mean'',
+        ``latest message'', ``none''
+    \item {\em default:} ``none''
+    \item {\em example:} \lstinline@sort column = T-start@
+\end{myitemize}
+
+\subsubsection{sort column ascending}
+
+For use in combination with \lstinline@sort column@, sets weather the column will
+be sorted using ascending or descending order.
+
+\begin{myitemize}
+    \item {\em type:} boolean
+    \item {\em legal values:} ``True'' (ascending), ``False'' (descending)
+    \item {\em default:} ``True''
+    \item {\em example:} \lstinline@sort column ascending = False@
+\end{myitemize}
+
 \subsection{[themes]}
 
 This section may contain task state color theme definitions.

--- a/doc/gcylcrc.tex
+++ b/doc/gcylcrc.tex
@@ -19,7 +19,8 @@ views.
 
 \begin{myitemize}
 \item {\em type:} string
-\item {\em legal values:} ``small'' (10px), ``medium'' (14px), ``large'' (20px)
+\item {\em legal values:} ``small'' (10px), ``medium'' (14px), ``large'' (20px),
+        ``extra large (30px)''
 \item {\em default:} ``medium''
 \end{myitemize}
 
@@ -27,12 +28,11 @@ views.
 \subsubsection{initial side-by-side views}
 
 Set the suite view panels initial orientation when the GUI starts.
-This can be changed later using the "View" menu "Toggle views side-by-side"
+This can be changed later using the ``View'' menu ``Toggle views side-by-side''
  option.
 
 \begin{myitemize}
 \item {\em type:} boolean (False or True)
-\item {\em legal values:} ``False'', ``True''.
 \item {\em default:} ``False''
 \end{myitemize}
 
@@ -67,7 +67,7 @@ definition order is not available at all.
 \subsubsection{sort column}
 
 If ``text'' is in \lstinline@initial views@ then \lstinline@sort column@ sets
-the column that will be sorted initially when the gui launches. Sorting can be
+the column that will be sorted initially when the GUI launches. Sorting can be
 changed later by clicking on the column headers.
 
 \begin{myitemize}
@@ -82,12 +82,11 @@ changed later by clicking on the column headers.
 
 \subsubsection{sort column ascending}
 
-For use in combination with \lstinline@sort column@, sets weather the column will
+For use in combination with \lstinline@sort column@, sets whether the column will
 be sorted using ascending or descending order.
 
 \begin{myitemize}
     \item {\em type:} boolean
-    \item {\em legal values:} ``True'' (ascending), ``False'' (descending)
     \item {\em default:} ``True''
     \item {\em example:} \lstinline@sort column ascending = False@
 \end{myitemize}
@@ -123,11 +122,10 @@ submit-failed, submit-retrying, running, succeeded, failed, retrying, runahead
 
 Transposes the content in dot view so that it displays from left to right rather
 than from top to bottom. Can be changed later using the options submenu
-avaliable via the view menu.
+available via the view menu.
 
 \begin{myitemize}
     \item {\em type:} boolean
-    \item {\em legal values:} ``True'' (left-to-right), ``False'' (top-to-bottom)
     \item {\em default:} ``False''
     \item {\em example:} \lstinline@transpose dot = True@
 \end{myitemize}
@@ -137,11 +135,10 @@ avaliable via the view menu.
 
 Transposes the content in graph view so that it displays from left to right
 rather than from top to bottom. Can be changed later using the options submenu
-avaliable via the view menu.
+via the view menu.
 
 \begin{myitemize}
     \item {\em type:} boolean
-    \item {\em legal values:} ``True'' (left-to-right), ``False'' (top-to-bottom)
     \item {\em default:} ``False''
     \item {\em example:} \lstinline@transpose graph = True@
 \end{myitemize}
@@ -180,13 +177,13 @@ to list your available themes.
 
 \subsubsection{window size}
 
-Sets the size of the cylc gui at startup.
+Sets the size (in pixels) of the cylc GUI at startup.
 
 \begin{myitemize}
     \item {\em type:} integer list (x, y)
-\item {\em legal values:} positive integers
-\item {\em default:} 800, 500
-\item {\em example:} \lstinline@window size = 1000, 700@
+    \item {\em legal values:} positive integers
+    \item {\em default:} 800, 500
+    \item {\em example:} \lstinline@window size = 1000, 700@
 \end{myitemize}
 
 

--- a/doc/gcylcrc.tex
+++ b/doc/gcylcrc.tex
@@ -12,6 +12,31 @@ command.
 
 \subsection{Top Level Items}
 
+\subsubsection{dot icon size}
+
+Set the size of the task state dot icons displayed in the text and dot
+views.
+
+\begin{myitemize}
+\item {\em type:} string
+\item {\em legal values:} ``small'' (10px), ``medium'' (14px), ``large'' (20px)
+\item {\em default:} ``medium''
+\end{myitemize}
+
+
+\subsubsection{initial side-by-side views}
+
+Set the suite view panels initial orientation when the GUI starts.
+This can be changed later using the "View" menu "Toggle views side-by-side"
+ option.
+
+\begin{myitemize}
+\item {\em type:} boolean (False or True)
+\item {\em legal values:} ``False'', ``True''.
+\item {\em default:} ``False''
+\end{myitemize}
+
+
 \subsubsection{initial views}
 
 Set the suite view panel(s) displayed initially, when the GUI starts.
@@ -23,6 +48,104 @@ This can be changed later using the tool bar.
 \item {\em default:} ``text''
 \item {\em example:} \lstinline@initial views = graph, dot@
 \end{myitemize}
+
+\subsubsection{sort by definition order}
+
+If this is not turned off the default sort order for task names and
+families in the dot and text views will the order they appear in the
+suite definition. Clicking on the task name column in the treeview will
+toggle to alphanumeric sort, and a View menu item does the same for the
+dot view.  If turned off, the default sort order is alphanumeric and
+definition order is not available at all.
+
+\begin{myitemize}
+\item {\em type:} boolean
+\item {\em default:} True
+\end{myitemize}
+
+
+\subsubsection{sort column}
+
+If ``text'' is in \lstinline@initial views@ then \lstinline@sort column@ sets
+the column that will be sorted initially when the gui launches. Sorting can be
+changed later by clicking on the column headers.
+
+\begin{myitemize}
+    \item {\em type:} string
+    \item {\em legal values:} ``task'', ``state'', ``host'', ``job system'',
+        ``job ID'', ``T-submit'', ``T-start'', ``T-finish'', ``dT-mean'',
+        ``latest message'', ``none''
+    \item {\em default:} ``none''
+    \item {\em example:} \lstinline@sort column = T-start@
+\end{myitemize}
+
+
+\subsubsection{sort column ascending}
+
+For use in combination with \lstinline@sort column@, sets weather the column will
+be sorted using ascending or descending order.
+
+\begin{myitemize}
+    \item {\em type:} boolean
+    \item {\em legal values:} ``True'' (ascending), ``False'' (descending)
+    \item {\em default:} ``True''
+    \item {\em example:} \lstinline@sort column ascending = False@
+\end{myitemize}
+
+
+\subsubsection{task filter highlight color}
+
+The color used to highlight active task filters in gcylc. It must be a name
+from the X11 rgb.txt file, e.g.\ \lstinline=SteelBlue=; or a
+{\em quoted} hexadecimal color code, e.g.\ \lstinline="#ff0000"= for red (quotes
+are required to prevent the hex code being interpreted as a comment).
+
+\begin{myitemize}
+    \item {\em type:} string
+    \item {\em default:} \lstinline=PowderBlue=
+\end{myitemize}
+
+
+\subsubsection{task states to filter out}
+
+Set the initial filtering options when the GUI starts. Later this can be
+changed by using the "View" menu "Task Filtering" option.
+
+\begin{myitemize}
+\item {\em type:} string list
+\item {\em legal values:} waiting, held, queued, ready, expired, submitted,
+submit-failed, submit-retrying, running, succeeded, failed, retrying, runahead
+\item {\em default:} runahead
+\end{myitemize}
+
+
+\subsubsection{transpose dot}
+
+Transposes the content in dot view so that it displays from left to right rather
+than from top to bottom. Can be changed later using the options submenu
+avaliable via the view menu.
+
+\begin{myitemize}
+    \item {\em type:} boolean
+    \item {\em legal values:} ``True'' (left-to-right), ``False'' (top-to-bottom)
+    \item {\em default:} ``False''
+    \item {\em example:} \lstinline@transpose dot = True@
+\end{myitemize}
+
+
+\subsubsection{transpose graph}
+
+Transposes the content in graph view so that it displays from left to right
+rather than from top to bottom. Can be changed later using the options submenu
+avaliable via the view menu.
+
+\begin{myitemize}
+    \item {\em type:} boolean
+    \item {\em legal values:} ``True'' (left-to-right), ``False'' (top-to-bottom)
+    \item {\em default:} ``False''
+    \item {\em example:} \lstinline@transpose graph = True@
+\end{myitemize}
+
 
 \subsubsection{ungrouped views}
 
@@ -36,6 +159,7 @@ using the tool bar.
 \item {\em default:} (none)
 \item {\em example:} \lstinline@ungrouped views = text, dot@
 \end{myitemize}
+
 
 \subsubsection{use theme}
 
@@ -53,66 +177,6 @@ to list your available themes.
 \item {\em default:} ``default''
 \end{myitemize}
 
-\subsubsection{initial side-by-side views}
-
-Set the suite view panels initial orientation when the GUI starts.
-This can be changed later using the "View" menu "Toggle views side-by-side"
- option.
-
-\begin{myitemize}
-\item {\em type:} boolean (False or True)
-\item {\em legal values:} ``False'', ``True''.
-\item {\em default:} ``False''
-\end{myitemize}
-
-\subsubsection{task states to filter out}
-
-Set the initial filtering options when the GUI starts. Later this can be
-changed by using the "View" menu "Task Filtering" option.
-
-\begin{myitemize}
-\item {\em type:} string list
-\item {\em legal values:} waiting, held, queued, ready, expired, submitted,
-submit-failed, submit-retrying, running, succeeded, failed, retrying, runahead
-\item {\em default:} runahead
-\end{myitemize}
-
-\subsubsection{dot icon size}
-
-Set the size of the task state dot icons displayed in the text and dot
-views.
-
-\begin{myitemize}
-\item {\em type:} string
-\item {\em legal values:} ``small'' (10px), ``medium'' (14px), ``large'' (20px)
-\item {\em default:} ``medium''
-\end{myitemize}
-
-\subsubsection{sort by definition order}
-
-If this is not turned off the default sort order for task names and
-families in the dot and text views will the order they appear in the
-suite definition. Clicking on the task name column in the treeview will
-toggle to alphanumeric sort, and a View menu item does the same for the
-dot view.  If turned off, the default sort order is alphanumeric and
-definition order is not available at all.
-
-\begin{myitemize}
-\item {\em type:} boolean
-\item {\em default:} True
-\end{myitemize}
-
-\subsubsection{task filter highlight color}
-
-The color used to highlight active task filters in gcylc. It must be a name
-from the X11 rgb.txt file, e.g.\ \lstinline=SteelBlue=; or a
-{\em quoted} hexadecimal color code, e.g.\ \lstinline="#ff0000"= for red (quotes
-are required to prevent the hex code being interpreted as a comment).
-
-\begin{myitemize}
-    \item {\em type:} string
-    \item {\em default:} \lstinline=PowderBlue=
-\end{myitemize}
 
 \subsubsection{window size}
 
@@ -125,58 +189,6 @@ Sets the size of the cylc gui at startup.
 \item {\em example:} \lstinline@window size = 1000, 700@
 \end{myitemize}
 
-\subsubsection{sort column}
-
-If ``text'' is in \lstinline@initial views@ then \lstinline@sort column@ sets
-the column that will be sorted initially when the gui launches. Sorting can be
-changed later by clicking on the column headers.
-
-\begin{myitemize}
-    \item {\em type:} string
-    \item {\em legal values:} ``task'', ``state'', ``host'', ``job system'',
-        ``job ID'', ``T-submit'', ``T-start'', ``T-finish'', ``dT-mean'',
-        ``latest message'', ``none''
-    \item {\em default:} ``none''
-    \item {\em example:} \lstinline@sort column = T-start@
-\end{myitemize}
-
-\subsubsection{sort column ascending}
-
-For use in combination with \lstinline@sort column@, sets weather the column will
-be sorted using ascending or descending order.
-
-\begin{myitemize}
-    \item {\em type:} boolean
-    \item {\em legal values:} ``True'' (ascending), ``False'' (descending)
-    \item {\em default:} ``True''
-    \item {\em example:} \lstinline@sort column ascending = False@
-\end{myitemize}
-
-\subsubsection{transpose graph}
-
-Transposes the content in graph view so that it displays from left to right
-rather than from top to bottom. Can be changed later using the options submenu
-avaliable via the view menu.
-
-\begin{myitemize}
-    \item {\em type:} boolean
-    \item {\em legal values:} ``True'' (left-to-right), ``False'' (top-to-bottom)
-    \item {\em default:} ``False''
-    \item {\em example:} \lstinline@transpose graph = True@
-\end{myitemize}
-
-\subsubsection{transpose dot}
-
-Transposes the content in dot view so that it displays from left to right rather
-than from top to bottom. Can be changed later using the options submenu
-avaliable via the view menu.
-
-\begin{myitemize}
-    \item {\em type:} boolean
-    \item {\em legal values:} ``True'' (left-to-right), ``False'' (top-to-bottom)
-    \item {\em default:} ``False''
-    \item {\em example:} \lstinline@transpose dot = True@
-\end{myitemize}
 
 \subsection{[themes]}
 

--- a/lib/cylc/cfgspec/gcylc.py
+++ b/lib/cylc/cfgspec/gcylc.py
@@ -50,6 +50,7 @@ SPEC = {
         options=["small", "medium", "large", "extra large"]),
     'sort by definition order': vdr(vtype='boolean', default=True),
     'task filter highlight color': vdr(vtype='string', default='PowderBlue'),
+    'window size': vdr(vtype='integer_list', default=[800, 500]),
     'initial side-by-side views': vdr(vtype='boolean', default=False),
     'task states to filter out': vdr(
         vtype='string_list',
@@ -173,8 +174,24 @@ class gconfig(config):
         cfg['themes'] = cfg_themes
 
     def check(self):
-        # check initial view config
         cfg = self.get(sparse=True)
+
+        # check window size config
+        if 'window size' in cfg:
+            fail = False
+            if len(cfg['window size']) != 2:
+                print >> sys.stderr, ("WARNING: window size requires two "
+                                      "values (x, y). Using default.")
+                fail = True
+            elif cfg['window size'][0] < 0 or cfg['window size'][1] < 0:
+                print >> sys.stderr, ("WARNING: window size values must be "
+                                      "positive. Using default.")
+                fail = True
+            # TODO: check for daft window sizes? (10, 5), (80000, 5000) ?
+            if fail:
+                cfg['window size'] = [800, 500]
+
+        # check initial view config
         if 'initial views' not in cfg:
             return
         views = copy(cfg['initial views'])

--- a/lib/cylc/cfgspec/gcylc.py
+++ b/lib/cylc/cfgspec/gcylc.py
@@ -42,25 +42,20 @@ SITE_FILE = os.path.join(
 USER_FILE = os.path.join(os.environ['HOME'], '.cylc', 'gcylc.rc')
 
 SPEC = {
-    'initial views': vdr(vtype='string_list', default=["text"]),
-    'ungrouped views': vdr(vtype='string_list', default=[]),
-    'use theme': vdr(vtype='string', default="default"),
     'dot icon size': vdr(
         vtype='string',
         default="medium",
         options=["small", "medium", "large", "extra large"]),
+    'initial side-by-side views': vdr(vtype='boolean', default=False),
+    'initial views': vdr(vtype='string_list', default=["text"]),
     'sort by definition order': vdr(vtype='boolean', default=True),
-    'task filter highlight color': vdr(vtype='string', default='PowderBlue'),
-    'window size': vdr(vtype='integer_list', default=[800, 500]),
-    'transpose graph': vdr(vtype='boolean', default=False),
-    'transpose dot': vdr(vtype='boolean', default=False),
     'sort column': vdr(
         vtype='string',
         default='none',
         options=[heading for heading in ControlTree.headings if heading is not
                  None] + ['none']),
     'sort column ascending': vdr(vtype='boolean', default=True),
-    'initial side-by-side views': vdr(vtype='boolean', default=False),
+    'task filter highlight color': vdr(vtype='string', default='PowderBlue'),
     'task states to filter out': vdr(
         vtype='string_list',
         default=[TASK_STATUS_RUNAHEAD]),
@@ -83,6 +78,11 @@ SPEC = {
             TASK_STATUS_RUNAHEAD: vdr(vtype='string_list'),
         },
     },
+    'transpose dot': vdr(vtype='boolean', default=False),
+    'transpose graph': vdr(vtype='boolean', default=False),
+    'ungrouped views': vdr(vtype='string_list', default=[]),
+    'use theme': vdr(vtype='string', default="default"),
+    'window size': vdr(vtype='integer_list', default=[800, 500]),
 }
 
 

--- a/lib/cylc/cfgspec/gcylc.py
+++ b/lib/cylc/cfgspec/gcylc.py
@@ -52,6 +52,8 @@ SPEC = {
     'sort by definition order': vdr(vtype='boolean', default=True),
     'task filter highlight color': vdr(vtype='string', default='PowderBlue'),
     'window size': vdr(vtype='integer_list', default=[800, 500]),
+    'transpose graph': vdr(vtype='boolean', default=False),
+    'transpose dot': vdr(vtype='boolean', default=False),
     'sort column': vdr(
         vtype='string',
         default='none',

--- a/lib/cylc/cfgspec/gcylc.py
+++ b/lib/cylc/cfgspec/gcylc.py
@@ -26,6 +26,7 @@ from parsec.config import config, ItemNotFoundError, itemstr
 from parsec.validate import validator as vdr
 from parsec.upgrade import upgrader
 from parsec.util import printcfg
+from cylc.gui.view_tree import ControlTree
 from cylc.task_state import (
     TASK_STATUSES_ALL, TASK_STATUS_RUNAHEAD, TASK_STATUS_HELD,
     TASK_STATUS_WAITING, TASK_STATUS_EXPIRED, TASK_STATUS_QUEUED,
@@ -51,6 +52,12 @@ SPEC = {
     'sort by definition order': vdr(vtype='boolean', default=True),
     'task filter highlight color': vdr(vtype='string', default='PowderBlue'),
     'window size': vdr(vtype='integer_list', default=[800, 500]),
+    'sort column': vdr(
+        vtype='string',
+        default='none',
+        options=[heading for heading in ControlTree.headings if heading is not
+                 None] + ['none']),
+    'sort column ascending': vdr(vtype='boolean', default=True),
     'initial side-by-side views': vdr(vtype='boolean', default=False),
     'task states to filter out': vdr(
         vtype='string_list',

--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -562,7 +562,8 @@ Main Control GUI that displays one or more views or interfaces to the suite.
         self.window = gtk.Window(gtk.WINDOW_TOPLEVEL)
 
         self.window.set_icon(get_icon())
-        self.window.set_default_size(800, 500)
+        window_size = gcfg.get(['window size'])
+        self.window.set_default_size(window_size[0], window_size[1])
         self.window.connect("delete_event", self.delete_event)
 
         self._prev_status = None

--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -669,11 +669,6 @@ Main Control GUI that displays one or more views or interfaces to the suite.
             elif i == 1:
                 self._set_menu_view1(view)
                 self._set_tool_bar_view1(view)
-            if gcfg.get(['sort column']) != 'none' and view == 'text':
-                self.current_views[i].sort_by_column(
-                    gcfg.get(['sort column']),
-                    ascending=gcfg.get(['sort column ascending'])
-                )
 
     def change_view_layout(self, horizontal=False):
         """Switch between horizontal or vertical positioning of views."""
@@ -884,6 +879,10 @@ Main Control GUI that displays one or more views or interfaces to the suite.
             view_widgets.set_size_request(1, 1)
         container.pack_start(view_widgets,
                              expand=True, fill=True)
+
+        # Set user default values for this view
+        self.set_view_defaults(viewname, view_num)
+
         # Handle menu
         menu = self.views_option_menus[view_num]
         for item in menu.get_children():
@@ -904,6 +903,23 @@ Main Control GUI that displays one or more views or interfaces to the suite.
             self.tool_bars[view_num].insert(toolitem, index + 1)
         self.current_view_toolitems[view_num] = new_toolitems
         self.window_show_all()
+
+    def set_view_defaults(self, viewname, view_num):
+        """Apply user settings defined in gcylc.rc on a new view.
+        Run this method before handling menus or toolbars."""
+        # Sort text view by column ('sort column')
+        if gcfg.get(['sort column']) != 'none' and viewname == 'text':
+            self.current_views[view_num].sort_by_column(
+                gcfg.get(['sort column']),
+                ascending=gcfg.get(['sort column ascending'])
+            )
+        # Transpose graph view ('transpose graph')
+        elif gcfg.get(['transpose graph']) and viewname == 'graph':
+            self.current_views[view_num].toggle_left_to_right_mode(None)
+        # Transpose dot view ('transpose dot')
+        elif gcfg.get(['transpose dot']) and viewname == 'dot':
+            view = self.current_views[view_num]
+            view.t.should_transpose_view = True
 
     def remove_view(self, view_num):
         """Remove a view instance."""

--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -669,6 +669,11 @@ Main Control GUI that displays one or more views or interfaces to the suite.
             elif i == 1:
                 self._set_menu_view1(view)
                 self._set_tool_bar_view1(view)
+            if gcfg.get(['sort column']) != 'none' and view == 'text':
+                self.current_views[i].sort_by_column(
+                    gcfg.get(['sort column']),
+                    ascending=gcfg.get(['sort column ascending'])
+                )
 
     def change_view_layout(self, horizontal=False):
         """Switch between horizontal or vertical positioning of views."""

--- a/lib/cylc/gui/view_tree.py
+++ b/lib/cylc/gui/view_tree.py
@@ -29,6 +29,11 @@ from isodatetime.parsers import DurationParser
 
 class ControlTree(object):
     """Text Treeview suite control interface."""
+    headings = [
+        None, 'task', 'state', 'host', 'job system', 'job ID', 'T-submit',
+        'T-start', 'T-finish', 'dT-mean', 'latest message',
+    ]
+
     def __init__(self, cfg, updater, theme, dot_size, info_bar,
                  get_right_click_menu, log_colors, insert_task_popup):
 
@@ -105,14 +110,10 @@ class ControlTree(object):
 
         self.ttreeview.connect(
             'button_press_event', self.on_treeview_button_pressed)
-        headings = [
-            None, 'task', 'state', 'host', 'job system', 'job ID', 'T-submit',
-            'T-start', 'T-finish', 'dT-mean', 'latest message',
-        ]
 
-        for n in range(1, len(headings)):
+        for n in range(1, len(ControlTree.headings)):
             # Skip first column (cycle point)
-            tvc = gtk.TreeViewColumn(headings[n])
+            tvc = gtk.TreeViewColumn(ControlTree.headings[n])
             if n == 1:
                 crp = gtk.CellRendererPixbuf()
                 tvc.pack_start(crp, False)
@@ -206,6 +207,18 @@ class ControlTree(object):
         # prevent a memory leak? But I'm not sure how to do this as yet.)
 
         return True
+
+    def sort_by_column(self, col_name=None, col_no=None, ascending=True):
+        """Sort this ControlTree by the column selected by the string
+        col_name OR by the index col_no."""
+        if col_name is not None and col_name in ControlTree.headings:
+            col_no = ControlTree.headings.index(col_name)
+        if col_no is not None:
+            self.sort_col_num = col_no
+            cols = self.ttreeview.get_columns()
+            order = gtk.SORT_ASCENDING if ascending else gtk.SORT_DESCENDING
+            cols[col_no].set_sort_order(order)
+            self.tmodelsort.set_sort_column_id(col_no - 1, order)
 
     def sort_column(self, model, iter1, iter2, col_num):
         cols = self.ttreeview.get_columns()


### PR DESCRIPTION
Closes #934 (bullet two)
Closes #817 
Closes #1622 

Added the following settings to gcylc.rc:
- `sort column` (#1622)
- `sort column ascending` (#1622)
- `transpose dot` (#934)
- `transpose graph` (#934)
- `window size` (#817)

Open to suggestions for better names for these settings.

@hjoliver Please Review
@benfitzpatrick Please Review