### PR TITLE
Increase task event handler (re)try log levels

### DIFF
--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -1024,20 +1024,20 @@ class TaskPool(object):
                 # Set timer if timeout is None.
                 if not try_state.is_timeout_set():
                     if try_state.next() is None:
-                        itask.log(ERROR, "%s failed" % str(key))
+                        itask.log(WARNING, "%s failed" % str(key))
                         del itask.event_handler_try_states[key]
                         continue
-                    # Report 1st and retries
-                    if try_state.num == 1:
-                        level = INFO
-                        tmpl = "%s will run after %s (after %s)"
-                    else:
-                        level = WARNING
+                    # Report retries and delayed 1st try
+                    tmpl = None
+                    if try_state.num > 1:
                         tmpl = "%s failed, retrying in %s (after %s)"
-                    itask.log(level, tmpl % (
-                        str(key),
-                        try_state.delay_as_seconds(),
-                        try_state.timeout_as_str()))
+                    elif try_state.delay:
+                        tmpl = "%s will run after %s (after %s)"
+                    if tmpl:
+                        itask.log(DEBUG, tmpl % (
+                            str(key),
+                            try_state.delay_as_seconds(),
+                            try_state.timeout_as_str()))
                 # Ready to run?
                 if not try_state.is_delay_done():
                     continue

--- a/tests/events/10-task-event-job-logs-retrieve.t
+++ b/tests/events/10-task-event-job-logs-retrieve.t
@@ -82,11 +82,7 @@ if [[ "${TEST_NAME_BASE}" == *-globalcfg ]]; then
 [t1.1] -('job-logs-retrieve', 3) will run after PT5S
 __LOG__
 else
-    cmp_ok 'edited-log' <<'__LOG__'
-[t1.1] -('job-logs-retrieve', 1) will run after P0Y
-[t1.1] -('job-logs-retrieve', 2) will run after P0Y
-[t1.1] -('job-logs-retrieve', 3) will run after P0Y
-__LOG__
+    cmp_ok 'edited-log' <'/dev/null'  # P0Y not displayed
 fi
 
 ssh -n -oBatchMode=yes -oConnectTimeout=5 "${HOST}" \

--- a/tests/events/15-host-task-event-handler-retry-globalcfg.t
+++ b/tests/events/15-host-task-event-handler-retry-globalcfg.t
@@ -55,9 +55,9 @@ __LOG__
 
 grep 'event-handler-00.*will run after' "${SUITE_RUN_DIR}/log/suite/log" \
     | cut -d' ' -f 4-11 >'edited-log'
+# Note: P0Y delays are not displayed
 cmp_ok 'edited-log' <<'__LOG__'
 [t1.1] -(('event-handler-00', 'succeeded'), 1) will run after PT1S
-[t2.1] -(('event-handler-00', 'succeeded'), 1) will run after P0Y
 __LOG__
 
 ssh -n -oBatchMode=yes -oConnectTimeout=5 "${HOST}" \


### PR DESCRIPTION
Reduce event handler failure (retries exhausted) to WARNING.
Only report attempt 1 if there is a delay.
Only report attempt 1 and retries on debug mode.