### PR TITLE
Triggering a task should reset its outputs

### DIFF
--- a/lib/cylc/task_state.py
+++ b/lib/cylc/task_state.py
@@ -397,6 +397,10 @@ class TaskState(object):
             self.set_prerequisites_not_satisfied()
             self.unset_special_outputs()
             self.outputs.set_all_incomplete()
+        elif status == TASK_STATUS_READY:
+            self.set_prerequisites_all_satisfied()
+            self.unset_special_outputs()
+            self.outputs.set_all_incomplete()
         elif status == TASK_STATUS_SUCCEEDED:
             self.set_prerequisites_all_satisfied()
             self.unset_special_outputs()

--- a/tests/cylc-trigger/06-reset-ready.t
+++ b/tests/cylc-trigger/06-reset-ready.t
@@ -1,0 +1,29 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2016 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "cylc trigger" a task should reset its output to incomplete.
+# https://github.com/cylc/cylc/issues/1852
+. "$(dirname "$0")/test_header"
+
+set_test_number 2
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+run_ok "${TEST_NAME_BASE}" cylc run --reference-test --debug "${SUITE_NAME}"
+
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/cylc-trigger/06-reset-ready/reference.log
+++ b/tests/cylc-trigger/06-reset-ready/reference.log
@@ -1,0 +1,9 @@
+2016-05-19T14:32:47+01 INFO - Run mode: live
+2016-05-19T14:32:47+01 INFO - Initial point: 1
+2016-05-19T14:32:47+01 INFO - Final point: 1
+2016-05-19T14:32:47+01 INFO - Cold Start 1
+2016-05-19T14:32:47+01 INFO - [t1.1] -triggered off []
+2016-05-19T14:32:51+01 INFO - [t2.1] -triggered off ['t1.1']
+2016-05-19T14:32:54+01 INFO - [t3.1] -triggered off ['t2.1']
+2016-05-19T14:32:56+01 INFO - [t1.1] -triggered off []
+2016-05-19T14:33:09+01 INFO - [t2.1] -triggered off ['t1.1']

--- a/tests/cylc-trigger/06-reset-ready/suite.rc
+++ b/tests/cylc-trigger/06-reset-ready/suite.rc
@@ -1,0 +1,25 @@
+[cylc]
+    [[reference test]]
+        required run mode = live
+        live mode suite timeout = PT1M
+        expected task failures = t2.1
+[scheduling]
+    [[dependencies]]
+        graph = """
+t1 => t2
+t2:failed => t3
+"""
+[runtime]
+    [[t1]]
+        script = """
+if ((${CYLC_TASK_SUBMIT_NUMBER} >= 2)); then
+    cylc reset --state='waiting' "${CYLC_SUITE_NAME}" 't2.1'
+    sleep 5
+    cylc broadcast "${CYLC_SUITE_NAME}" -s '[environment]CYLC_TEST_VAR_X=x'
+    sleep 5
+fi
+"""
+    [[t2]]
+        script = printenv CYLC_TEST_VAR_X
+    [[t3]]
+        script = cylc trigger "${CYLC_SUITE_NAME}" 't1.1'


### PR DESCRIPTION
A manually triggered task should have its outputs reset to all incomplete.

Fix #1852.

@benfitzpatrick @hjoliver please review.