### PR TITLE
Don't reset task outputs on retry

### DIFF
--- a/lib/cylc/task_state.py
+++ b/lib/cylc/task_state.py
@@ -461,7 +461,6 @@ class TaskState(object):
         self.outputs.remove(TASK_OUTPUT_SUBMITTED)
         self.set_state(TASK_STATUS_SUBMIT_RETRYING)
         self.set_prerequisites_all_satisfied()
-        self.outputs.set_all_incomplete()
         if self.hold_on_retry:
             self.reset_state(TASK_STATUS_HELD)
 
@@ -516,7 +515,6 @@ class TaskState(object):
         """Manipulate state for job execution retry."""
         self.set_state(TASK_STATUS_RETRYING)
         self.set_prerequisites_all_satisfied()
-        self.outputs.set_all_incomplete()
         if self.hold_on_retry:
             self.reset_state(TASK_STATUS_HELD)
 


### PR DESCRIPTION
This simple change should fix #1600. It is, however, extremely difficult to write a reliable test - as it relies on the timing in the main loop of the scheduler.