### PR TITLE
Fix insert new task after a reload+broadcast

### DIFF
--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -1194,7 +1194,10 @@ conditions; see `cylc conditions`.
         if self.run_mode != self.config.run_mode:
             self.run_mode = self.config.run_mode
 
-        if not reconfigure:
+        if reconfigure:
+            BroadcastServer.get_inst().linearized_ancestors = (
+                self.config.get_linearized_ancestors())
+        else:
             # Things that can't change on suite reload.
 
             self.state_dumper = SuiteStateDumper(

--- a/tests/reload/20-broadcast-insert.t
+++ b/tests/reload/20-broadcast-insert.t
@@ -1,0 +1,29 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2016 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test reload with new task + broadcast + insert new task.
+. "$(dirname "$0")/test_header"
+
+set_test_number 2
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+suite_run_ok "${TEST_NAME_BASE}-run" \
+    cylc run --debug --reference-test "${SUITE_NAME}"
+
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/reload/20-broadcast-insert/reference.log
+++ b/tests/reload/20-broadcast-insert/reference.log
@@ -1,0 +1,4 @@
+2016-07-08T14:53:12+01 INFO - Initial point: 1
+2016-07-08T14:53:12+01 INFO - Final point: 1
+2016-07-08T14:53:12+01 INFO - [foo.1] -triggered off []
+2016-07-08T14:53:19+01 INFO - [bar.1] -triggered off []

--- a/tests/reload/20-broadcast-insert/suite-2.rc
+++ b/tests/reload/20-broadcast-insert/suite-2.rc
@@ -1,0 +1,11 @@
+[cylc]
+   [[reference test]]
+       live mode suite timeout = PT1M
+       required run mode = live
+[scheduling]
+    [[dependencies]]
+        graph=foo&bar
+
+[runtime]
+    [[foo,bar]]
+        script=true

--- a/tests/reload/20-broadcast-insert/suite.rc
+++ b/tests/reload/20-broadcast-insert/suite.rc
@@ -1,0 +1,17 @@
+[cylc]
+   [[reference test]]
+       live mode suite timeout = PT1M
+       required run mode = live
+[scheduling]
+    [[dependencies]]
+        graph=foo
+
+[runtime]
+    [[foo]]
+        script="""
+cylc broadcast "${CYLC_SUITE_NAME}" -s '[environment]CYLC_TEST_VAR=1'
+cp -p "${CYLC_SUITE_DEF_PATH}/suite-2.rc" "${CYLC_SUITE_DEF_PATH}/suite.rc"
+cylc reload "${CYLC_SUITE_NAME}"
+sleep 5
+cylc insert "${CYLC_SUITE_NAME}" 'bar.1'
+"""


### PR DESCRIPTION
Before this change, suite would die when:
* Reload with a new task.
* Broadcast an unrelated setting.
* Insert the new task at a cycle point that has the broadcast setting.

This change ensures that `linearized_ancestors` in the broadcast server is renewed after a reload.