### PR TITLE
gcylc dot-view: collapse and expand individual namespaces

### DIFF
--- a/lib/cylc/gui/updater_dot.py
+++ b/lib/cylc/gui/updater_dot.py
@@ -26,6 +26,10 @@ from cylc.gui.dot_maker import DotMaker
 from cylc.network.suite_state import get_id_summary
 from copy import deepcopy
 
+import warnings
+warnings.filterwarnings('ignore', '^.*was not found when attempting to ' +
+                        'remove it', Warning)
+
 
 class DotUpdater(threading.Thread):
 

--- a/lib/cylc/gui/view_dot.py
+++ b/lib/cylc/gui/view_dot.py
@@ -274,7 +274,7 @@ LED suite control interface.
             "Dot View - Click to group tasks by families")
 
         self.transpose_toolbutton = gtk.ToggleToolButton()
-        self.transpose_toolbutton.set_active(False)
+        self.transpose_toolbutton.set_active(self.t.should_transpose_view)
         g_image = gtk.image_new_from_stock(
             'transpose', gtk.ICON_SIZE_SMALL_TOOLBAR)
         self.transpose_toolbutton.set_icon_widget(g_image)

--- a/lib/cylc/gui/view_graph.py
+++ b/lib/cylc/gui/view_graph.py
@@ -330,7 +330,8 @@ Dependency graph suite control interface.
         items.append(self.ungroup_toolbutton)
 
         self.transpose_toolbutton = gtk.ToggleToolButton()
-        self.transpose_toolbutton.set_active(False)
+        self.transpose_toolbutton.set_active(not self.t.orientation == "TB")
+
         g_image = gtk.image_new_from_stock('transpose',
                                            gtk.ICON_SIZE_SMALL_TOOLBAR)
         self.transpose_toolbutton.set_icon_widget(g_image)


### PR DESCRIPTION
Closes #132 
Families can now be expanded/collapsed in the dot view.

@hjoliver Please Review
@benfitzpatrick Please Review