### PR TITLE
cylc tab completion.

### DIFF
--- a/bin/cylc-version
+++ b/bin/cylc-version
@@ -28,6 +28,7 @@ For the cylc version of running a suite daemon see
   "cylc get-suite-version"."""
 
 import sys
+import os
 from cylc.remote import remrun
 if remrun().execute():
     sys.exit(0)
@@ -40,8 +41,15 @@ from cylc.version import CYLC_VERSION
 
 def main():
     parser = cop(__doc__, argdoc=[])
+    parser.add_option(
+        "--long",
+        help="Print the path to the current cylc version",
+        action="store_true", dest="long_version", default=False)
     (options, args) = parser.parse_args()
-    print CYLC_VERSION
+    if options.long_version:
+        print "%s (%s)" % (CYLC_VERSION, os.environ["CYLC_DIR"])
+    else:
+        print CYLC_VERSION
 
 
 if __name__ == "__main__":

--- a/conf/cylc-bash-completion
+++ b/conf/cylc-bash-completion
@@ -1,0 +1,52 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2016 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# USAGE
+#     Sets up bash auto-completion for cylc commands.
+#
+#     Users should source this file in their ~/.bashrc, using something
+#     like this:
+#     if [[ $- =~ i && -f /path/to/cylc-bash-completion ]]; then
+#         . /path/to/cylc-bash-completion
+#     fi
+#     where /path/to/cylc-bash-completion is replaced by the path to
+#     this file.
+#
+#     Administrators may want to place this file in the
+#     /etc/bash_completion.d/ (or equivalent) directory.
+#-------------------------------------------------------------------------------
+
+_cylc() {
+
+    local cur prev opts base
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+
+    CYLC_DIR=$(__cylc_get_cylc_dir)
+    cylc_cmds=$(cd $CYLC_DIR/bin && ls cylc-* | sed "s/^cylc-//g")
+
+    COMPREPLY=($(compgen -W "${cylc_cmds}" -- ${cur}))
+    return 0
+
+}
+
+__cylc_get_cylc_dir() {
+    cylc version --long | sed "s/.*(\(.*\))/\1/"
+}
+
+complete -o bashdefault -o default -o nospace -F _cylc cylc


### PR DESCRIPTION
Closes #667 

Implements basic tab completion of cylc commands. Required the addition of a `--long` option to cylc version in order to get the path to the cylc bin directory.

@oliver-sanders @hjoliver please review.