### PR TITLE
Task array proof of concept.

### DIFF
--- a/lib/cylc/cfgspec/suite.py
+++ b/lib/cylc/cfgspec/suite.py
@@ -252,6 +252,9 @@ SPEC = {
                     :PRIVILEGE_LEVELS.index('shutdown') + 1],
                 default=GLOBAL_CFG.get(['authentication', 'public']))
         },
+        'task array sizes': {
+            '__MANY__': vdr(vtype='integer'),
+        },
     },
     'scheduling': {
         'initial cycle point': vdr(vtype='cycletime'),


### PR DESCRIPTION
@cylc/core - sorry, couldn't resist a quick hack at a proof of concept :grimacing: (not intended for merge)

I've banged this in in the most brain dead way possible, in ~45 min, enough to support the following simple suite - but I think it would be pretty easy to do it properly!  

```
[cylc]
    [[task array sizes]]
        M = 5
[scheduling]
    [[dependencies]]
        graph = foo_<M> => bar_<M>
[runtime]
    [[foo_<M>]]
        script = echo "I am job <M>"
```
Run suite, then:
```
$ cylc log -o foo foo_4.1
...
I am job 4
...
```

![foo](https://cloud.githubusercontent.com/assets/2362137/16275828/4b2a3ab2-389b-11e6-94df-9d4483a758f4.png)

(this is just syntax expansion, not an internal array as matt was suggesting, obviously)