### PR TITLE
cylc validate: better error for blank inherit

### DIFF
--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -836,8 +836,8 @@ class SuiteConfig(object):
                 if p not in self.cfg['runtime']:
                     raise SuiteConfigError(
                         "ERROR, undefined parent for " + name + ": " + p)
-            if pts[0] == "None":
-                if len(pts) == 1:
+            if not pts or pts[0] == "None":
+                if len(pts) < 2:
                     raise SuiteConfigError(
                         "ERROR: null parentage for " + name)
                 demoted[name] = pts[1]

--- a/tests/validate/55-missing-parentage.t
+++ b/tests/validate/55-missing-parentage.t
@@ -1,0 +1,29 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2016 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test strict validation of suite for tasks with inherit = [blank]
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 2
+#-------------------------------------------------------------------------------
+install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-val
+run_fail $TEST_NAME cylc validate $SUITE_NAME
+grep_ok 'ERROR: null parentage for foo' "$TEST_NAME.stderr"
+#-------------------------------------------------------------------------------
+purge_suite $SUITE_NAME

--- a/tests/validate/55-missing-parentage/suite.rc
+++ b/tests/validate/55-missing-parentage/suite.rc
@@ -1,0 +1,6 @@
+[scheduling]
+    [[dependencies]]
+        graph = "foo"
+[runtime]
+    [[foo]]
+        inherit =


### PR DESCRIPTION
This fixes a problem where a suite with a null string for a task inherit option will produce the following traceback on validate:

```
Traceback (most recent call last):
  File "/opt/cylc/bin/cylc-validate", line 124, in <module>
    main()
  File "/opt/cylc/bin/cylc-validate", line 73, in main
    write_proc=not options.nowrite)
  File "/opt/cylc/lib/cylc/config.py", line 149, in get_inst
    vis_start_string, vis_stop_string, mem_log_func)
  File "/opt/cylc/lib/cylc/config.py", line 316, in __init__
    self.compute_family_tree()
  File "/opt/cylc/lib/cylc/config.py", line 839, in compute_family_tree
    if pts[0] == "None":
IndexError: list index out of range
```

It now produces a nice `ERROR: null parentage for foo`.

The new test is a copy of tests/validate/07-null-parentage.t, but with the necessary change to the `inherit =`.

@arjclark, please review - I don't think this needs two reviews.