### PR TITLE
cylc gui: enabled multiple selection in tree view

### DIFF
--- a/lib/cylc/gui/updater_tree.py
+++ b/lib/cylc/gui/updater_tree.py
@@ -30,7 +30,6 @@ from cylc.wallclock import get_time_string_from_unix_time
 from cylc.task_state import TASK_STATUSES_AUTO_EXPAND
 
 
-
 def _time_trim(time_value):
     if time_value is not None:
         return time_value.rsplit(".", 1)[0]

--- a/lib/cylc/gui/updater_tree.py
+++ b/lib/cylc/gui/updater_tree.py
@@ -17,7 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from copy import deepcopy
-import datetime
 import time
 import gobject
 import itertools
@@ -27,13 +26,9 @@ from time import sleep
 from cylc.task_id import TaskID
 from cylc.gui.dot_maker import DotMaker
 from cylc.network.suite_state import get_id_summary
-from cylc.strftime import isoformat_strftime
-from cylc.wallclock import (
-    get_current_time_string,
-    get_time_string_from_unix_time,
-    TIME_ZONE_STRING_LOCAL_BASIC
-)
+from cylc.wallclock import get_time_string_from_unix_time
 from cylc.task_state import TASK_STATUSES_AUTO_EXPAND
+
 
 
 def _time_trim(time_value):

--- a/lib/cylc/gui/view_dot.py
+++ b/lib/cylc/gui/view_dot.py
@@ -106,16 +106,13 @@ LED suite control interface.
             if task_id not in self.t.fam_state_summary:
                 return False
             task_state = self.t.fam_state_summary[task_id]['state']
-            submit_num = None
         else:
             if task_id not in self.t.state_summary:
                 return False
             task_state = self.t.state_summary[task_id]['state']
-            submit_num = self.t.state_summary[task_id]['submit_num']
 
         menu = self.get_right_click_menu(
-            task_id, t_state=task_state,
-            task_is_family=is_fam, submit_num=submit_num)
+            task_id, t_state=task_state, task_is_family=is_fam)
 
         sep = gtk.SeparatorMenuItem()
         sep.show()

--- a/lib/cylc/gui/view_dot.py
+++ b/lib/cylc/gui/view_dot.py
@@ -112,7 +112,7 @@ LED suite control interface.
             task_state = self.t.state_summary[task_id]['state']
 
         menu = self.get_right_click_menu(
-            task_id, t_state=task_state, task_is_family=is_fam)
+            [task_id], [task_state], task_is_family=[is_fam])
 
         sep = gtk.SeparatorMenuItem()
         sep.show()

--- a/lib/cylc/gui/view_graph.py
+++ b/lib/cylc/gui/view_graph.py
@@ -194,7 +194,7 @@ Dependency graph suite control interface.
                     return False
                 t_state = self.t.state_summary[task_id]['state']
             default_menu = self.get_right_click_menu(
-                task_id, t_state, task_is_family=is_fam)
+                [task_id], [t_state], task_is_family=[is_fam])
             dm_kids = default_menu.get_children()
             for item in reversed(dm_kids[:2]):
                 # Put task name and URL at the top.

--- a/lib/cylc/gui/view_graph.py
+++ b/lib/cylc/gui/view_graph.py
@@ -189,14 +189,12 @@ Dependency graph suite control interface.
                 if task_id not in self.t.fam_state_summary:
                     return False
                 t_state = self.t.fam_state_summary[task_id]['state']
-                submit_num = None
             else:
                 if task_id not in self.t.state_summary:
                     return False
                 t_state = self.t.state_summary[task_id]['state']
-                submit_num = self.t.state_summary[task_id]['submit_num']
             default_menu = self.get_right_click_menu(
-                task_id, t_state, task_is_family=is_fam, submit_num=submit_num)
+                task_id, t_state, task_is_family=is_fam)
             dm_kids = default_menu.get_children()
             for item in reversed(dm_kids[:2]):
                 # Put task name and URL at the top.

--- a/lib/cylc/gui/view_tree.py
+++ b/lib/cylc/gui/view_tree.py
@@ -17,12 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import gtk
-import os
-import re
 import gobject
 from updater_tree import TreeUpdater
-from gcapture import gcapture_tmpfile
-from warning_dialog import warning_dialog, info_dialog
 from cylc.task_id import TaskID
 from isodatetime.parsers import DurationParser
 


### PR DESCRIPTION
Closes #1536 

For multiple selection the right click context menu yields all the normal items minus:
- Browse task URL
- View
- Trigger (edit run)

For multiple selection the following right click items are greyed out unless the action is valid for all tasks in the selection:
- Trigger (run now)
- Poll
- Kill

@hjoliver Please Review
@benfitzpatrick Please Review