### PR TITLE
Fix spawn before remove. 

### DIFF
--- a/bin/cylc-remove
+++ b/bin/cylc-remove
@@ -47,7 +47,7 @@ def main():
     parser.add_option(
         "--no-spawn",
         help="Do not spawn successors before removal.",
-        action="store_false", default=True, dest="spawn")
+        action="store_true", default=False, dest="no_spawn")
 
     options, args = parser.parse_args()
 
@@ -58,7 +58,8 @@ def main():
         options.port, options.db, my_uuid=options.set_uuid,
         print_uuid=options.print_uuid)
     items, compat = parser.parse_multitask_compat(options, args)
-    pclient.put_command('remove_task', items, compat, options.spawn)
+    pclient.put_command('remove_task', items, compat,
+                        None, not options.no_spawn)
 
 
 if __name__ == "__main__":

--- a/tests/cylc-remove/02-cycling.t
+++ b/tests/cylc-remove/02-cycling.t
@@ -1,0 +1,31 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2016 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test cylc remove in a cycling suite (spawn before remove, and not). 
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 2
+#-------------------------------------------------------------------------------
+install_suite "$TEST_NAME_BASE" "$TEST_NAME_BASE"
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-validate
+run_ok $TEST_NAME cylc validate $SUITE_NAME
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-run
+suite_run_ok $TEST_NAME cylc run --reference-test --debug $SUITE_NAME
+#-------------------------------------------------------------------------------
+purge_suite $SUITE_NAME

--- a/tests/cylc-remove/02-cycling/reference.log
+++ b/tests/cylc-remove/02-cycling/reference.log
@@ -1,0 +1,8 @@
+2016-07-07T22:17:12Z INFO - Run mode: live
+2016-07-07T22:17:12Z INFO - Initial point: 2020
+2016-07-07T22:17:12Z INFO - Final point: 2021
+2016-07-07T22:17:12Z INFO - Cold Start 2020
+2016-07-07T22:17:12Z INFO - [remover.2020] -triggered off []
+2016-07-07T22:17:12Z INFO - [foo.2020] -triggered off []
+2016-07-07T22:17:14Z INFO - [foo.2021] -triggered off []
+2016-07-07T22:17:29Z INFO - [bar.2021] -triggered off ['foo.2021']

--- a/tests/cylc-remove/02-cycling/suite.rc
+++ b/tests/cylc-remove/02-cycling/suite.rc
@@ -1,0 +1,26 @@
+[cylc]
+    UTC mode = True
+    cycle point format = %Y
+    [[reference test]]
+        required run mode = live
+        live mode suite timeout = PT30S
+
+[scheduling]
+    initial cycle point = 2020
+    final cycle point = 2021
+    [[dependencies]]
+        [[[R1]]]
+            graph = remover
+        [[[P1Y]]]
+            graph = foo => bar & baz
+[runtime]
+    [[remover]]
+        script = """
+# Remove first bar, after spawning it
+# (it will run in the second cycle).
+cylc remove $CYLC_SUITE_NAME bar.2020
+# Remove first baz, without spawning it
+# (so it will not run at all).
+cylc remove --no-spawn $CYLC_SUITE_NAME baz.2020"""
+    [[bar, baz]]
+        script = true


### PR DESCRIPTION
This fixes the bug revealed by Jerry on the cylc group today - `cylc remove` should force a task to spawn its successor before removal, by default - and provides a test to maintain the behaviour (our existing "remove" tests were based on non-cycling suites so didn't catch this).

@matthewrmshin - it appears this was caused by command arg backward compatibility concerns in #1715 .  I'm not sure my change is the cleanest way to fix it.  Can you also consider if the few other instances of `_=None` args you introduced there are ok?