### PR TITLE
t: abort on stalled with --hold

### DIFF
--- a/tests/events/25-held-not-stalled.t
+++ b/tests/events/25-held-not-stalled.t
@@ -1,0 +1,28 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2016 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test abort on stalled with hold, ensure abort on stalled does not applied to
+# a suite started with --hold.
+. "$(dirname "$0")/test_header"
+set_test_number 2
+
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+suite_run_ok "${TEST_NAME_BASE}-run" cylc run --hold --no-detach "${SUITE_NAME}"
+
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/events/25-held-not-stalled/suite.rc
+++ b/tests/events/25-held-not-stalled/suite.rc
@@ -1,0 +1,11 @@
+[cylc]
+    [[event hooks]]
+        abort on stalled = True
+        timeout handler = cylc release '%(suite)s'
+        timeout = PT5S
+[scheduling]
+    [[dependencies]]
+        graph = t1
+[runtime]
+    [[t1]]
+        script = true


### PR DESCRIPTION
Test abort on stalled setting when a suite is started up with --hold.

Test for #1860. @arjclark please review.

The test suite will stall and die with the version just before #1860, but will release itself on timeout with current HEAD.