### PR TITLE
gscan: information on hover.

### DIFF
--- a/lib/cylc/network/suite_identifier.py
+++ b/lib/cylc/network/suite_identifier.py
@@ -62,6 +62,8 @@ class SuiteIdServer(PyroServer):
             result['states'] = StateSummaryServer.get_inst().get_state_totals()
             result['update-time'] = (
                 StateSummaryServer.get_inst().get_summary_update_time())
+            result['tasks-by-state'] = (
+                StateSummaryServer.get_inst().get_tasks_by_state())
         return result
 
     def id(self):

--- a/lib/cylc/network/suite_state.py
+++ b/lib/cylc/network/suite_state.py
@@ -273,7 +273,14 @@ class StateSummaryServer(PyroServer):
                         self.task_summary[task][time_string]):
                     time_strings.append(self.task_summary[task][time_string])
             task_name, point_string = task.rsplit('.', 1)
-            ret[state].append((max(time_strings), task_name, point_string))
+            ret[state].append((max(time_strings), task_name, point_string,))
+        for state in ret:
+            ret[state].sort(reverse=True)
+            if len(ret[state]) < 7:
+                ret[state] = ret[state][0:6]
+            else:
+                ret[state] = ret[state][0:5] + [
+                    (None, len(ret[state]) - 5, None,)]
         return ret
 
     def get_summary_update_time(self):


### PR DESCRIPTION
Closes #1244 

Added tooltip text for the status indicators in gscan. The 5 most recent tasks are displayed, ordered by the most recent of `submitted_time_string`, `started_time_string` and `finished_time_string`. If the row is displaying tasks at a given cycle point the tooltip will show only tasks at that point.


@hjoliver Please Review
@benfitzpatrick Please Review