### PR TITLE
Force Pyro threads to join before shutdown.

### DIFF
--- a/lib/cylc/network/pyro_daemon.py
+++ b/lib/cylc/network/pyro_daemon.py
@@ -64,6 +64,10 @@ class PyroDaemon(object):
         except socket.error:
             traceback.print_exc()
 
+        # Force all Pyro threads to stop now, to prevent them from raising any
+        # exceptions during Python interpreter shutdown - see GitHub #1890.
+        self.daemon.closedown()
+
     def connect(self, obj, name):
         """Connect obj and name to the daemon."""
         if not obj.__class__.__name__ == 'SuiteIdServer':


### PR DESCRIPTION
Close #1890.

@matthewrmshin - I think your passphrase utility refactor somehow exposed this bug rather than caused it.  It does seem to result from Pyro threads still running and raising a routine exception (it happens constantly as a suite runs) - as the traceback says - when the Python interpreter is in the process of shutting down, hence the bizarre uncaught exception behaviour.  The solution we discussed doesn't work, it just causes other problems.  I found a Pyro method that explicitly joins the threads.  Haven't seen any adverse side-effects in testing.