### PR TITLE
Refactor scheduler run loop and stop-related logic

### DIFF
--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -69,7 +69,7 @@ from cylc.wallclock import (
 from cylc.task_state import (
     TaskState, TASK_STATUSES_ALL, TASK_STATUSES_RESTRICTED,
     TASK_STATUSES_WITH_JOB_SCRIPT, TASK_STATUSES_WITH_JOB_LOGS,
-    TASK_STATUSES_TRIGGERABLE, TASK_STATUSES_POLLABLE, TASK_STATUSES_KILLABLE,
+    TASK_STATUSES_TRIGGERABLE, TASK_STATUSES_POLLABLE, TASK_STATUSES_ACTIVE,
     TASK_STATUS_WAITING, TASK_STATUS_READY,
     TASK_STATUS_RUNNING, TASK_STATUS_SUCCEEDED, TASK_STATUS_FAILED)
 
@@ -1367,7 +1367,7 @@ been defined for this suite""").inform()
         menu.append(kill_item)
         kill_item.connect('activate', self.kill_task, task_ids)
         kill_item.set_sensitive(
-            all([t_state in TASK_STATUSES_KILLABLE for t_state in t_states])
+            all([t_state in TASK_STATUSES_ACTIVE for t_state in t_states])
         )
 
         # Separator.

--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -203,7 +203,6 @@ class TaskProxy(object):
     POLLED_INDICATOR = "(polled)"
 
     event_handler_env = {}
-    stop_sim_mode_job_submission = False
 
     def __init__(
             self, tdef, start_point, status=TASK_STATUS_WAITING,
@@ -856,14 +855,11 @@ class TaskProxy(object):
 
         if self.tdef.run_mode == 'simulation':
             # Simulate job execution at this point.
-            if self.__class__.stop_sim_mode_job_submission:
-                self.state.set_ready_to_submit()
-            else:
-                self.started_time = time.time()
-                self.summary['started_time'] = self.started_time
-                self.summary['started_time_string'] = (
-                    get_time_string_from_unix_time(self.started_time))
-                self.state.set_executing()
+            self.started_time = time.time()
+            self.summary['started_time'] = self.started_time
+            self.summary['started_time_string'] = (
+                get_time_string_from_unix_time(self.started_time))
+            self.state.set_executing()
             return
 
         self.submitted_time = time.time()

--- a/lib/cylc/task_state.py
+++ b/lib/cylc/task_state.py
@@ -86,14 +86,11 @@ TASK_STATUSES_CAN_RESET_TO = set([
     TASK_STATUS_FAILED
 ])
 
-# Task statuses that are killable.
-TASK_STATUSES_KILLABLE = set([
+# Task statuses that are active (i.e. pollable and killable).
+TASK_STATUSES_ACTIVE = set([
     TASK_STATUS_SUBMITTED,
     TASK_STATUS_RUNNING
 ])
-
-# Task statuses that are externally active.
-TASK_STATUSES_ACTIVE = TASK_STATUSES_KILLABLE
 
 # Task statuses that are pollable.
 TASK_STATUSES_POLLABLE = set([


### PR DESCRIPTION
In preparation for #1282 (which is best done after #1827), I thought I would do some re-factor of the scheduler main loop and some of the stop/kill related logic.

* Take out a few unnecessary instance variables.
  * E.g. `shut_down_now` was a variable used locally and had nothing to do with `shutdown --now`.
* Break up fragments of the run loop into several private methods.
  * Group shutdown logic together, and put them all at the end of the loop.
    Now when it is ready to shutdown, there is no need to `sleep(1)` before do so.
* `abort if any task fails` will now abort with the equivalent of `cylc stop --kill`.
  * It will kill other active tasks to ensure that we do not end up with orphaned tasks.
  * It will wait for event handlers (and event handler retries).
* Deal with this comment https://github.com/cylc/cylc/pull/1892#issuecomment-227383351
* Deal with some incorrectness in the shutdown method.
* Do some very easy pylint changes to `cylc.scheduler`.