### PR TITLE
Improve configuration dumping logic

### DIFF
--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -15,6 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"Cylc site and user configuration file spec."
 
 import os
 import sys
@@ -24,24 +25,16 @@ import shutil
 from tempfile import mkdtemp
 from parsec.config import config
 from parsec.validate import validator as vdr
-from parsec.validate import (
-    coercers, _strip_and_unquote, _strip_and_unquote_list, _expand_list,
-    IllegalValueError
-)
+from parsec.validate import coercers
 from parsec import ParsecError
-from parsec.util import itemstr
 from parsec.upgrade import upgrader, converter
-from parsec.fileparse import parse
 from cylc.owner import USER
 from cylc.envvar import expandvars
 from cylc.mkdir_p import mkdir_p
 import cylc.flags
-from cylc.cfgspec.utils import coerce_interval
-from cylc.cfgspec.utils import coerce_interval_list
+from cylc.cfgspec.utils import (
+    coerce_interval, coerce_interval_list, DurationFloat)
 from cylc.network import PRIVILEGE_LEVELS
-
-
-"Cylc site and user configuration file spec."
 
 coercers['interval_seconds'] = lambda *args: coerce_interval(
     *args, check_syntax_version=False)
@@ -66,11 +59,13 @@ SPEC = {
         vtype='interval_minutes_list', default=[]),
 
     'task host select command timeout': vdr(
-        vtype='interval_seconds', default=10),
+        vtype='interval_seconds', default=DurationFloat(10)),
     'task messaging': {
-        'retry interval': vdr(vtype='interval_seconds', default=5),
+        'retry interval': vdr(
+            vtype='interval_seconds', default=DurationFloat(5)),
         'maximum number of tries': vdr(vtype='integer', vmin=1, default=7),
-        'connection timeout': vdr(vtype='interval_seconds', default=30),
+        'connection timeout': vdr(
+            vtype='interval_seconds', default=DurationFloat(30)),
 
     },
 
@@ -202,12 +197,12 @@ SPEC = {
                 vtype='string', options=["pyro", "ssh", "poll"]),
             'remote copy template': vdr(vtype='string'),
             'remote shell template': vdr(vtype='string'),
-            'use login shell': vdr(vtype='boolean'),
+            'use login shell': vdr(vtype='boolean', default=None),
             'cylc executable': vdr(vtype='string'),
             'global init-script': vdr(vtype='string'),
             'copyable environment variables': vdr(
                 vtype='string_list', default=[]),
-            'retrieve job logs': vdr(vtype='boolean'),
+            'retrieve job logs': vdr(vtype='boolean', default=None),
             'retrieve job logs command': vdr(vtype='string'),
             'retrieve job logs max size': vdr(vtype='string'),
             'retrieve job logs retry delays': vdr(
@@ -292,6 +287,7 @@ SPEC = {
 
 
 def upg(cfg, descr):
+    """Upgrader."""
     add_bin_dir = converter(lambda x: x + '/bin', "Added + '/bin' to path")
     use_ssh = converter(lambda x: "ssh", "set to 'ssh'")
     u = upgrader(cfg, descr)
@@ -346,11 +342,10 @@ def upg(cfg, descr):
 
 
 class GlobalConfigError(Exception):
-    def __init__(self, msg):
-        self.msg = msg
+    """Error in global site/user configuration."""
 
     def __str__(self):
-        return repr(self.msg)
+        return repr(self.args[0])
 
 
 class GlobalConfig(config):
@@ -370,7 +365,7 @@ class GlobalConfig(config):
     OLD_USER_CONF_BASE = os.path.join("user.rc")
 
     @classmethod
-    def default(cls):
+    def get_inst(cls):
         """Return the singleton instance."""
         if not cls._DEFAULT:
             if cylc.flags.verbose:
@@ -466,9 +461,9 @@ class GlobalConfig(config):
                 host_key = host
             else:
                 # try for a pattern match
-                for h in cfg['hosts']:
-                    if re.match(h, host):
-                        host_key = h
+                for cfg_host in cfg['hosts']:
+                    if re.match(cfg_host, host):
+                        host_key = cfg_host
                         break
         modify_dirs = False
         if host_key:
@@ -507,10 +502,11 @@ class GlobalConfig(config):
         self.create_directory(d, name)
 
     def create_directory(self, d, name):
+        """Create directory. Raise GlobalConfigError on error."""
         try:
             mkdir_p(d)
-        except Exception, x:
-            print >> sys.stderr, str(x)
+        except Exception, exc:
+            print >> sys.stderr, str(exc)
             raise GlobalConfigError(
                 'Failed to create directory "' + name + '"')
 
@@ -574,7 +570,11 @@ class GlobalConfig(config):
         return tmpdir
 
     def transform(self):
-        # host item values of None default to modified localhost values
+        """Transform various settings.
+
+        Host item values of None default to modified localhost values.
+        Expand environment variables and ~ notations.
+        """
         cfg = self.get()
 
         for host in cfg['hosts']:
@@ -600,4 +600,4 @@ class GlobalConfig(config):
                 cfg['hosts']['localhost'][key] = expandvars(val)
 
 
-GLOBAL_CFG = GlobalConfig.default()
+GLOBAL_CFG = GlobalConfig.get_inst()

--- a/lib/cylc/cfgspec/suite.py
+++ b/lib/cylc/cfgspec/suite.py
@@ -15,36 +15,32 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"Define all legal items and values for cylc suite definition files."
 
 import re
 
 from parsec.validate import validator as vdr
-from parsec.validate import (
-    coercers, _strip_and_unquote, _strip_and_unquote_list, _expand_list,
-    IllegalValueError
-)
+from parsec.validate import coercers, _strip_and_unquote, IllegalValueError
 from parsec.util import itemstr
 from parsec.upgrade import upgrader, converter
-from parsec.fileparse import parse
 from parsec.config import config
 from cylc.syntax_flags import (
-    set_syntax_version, VERSION_PREV, VERSION_NEW, SyntaxVersionError
-)
+    set_syntax_version, VERSION_PREV, VERSION_NEW, SyntaxVersionError)
 from isodatetime.dumpers import TimePointDumper
 from isodatetime.data import Calendar, TimePoint
 from isodatetime.parsers import TimePointParser, DurationParser
 from cylc.cycling.integer import REC_INTERVAL as REC_INTEGER_INTERVAL
 
-from cylc.cfgspec.utils import coerce_interval
-from cylc.cfgspec.utils import coerce_interval_list
+from cylc.cfgspec.utils import (
+    coerce_interval, coerce_interval_list, DurationFloat)
 from cylc.cfgspec.globalcfg import GLOBAL_CFG
 from cylc.network import PRIVILEGE_LEVELS
 
-"Define all legal items and values for cylc suite definition files."
 
-
-def _coerce_cycleinterval(value, keys, args):
+def _coerce_cycleinterval(value, keys, _):
     """Coerce value to a cycle interval."""
+    if not value:
+        return None
     value = _strip_and_unquote(keys, value)
     if value.isdigit():
         # Old runahead limit format.
@@ -69,8 +65,10 @@ def _coerce_cycleinterval(value, keys, args):
     return value
 
 
-def _coerce_cycletime(value, keys, args):
+def _coerce_cycletime(value, keys, _):
     """Coerce value to a cycle point."""
+    if not value:
+        return None
     if value == "now":
         # Handle this later in config.py when the suite UTC mode is known.
         return value
@@ -99,13 +97,15 @@ def _coerce_cycletime(value, keys, args):
     return value
 
 
-def _coerce_cycletime_format(value, keys, args):
+def _coerce_cycletime_format(value, keys, _):
     """Coerce value to a cycle point format (either CCYYMM... or %Y%m...)."""
     value = _strip_and_unquote(keys, value)
-    set_syntax_version(VERSION_NEW,
-                       "use of [cylc]cycle point format",
-                       exc_class=IllegalValueError,
-                       exc_args=("cycle point format", keys, value))
+    if not value:
+        return None
+    try:
+        set_syntax_version(VERSION_NEW, "use of [cylc]cycle point format")
+    except SyntaxVersionError:
+        raise IllegalValueError("cycle point format", keys, value)
     test_timepoint = TimePoint(year=2001, month_of_year=3, day_of_month=1,
                                hour_of_day=4, minute_of_hour=30,
                                second_of_minute=54)
@@ -134,13 +134,16 @@ def _coerce_cycletime_format(value, keys, args):
     return value
 
 
-def _coerce_cycletime_time_zone(value, keys, args):
+def _coerce_cycletime_time_zone(value, keys, _):
     """Coerce value to a cycle point time zone format - Z, +13, -0800..."""
     value = _strip_and_unquote(keys, value)
-    set_syntax_version(VERSION_NEW,
-                       "use of [cylc]cycle point time zone format",
-                       exc_class=IllegalValueError,
-                       exc_args=("cycle point time zone format", keys, value))
+    if not value:
+        return None
+    try:
+        set_syntax_version(
+            VERSION_NEW, "use of [cylc]cycle point time zone format")
+    except SyntaxVersionError:
+        raise IllegalValueError("cycle point time zone format", keys, value)
     test_timepoint = TimePoint(year=2001, month_of_year=3, day_of_month=1,
                                hour_of_day=4, minute_of_hour=30,
                                second_of_minute=54)
@@ -155,10 +158,9 @@ def _coerce_cycletime_time_zone(value, keys, args):
     return value
 
 
-def _coerce_final_cycletime(value, keys, args):
+def _coerce_final_cycletime(value, keys, _):
     """Coerce final cycle point."""
-    value = _strip_and_unquote(keys, value)
-    return value
+    return _strip_and_unquote(keys, value)
 
 
 coercers['cycletime'] = _coerce_cycletime
@@ -190,9 +192,9 @@ SPEC = {
         'cycle point time zone': vdr(
             vtype='cycletime_time_zone', default=None),
         'required run mode': vdr(
-            vtype='string', options=['live', 'dummy', 'simulation']),
+            vtype='string', options=['live', 'dummy', 'simulation', '']),
         'force run mode': vdr(
-            vtype='string', options=['live', 'dummy', 'simulation']),
+            vtype='string', options=['live', 'dummy', 'simulation', '']),
         'abort if any task fails': vdr(vtype='boolean', default=False),
         'log resolved dependencies': vdr(vtype='boolean', default=False),
         'disable automatic shutdown': vdr(vtype='boolean', default=False),
@@ -216,8 +218,8 @@ SPEC = {
                 vtype='boolean', default=False),
             'abort if stalled handler fails': vdr(
                 vtype='boolean', default=False),
-            'abort on stalled': vdr(vtype='boolean'),
-            'abort on timeout': vdr(vtype='boolean'),
+            'abort on stalled': vdr(vtype='boolean', default=None),
+            'abort on timeout': vdr(vtype='boolean', default=None),
             'mail events': vdr(vtype='string_list'),
             'mail from': vdr(vtype='string'),
             'mail smtp': vdr(vtype='string'),
@@ -233,15 +235,15 @@ SPEC = {
             'suite shutdown event handler': vdr(
                 vtype='string', default='cylc hook check-triggering'),
             'required run mode': vdr(
-                vtype='string', options=['live', 'simulation', 'dummy']),
+                vtype='string', options=['live', 'simulation', 'dummy', '']),
             'allow task failures': vdr(vtype='boolean', default=False),
             'expected task failures': vdr(vtype='string_list', default=[]),
             'live mode suite timeout': vdr(
-                vtype='interval_minutes', default=60),
+                vtype='interval_minutes', default=DurationFloat(60)),
             'dummy mode suite timeout': vdr(
-                vtype='interval_minutes', default=60),
+                vtype='interval_minutes', default=DurationFloat(60)),
             'simulation mode suite timeout': vdr(
-                vtype='interval_minutes', default=60),
+                vtype='interval_minutes', default=DurationFloat(60)),
         },
         'authentication': {
             # Allow owners to grant public shutdown rights at the most, not
@@ -269,6 +271,7 @@ SPEC = {
         'queues': {
             'default': {
                 'limit': vdr(vtype='integer', default=0),
+                'members': vdr(vtype='string_list', default=[]),
             },
             '__MANY__': {
                 'limit': vdr(vtype='integer', default=0),
@@ -317,7 +320,8 @@ SPEC = {
             },
             'simulation mode': {
                 'run time range': vdr(
-                    vtype='interval_seconds_list', default=[1, 16]),
+                    vtype='interval_seconds_list',
+                    default=[DurationFloat(1), DurationFloat(16)]),
                 'simulate failure': vdr(vtype='boolean', default=False),
                 'disable task event hooks': vdr(vtype='boolean', default=True),
                 'disable retries': vdr(vtype='boolean', default=True),
@@ -349,7 +353,7 @@ SPEC = {
                 'host': vdr(vtype='string'),
                 'owner': vdr(vtype='string'),
                 'suite definition directory': vdr(vtype='string'),
-                'retrieve job logs': vdr(vtype='boolean'),
+                'retrieve job logs': vdr(vtype='boolean', default=None),
                 'retrieve job logs max size': vdr(vtype='string'),
                 'retrieve job logs retry delays': vdr(
                     vtype='interval_minutes_list'),
@@ -366,7 +370,7 @@ SPEC = {
                 'mail to': vdr(vtype='string'),
                 'register job logs retry delays': vdr(
                     vtype='interval_minutes_list'),
-                'reset timer': vdr(vtype='boolean'),
+                'reset timer': vdr(vtype='boolean', default=None),
                 'submission timeout': vdr(vtype='interval_minutes'),
 
                 'expired handler': vdr(vtype='string_list', default=[]),
@@ -392,7 +396,7 @@ SPEC = {
                 'max-polls': vdr(vtype='integer'),
                 'run-dir': vdr(vtype='string'),
                 'template': vdr(vtype='string'),
-                'verbose mode': vdr(vtype='boolean'),
+                'verbose mode': vdr(vtype='boolean', default=None),
             },
             'environment': {
                 '__MANY__': vdr(vtype='string'),
@@ -428,6 +432,7 @@ SPEC = {
 
 
 def upg(cfg, descr):
+    """Upgrade old suite configuration."""
     u = upgrader(cfg, descr)
     u.deprecate(
         '5.2.0',
@@ -559,7 +564,7 @@ def upg(cfg, descr):
     # ___________________________
     try:
         old_cycling_mode = cfg['scheduling']['cycling']
-    except:
+    except KeyError:
         pass
     else:
         if old_cycling_mode in ['Yearly', 'Monthly', 'Daily']:
@@ -574,22 +579,22 @@ def upg(cfg, descr):
             pass
 
 
-class sconfig(config):
-    pass
+class RawSuiteConfig(config):
+    """Raw suite configuration."""
+    _SUITECFG = None
+    _CFPATH = None
 
-
-suitecfg = None
-cfpath = None
-
-
-def get_suitecfg(
-        fpath, force=False, tvars=[], tvars_file=None, write_proc=False):
-    global suitecfg, cfpath
-    if not suitecfg or fpath != cfpath or force:
-        cfpath = fpath
-        # TODO - write_proc should be in loadcfg
-        suitecfg = sconfig(
-            SPEC, upg, tvars=tvars, tvars_file=tvars_file,
-            write_proc=write_proc)
-        suitecfg.loadcfg(fpath, "suite definition")
-    return suitecfg
+    @classmethod
+    def get_inst(cls, fpath, force=False, tvars=None, tvars_file=None,
+                 write_proc=False):
+        """Return the default instance."""
+        if cls._SUITECFG is None or fpath != cls._CFPATH or force:
+            cls._CFPATH = fpath
+            if tvars is None:
+                tvars = []
+            # TODO - write_proc should be in loadcfg
+            cls._SUITECFG = cls(
+                SPEC, upg, tvars=tvars, tvars_file=tvars_file,
+                write_proc=write_proc)
+            cls._SUITECFG.loadcfg(fpath, "suite definition")
+        return cls._SUITECFG

--- a/lib/cylc/job_file.py
+++ b/lib/cylc/job_file.py
@@ -289,11 +289,11 @@ unset S""" % args)
             "\nexport CYLC_TASK_MSG_MAX_TRIES=" +
             str(GLOBAL_CFG.get(['task messaging', 'maximum number of tries'])))
         handle.write(
-            "\nexport CYLC_TASK_MSG_RETRY_INTVL=" + str(GLOBAL_CFG.get(
-                ['task messaging', 'retry interval'])))
+            "\nexport CYLC_TASK_MSG_RETRY_INTVL=%f" %
+            GLOBAL_CFG.get(['task messaging', 'retry interval']))
         handle.write(
-            "\nexport CYLC_TASK_MSG_TIMEOUT=" + str(GLOBAL_CFG.get(
-                ['task messaging', 'connection timeout'])))
+            "\nexport CYLC_TASK_MSG_TIMEOUT=%f" %
+            GLOBAL_CFG.get(['task messaging', 'connection timeout']))
         handle.write("\nexport CYLC_TASK_NAME=" + task_name)
         handle.write(
             '\nexport CYLC_TASK_NAMESPACE_HIERARCHY="' +

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -949,13 +949,12 @@ conditions; see `cylc conditions`.
         base_name = "%s-%s.rc" % (time_str, load_type)
         file_name = os.path.join(cfg_logdir, base_name)
         try:
-            handle = open(file_name, "wb")
+            with open(file_name, "wb") as handle:
+                handle.write("# cylc-version: %s\n" % CYLC_VERSION)
+                printcfg(self.config.cfg, none_str=None, handle=handle)
         except IOError as exc:
             sys.stderr.write(str(exc) + "\n")
             raise SchedulerError("Unable to log the loaded suite definition")
-        handle.write("# cylc-version: %s\n" % CYLC_VERSION)
-        printcfg(self.config.cfg, handle=handle)
-        handle.close()
 
     def _load_initial_cycle_point(self, _, row):
         """Load previous initial cycle point.

--- a/lib/cylc/syntax_flags.py
+++ b/lib/cylc/syntax_flags.py
@@ -43,26 +43,13 @@ class SyntaxVersionError(ValueError):
                 self.args[0], self.args[1]))
 
 
-def set_syntax_version(version, message, exc_class=None,
-                       exc_args=None, exc_kwargs=None):
+def set_syntax_version(version, message):
     """Attempt to define the syntax version.
 
-    If it's already defined differently, raise an exception.
-    The exception is exc_class if it is not None, raised
-    using *exc_args and **exc_kwargs (or using message as the
-    first argument if exc_args and exc_kwargs aren't set).
-    Otherwise, raise SyntaxVersionError.
-
+    If it's already defined differently, raise SyntaxVersionError.
     """
-    if exc_args is None:
-        exc_args = (message,)
-    if exc_kwargs is None:
-        exc_kwargs = {}
-    if exc_class is None:
-        exc_class = SyntaxVersionError
-        exc_args = (version, message)
     if SyntaxVersion.VERSION is None:
         SyntaxVersion.VERSION = version
         SyntaxVersion.VERSION_REASON = message
     elif SyntaxVersion.VERSION != version:
-        raise exc_class(*exc_args, **exc_kwargs)
+        raise SyntaxVersionError(version, message)

--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -1144,6 +1144,9 @@ class TaskProxy(object):
         self.is_manual_submit = False
 
         script, pre_script, post_script = self._get_job_scripts(rtconfig)
+        execution_time_limit = rtconfig['job']['execution time limit']
+        if execution_time_limit:
+            execution_time_limit = float(execution_time_limit)
 
         # Location of job file, etc
         self._create_job_log_path()
@@ -1154,7 +1157,7 @@ class TaskProxy(object):
                 rtconfig['job']['batch submit command template']),
             'batch system conf': batch_sys_conf,
             'directives': rtconfig['directives'],
-            'execution time limit': rtconfig['job']['execution time limit'],
+            'execution time limit': execution_time_limit,
             'env-script': rtconfig['env-script'],
             'host': self.task_host,
             'init-script': rtconfig['init-script'],

--- a/lib/parsec/util.py
+++ b/lib/parsec/util.py
@@ -15,123 +15,140 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Utility functions for printing and manipulating PARSEC NESTED DICTS.
 
-import os
-import sys
-from copy import copy
-from parsec.OrderedDict import OrderedDictWithDefaults
-
-"""
-Utility functions for printing and manipulating PARSEC NESTED DICTS.
 The copy and override functions below assume values are either dicts
 (nesting) or shallow collections of simple types.
 """
 
-def listjoin( lst, none_str='' ):
+import sys
+from copy import copy
+from parsec.OrderedDict import OrderedDictWithDefaults
+
+
+def listjoin(lst, none_str=''):
+    """Return string from joined list.
+
+    Quote all elements if any of them contain comment or list-delimiter
+    characters (currently quoting must be consistent across all elements).
+
+    Note: multi-line values in list is not handle.
+    """
     if not lst:
         # empty list
         return none_str
-    else:
-        # return string from joined list, but quote all elements if any
-        # of them contain comment or list-delimiter characters
-        # (currently quoting must be consistent across all elements)
-        nlst = []
-        quote_me = False
-        for item in lst:
-            if isinstance( item, str ) and ( '#' in item or ',' in item ):
-                quote_me = True
-                break
-        if quote_me:
-            # TODO - this assumes no internal double-quotes
-            return ', '.join( [ '"' + str(item) + '"' for item in lst ] )
+    items = []
+    for item in lst:
+        if item is None:
+            items.append(none_str)
+        elif any([char in str(item) for char in ',#"\'']):
+            items.append(repr(item))  # will be quoted
         else:
-            return ', '.join( [ str(item) for item in lst ] )
+            items.append(str(item))
+    return ', '.join(items)
 
-def printcfg(cfg, level=0, indent=0, prefix='', none_str='', handle=sys.stdout):
+
+def printcfg(cfg, level=0, indent=0, prefix='', none_str='',
+             handle=sys.stdout):
+    """Pretty-print a parsec config item or section (nested dict).
+
+    As returned by parse.config.get().
     """
-    Recursively pretty-print a parsec config item or section (nested
-    dict), as returned by parse.config.get().
-    """
-    spacer = '   '*indent
-    if isinstance(cfg, list):
-        # cfg is a single list value
-        handle.write("%s%s%s\n" % (prefix, spacer, listjoin(cfg, none_str)))
-    elif not isinstance(cfg,dict):
-        # cfg is a single value
-        if not cfg:
-            cfg = none_str
-        handle.write("%s%s%s\n" % (prefix, spacer, str(cfg)))
-    else:
-        # cfg is a possibly-nested section
-        delayed=[]
-        for key,val in cfg.items():
-            if isinstance( val, dict ):
-                # nested (val is a section)
-                # delay output to print top level items before recursing
-                delayed.append((key,val))
-            else:
-                # val is a single value
-                if isinstance( val, list ):
-                    v = listjoin( val, none_str )
-                elif val is None:
-                    v = none_str
+    stack = [("", cfg, level, indent)]
+    while stack:
+        key_i, cfg_i, level_i, indent_i = stack.pop()
+        spacer = " " * 4 * (indent_i - 1)
+        if isinstance(cfg_i, dict):
+            if not cfg_i and none_str is None:
+                # Don't print empty sections if none_str is None. This does not
+                # handle sections with no items printed because the values of
+                # all items are empty or None.
+                continue
+            if key_i and level_i:
+                # Print heading
+                handle.write("%s%s%s%s%s\n" % (
+                    prefix, spacer, '[' * level_i, str(key_i), ']' * level_i))
+            # Nested sections are printed after normal settings
+            subsections = []
+            values = []
+            for key, item in cfg_i.items():
+                if isinstance(item, dict):
+                    subsections.append((key, item, level_i + 1, indent_i + 1))
                 else:
-                    v = str(val)
-                # print "key = val"
-                handle.write("%s%s%s = %s\n" % (prefix, spacer, str(key), v))
+                    values.append((key, item, level_i + 1, indent_i + 1))
 
-        for key,val in delayed:
-            # print heading
-            #if val != None:
-            handle.write("%s%s%s%s%s\n" % (prefix, spacer, '['*(level+1), str(key), ']'*(level+1)))
-            # recurse into section
-            printcfg(val, level+1, indent+1, prefix, none_str, handle)
+            stack += reversed(subsections)
+            stack += reversed(values)
+        else:
+            key = ""
+            if key_i:
+                key = "%s = " % key_i
+            if cfg_i is None:
+                value = none_str
+            elif isinstance(cfg_i, list):
+                value = listjoin(cfg_i, none_str)
+            elif "\n" in str(cfg_i) and key:
+                value = '"""\n%s\n"""' % (cfg_i)
+            else:
+                value = str(cfg_i)
+            if value is not None:
+                handle.write("%s%s%s%s\n" % (prefix, spacer, key, value))
 
-def replicate( target, source ):
-    """
-    Replicate source *into* target. Source elements need not exist in
-    target already, so source overrides common elements in target and
-    otherwise adds elements to it.
+
+def replicate(target, source):
+    """Replicate source *into* target.
+
+    Source elements need not exist in target already, so source overrides
+    common elements in target and otherwise adds elements to it.
     """
     if not source:
         target = OrderedDictWithDefaults()
         return
     if hasattr(source, "defaults_"):
         target.defaults_ = pdeepcopy(source.defaults_)
-    for key,val in source.items():
-        if isinstance( val, dict ):
+    for key, val in source.items():
+        if isinstance(val, dict):
             if key not in target:
                 target[key] = OrderedDictWithDefaults()
             if hasattr(val, 'defaults_'):
                 target[key].defaults_ = pdeepcopy(val.defaults_)
-            replicate( target[key], val )
-        elif isinstance( val, list ):
+            replicate(target[key], val)
+        elif isinstance(val, list):
             target[key] = val[:]
         else:
             target[key] = val
+
 
 def pdeepcopy(source):
     """Make a deep copy of a pdict source"""
     target = OrderedDictWithDefaults()
-    replicate( target, source )
+    replicate(target, source)
     return target
 
-def poverride( target, sparse ):
-    """Override items in a target pdict, target sub-dicts must already exist."""
+
+def poverride(target, sparse):
+    """Override items in a target pdict.
+
+    Target sub-dicts must already exist.
+    """
     if not sparse:
         target = OrderedDictWithDefaults()
         return
-    for key,val in sparse.items():
-        if isinstance( val, dict ):
-            poverride( target[key], val )
-        elif isinstance( val, list ):
+    for key, val in sparse.items():
+        if isinstance(val, dict):
+            poverride(target[key], val)
+        elif isinstance(val, list):
             target[key] = val[:]
         else:
             target[key] = val
 
-def m_override( target, sparse ):
-    """Override items in a target pdict. Target keys must already exist
-    unless there is a "__MANY__" placeholder in the right position."""
+
+def m_override(target, sparse):
+    """Override items in a target pdict.
+
+    Target keys must already exist unless there is a "__MANY__" placeholder in
+    the right position.
+    """
     if not sparse:
         target = OrderedDictWithDefaults()
         return
@@ -142,7 +159,7 @@ def m_override( target, sparse ):
         if many_defaults:
             defaults_list.append((dest, many_defaults))
         for key, val in source.items():
-            if isinstance( val, dict ):
+            if isinstance(val, dict):
                 if key in many_defaults:
                     child_many_defaults = many_defaults[key]
                 else:
@@ -158,27 +175,31 @@ def m_override( target, sparse ):
                     elif key in many_defaults:
                         dest[key] = OrderedDictWithDefaults()
                     else:
-                        # TODO - validation prevents this, but handle properly for completeness.
+                        # TODO - validation prevents this, but handle properly
+                        # for completeness.
                         raise Exception(
                             "parsec dict override: no __MANY__ placeholder" +
                             "%s" % (keylist + [key])
                         )
-                stack.append((val, dest[key], keylist + [key], child_many_defaults))
+                stack.append(
+                    (val, dest[key], keylist + [key], child_many_defaults))
             else:
                 if key not in dest:
-                    if '__MANY__' in dest or key in many_defaults or '__MANY__' in many_defaults:
-                        if isinstance( val, list ):
+                    if ('__MANY__' in dest or key in many_defaults or
+                            '__MANY__' in many_defaults):
+                        if isinstance(val, list):
                             dest[key] = val[:]
                         else:
                             dest[key] = val
 
                     else:
-                        # TODO - validation prevents this, but handle properly for completeness.
+                        # TODO - validation prevents this, but handle properly
+                        # for completeness.
                         raise Exception(
                             "parsec dict override: no __MANY__ placeholder" +
                             "%s" % (keylist + [key])
                         )
-                if isinstance( val, list ):
+                if isinstance(val, list):
                     dest[key] = val[:]
                 else:
                     dest[key] = val
@@ -186,11 +207,11 @@ def m_override( target, sparse ):
         dest_dict.defaults_ = defaults
 
 
-def un_many( cfig ):
+def un_many(cfig):
     """Remove any '__MANY__' items from a nested dict, in-place."""
     if not cfig:
         return
-    for key,val in cfig.items():
+    for key, val in cfig.items():
         if key == '__MANY__':
             try:
                 del cfig[key]
@@ -199,53 +220,55 @@ def un_many( cfig ):
                     del cfig.defaults_[key]
                 else:
                     raise
-        elif isinstance( val, dict ):
-            un_many( cfig[key] )
+        elif isinstance(val, dict):
+            un_many(cfig[key])
 
 
-def itemstr( parents=[], item=None, value=None ):
+def itemstr(parents=None, item=None, value=None):
     """
     Pretty-print an item from list of sections, item name, and value
     E.g.: ([sec1, sec2], item, value) to '[sec1][sec2]item = value'.
     """
-    keys = copy(parents)
-    if keys and value and not item:
-        # last parent is the item
-        item = keys[-1]
-        keys.remove(item)
-    if keys:
-        s = '[' + ']['.join(keys) + ']'
+    if parents:
+        keys = copy(parents)
+        if value and not item:
+            # last parent is the item
+            item = keys[-1]
+            keys.remove(item)
+        text = '[' + ']['.join(keys) + ']'
     else:
-        s = ''
+        text = ''
     if item:
-        s += str(item)
+        text += str(item)
         if value:
-            s += " = " + str(value)
-    if not s:
-        s = str(value)
+            text += " = " + str(value)
+    if not text:
+        text = str(value)
 
-    return s
+    return text
 
 
 if __name__ == "__main__":
     print 'Item strings:'
-    print '  ', itemstr( ['sec1','sec2'], 'item', 'value' )
-    print '  ', itemstr( ['sec1','sec2'], 'item' )
-    print '  ', itemstr( ['sec1','sec2'] )
-    print '  ', itemstr( ['sec1'] )
-    print '  ', itemstr( item='item', value='value' )
-    print '  ', itemstr( item='item' )
-    print '  ', itemstr( value='value' )
-    print '  ', itemstr( parents=['sec1','sec2'], value='value' ) # error or useful?
+    print '  ', itemstr(['sec1', 'sec2'], 'item', 'value')
+    print '  ', itemstr(['sec1', 'sec2'], 'item')
+    print '  ', itemstr(['sec1', 'sec2'])
+    print '  ', itemstr(['sec1'])
+    print '  ', itemstr(item='item', value='value')
+    print '  ', itemstr(item='item')
+    print '  ', itemstr(value='value')
+    # error or useful?
+    print '  ', itemstr(parents=['sec1', 'sec2'], value='value')
 
     print 'Configs:'
-    printcfg( 'foo', prefix=' > ' )
-    printcfg( ['foo','bar'], prefix=' > ' )
-    printcfg( {}, prefix=' > ' )
-    printcfg( { 'foo' : 1 }, prefix=' > ' )
-    printcfg( { 'foo' : None }, prefix=' > ' )
-    printcfg( { 'foo' : None }, none_str='(none)', prefix=' > ' )
-    printcfg( { 'foo' : { 'bar' : 1 } }, prefix=' > ' )
-    printcfg( { 'foo' : { 'bar' : None } }, prefix=' > ' )
-    printcfg( { 'foo' : { 'bar' : None } }, none_str='(none)', prefix=' > ' )
-    printcfg( { 'foo' : { 'bar' : 1, 'baz' : 2, 'qux' : { 'boo' : None} } }, none_str='(none)', prefix=' > ' )
+    printcfg('foo', prefix=' > ')
+    printcfg(['foo', 'bar'], prefix=' > ')
+    printcfg({}, prefix=' > ')
+    printcfg({'foo': 1}, prefix=' > ')
+    printcfg({'foo': None}, prefix=' > ')
+    printcfg({'foo': None}, none_str='(none)', prefix=' > ')
+    printcfg({'foo': {'bar': 1}}, prefix=' > ')
+    printcfg({'foo': {'bar': None}}, prefix=' > ')
+    printcfg({'foo': {'bar': None}}, none_str='(none)', prefix=' > ')
+    printcfg({'foo': {'bar': 1, 'baz': 2, 'qux': {'boo': None}}},
+             none_str='(none)', prefix=' > ')

--- a/tests/config-log/00-basic.t
+++ b/tests/config-log/00-basic.t
@@ -18,7 +18,7 @@
 # Test suite config logging.
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
-set_test_number 6
+set_test_number 8
 #-------------------------------------------------------------------------------
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
@@ -50,6 +50,8 @@ RUN_LOG=$(ls $LOG_DIR/*run.rc)
 REL_LOG=$(ls $LOG_DIR/*reload.rc)
 RES_LOG=$(ls $LOG_DIR/*restart.rc)
 cmp_ok $RUN_LOG $REL_LOG
+run_ok "${TEST_NAME_BASE}-validate-run-rc" cylc validate "${RUN_LOG}"
+run_ok "${TEST_NAME_BASE}-validate-restart-rc" cylc validate "${RES_LOG}"
 #-------------------------------------------------------------------------------
 # The run and restart logs should differ in the suite description.
 TEST_NAME=$TEST_NAME_BASE-comp1

--- a/tests/cylc-get-config/00-simple.t
+++ b/tests/cylc-get-config/00-simple.t
@@ -16,15 +16,16 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test cylc get-config
-. $(dirname $0)/test_header
+. "$(dirname "$0")/test_header"
 #-------------------------------------------------------------------------------
-set_test_number 14
+set_test_number 15
 #-------------------------------------------------------------------------------
-init_suite "$TEST_NAME_BASE" "$TEST_SOURCE_DIR/$TEST_NAME_BASE/suite.rc"
+init_suite "${TEST_NAME_BASE}" "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/suite.rc"
 #-------------------------------------------------------------------------------
-TEST_NAME=$TEST_NAME_BASE-all
-run_ok $TEST_NAME cylc get-config $SUITE_NAME
-cmp_ok $TEST_NAME.stderr - </dev/null
+TEST_NAME="${TEST_NAME_BASE}-all"
+run_ok "${TEST_NAME}" cylc get-config "${SUITE_NAME}"
+run_ok "${TEST_NAME}-validate" cylc validate --strict "${TEST_NAME}.stdout"
+cmp_ok "${TEST_NAME}.stderr" <'/dev/null'
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-section1
 run_ok $TEST_NAME cylc get-config --item=[scheduling] $SUITE_NAME

--- a/tests/cylc-get-config/00-simple/section1.stdout
+++ b/tests/cylc-get-config/00-simple/section1.stdout
@@ -7,17 +7,17 @@ initial cycle point = 1
 initial cycle point constraints = 
 final cycle point = 1
 [[dependencies]]
-   graph = OPS:finish-all => VAR
+    graph = OPS:finish-all => VAR
 [[queues]]
-   [[[default]]]
-      limit = 0
-      members = ops_s1, ops_s2, ops_p1, ops_p2, var_p1, var_p2, var_s1, var_s2
+    [[[default]]]
+        limit = 0
+        members = ops_s1, ops_s2, ops_p1, ops_p2, var_p1, var_p2, var_s1, var_s2
 [[special tasks]]
-   clock-trigger = 
-   external-trigger = 
-   sequential = 
-   clock-expire = 
-   include at start-up = 
-   start-up = 
-   exclude at start-up = 
-   cold-start = 
+    clock-trigger = 
+    external-trigger = 
+    sequential = 
+    clock-expire = 
+    include at start-up = 
+    start-up = 
+    exclude at start-up = 
+    cold-start = 

--- a/tests/cylc-get-config/00-simple/section2.stdout
+++ b/tests/cylc-get-config/00-simple/section2.stdout
@@ -1,1024 +1,1024 @@
 [[var_p2]]
-   script = echo "RUN: run-var.sh"
-   enable resurrection = False
-   env-script = 
-   title = 
-   URL = 
-   extra log files = 
-   work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
-   description = 
-   init-script = 
-   pre-script = 
-   post-script = 
-   inherit = VAR, PARALLEL
-   [[[events]]]
-      submission timeout handler = 
-      submitted handler = 
-      started handler = 
-      execution timeout handler = 
-      expired handler = 
-      submission failed handler = 
-      submission retry handler = 
-      warning handler = 
-      succeeded handler = 
-      retry handler = 
-      failed handler = 
-      handler events = 
-      mail smtp = 
-      handlers = 
-      mail events = 
-      mail retry delays = 
-      handler retry delays = 
-      mail to = 
-      mail from = 
-      execution timeout = 
-      submission timeout = 
-      register job logs retry delays = 
-      reset timer = 
-   [[[environment]]]
-   [[[directives]]]
-      job_type = parallel
-   [[[environment filter]]]
-      exclude = 
-      include = 
-   [[[dummy mode]]]
-      disable pre-script = True
-      disable post-script = True
-      disable retries = True
-      script = echo Dummy task; sleep $(cylc rnd 1 16)
-      disable task event hooks = True
-   [[[outputs]]]
-   [[[simulation mode]]]
-      run time range = 1, 16
-      simulate failure = False
-      disable retries = True
-      disable task event hooks = True
-   [[[suite state polling]]]
-      interval = 
-      host = 
-      max-polls = 
-      run-dir = 
-      user = 
-      template = 
-      verbose mode = 
-   [[[remote]]]
-      owner = 
-      suite definition directory = 
-      host = 
-      retrieve job logs = 
-      retrieve job logs max size = 
-      retrieve job logs retry delays = 
-   [[[job]]]
-      shell = /bin/bash
-      batch submit command template = 
-      batch system = background
-      submission retry delays = 
-      execution retry delays = 
-      submission polling intervals = 
-      execution polling intervals = 
-      execution time limit = 
+    script = echo "RUN: run-var.sh"
+    enable resurrection = False
+    env-script = 
+    title = 
+    URL = 
+    extra log files = 
+    work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
+    description = 
+    init-script = 
+    pre-script = 
+    post-script = 
+    inherit = VAR, PARALLEL
+    [[[events]]]
+        submission timeout handler = 
+        submitted handler = 
+        started handler = 
+        execution timeout handler = 
+        expired handler = 
+        submission failed handler = 
+        submission retry handler = 
+        warning handler = 
+        succeeded handler = 
+        retry handler = 
+        failed handler = 
+        handler events = 
+        mail smtp = 
+        handlers = 
+        mail events = 
+        mail retry delays = 
+        handler retry delays = 
+        mail to = 
+        mail from = 
+        execution timeout = 
+        submission timeout = 
+        register job logs retry delays = 
+        reset timer = 
+    [[[environment]]]
+    [[[directives]]]
+        job_type = parallel
+    [[[environment filter]]]
+        exclude = 
+        include = 
+    [[[dummy mode]]]
+        disable pre-script = True
+        disable post-script = True
+        disable retries = True
+        script = echo Dummy task; sleep $(cylc rnd 1 16)
+        disable task event hooks = True
+    [[[outputs]]]
+    [[[simulation mode]]]
+        run time range = PT1S, PT16S
+        simulate failure = False
+        disable retries = True
+        disable task event hooks = True
+    [[[suite state polling]]]
+        interval = 
+        host = 
+        max-polls = 
+        run-dir = 
+        user = 
+        template = 
+        verbose mode = 
+    [[[remote]]]
+        owner = 
+        suite definition directory = 
+        host = 
+        retrieve job logs = 
+        retrieve job logs max size = 
+        retrieve job logs retry delays = 
+    [[[job]]]
+        shell = /bin/bash
+        batch submit command template = 
+        batch system = background
+        submission retry delays = 
+        execution retry delays = 
+        submission polling intervals = 
+        execution polling intervals = 
+        execution time limit = 
 [[OPS]]
-   script = echo "RUN: run-ops.sh"
-   enable resurrection = False
-   env-script = 
-   title = 
-   URL = 
-   extra log files = 
-   work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
-   description = 
-   init-script = 
-   pre-script = 
-   post-script = 
-   inherit = 
-   [[[events]]]
-      submission timeout handler = 
-      submitted handler = 
-      started handler = 
-      execution timeout handler = 
-      expired handler = 
-      submission failed handler = 
-      submission retry handler = 
-      warning handler = 
-      succeeded handler = 
-      retry handler = 
-      failed handler = 
-      handler events = 
-      mail smtp = 
-      handlers = 
-      mail events = 
-      mail retry delays = 
-      handler retry delays = 
-      mail to = 
-      mail from = 
-      execution timeout = 
-      submission timeout = 
-      register job logs retry delays = 
-      reset timer = 
-   [[[environment]]]
-   [[[directives]]]
-   [[[environment filter]]]
-      exclude = 
-      include = 
-   [[[dummy mode]]]
-      disable pre-script = True
-      disable post-script = True
-      disable retries = True
-      script = echo Dummy task; sleep $(cylc rnd 1 16)
-      disable task event hooks = True
-   [[[outputs]]]
-   [[[simulation mode]]]
-      run time range = 1, 16
-      simulate failure = False
-      disable retries = True
-      disable task event hooks = True
-   [[[suite state polling]]]
-      interval = 
-      host = 
-      max-polls = 
-      run-dir = 
-      user = 
-      template = 
-      verbose mode = 
-   [[[remote]]]
-      owner = 
-      suite definition directory = 
-      host = 
-      retrieve job logs = 
-      retrieve job logs max size = 
-      retrieve job logs retry delays = 
-   [[[job]]]
-      shell = /bin/bash
-      batch submit command template = 
-      batch system = background
-      submission retry delays = 
-      execution retry delays = 
-      submission polling intervals = 
-      execution polling intervals = 
-      execution time limit = 
+    script = echo "RUN: run-ops.sh"
+    enable resurrection = False
+    env-script = 
+    title = 
+    URL = 
+    extra log files = 
+    work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
+    description = 
+    init-script = 
+    pre-script = 
+    post-script = 
+    inherit = 
+    [[[events]]]
+        submission timeout handler = 
+        submitted handler = 
+        started handler = 
+        execution timeout handler = 
+        expired handler = 
+        submission failed handler = 
+        submission retry handler = 
+        warning handler = 
+        succeeded handler = 
+        retry handler = 
+        failed handler = 
+        handler events = 
+        mail smtp = 
+        handlers = 
+        mail events = 
+        mail retry delays = 
+        handler retry delays = 
+        mail to = 
+        mail from = 
+        execution timeout = 
+        submission timeout = 
+        register job logs retry delays = 
+        reset timer = 
+    [[[environment]]]
+    [[[directives]]]
+    [[[environment filter]]]
+        exclude = 
+        include = 
+    [[[dummy mode]]]
+        disable pre-script = True
+        disable post-script = True
+        disable retries = True
+        script = echo Dummy task; sleep $(cylc rnd 1 16)
+        disable task event hooks = True
+    [[[outputs]]]
+    [[[simulation mode]]]
+        run time range = PT1S, PT16S
+        simulate failure = False
+        disable retries = True
+        disable task event hooks = True
+    [[[suite state polling]]]
+        interval = 
+        host = 
+        max-polls = 
+        run-dir = 
+        user = 
+        template = 
+        verbose mode = 
+    [[[remote]]]
+        owner = 
+        suite definition directory = 
+        host = 
+        retrieve job logs = 
+        retrieve job logs max size = 
+        retrieve job logs retry delays = 
+    [[[job]]]
+        shell = /bin/bash
+        batch submit command template = 
+        batch system = background
+        submission retry delays = 
+        execution retry delays = 
+        submission polling intervals = 
+        execution polling intervals = 
+        execution time limit = 
 [[ops_s1]]
-   script = echo "RUN: run-ops.sh"
-   enable resurrection = False
-   env-script = 
-   title = 
-   URL = 
-   extra log files = 
-   work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
-   description = 
-   init-script = 
-   pre-script = 
-   post-script = 
-   inherit = OPS, SERIAL
-   [[[events]]]
-      submission timeout handler = 
-      submitted handler = 
-      started handler = 
-      execution timeout handler = 
-      expired handler = 
-      submission failed handler = 
-      submission retry handler = 
-      warning handler = 
-      succeeded handler = 
-      retry handler = 
-      failed handler = 
-      handler events = 
-      mail smtp = 
-      handlers = 
-      mail events = 
-      mail retry delays = 
-      handler retry delays = 
-      mail to = 
-      mail from = 
-      execution timeout = 
-      submission timeout = 
-      register job logs retry delays = 
-      reset timer = 
-   [[[environment]]]
-   [[[directives]]]
-      job_type = serial
-   [[[environment filter]]]
-      exclude = 
-      include = 
-   [[[dummy mode]]]
-      disable pre-script = True
-      disable post-script = True
-      disable retries = True
-      script = echo Dummy task; sleep $(cylc rnd 1 16)
-      disable task event hooks = True
-   [[[outputs]]]
-   [[[simulation mode]]]
-      run time range = 1, 16
-      simulate failure = False
-      disable retries = True
-      disable task event hooks = True
-   [[[suite state polling]]]
-      interval = 
-      host = 
-      max-polls = 
-      run-dir = 
-      user = 
-      template = 
-      verbose mode = 
-   [[[remote]]]
-      owner = 
-      suite definition directory = 
-      host = 
-      retrieve job logs = 
-      retrieve job logs max size = 
-      retrieve job logs retry delays = 
-   [[[job]]]
-      shell = /bin/bash
-      batch submit command template = 
-      batch system = background
-      submission retry delays = 
-      execution retry delays = 
-      submission polling intervals = 
-      execution polling intervals = 
-      execution time limit = 
+    script = echo "RUN: run-ops.sh"
+    enable resurrection = False
+    env-script = 
+    title = 
+    URL = 
+    extra log files = 
+    work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
+    description = 
+    init-script = 
+    pre-script = 
+    post-script = 
+    inherit = OPS, SERIAL
+    [[[events]]]
+        submission timeout handler = 
+        submitted handler = 
+        started handler = 
+        execution timeout handler = 
+        expired handler = 
+        submission failed handler = 
+        submission retry handler = 
+        warning handler = 
+        succeeded handler = 
+        retry handler = 
+        failed handler = 
+        handler events = 
+        mail smtp = 
+        handlers = 
+        mail events = 
+        mail retry delays = 
+        handler retry delays = 
+        mail to = 
+        mail from = 
+        execution timeout = 
+        submission timeout = 
+        register job logs retry delays = 
+        reset timer = 
+    [[[environment]]]
+    [[[directives]]]
+        job_type = serial
+    [[[environment filter]]]
+        exclude = 
+        include = 
+    [[[dummy mode]]]
+        disable pre-script = True
+        disable post-script = True
+        disable retries = True
+        script = echo Dummy task; sleep $(cylc rnd 1 16)
+        disable task event hooks = True
+    [[[outputs]]]
+    [[[simulation mode]]]
+        run time range = PT1S, PT16S
+        simulate failure = False
+        disable retries = True
+        disable task event hooks = True
+    [[[suite state polling]]]
+        interval = 
+        host = 
+        max-polls = 
+        run-dir = 
+        user = 
+        template = 
+        verbose mode = 
+    [[[remote]]]
+        owner = 
+        suite definition directory = 
+        host = 
+        retrieve job logs = 
+        retrieve job logs max size = 
+        retrieve job logs retry delays = 
+    [[[job]]]
+        shell = /bin/bash
+        batch submit command template = 
+        batch system = background
+        submission retry delays = 
+        execution retry delays = 
+        submission polling intervals = 
+        execution polling intervals = 
+        execution time limit = 
 [[ops_s2]]
-   script = echo "RUN: run-ops.sh"
-   enable resurrection = False
-   env-script = 
-   title = 
-   URL = 
-   extra log files = 
-   work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
-   description = 
-   init-script = 
-   pre-script = 
-   post-script = 
-   inherit = OPS, SERIAL
-   [[[events]]]
-      submission timeout handler = 
-      submitted handler = 
-      started handler = 
-      execution timeout handler = 
-      expired handler = 
-      submission failed handler = 
-      submission retry handler = 
-      warning handler = 
-      succeeded handler = 
-      retry handler = 
-      failed handler = 
-      handler events = 
-      mail smtp = 
-      handlers = 
-      mail events = 
-      mail retry delays = 
-      handler retry delays = 
-      mail to = 
-      mail from = 
-      execution timeout = 
-      submission timeout = 
-      register job logs retry delays = 
-      reset timer = 
-   [[[environment]]]
-   [[[directives]]]
-      job_type = serial
-   [[[environment filter]]]
-      exclude = 
-      include = 
-   [[[dummy mode]]]
-      disable pre-script = True
-      disable post-script = True
-      disable retries = True
-      script = echo Dummy task; sleep $(cylc rnd 1 16)
-      disable task event hooks = True
-   [[[outputs]]]
-   [[[simulation mode]]]
-      run time range = 1, 16
-      simulate failure = False
-      disable retries = True
-      disable task event hooks = True
-   [[[suite state polling]]]
-      interval = 
-      host = 
-      max-polls = 
-      run-dir = 
-      user = 
-      template = 
-      verbose mode = 
-   [[[remote]]]
-      owner = 
-      suite definition directory = 
-      host = 
-      retrieve job logs = 
-      retrieve job logs max size = 
-      retrieve job logs retry delays = 
-   [[[job]]]
-      shell = /bin/bash
-      batch submit command template = 
-      batch system = background
-      submission retry delays = 
-      execution retry delays = 
-      submission polling intervals = 
-      execution polling intervals = 
-      execution time limit = 
+    script = echo "RUN: run-ops.sh"
+    enable resurrection = False
+    env-script = 
+    title = 
+    URL = 
+    extra log files = 
+    work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
+    description = 
+    init-script = 
+    pre-script = 
+    post-script = 
+    inherit = OPS, SERIAL
+    [[[events]]]
+        submission timeout handler = 
+        submitted handler = 
+        started handler = 
+        execution timeout handler = 
+        expired handler = 
+        submission failed handler = 
+        submission retry handler = 
+        warning handler = 
+        succeeded handler = 
+        retry handler = 
+        failed handler = 
+        handler events = 
+        mail smtp = 
+        handlers = 
+        mail events = 
+        mail retry delays = 
+        handler retry delays = 
+        mail to = 
+        mail from = 
+        execution timeout = 
+        submission timeout = 
+        register job logs retry delays = 
+        reset timer = 
+    [[[environment]]]
+    [[[directives]]]
+        job_type = serial
+    [[[environment filter]]]
+        exclude = 
+        include = 
+    [[[dummy mode]]]
+        disable pre-script = True
+        disable post-script = True
+        disable retries = True
+        script = echo Dummy task; sleep $(cylc rnd 1 16)
+        disable task event hooks = True
+    [[[outputs]]]
+    [[[simulation mode]]]
+        run time range = PT1S, PT16S
+        simulate failure = False
+        disable retries = True
+        disable task event hooks = True
+    [[[suite state polling]]]
+        interval = 
+        host = 
+        max-polls = 
+        run-dir = 
+        user = 
+        template = 
+        verbose mode = 
+    [[[remote]]]
+        owner = 
+        suite definition directory = 
+        host = 
+        retrieve job logs = 
+        retrieve job logs max size = 
+        retrieve job logs retry delays = 
+    [[[job]]]
+        shell = /bin/bash
+        batch submit command template = 
+        batch system = background
+        submission retry delays = 
+        execution retry delays = 
+        submission polling intervals = 
+        execution polling intervals = 
+        execution time limit = 
 [[ops_p1]]
-   script = echo "RUN: run-ops.sh"
-   enable resurrection = False
-   env-script = 
-   title = 
-   URL = 
-   extra log files = 
-   work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
-   description = 
-   init-script = 
-   pre-script = 
-   post-script = 
-   inherit = OPS, PARALLEL
-   [[[events]]]
-      submission timeout handler = 
-      submitted handler = 
-      started handler = 
-      execution timeout handler = 
-      expired handler = 
-      submission failed handler = 
-      submission retry handler = 
-      warning handler = 
-      succeeded handler = 
-      retry handler = 
-      failed handler = 
-      handler events = 
-      mail smtp = 
-      handlers = 
-      mail events = 
-      mail retry delays = 
-      handler retry delays = 
-      mail to = 
-      mail from = 
-      execution timeout = 
-      submission timeout = 
-      register job logs retry delays = 
-      reset timer = 
-   [[[environment]]]
-   [[[directives]]]
-      job_type = parallel
-   [[[environment filter]]]
-      exclude = 
-      include = 
-   [[[dummy mode]]]
-      disable pre-script = True
-      disable post-script = True
-      disable retries = True
-      script = echo Dummy task; sleep $(cylc rnd 1 16)
-      disable task event hooks = True
-   [[[outputs]]]
-   [[[simulation mode]]]
-      run time range = 1, 16
-      simulate failure = False
-      disable retries = True
-      disable task event hooks = True
-   [[[suite state polling]]]
-      interval = 
-      host = 
-      max-polls = 
-      run-dir = 
-      user = 
-      template = 
-      verbose mode = 
-   [[[remote]]]
-      owner = 
-      suite definition directory = 
-      host = 
-      retrieve job logs = 
-      retrieve job logs max size = 
-      retrieve job logs retry delays = 
-   [[[job]]]
-      shell = /bin/bash
-      batch submit command template = 
-      batch system = background
-      submission retry delays = 
-      execution retry delays = 
-      submission polling intervals = 
-      execution polling intervals = 
-      execution time limit = 
+    script = echo "RUN: run-ops.sh"
+    enable resurrection = False
+    env-script = 
+    title = 
+    URL = 
+    extra log files = 
+    work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
+    description = 
+    init-script = 
+    pre-script = 
+    post-script = 
+    inherit = OPS, PARALLEL
+    [[[events]]]
+        submission timeout handler = 
+        submitted handler = 
+        started handler = 
+        execution timeout handler = 
+        expired handler = 
+        submission failed handler = 
+        submission retry handler = 
+        warning handler = 
+        succeeded handler = 
+        retry handler = 
+        failed handler = 
+        handler events = 
+        mail smtp = 
+        handlers = 
+        mail events = 
+        mail retry delays = 
+        handler retry delays = 
+        mail to = 
+        mail from = 
+        execution timeout = 
+        submission timeout = 
+        register job logs retry delays = 
+        reset timer = 
+    [[[environment]]]
+    [[[directives]]]
+        job_type = parallel
+    [[[environment filter]]]
+        exclude = 
+        include = 
+    [[[dummy mode]]]
+        disable pre-script = True
+        disable post-script = True
+        disable retries = True
+        script = echo Dummy task; sleep $(cylc rnd 1 16)
+        disable task event hooks = True
+    [[[outputs]]]
+    [[[simulation mode]]]
+        run time range = PT1S, PT16S
+        simulate failure = False
+        disable retries = True
+        disable task event hooks = True
+    [[[suite state polling]]]
+        interval = 
+        host = 
+        max-polls = 
+        run-dir = 
+        user = 
+        template = 
+        verbose mode = 
+    [[[remote]]]
+        owner = 
+        suite definition directory = 
+        host = 
+        retrieve job logs = 
+        retrieve job logs max size = 
+        retrieve job logs retry delays = 
+    [[[job]]]
+        shell = /bin/bash
+        batch submit command template = 
+        batch system = background
+        submission retry delays = 
+        execution retry delays = 
+        submission polling intervals = 
+        execution polling intervals = 
+        execution time limit = 
 [[ops_p2]]
-   script = echo "RUN: run-ops.sh"
-   enable resurrection = False
-   env-script = 
-   title = 
-   URL = 
-   extra log files = 
-   work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
-   description = 
-   init-script = 
-   pre-script = 
-   post-script = 
-   inherit = OPS, PARALLEL
-   [[[events]]]
-      handler events = 
-      mail smtp = 
-      handlers = 
-      mail events = 
-      mail retry delays = 
-      handler retry delays = 
-      mail to = 
-      mail from = 
-      execution timeout = 
-      submission timeout = 
-      register job logs retry delays = 
-      reset timer = 
-      submission timeout handler = 
-      submitted handler = 
-      started handler = 
-      execution timeout handler = 
-      expired handler = 
-      submission failed handler = 
-      submission retry handler = 
-      warning handler = 
-      succeeded handler = 
-      retry handler = 
-      failed handler = 
-   [[[environment]]]
-   [[[directives]]]
-      job_type = parallel
-   [[[environment filter]]]
-      exclude = 
-      include = 
-   [[[dummy mode]]]
-      disable pre-script = True
-      disable post-script = True
-      disable retries = True
-      script = echo Dummy task; sleep $(cylc rnd 1 16)
-      disable task event hooks = True
-   [[[outputs]]]
-   [[[simulation mode]]]
-      run time range = 1, 16
-      simulate failure = False
-      disable retries = True
-      disable task event hooks = True
-   [[[suite state polling]]]
-      interval = 
-      host = 
-      max-polls = 
-      run-dir = 
-      user = 
-      template = 
-      verbose mode = 
-   [[[remote]]]
-      owner = 
-      suite definition directory = 
-      host = 
-      retrieve job logs = 
-      retrieve job logs max size = 
-      retrieve job logs retry delays = 
-   [[[job]]]
-      shell = /bin/bash
-      batch submit command template = 
-      batch system = background
-      submission retry delays = 
-      execution retry delays = 
-      submission polling intervals = 
-      execution polling intervals = 
-      execution time limit = 
+    script = echo "RUN: run-ops.sh"
+    enable resurrection = False
+    env-script = 
+    title = 
+    URL = 
+    extra log files = 
+    work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
+    description = 
+    init-script = 
+    pre-script = 
+    post-script = 
+    inherit = OPS, PARALLEL
+    [[[events]]]
+        handler events = 
+        mail smtp = 
+        handlers = 
+        mail events = 
+        mail retry delays = 
+        handler retry delays = 
+        mail to = 
+        mail from = 
+        execution timeout = 
+        submission timeout = 
+        register job logs retry delays = 
+        reset timer = 
+        submission timeout handler = 
+        submitted handler = 
+        started handler = 
+        execution timeout handler = 
+        expired handler = 
+        submission failed handler = 
+        submission retry handler = 
+        warning handler = 
+        succeeded handler = 
+        retry handler = 
+        failed handler = 
+    [[[environment]]]
+    [[[directives]]]
+        job_type = parallel
+    [[[environment filter]]]
+        exclude = 
+        include = 
+    [[[dummy mode]]]
+        disable pre-script = True
+        disable post-script = True
+        disable retries = True
+        script = echo Dummy task; sleep $(cylc rnd 1 16)
+        disable task event hooks = True
+    [[[outputs]]]
+    [[[simulation mode]]]
+        run time range = PT1S, PT16S
+        simulate failure = False
+        disable retries = True
+        disable task event hooks = True
+    [[[suite state polling]]]
+        interval = 
+        host = 
+        max-polls = 
+        run-dir = 
+        user = 
+        template = 
+        verbose mode = 
+    [[[remote]]]
+        owner = 
+        suite definition directory = 
+        host = 
+        retrieve job logs = 
+        retrieve job logs max size = 
+        retrieve job logs retry delays = 
+    [[[job]]]
+        shell = /bin/bash
+        batch submit command template = 
+        batch system = background
+        submission retry delays = 
+        execution retry delays = 
+        submission polling intervals = 
+        execution polling intervals = 
+        execution time limit = 
 [[var_p1]]
-   script = echo "RUN: run-var.sh"
-   enable resurrection = False
-   env-script = 
-   title = 
-   URL = 
-   extra log files = 
-   work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
-   description = 
-   init-script = 
-   pre-script = 
-   post-script = 
-   inherit = VAR, PARALLEL
-   [[[events]]]
-      handler events = 
-      mail smtp = 
-      handlers = 
-      mail events = 
-      mail retry delays = 
-      handler retry delays = 
-      mail to = 
-      mail from = 
-      execution timeout = 
-      submission timeout = 
-      register job logs retry delays = 
-      reset timer = 
-      submission timeout handler = 
-      submitted handler = 
-      started handler = 
-      execution timeout handler = 
-      expired handler = 
-      submission failed handler = 
-      submission retry handler = 
-      warning handler = 
-      succeeded handler = 
-      retry handler = 
-      failed handler = 
-   [[[environment]]]
-   [[[directives]]]
-      job_type = parallel
-   [[[environment filter]]]
-      exclude = 
-      include = 
-   [[[dummy mode]]]
-      disable pre-script = True
-      disable post-script = True
-      disable retries = True
-      script = echo Dummy task; sleep $(cylc rnd 1 16)
-      disable task event hooks = True
-   [[[outputs]]]
-   [[[simulation mode]]]
-      run time range = 1, 16
-      simulate failure = False
-      disable retries = True
-      disable task event hooks = True
-   [[[suite state polling]]]
-      interval = 
-      host = 
-      max-polls = 
-      run-dir = 
-      user = 
-      template = 
-      verbose mode = 
-   [[[remote]]]
-      owner = 
-      suite definition directory = 
-      host = 
-      retrieve job logs = 
-      retrieve job logs max size = 
-      retrieve job logs retry delays = 
-   [[[job]]]
-      shell = /bin/bash
-      batch submit command template = 
-      batch system = background
-      submission retry delays = 
-      execution retry delays = 
-      submission polling intervals = 
-      execution polling intervals = 
-      execution time limit = 
+    script = echo "RUN: run-var.sh"
+    enable resurrection = False
+    env-script = 
+    title = 
+    URL = 
+    extra log files = 
+    work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
+    description = 
+    init-script = 
+    pre-script = 
+    post-script = 
+    inherit = VAR, PARALLEL
+    [[[events]]]
+        handler events = 
+        mail smtp = 
+        handlers = 
+        mail events = 
+        mail retry delays = 
+        handler retry delays = 
+        mail to = 
+        mail from = 
+        execution timeout = 
+        submission timeout = 
+        register job logs retry delays = 
+        reset timer = 
+        submission timeout handler = 
+        submitted handler = 
+        started handler = 
+        execution timeout handler = 
+        expired handler = 
+        submission failed handler = 
+        submission retry handler = 
+        warning handler = 
+        succeeded handler = 
+        retry handler = 
+        failed handler = 
+    [[[environment]]]
+    [[[directives]]]
+        job_type = parallel
+    [[[environment filter]]]
+        exclude = 
+        include = 
+    [[[dummy mode]]]
+        disable pre-script = True
+        disable post-script = True
+        disable retries = True
+        script = echo Dummy task; sleep $(cylc rnd 1 16)
+        disable task event hooks = True
+    [[[outputs]]]
+    [[[simulation mode]]]
+        run time range = PT1S, PT16S
+        simulate failure = False
+        disable retries = True
+        disable task event hooks = True
+    [[[suite state polling]]]
+        interval = 
+        host = 
+        max-polls = 
+        run-dir = 
+        user = 
+        template = 
+        verbose mode = 
+    [[[remote]]]
+        owner = 
+        suite definition directory = 
+        host = 
+        retrieve job logs = 
+        retrieve job logs max size = 
+        retrieve job logs retry delays = 
+    [[[job]]]
+        shell = /bin/bash
+        batch submit command template = 
+        batch system = background
+        submission retry delays = 
+        execution retry delays = 
+        submission polling intervals = 
+        execution polling intervals = 
+        execution time limit = 
 [[VAR]]
-   script = echo "RUN: run-var.sh"
-   enable resurrection = False
-   env-script = 
-   title = 
-   URL = 
-   extra log files = 
-   work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
-   description = 
-   init-script = 
-   pre-script = 
-   post-script = 
-   inherit = 
-   [[[events]]]
-      handler events = 
-      mail smtp = 
-      handlers = 
-      mail events = 
-      mail retry delays = 
-      handler retry delays = 
-      mail to = 
-      mail from = 
-      execution timeout = 
-      submission timeout = 
-      register job logs retry delays = 
-      reset timer = 
-      submission timeout handler = 
-      submitted handler = 
-      started handler = 
-      execution timeout handler = 
-      expired handler = 
-      submission failed handler = 
-      submission retry handler = 
-      warning handler = 
-      succeeded handler = 
-      retry handler = 
-      failed handler = 
-   [[[environment]]]
-   [[[directives]]]
-   [[[environment filter]]]
-      exclude = 
-      include = 
-   [[[dummy mode]]]
-      disable pre-script = True
-      disable post-script = True
-      disable retries = True
-      script = echo Dummy task; sleep $(cylc rnd 1 16)
-      disable task event hooks = True
-   [[[outputs]]]
-   [[[simulation mode]]]
-      run time range = 1, 16
-      simulate failure = False
-      disable retries = True
-      disable task event hooks = True
-   [[[suite state polling]]]
-      interval = 
-      host = 
-      max-polls = 
-      run-dir = 
-      user = 
-      template = 
-      verbose mode = 
-   [[[remote]]]
-      owner = 
-      suite definition directory = 
-      host = 
-      retrieve job logs = 
-      retrieve job logs max size = 
-      retrieve job logs retry delays = 
-   [[[job]]]
-      shell = /bin/bash
-      batch submit command template = 
-      batch system = background
-      submission retry delays = 
-      execution retry delays = 
-      submission polling intervals = 
-      execution polling intervals = 
-      execution time limit = 
+    script = echo "RUN: run-var.sh"
+    enable resurrection = False
+    env-script = 
+    title = 
+    URL = 
+    extra log files = 
+    work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
+    description = 
+    init-script = 
+    pre-script = 
+    post-script = 
+    inherit = 
+    [[[events]]]
+        handler events = 
+        mail smtp = 
+        handlers = 
+        mail events = 
+        mail retry delays = 
+        handler retry delays = 
+        mail to = 
+        mail from = 
+        execution timeout = 
+        submission timeout = 
+        register job logs retry delays = 
+        reset timer = 
+        submission timeout handler = 
+        submitted handler = 
+        started handler = 
+        execution timeout handler = 
+        expired handler = 
+        submission failed handler = 
+        submission retry handler = 
+        warning handler = 
+        succeeded handler = 
+        retry handler = 
+        failed handler = 
+    [[[environment]]]
+    [[[directives]]]
+    [[[environment filter]]]
+        exclude = 
+        include = 
+    [[[dummy mode]]]
+        disable pre-script = True
+        disable post-script = True
+        disable retries = True
+        script = echo Dummy task; sleep $(cylc rnd 1 16)
+        disable task event hooks = True
+    [[[outputs]]]
+    [[[simulation mode]]]
+        run time range = PT1S, PT16S
+        simulate failure = False
+        disable retries = True
+        disable task event hooks = True
+    [[[suite state polling]]]
+        interval = 
+        host = 
+        max-polls = 
+        run-dir = 
+        user = 
+        template = 
+        verbose mode = 
+    [[[remote]]]
+        owner = 
+        suite definition directory = 
+        host = 
+        retrieve job logs = 
+        retrieve job logs max size = 
+        retrieve job logs retry delays = 
+    [[[job]]]
+        shell = /bin/bash
+        batch submit command template = 
+        batch system = background
+        submission retry delays = 
+        execution retry delays = 
+        submission polling intervals = 
+        execution polling intervals = 
+        execution time limit = 
 [[var_s1]]
-   script = echo "RUN: run-var.sh"
-   enable resurrection = False
-   env-script = 
-   title = 
-   URL = 
-   extra log files = 
-   work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
-   description = 
-   init-script = 
-   pre-script = 
-   post-script = 
-   inherit = VAR, SERIAL
-   [[[events]]]
-      handler events = 
-      mail smtp = 
-      handlers = 
-      mail events = 
-      mail retry delays = 
-      handler retry delays = 
-      mail to = 
-      mail from = 
-      execution timeout = 
-      submission timeout = 
-      register job logs retry delays = 
-      reset timer = 
-      submission timeout handler = 
-      submitted handler = 
-      started handler = 
-      execution timeout handler = 
-      expired handler = 
-      submission failed handler = 
-      submission retry handler = 
-      warning handler = 
-      succeeded handler = 
-      retry handler = 
-      failed handler = 
-   [[[environment]]]
-   [[[directives]]]
-      job_type = serial
-   [[[environment filter]]]
-      exclude = 
-      include = 
-   [[[dummy mode]]]
-      disable pre-script = True
-      disable post-script = True
-      disable retries = True
-      script = echo Dummy task; sleep $(cylc rnd 1 16)
-      disable task event hooks = True
-   [[[outputs]]]
-   [[[simulation mode]]]
-      run time range = 1, 16
-      simulate failure = False
-      disable retries = True
-      disable task event hooks = True
-   [[[suite state polling]]]
-      interval = 
-      host = 
-      max-polls = 
-      run-dir = 
-      user = 
-      template = 
-      verbose mode = 
-   [[[remote]]]
-      owner = 
-      suite definition directory = 
-      host = 
-      retrieve job logs = 
-      retrieve job logs max size = 
-      retrieve job logs retry delays = 
-   [[[job]]]
-      shell = /bin/bash
-      batch submit command template = 
-      batch system = background
-      submission retry delays = 
-      execution retry delays = 
-      submission polling intervals = 
-      execution polling intervals = 
-      execution time limit = 
+    script = echo "RUN: run-var.sh"
+    enable resurrection = False
+    env-script = 
+    title = 
+    URL = 
+    extra log files = 
+    work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
+    description = 
+    init-script = 
+    pre-script = 
+    post-script = 
+    inherit = VAR, SERIAL
+    [[[events]]]
+        handler events = 
+        mail smtp = 
+        handlers = 
+        mail events = 
+        mail retry delays = 
+        handler retry delays = 
+        mail to = 
+        mail from = 
+        execution timeout = 
+        submission timeout = 
+        register job logs retry delays = 
+        reset timer = 
+        submission timeout handler = 
+        submitted handler = 
+        started handler = 
+        execution timeout handler = 
+        expired handler = 
+        submission failed handler = 
+        submission retry handler = 
+        warning handler = 
+        succeeded handler = 
+        retry handler = 
+        failed handler = 
+    [[[environment]]]
+    [[[directives]]]
+        job_type = serial
+    [[[environment filter]]]
+        exclude = 
+        include = 
+    [[[dummy mode]]]
+        disable pre-script = True
+        disable post-script = True
+        disable retries = True
+        script = echo Dummy task; sleep $(cylc rnd 1 16)
+        disable task event hooks = True
+    [[[outputs]]]
+    [[[simulation mode]]]
+        run time range = PT1S, PT16S
+        simulate failure = False
+        disable retries = True
+        disable task event hooks = True
+    [[[suite state polling]]]
+        interval = 
+        host = 
+        max-polls = 
+        run-dir = 
+        user = 
+        template = 
+        verbose mode = 
+    [[[remote]]]
+        owner = 
+        suite definition directory = 
+        host = 
+        retrieve job logs = 
+        retrieve job logs max size = 
+        retrieve job logs retry delays = 
+    [[[job]]]
+        shell = /bin/bash
+        batch submit command template = 
+        batch system = background
+        submission retry delays = 
+        execution retry delays = 
+        submission polling intervals = 
+        execution polling intervals = 
+        execution time limit = 
 [[SERIAL]]
-   script = echo Dummy task; sleep $(cylc rnd 1 16)
-   enable resurrection = False
-   env-script = 
-   title = 
-   URL = 
-   extra log files = 
-   work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
-   description = 
-   init-script = 
-   pre-script = 
-   post-script = 
-   inherit = 
-   [[[events]]]
-      handler events = 
-      mail smtp = 
-      handlers = 
-      mail events = 
-      mail retry delays = 
-      handler retry delays = 
-      mail to = 
-      mail from = 
-      execution timeout = 
-      submission timeout = 
-      register job logs retry delays = 
-      reset timer = 
-      submission timeout handler = 
-      submitted handler = 
-      started handler = 
-      execution timeout handler = 
-      expired handler = 
-      submission failed handler = 
-      submission retry handler = 
-      warning handler = 
-      succeeded handler = 
-      retry handler = 
-      failed handler = 
-   [[[environment]]]
-   [[[directives]]]
-      job_type = serial
-   [[[environment filter]]]
-      exclude = 
-      include = 
-   [[[dummy mode]]]
-      disable pre-script = True
-      disable post-script = True
-      disable retries = True
-      script = echo Dummy task; sleep $(cylc rnd 1 16)
-      disable task event hooks = True
-   [[[outputs]]]
-   [[[simulation mode]]]
-      run time range = 1, 16
-      simulate failure = False
-      disable retries = True
-      disable task event hooks = True
-   [[[suite state polling]]]
-      interval = 
-      host = 
-      max-polls = 
-      run-dir = 
-      user = 
-      template = 
-      verbose mode = 
-   [[[remote]]]
-      owner = 
-      suite definition directory = 
-      host = 
-      retrieve job logs = 
-      retrieve job logs max size = 
-      retrieve job logs retry delays = 
-   [[[job]]]
-      shell = /bin/bash
-      batch submit command template = 
-      batch system = background
-      submission retry delays = 
-      execution retry delays = 
-      submission polling intervals = 
-      execution polling intervals = 
-      execution time limit = 
+    script = echo Dummy task; sleep $(cylc rnd 1 16)
+    enable resurrection = False
+    env-script = 
+    title = 
+    URL = 
+    extra log files = 
+    work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
+    description = 
+    init-script = 
+    pre-script = 
+    post-script = 
+    inherit = 
+    [[[events]]]
+        handler events = 
+        mail smtp = 
+        handlers = 
+        mail events = 
+        mail retry delays = 
+        handler retry delays = 
+        mail to = 
+        mail from = 
+        execution timeout = 
+        submission timeout = 
+        register job logs retry delays = 
+        reset timer = 
+        submission timeout handler = 
+        submitted handler = 
+        started handler = 
+        execution timeout handler = 
+        expired handler = 
+        submission failed handler = 
+        submission retry handler = 
+        warning handler = 
+        succeeded handler = 
+        retry handler = 
+        failed handler = 
+    [[[environment]]]
+    [[[directives]]]
+        job_type = serial
+    [[[environment filter]]]
+        exclude = 
+        include = 
+    [[[dummy mode]]]
+        disable pre-script = True
+        disable post-script = True
+        disable retries = True
+        script = echo Dummy task; sleep $(cylc rnd 1 16)
+        disable task event hooks = True
+    [[[outputs]]]
+    [[[simulation mode]]]
+        run time range = PT1S, PT16S
+        simulate failure = False
+        disable retries = True
+        disable task event hooks = True
+    [[[suite state polling]]]
+        interval = 
+        host = 
+        max-polls = 
+        run-dir = 
+        user = 
+        template = 
+        verbose mode = 
+    [[[remote]]]
+        owner = 
+        suite definition directory = 
+        host = 
+        retrieve job logs = 
+        retrieve job logs max size = 
+        retrieve job logs retry delays = 
+    [[[job]]]
+        shell = /bin/bash
+        batch submit command template = 
+        batch system = background
+        submission retry delays = 
+        execution retry delays = 
+        submission polling intervals = 
+        execution polling intervals = 
+        execution time limit = 
 [[root]]
-   script = echo Dummy task; sleep $(cylc rnd 1 16)
-   enable resurrection = False
-   env-script = 
-   title = 
-   URL = 
-   extra log files = 
-   work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
-   description = 
-   init-script = 
-   pre-script = 
-   post-script = 
-   inherit = 
-   [[[events]]]
-      handler events = 
-      mail smtp = 
-      handlers = 
-      mail events = 
-      mail retry delays = 
-      handler retry delays = 
-      mail to = 
-      mail from = 
-      execution timeout = 
-      submission timeout = 
-      register job logs retry delays = 
-      reset timer = 
-      submission timeout handler = 
-      submitted handler = 
-      started handler = 
-      execution timeout handler = 
-      expired handler = 
-      submission failed handler = 
-      submission retry handler = 
-      warning handler = 
-      succeeded handler = 
-      retry handler = 
-      failed handler = 
-   [[[environment]]]
-   [[[directives]]]
-   [[[environment filter]]]
-      exclude = 
-      include = 
-   [[[dummy mode]]]
-      disable pre-script = True
-      disable post-script = True
-      disable retries = True
-      script = echo Dummy task; sleep $(cylc rnd 1 16)
-      disable task event hooks = True
-   [[[outputs]]]
-   [[[simulation mode]]]
-      run time range = 1, 16
-      simulate failure = False
-      disable retries = True
-      disable task event hooks = True
-   [[[suite state polling]]]
-      interval = 
-      host = 
-      max-polls = 
-      run-dir = 
-      user = 
-      template = 
-      verbose mode = 
-   [[[remote]]]
-      owner = 
-      suite definition directory = 
-      host = 
-      retrieve job logs = 
-      retrieve job logs max size = 
-      retrieve job logs retry delays = 
-   [[[job]]]
-      shell = /bin/bash
-      batch submit command template = 
-      batch system = background
-      submission retry delays = 
-      execution retry delays = 
-      submission polling intervals = 
-      execution polling intervals = 
-      execution time limit = 
+    script = echo Dummy task; sleep $(cylc rnd 1 16)
+    enable resurrection = False
+    env-script = 
+    title = 
+    URL = 
+    extra log files = 
+    work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
+    description = 
+    init-script = 
+    pre-script = 
+    post-script = 
+    inherit = 
+    [[[events]]]
+        handler events = 
+        mail smtp = 
+        handlers = 
+        mail events = 
+        mail retry delays = 
+        handler retry delays = 
+        mail to = 
+        mail from = 
+        execution timeout = 
+        submission timeout = 
+        register job logs retry delays = 
+        reset timer = 
+        submission timeout handler = 
+        submitted handler = 
+        started handler = 
+        execution timeout handler = 
+        expired handler = 
+        submission failed handler = 
+        submission retry handler = 
+        warning handler = 
+        succeeded handler = 
+        retry handler = 
+        failed handler = 
+    [[[environment]]]
+    [[[directives]]]
+    [[[environment filter]]]
+        exclude = 
+        include = 
+    [[[dummy mode]]]
+        disable pre-script = True
+        disable post-script = True
+        disable retries = True
+        script = echo Dummy task; sleep $(cylc rnd 1 16)
+        disable task event hooks = True
+    [[[outputs]]]
+    [[[simulation mode]]]
+        run time range = PT1S, PT16S
+        simulate failure = False
+        disable retries = True
+        disable task event hooks = True
+    [[[suite state polling]]]
+        interval = 
+        host = 
+        max-polls = 
+        run-dir = 
+        user = 
+        template = 
+        verbose mode = 
+    [[[remote]]]
+        owner = 
+        suite definition directory = 
+        host = 
+        retrieve job logs = 
+        retrieve job logs max size = 
+        retrieve job logs retry delays = 
+    [[[job]]]
+        shell = /bin/bash
+        batch submit command template = 
+        batch system = background
+        submission retry delays = 
+        execution retry delays = 
+        submission polling intervals = 
+        execution polling intervals = 
+        execution time limit = 
 [[PARALLEL]]
-   script = echo Dummy task; sleep $(cylc rnd 1 16)
-   enable resurrection = False
-   env-script = 
-   title = 
-   URL = 
-   extra log files = 
-   work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
-   description = 
-   init-script = 
-   pre-script = 
-   post-script = 
-   inherit = 
-   [[[events]]]
-      handler events = 
-      mail smtp = 
-      handlers = 
-      mail events = 
-      mail retry delays = 
-      handler retry delays = 
-      mail to = 
-      mail from = 
-      execution timeout = 
-      submission timeout = 
-      register job logs retry delays = 
-      reset timer = 
-      submission timeout handler = 
-      submitted handler = 
-      started handler = 
-      execution timeout handler = 
-      expired handler = 
-      submission failed handler = 
-      submission retry handler = 
-      warning handler = 
-      succeeded handler = 
-      retry handler = 
-      failed handler = 
-   [[[environment]]]
-   [[[directives]]]
-      job_type = parallel
-   [[[environment filter]]]
-      exclude = 
-      include = 
-   [[[dummy mode]]]
-      disable pre-script = True
-      disable post-script = True
-      disable retries = True
-      script = echo Dummy task; sleep $(cylc rnd 1 16)
-      disable task event hooks = True
-   [[[outputs]]]
-   [[[simulation mode]]]
-      run time range = 1, 16
-      simulate failure = False
-      disable retries = True
-      disable task event hooks = True
-   [[[suite state polling]]]
-      interval = 
-      host = 
-      max-polls = 
-      run-dir = 
-      user = 
-      template = 
-      verbose mode = 
-   [[[remote]]]
-      owner = 
-      suite definition directory = 
-      host = 
-      retrieve job logs = 
-      retrieve job logs max size = 
-      retrieve job logs retry delays = 
-   [[[job]]]
-      shell = /bin/bash
-      batch submit command template = 
-      batch system = background
-      submission retry delays = 
-      execution retry delays = 
-      submission polling intervals = 
-      execution polling intervals = 
-      execution time limit = 
+    script = echo Dummy task; sleep $(cylc rnd 1 16)
+    enable resurrection = False
+    env-script = 
+    title = 
+    URL = 
+    extra log files = 
+    work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
+    description = 
+    init-script = 
+    pre-script = 
+    post-script = 
+    inherit = 
+    [[[events]]]
+        handler events = 
+        mail smtp = 
+        handlers = 
+        mail events = 
+        mail retry delays = 
+        handler retry delays = 
+        mail to = 
+        mail from = 
+        execution timeout = 
+        submission timeout = 
+        register job logs retry delays = 
+        reset timer = 
+        submission timeout handler = 
+        submitted handler = 
+        started handler = 
+        execution timeout handler = 
+        expired handler = 
+        submission failed handler = 
+        submission retry handler = 
+        warning handler = 
+        succeeded handler = 
+        retry handler = 
+        failed handler = 
+    [[[environment]]]
+    [[[directives]]]
+        job_type = parallel
+    [[[environment filter]]]
+        exclude = 
+        include = 
+    [[[dummy mode]]]
+        disable pre-script = True
+        disable post-script = True
+        disable retries = True
+        script = echo Dummy task; sleep $(cylc rnd 1 16)
+        disable task event hooks = True
+    [[[outputs]]]
+    [[[simulation mode]]]
+        run time range = PT1S, PT16S
+        simulate failure = False
+        disable retries = True
+        disable task event hooks = True
+    [[[suite state polling]]]
+        interval = 
+        host = 
+        max-polls = 
+        run-dir = 
+        user = 
+        template = 
+        verbose mode = 
+    [[[remote]]]
+        owner = 
+        suite definition directory = 
+        host = 
+        retrieve job logs = 
+        retrieve job logs max size = 
+        retrieve job logs retry delays = 
+    [[[job]]]
+        shell = /bin/bash
+        batch submit command template = 
+        batch system = background
+        submission retry delays = 
+        execution retry delays = 
+        submission polling intervals = 
+        execution polling intervals = 
+        execution time limit = 
 [[var_s2]]
-   script = echo "RUN: run-var.sh"
-   enable resurrection = False
-   env-script = 
-   title = 
-   URL = 
-   extra log files = 
-   work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
-   description = 
-   init-script = 
-   pre-script = 
-   post-script = 
-   inherit = VAR, SERIAL
-   [[[events]]]
-      handler events = 
-      mail smtp = 
-      handlers = 
-      mail events = 
-      mail retry delays = 
-      handler retry delays = 
-      mail to = 
-      mail from = 
-      execution timeout = 
-      submission timeout = 
-      register job logs retry delays = 
-      reset timer = 
-      submission timeout handler = 
-      submitted handler = 
-      started handler = 
-      execution timeout handler = 
-      expired handler = 
-      submission failed handler = 
-      submission retry handler = 
-      warning handler = 
-      succeeded handler = 
-      retry handler = 
-      failed handler = 
-   [[[environment]]]
-   [[[directives]]]
-      job_type = serial
-   [[[environment filter]]]
-      exclude = 
-      include = 
-   [[[dummy mode]]]
-      disable pre-script = True
-      disable post-script = True
-      disable retries = True
-      script = echo Dummy task; sleep $(cylc rnd 1 16)
-      disable task event hooks = True
-   [[[outputs]]]
-   [[[simulation mode]]]
-      run time range = 1, 16
-      simulate failure = False
-      disable retries = True
-      disable task event hooks = True
-   [[[suite state polling]]]
-      interval = 
-      host = 
-      max-polls = 
-      run-dir = 
-      user = 
-      template = 
-      verbose mode = 
-   [[[remote]]]
-      owner = 
-      suite definition directory = 
-      host = 
-      retrieve job logs = 
-      retrieve job logs max size = 
-      retrieve job logs retry delays = 
-   [[[job]]]
-      shell = /bin/bash
-      batch submit command template = 
-      batch system = background
-      submission retry delays = 
-      execution retry delays = 
-      submission polling intervals = 
-      execution polling intervals = 
-      execution time limit = 
+    script = echo "RUN: run-var.sh"
+    enable resurrection = False
+    env-script = 
+    title = 
+    URL = 
+    extra log files = 
+    work sub-directory = $CYLC_TASK_CYCLE_POINT/$CYLC_TASK_NAME
+    description = 
+    init-script = 
+    pre-script = 
+    post-script = 
+    inherit = VAR, SERIAL
+    [[[events]]]
+        handler events = 
+        mail smtp = 
+        handlers = 
+        mail events = 
+        mail retry delays = 
+        handler retry delays = 
+        mail to = 
+        mail from = 
+        execution timeout = 
+        submission timeout = 
+        register job logs retry delays = 
+        reset timer = 
+        submission timeout handler = 
+        submitted handler = 
+        started handler = 
+        execution timeout handler = 
+        expired handler = 
+        submission failed handler = 
+        submission retry handler = 
+        warning handler = 
+        succeeded handler = 
+        retry handler = 
+        failed handler = 
+    [[[environment]]]
+    [[[directives]]]
+        job_type = serial
+    [[[environment filter]]]
+        exclude = 
+        include = 
+    [[[dummy mode]]]
+        disable pre-script = True
+        disable post-script = True
+        disable retries = True
+        script = echo Dummy task; sleep $(cylc rnd 1 16)
+        disable task event hooks = True
+    [[[outputs]]]
+    [[[simulation mode]]]
+        run time range = PT1S, PT16S
+        simulate failure = False
+        disable retries = True
+        disable task event hooks = True
+    [[[suite state polling]]]
+        interval = 
+        host = 
+        max-polls = 
+        run-dir = 
+        user = 
+        template = 
+        verbose mode = 
+    [[[remote]]]
+        owner = 
+        suite definition directory = 
+        host = 
+        retrieve job logs = 
+        retrieve job logs max size = 
+        retrieve job logs retry delays = 
+    [[[job]]]
+        shell = /bin/bash
+        batch submit command template = 
+        batch system = background
+        submission retry delays = 
+        execution retry delays = 
+        submission polling intervals = 
+        execution polling intervals = 
+        execution time limit = 

--- a/tests/cylc-get-config/02-cycling.t
+++ b/tests/cylc-get-config/02-cycling.t
@@ -15,18 +15,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test cylc get-config with a suite with an explicitly empty final cycle point
-. $(dirname $0)/test_header
-#-------------------------------------------------------------------------------
-set_test_number 2
-#-------------------------------------------------------------------------------
-init_suite "$TEST_NAME_BASE" "$TEST_SOURCE_DIR/$TEST_NAME_BASE/suite.rc"
-#-------------------------------------------------------------------------------
-TEST_NAME=$TEST_NAME_BASE-all
-run_ok $TEST_NAME cylc get-config $SUITE_NAME --item='[scheduling]final cycle point'
-cmp_ok $TEST_NAME.stdout - << __OUT__
+# Test "cylc get-config" on a cycling suite, result should validate.
+. "$(dirname "$0")/test_header"
 
-__OUT__
-#-------------------------------------------------------------------------------
-purge_suite $SUITE_NAME
+set_test_number 2
+
+init_suite "${TEST_NAME_BASE}" "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/suite.rc"
+
+run_ok "${TEST_NAME_BASE}" cylc get-config "${SUITE_NAME}"
+run_ok "${TEST_NAME_BASE}-validate" \
+    cylc validate --strict "${TEST_NAME_BASE}.stdout"
+purge_suite "${SUITE_NAME}"
 exit

--- a/tests/cylc-get-config/02-cycling/suite.rc
+++ b/tests/cylc-get-config/02-cycling/suite.rc
@@ -1,0 +1,12 @@
+[scheduling]
+    initial cycle point = 2020
+    final cycle point = 2030
+    [[dependencies]]
+        [[[P1Y]]]
+            graph = foo
+[runtime]
+    [[foo]]
+        script = """
+echo this
+echo that
+"""

--- a/tests/cylc-get-config/03-cycling-compat.t
+++ b/tests/cylc-get-config/03-cycling-compat.t
@@ -1,0 +1,1 @@
+02-cycling.t

--- a/tests/cylc-get-config/03-cycling-compat/suite.rc
+++ b/tests/cylc-get-config/03-cycling-compat/suite.rc
@@ -1,0 +1,12 @@
+[scheduling]
+    initial cycle point = 2020010100
+    final cycle point = 2020010110
+    [[dependencies]]
+        [[[00,12]]]
+            graph = foo
+[runtime]
+    [[foo]]
+        script = """
+echo this
+echo that
+"""

--- a/tests/inheritance/00-namespace-list.t
+++ b/tests/inheritance/00-namespace-list.t
@@ -32,17 +32,17 @@ cmp_ok runtime.out <<'__DONE__'
 [[root]]
 [[FAMILY]]
 [[m1]]
-   inherit = FAMILY
-   [[[environment]]]
-      FOO = foo
+    inherit = FAMILY
+    [[[environment]]]
+        FOO = foo
 [[m2]]
-   inherit = FAMILY
-   [[[environment]]]
-      FOO = bar
+    inherit = FAMILY
+    [[[environment]]]
+        FOO = bar
 [[m3]]
-   inherit = FAMILY
-   [[[environment]]]
-      FOO = foo
+    inherit = FAMILY
+    [[[environment]]]
+        FOO = foo
 __DONE__
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/validate/55-missing-parentage/suite.rc
+++ b/tests/validate/55-missing-parentage/suite.rc
@@ -3,4 +3,4 @@
         graph = "foo"
 [runtime]
     [[foo]]
-        inherit =
+        inherit = None


### PR DESCRIPTION
The configuration generated by `cylc get-config` and in a suite's `~/cylc-run/SUITE/log/suiterc/` should now pass `cylc validate`.

Ability to skip printing settings with `None` values.
Duration will now be dumped in ISO8601 format by default.
Improve quoting of values in lists.
Triple quote multi-line values.
Allow empty values for settings expecting a set of predefined strings.
Settings expecting `int`, `float` and `boolean` are now set to `None` if given empty values.
If an `inherit` setting has an empty value, it will default to `inherit = root`.
4 spaces indent instead of 3.

And some style updates to pass pylint and pep8.

Close #1915.