### PR TITLE
stalled handler: Cater for held tasks.

### DIFF
--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -760,7 +760,8 @@ class TaskPool(object):
         """Return True if no active, queued or clock trigger awaiting tasks"""
         for itask in self.get_tasks():
             if (itask.state.status in [TASK_STATUS_QUEUED,
-                                       TASK_STATUS_READY] or
+                                       TASK_STATUS_READY,
+                                       TASK_STATUS_HELD] or
                     itask.state.status in TASK_STATUSES_ACTIVE):
                 return False
             if (not itask.start_time_reached() and


### PR DESCRIPTION
As reported by @dpmatthews I neglected to cater for held tasks which can result in an unhelpful stalled suite handler triggering if you start the suite in held status.

@matthewrmshin - please review. Not sure if it needs a review 2 given how simple the fix is - up to you.