### PR TITLE
Fix stop --kill on jobs-kill command fail

### DIFF
--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -908,7 +908,8 @@ class TaskPool(object):
             for job_log_dir in job_log_dirs:
                 point, name, submit_num = job_log_dir.split(os.sep, 2)
                 itask = tasks[(point, name, submit_num)]
-                out += "|".join([ctx.timestamp, job_log_dir, "1"]) + "\n"
+                out += (BATCH_SYS_MANAGER.OUT_PREFIX_SUMMARY +
+                        "|".join([ctx.timestamp, job_log_dir, "1"]) + "\n")
         for line in out.splitlines(True):
             for prefix, callback in handlers:
                 if line.startswith(prefix):

--- a/tests/shutdown/06-kill-fail.t
+++ b/tests/shutdown/06-kill-fail.t
@@ -1,0 +1,36 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2016 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test kill command fail on shutdown --kill.
+. "$(dirname "$0")/test_header"
+
+set_test_number 3
+
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+run_ok "${TEST_NAME_BASE}-run" cylc run "${SUITE_NAME}"
+LOGD="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/log/job"
+JLOGD="${LOGD}/1/t1/01"
+poll test '!' -f "${JLOGD}/job.status"
+poll '!' grep -q 'CYLC_JOB_INIT_TIME' "${JLOGD}/job.status" 2>'/dev/null'
+mv "${JLOGD}/job.status" "${JLOGD}/job.status.old"
+run_ok "${TEST_NAME_BASE}-shutdown" \
+    cylc shutdown --kill --max-polls=10 --interval=2 "${SUITE_NAME}"
+mv "${JLOGD}/job.status.old" "${JLOGD}/job.status"
+cylc jobs-kill "${LOGD}" '1/t1/01' 1>'/dev/null' 2>&1
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/shutdown/06-kill-fail/suite.rc
+++ b/tests/shutdown/06-kill-fail/suite.rc
@@ -1,0 +1,12 @@
+[cylc]
+    [[event hooks]]
+        abort on timeout = True
+        timeout = PT1M
+
+[scheduling]
+    [[dependencies]]
+        graph = t1
+
+[runtime]
+    [[t1]]
+        script = sleep 60


### PR DESCRIPTION
Ensure `cylc jobs-kill` produces output on missing `job.status` file.
Ensure callback of `cylc jobs-kill` works without standard output.

(The symptom was that `cylc stop --kill` causes the suite to attempt kill continuously if `cylc jobs-kill` returns no sensible standard output.)

@benfitzpatrick @arjclark please review.