### PR TITLE
gscan: visual notification of new errors

### DIFF
--- a/lib/cylc/gui/gscan.py
+++ b/lib/cylc/gui/gscan.py
@@ -694,9 +694,11 @@ class ScanApp(object):
                 if (suite, host) not in self.warnings or not self.warnings[
                         (suite, host)]:
                     return False
-                tooltip.set_markup(tooltip_prefix +
-                                   '\n<b>New failures</b> (<i>last 5</i>)\n' +
-                                   self.warnings[(suite, host)])
+                tooltip.set_markup(
+                    tooltip_prefix +
+                    '\n<b>New failures</b> (<i>last 5</i>) <i><span ' +
+                    'foreground="#2222BB">click to dismiss</span></i>\n' +
+                    self.warnings[(suite, host)])
                 return True
             else:
                 # Hovering over a status indicator.

--- a/lib/cylc/gui/gscan.py
+++ b/lib/cylc/gui/gscan.py
@@ -486,6 +486,7 @@ class ScanApp(object):
             self.warn_icon_grey, 0, False)  # b&w warn icon pixbuf
         status_column.pack_start(warn_icon, expand=False)
         status_column.set_cell_data_func(warn_icon, self._set_error_icon_state)
+        warn_icon.set_property('visible', False)
 
         # Task status icons.
         for i in range(len(TASK_STATUSES_ORDERED)):
@@ -521,6 +522,8 @@ class ScanApp(object):
         self.window.set_default_size(300, 150)
         self.suite_treeview.grab_focus()
         self.window.show()
+
+        self.warning_icon_shown = []
 
     def _on_button_press_event(self, treeview, event):
         x = int(event.x)
@@ -681,8 +684,8 @@ class ScanApp(object):
         # If hovering over a status indicator set tooltip to show most recent
         # tasks.
         dot_offset, dot_width = tuple(column.cell_get_position(
-            column.get_cell_renderers()[1]))
-        cell_index = (cell_x - dot_offset) // dot_width
+            column.get_cell_renderers()[2]))
+        cell_index = ((cell_x - dot_offset) // dot_width) + 1
         if cell_index >= 0:
             # NOTE: TreeViewColumn.get_cell_renderers() does not always return
             # cell renderers for the correct row.
@@ -754,10 +757,16 @@ class ScanApp(object):
             cell.set_property('pixbuf', None)
         elif warnings:
             cell.set_property('pixbuf', self.warn_icon_colour)
+            self.warning_icon_shown.append((suite, host))
+            cell.set_property('visible', True)
             self.warnings[(suite, host)] = warnings
         else:
             cell.set_property('pixbuf', self.warn_icon_grey)
             self.warnings[(suite, host)] = None
+            if (suite, host) in self.warning_icon_shown:
+                cell.set_property('visible', True)
+            else:
+                cell.set_property('visible', False)
 
     def _set_cell_text_host(self, column, cell, model, iter_):
         host = model.get_value(iter_, self.HOST_COLUMN)

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -64,7 +64,8 @@ from cylc.task_state import (
     TASK_STATUS_SUBMIT_FAILED, TASK_STATUS_SUBMIT_RETRYING,
     TASK_STATUS_RUNNING, TASK_STATUS_SUCCEEDED, TASK_STATUS_FAILED,
     TASK_STATUS_RETRYING)
-from cylc.wallclock import get_current_time_string
+from cylc.wallclock import (get_current_time_string,
+                            get_time_string_from_unix_time)
 
 
 class TaskPool(object):
@@ -1400,6 +1401,12 @@ class TaskPool(object):
                 itask.state.set_prerequisites_all_satisfied()
                 itask.state.unset_special_outputs()
                 itask.state.outputs.set_all_incomplete()
+            elif status in [TASK_STATUS_FAILED, TASK_STATUS_SUBMIT_FAILED]:
+                itask.state.reset_state(status)
+                time_ = time()
+                itask.summary['finished_time'] = time_
+                itask.summary['finished_time_string'] = (
+                    get_time_string_from_unix_time(time_))
             else:
                 itask.state.reset_state(status)
         return n_warnings

--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -811,6 +811,9 @@ class TaskProxy(object):
             pass
         if self.sub_try_state.next() is None:
             # No submission retry lined up: definitive failure.
+            self.summary['finished_time'] = float(
+                get_unix_time_from_time_string(event_time))
+            self.summary['finished_time_string'] = event_time
             flags.pflag = True
             # See github #476.
             self.setup_event_handlers(


### PR DESCRIPTION
Closes #1887 

If over six tasks fail between `update` calls then only the six most recent failures will be reported as 'new' warnings, the remainder will be passed over. Otherwise all failures will be shown when hovering over the error icon until dismissed (by clicking on the icon itself).

@benfitzpatrick Please review
@hjoliver Please review