### PR TITLE
Tidy submits of previous runs on suite host

### DIFF
--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -1229,15 +1229,19 @@ class TaskProxy(object):
         """
         job_file_dir = self.get_job_log_path(self.HEAD_MODE_LOCAL)
         task_log_dir = os.path.dirname(job_file_dir)
-        try:
-            if self.submit_num == 1:
-                for name in os.listdir(task_log_dir):
-                    if name != "01":
-                        rmtree(os.path.join(task_log_dir, name))
+        if self.submit_num == 1:
+            try:
+                names = os.listdir(task_log_dir)
+            except OSError:
+                pass
             else:
-                rmtree(job_file_dir)
-        except OSError:
-            pass
+                for name in names:
+                    if name not in ["01", self.NN]:
+                        rmtree(
+                            os.path.join(task_log_dir, name),
+                            ignore_errors=True)
+        else:
+            rmtree(job_file_dir, ignore_errors=True)
 
         mkdir_p(job_file_dir)
         target = os.path.join(task_log_dir, self.NN)

--- a/tests/job-submission/13-tidy-submits-of-prev-run-remote-host.t
+++ b/tests/job-submission/13-tidy-submits-of-prev-run-remote-host.t
@@ -50,8 +50,7 @@ suite_run_ok "${TEST_NAME_BASE}-run" \
 run_ok "exists-rlogd1" ${SSH} "${CYLC_TEST_HOST}" test -e "${RLOGD1}"
 run_fail "not-exists-rlogd2" ${SSH} "${CYLC_TEST_HOST}" test -e "${RLOGD2}"
 exists_ok "${LOGD1}"
-skip 1 '02-file-exists-fail - will fix as part of cylc/cylc#1880'
-#exists_fail "${LOGD2}"
+exists_fail "${LOGD2}"
 #-------------------------------------------------------------------------------
 ssh -n -oBatchMode=yes -oConnectTimeout=5 "${CYLC_TEST_HOST}" \
     "rm -rf 'cylc-run/${SUITE_NAME}'"


### PR DESCRIPTION
Don't try to remove `NN` with `rmtree`.
Ignore `rmtree` errors.

This should fix job submission tests 13 and 14.

@hjoliver @arjclark please review.