### PR TITLE
Fix cylc-kill test 2

### DIFF
--- a/tests/cylc-kill/02-submitted/suite.rc
+++ b/tests/cylc-kill/02-submitted/suite.rc
@@ -21,7 +21,11 @@ sleep 60
     [[killable-1, killable-2, killable-3]]
         inherit=KILLABLE
     [[killer]]
-        script=cylc kill -m "${CYLC_SUITE_NAME}" '*:submitted'
+        script="""
+wait "${CYLC_TASK_MESSAGE_STARTED_PID}" 2>/dev/null || true
+sleep 5
+cylc kill -m "${CYLC_SUITE_NAME}" '*:submitted'
+"""
     [[sleeper]]
         script=sleep 20
     [[stopper]]


### PR DESCRIPTION
Ensure that the started message from killer task is sent and received
before issuing the kill command. This prevents the kill command from
killing the killer task itself.

The test has become a bit flaky, possibly due to #1855.