### PR TITLE
cylc syntax highlighting: support multiline Jinja2

### DIFF
--- a/conf/cylc-mode.el
+++ b/conf/cylc-mode.el
@@ -15,6 +15,8 @@
 
 (setq cylc-font-lock-keywords
       '(("{%[[:alnum:], _=\\(\\)]*%}" . font-lock-constant-face) 
+        ("{#[^\}]+#}" . font-lock-comment-face)
+        ("#.*" . font-lock-comment-face)
 	("{{[[:alnum:] ]*}}" . font-lock-constant-face) 
         ("\\[\\[\\[[[:alnum:], _]+\\]\\]\\]" . font-lock-type-face)
         ("\\[\\[\\[[[:alnum:], _]+" . font-lock-type-face)
@@ -27,7 +29,7 @@
 	))
 
 ;; define the mode
-(define-derived-mode cylc-mode shell-script-mode
+(define-derived-mode cylc-mode fundamental-mode
   "cylc mode"
   "Major mode for editing CYLC .cylc files"
 

--- a/conf/cylc.xml
+++ b/conf/cylc.xml
@@ -136,12 +136,17 @@
         <DetectChar attribute='String' char='"'/>
         <DetectChar attribute='String' char="'"/>
         <DetectChar attribute="Assignment" char="\" />
-        <RegExpr attribute='Comment' String="\{#.*#\}"/>
         <RegExpr attribute='Jinja2' String="\{%.*%\}"/>
         <RegExpr attribute='Jinja2' String="\{\{.*\}\}"/>
         <RegExpr attribute="Comment" String="#.*$" />
         <RegExpr attribute="Environment" String="\$\w+" />
         <RegExpr attribute="Environment" String="\$\{\w+\}" />
+        <Detect2Chars attribute="Comment" context="MultiLineJinja2"
+        char="{" char1="#" beginRegion="Comment2" />
+      </context>
+      <context attribute="Comment" lineEndContext="#stay" name="MultiLineJinja2">
+        <Detect2Chars attribute="Comment" context="#pop" char="#" char1="}"
+        endRegion="Comment2" />
       </context>
     </contexts>
 
@@ -159,6 +164,7 @@
   
   <general>
     <comments>
+      <comment name="multiLine" start="{#" end="#}"/>
       <comment name="singleLine" start="#"/>
     </comments>
   </general>


### PR DESCRIPTION
Closes #1573 

Added syntax highlighting to kate and emacs for multi-line jinja2 comment strings of the form:

```
{# foo bar
   baz #}
```

@benfitzpatrick Please Review
@hjoliver Please Review