### PR TITLE
cylc test-battery: remove redundant Slurm output file directives

### DIFF
--- a/tests/job-kill/03-slurm/suite.rc
+++ b/tests/job-kill/03-slurm/suite.rc
@@ -17,8 +17,6 @@
         [[[job submission]]]
             method=slurm
         [[[directives]]]
-            --output=slurm-%j.out
-            --error=slurm-%j.err
             --time=03:00
 {% if "CYLC_TEST_BATCH_SITE_DIRECTIVES" in environ and environ["CYLC_TEST_BATCH_SITE_DIRECTIVES"] %}
             {{environ["CYLC_TEST_BATCH_SITE_DIRECTIVES"]}}


### PR DESCRIPTION
This fixes some redundant directives in the Slurm job-kill test that can cause it to fail.
Cylc sets good defaults for these directives anyway.

@arjclark, please review.