### PR TITLE
gcylc: count down to next reconnect attempt

### DIFF
--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -64,7 +64,8 @@ from cylc.gui.gcapture import gcapture_tmpfile
 from cylc.suite_logging import suite_log
 from cylc.cfgspec.globalcfg import GLOBAL_CFG
 from cylc.cfgspec.gcylc import gcfg
-from cylc.wallclock import get_time_string_from_unix_time
+from cylc.wallclock import (
+    get_seconds_as_interval_string, get_time_string_from_unix_time)
 from cylc.task_state import (
     TaskState, TASK_STATUSES_ALL, TASK_STATUSES_RESTRICTED,
     TASK_STATUSES_WITH_JOB_SCRIPT, TASK_STATUSES_WITH_JOB_LOGS,
@@ -184,9 +185,9 @@ Class to hold initialisation data.
 
 
 class InfoBar(gtk.VBox):
-    """
-Class to create an information bar.
-    """
+    """Class to create an information bar."""
+
+    DISCONNECTED_TEXT = "(not connected)"
 
     def __init__(self, host, theme, dot_size, filter_states_excl,
                  filter_launcher,
@@ -238,9 +239,16 @@ Class to create an information bar.
 
         self._runahead = ""
 
-        self._time = "time..."
+        self.update_time_str = "time..."
         self.time_widget = gtk.Label()
         self._set_tooltip(self.time_widget, "last update time")
+
+        self.reconnect_duration_widget = gtk.Label()
+        self._set_tooltip(
+            self.reconnect_duration_widget,
+            r"""Duration to next reconnect attempt
+
+Use (Re-)connect button to reconnect immediately.""")
 
         hbox = gtk.HBox(spacing=0)
         self.pack_start(hbox, False, False)
@@ -254,35 +262,26 @@ Class to create an information bar.
         vbox.pack_end(self.prog_bar, False, True)
         # Add some text to get full height.
         self.prog_bar.set_text("...")
+
         eb = gtk.EventBox()
         eb.add(vbox)
         eb.connect('button-press-event', self.prog_bar_disable)
         hbox.pack_start(eb, False)
 
-        eb = gtk.EventBox()
-        eb.add(self.status_widget)
-        hbox.pack_start(eb, False)
-
-        eb = gtk.EventBox()
-        eb.add(self.filter_state_widget)
-        hbox.pack_start(eb, False)
-
-        eb = gtk.EventBox()
-        eb.add(self.mode_widget)
-        hbox.pack_start(eb, False)
+        for widget in [
+                self.status_widget, self.state_widget,
+                self.filter_state_widget, self.mode_widget]:
+            eb = gtk.EventBox()
+            eb.add(widget)
+            hbox.pack_start(eb, False)
 
         # From the right.
-        eb = gtk.EventBox()
-        eb.add(self.log_widget)
-        hbox.pack_end(eb, False)
-
-        eb = gtk.EventBox()
-        eb.add(self.time_widget)
-        hbox.pack_end(eb, False)
-
-        eb = gtk.EventBox()
-        eb.add(self.state_widget)
-        hbox.pack_end(eb, False)
+        for widget in [
+                self.log_widget, self.time_widget,
+                self.reconnect_duration_widget]:
+            eb = gtk.EventBox()
+            eb.add(widget)
+            hbox.pack_end(eb, False)
 
     def set_theme(self, theme, dot_size):
         self.dots = DotMaker(theme, size=dot_size)
@@ -426,18 +425,27 @@ Class to create an information bar.
         if num_failed:
             summary += ": %s failed tasks" % num_failed
         self.set_status(summary)
-        dt = glob["last_updated"]
-        self.set_time(get_time_string_from_unix_time(dt))
+        self.set_update_time(
+            get_time_string_from_unix_time(glob["last_updated"]),
+            self.DISCONNECTED_TEXT)
         # (called on idle_add)
         return False
 
-    def set_time(self, time):
+    def set_update_time(self, update_time_str, next_update_dt_str=None):
         """Set last update text."""
-        if time == self._time:
-            return False
-        self._time = time
-        time_for_display = time.strip().rsplit(".", 1)[0]
-        gobject.idle_add(self.time_widget.set_text, " %s " % time_for_display)
+        if update_time_str != self.update_time_str:
+            self.update_time_str = update_time_str
+            gobject.idle_add(
+                self.time_widget.set_text, " %s " % update_time_str)
+        if next_update_dt_str is None:
+            gobject.idle_add(self.reconnect_duration_widget.set_text, "")
+        elif next_update_dt_str == self.DISCONNECTED_TEXT:
+            gobject.idle_add(
+                self.reconnect_duration_widget.set_text, next_update_dt_str)
+        else:
+            gobject.idle_add(
+                self.reconnect_duration_widget.set_text,
+                " (reconnect in %s) " % next_update_dt_str)
 
     def _set_tooltip(self, widget, text):
         tooltip = gtk.Tooltips()
@@ -1161,7 +1169,7 @@ been defined for this suite""").inform()
                            self.window).warn()
             success = False
 
-        self.reset_connection_polling(None)
+        self.reset_connect(None)
 
     def about(self, bt):
         about = gtk.AboutDialog()
@@ -2272,16 +2280,18 @@ shown here in the state they were in at the time of triggering.''')
 
         self.view_menu.append(gtk.SeparatorMenuItem())
 
-        poll_item = gtk.ImageMenuItem("Reset Connection _Polling")
+        self.reset_connect_menuitem = gtk.ImageMenuItem("(_Re-)connect")
         img = gtk.image_new_from_stock(gtk.STOCK_REFRESH, gtk.ICON_SIZE_MENU)
-        poll_item.set_image(img)
+        self.reset_connect_menuitem.set_image(img)
         self._set_tooltip(
-            poll_item,
-            """If gcylc is not connected to a running suite
+            self.reset_connect_menuitem,
+            """(Re-)connect to suite immediately.
+
+If gcylc is not connected to a running suite
 it tries to reconnect after increasingly long delays,
 to reduce network traffic.""")
-        self.view_menu.append(poll_item)
-        poll_item.connect('activate', self.reset_connection_polling)
+        self.view_menu.append(self.reset_connect_menuitem)
+        self.reset_connect_menuitem.connect('activate', self.reset_connect)
 
         self.view_menu.append(gtk.SeparatorMenuItem())
         filter_item = gtk.ImageMenuItem("Task _Filtering")
@@ -2855,10 +2865,12 @@ This is what my suite does:..."""
             if res:
                 self.reset(suite)
 
-    def reset_connection_polling(self, bt):
-        # Force the polling schedule to go back to short intervals so
-        # that the GUI can immediately connect to the started suite.
-        self.updater.poll_schd.stop()
+    def reset_connect(self, bt):
+        """Force the polling schedule to go back to short intervals.
+
+        This is so that the GUI can immediately connect to the started suite.
+        """
+        self.updater.connect_schd.stop()
 
     def construct_command_menu(self, menu):
         cat_menu = gtk.Menu()
@@ -3075,6 +3087,24 @@ This is what my suite does:..."""
         self.tool_bars[0].insert(self.view_toolitems[0], 0)
         self.tool_bars[0].insert(view0_label_item, 0)
         self.tool_bars[0].insert(gtk.SeparatorToolItem(), 0)
+
+        self.reset_connect_toolbutton = gtk.ToolButton(
+            icon_widget=gtk.image_new_from_stock(
+                gtk.STOCK_REFRESH, gtk.ICON_SIZE_SMALL_TOOLBAR))
+        self.reset_connect_toolbutton.set_label("(Re-)connect")
+        tooltip = gtk.Tooltips()
+        tooltip.enable()
+        tooltip.set_tip(
+            self.reset_connect_toolbutton,
+            """(Re-)connect to suite immediately.
+
+If gcylc is not connected to a running suite
+it tries to reconnect after increasingly long delays,
+to reduce network traffic.""")
+        self.reset_connect_toolbutton.connect("clicked", self.reset_connect)
+        self.tool_bars[0].insert(self.reset_connect_toolbutton, 0)
+
+        self.tool_bars[0].insert(gtk.SeparatorToolItem(), 0)
         stop_icon = gtk.image_new_from_stock(gtk.STOCK_MEDIA_STOP,
                                              gtk.ICON_SIZE_SMALL_TOOLBAR)
         self.stop_toolbutton = gtk.ToolButton(icon_widget=stop_icon)
@@ -3121,6 +3151,8 @@ For more Stop options use the Control menu.""")
         self.stop_menuitem.set_sensitive(stop_ok)
         self.stop_toolbutton.set_sensitive(stop_ok and
                                            "stopping" not in new_status)
+        self.reset_connect_menuitem.set_sensitive(run_ok)
+        self.reset_connect_toolbutton.set_sensitive(run_ok)
         if pause_ok:
             icon = gtk.STOCK_MEDIA_PAUSE
             tip_text = "Hold Suite (pause)"

--- a/lib/cylc/gui/updater.py
+++ b/lib/cylc/gui/updater.py
@@ -216,7 +216,7 @@ class Updater(threading.Thread):
                     self.info_bar.set_stop_summary, self.stop_summary)
             else:
                 self.info_bar.set_update_time(
-                    get_current_time_string(), self.info_bar.DISCONNECTED_TEXT)
+                    None, self.info_bar.DISCONNECTED_TEXT)
             return
         except Pyro.errors.NamingError as exc:
             if cylc.flags.debug:
@@ -406,7 +406,7 @@ class Updater(threading.Thread):
             return False
         if not self.connect_schd.ready():
             self.info_bar.set_update_time(
-                get_time_string_from_unix_time(self.connect_schd.t_prev),
+                None,
                 get_seconds_as_interval_string(
                     round(self.connect_schd.dt_next)))
             return False

--- a/lib/cylc/gui/updater_graph.py
+++ b/lib/cylc/gui/updater_graph.py
@@ -94,7 +94,7 @@ class GraphUpdater(threading.Thread):
 
         self.god = None
         self.mode = "waiting..."
-        self.dt = "waiting..."
+        self.update_time_str = "waiting..."
 
         self.prev_graph_id = ()
 

--- a/lib/cylc/gui/updater_tree.py
+++ b/lib/cylc/gui/updater_tree.py
@@ -201,8 +201,8 @@ class TreeUpdater(threading.Thread):
 
         self.ttree_paths.clear()
 
-        if "T" in self.updater.dt:
-            last_update_date = self.updater.dt.split("T")[0]
+        if "T" in self.updater.update_time_str:
+            last_update_date = self.updater.update_time_str.split("T")[0]
         else:
             last_update_date = None
 

--- a/lib/cylc/gui/view_tree.py
+++ b/lib/cylc/gui/view_tree.py
@@ -294,8 +294,8 @@ class ControlTree(object):
     def _set_cell_text_time(self, column, cell, model, iter_, n):
         """Remove the date part if it matches the last update date."""
         date_time_string = model.get_value(iter_, n)
-        if "T" in self.updater.dt:
-            last_update_date = self.updater.dt.split("T")[0]
+        if "T" in self.updater.update_time_str:
+            last_update_date = self.updater.update_time_str.split("T")[0]
             date_time_string = date_time_string.replace(
                 last_update_date + "T", "", 1)
         if n == 8:


### PR DESCRIPTION
Rename `Reset Connection Polling` to `Reset Connection Schedule` to avoid terminology confusion (with polling of task jobs).
Add tool button for `Reset Connection Schedule`.
Set sensitivity of `Reset Connection Schedule` to True only when suite is stopped.
Reconnection count down in ISO8601 duration next to last update time.

Partially address #1576. @hjoliver @benfitzpatrick please review.