### PR TITLE
cylc test-battery: tidy Slurm directives

### DIFF
--- a/tests/cylc-job-poll/03-slurm.t
+++ b/tests/cylc-job-poll/03-slurm.t
@@ -39,7 +39,6 @@ function get_real_job_id() {
 #SBATCH --output=/dev/null
 #SBATCH --error=/dev/null
 #SBATCH --time=02:00
-#SBATCH --tasks=1
 __SBATCH__
     while read; do
         if [[ -z $REPLY ]]; then

--- a/tests/directives/slurm/suite.rc
+++ b/tests/directives/slurm/suite.rc
@@ -17,9 +17,6 @@
             method = slurm
         [[[directives]]]
             --time = 02:00
-            --nodes = 1
-            --tasks-per-node = 1
-            --cpus-per-task = 1
             {{SITE_DIRECTIVES}}
         [[[remote]]]
             host = {{ HOST }}

--- a/tests/job-kill/03-slurm/suite.rc
+++ b/tests/job-kill/03-slurm/suite.rc
@@ -20,10 +20,6 @@
             --output=slurm-%j.out
             --error=slurm-%j.err
             --time=03:00
-            --tasks=1
-            --nodes=1
-            --tasks-per-node=1
-            --cpus-per-task=1
 {% if "CYLC_TEST_BATCH_SITE_DIRECTIVES" in environ and environ["CYLC_TEST_BATCH_SITE_DIRECTIVES"] %}
             {{environ["CYLC_TEST_BATCH_SITE_DIRECTIVES"]}}
 {% endif %}


### PR DESCRIPTION
The directives here don't make a lot of sense (I've learnt quite a lot more about Slurm since writing these tests...). The Slurm default is to have 1 task, so these were redundant.

@matthewrmshin, please review.