### PR TITLE
cylc insert: wildcard OK in task ID arguments

### DIFF
--- a/bin/cylc-insert
+++ b/bin/cylc-insert
@@ -77,7 +77,7 @@ def main():
     else:
         items, compat = (args, None)
         for i, item in enumerate(items):
-            if not TaskID.is_valid_id_2(item):
+            if not TaskID.is_valid_id_for_insert(item):
                 sys.exit('ERROR: "%s": invalid task ID (argument %d)' % (
                     item, i + 1))
         prompt('Insert %s in %s' % (items, suite), options.force)

--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -2056,7 +2056,7 @@ shown here in the state they were in at the time of triggering.''')
             warning_dialog('Enter valid task/family IDs', self.window).warn()
             return
         for i, task_id in enumerate(task_ids):
-            if not TaskID.is_valid_id_2(task_id):
+            if not TaskID.is_valid_id_for_insert(task_id):
                 warning_dialog(
                     '"%s": invalid task ID (argument %d)' % (task_id, i + 1),
                     self.window).warn()

--- a/lib/cylc/task_id.py
+++ b/lib/cylc/task_id.py
@@ -59,19 +59,10 @@ class TaskID(object):
                 point and cls.POINT_REC.match(point))
 
     @classmethod
-    def is_valid_id_2(cls, id_str):
-        """Return whether a task id is valid.
+    def is_valid_id_for_insert(cls, id_str):
+        """Return whether id_str is good as an insert client argument.
 
-        Accept "NAME.POINT" or "POINT/NAME" format.
+        Return True if "." or "/" appears once in the string. Cannot really
+        do more as the string may have wildcards.
         """
-        if cls.DELIM not in id_str and cls.DELIM2 not in id_str:
-            return False
-        try:
-            point, name = id_str.split(cls.DELIM2, 1)
-        except ValueError:
-            return cls.is_valid_id(id_str)
-        else:
-            return (
-                name and cls.NAME_REC.match(name) and
-                point and cls.POINT_REC.match(point)
-            )
+        return id_str.count(cls.DELIM) == 1 or id_str.count(cls.DELIM2) == 1

--- a/tests/cylc-insert/10-wildcard.t
+++ b/tests/cylc-insert/10-wildcard.t
@@ -1,0 +1,29 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2016 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test cylc insert command, with wildcard in a task name string
+. "$(dirname "$0")/test_header"
+set_test_number 2
+
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+suite_run_ok "${TEST_NAME_BASE}" \
+    cylc run --reference-test --debug "${SUITE_NAME}"
+
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/cylc-insert/10-wildcard/reference.log
+++ b/tests/cylc-insert/10-wildcard/reference.log
@@ -1,0 +1,7 @@
+2016-05-23T12:22:35+01 INFO - Run mode: live
+2016-05-23T12:22:35+01 INFO - Initial point: 1
+2016-05-23T12:22:35+01 INFO - Final point: 1
+2016-05-23T12:22:35+01 INFO - Cold Start 1
+2016-05-23T12:22:35+01 INFO - [i1.1] -triggered off []
+2016-05-23T12:22:39+01 INFO - [t1.1] -triggered off ['i1.1']
+2016-05-23T12:22:43+01 INFO - [t2.1] -triggered off ['i1.1']

--- a/tests/cylc-insert/10-wildcard/suite.rc
+++ b/tests/cylc-insert/10-wildcard/suite.rc
@@ -1,0 +1,19 @@
+title = cylc insert with wild card in task name string
+[cylc]
+    [[reference test]]
+        required run mode = live
+        live mode suite timeout = PT1M
+[scheduling]
+    [[special tasks]]
+        exclude at start-up = t1, t2
+    [[dependencies]]
+        graph = """
+i1 => t1 & t2
+"""
+[runtime]
+    [[i1]]
+        script = """
+cylc insert "${CYLC_SUITE_NAME}" 't?.1'
+"""
+    [[t1, t2]]
+        script = true


### PR DESCRIPTION
#1814 has been too strict when checking the argument to `cylc insert`. This change relaxes the check.

@hjoliver @benfitzpatrick please review.