### PR TITLE
Update mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -14,3 +14,6 @@ Kerry Day                  <kerry.day@metoffice.gov.uk>         kaday           
 Kerry Day                  <kerry.day@metoffice.gov.uk>         Kerry Day           <kaday@users.noreply.github.com>
 Patrick Alexander Reinecke <alex.reinecke@nrlmry.navy.mil>      P. A. Reinecke      <alex.reinecke@nrlmry.navy.mil>
 Luis Kornblueh             <luis.kornblueh@zmaw.de>             Luis Kornblueh      <m214089@cinglung.fritz.box>
+Oliver Sanders             <oliver.sanders@metoffice.gov.uk>    Oliver sanders      <oliver.sanders@metoffice.gov.uk>
+Tim Whitcomb               <tim.whitcomb@nrlmry.navy.mil>       Tim Whitcomb        <twhitcomb@gmail.com>
+Tim Whitcomb               <tim.whitcomb@nrlmry.navy.mil>       trwhitcomb          <twhitcomb@gmail.com>


### PR DESCRIPTION
This corrects the display for `git shortlog`.

@benfitzpatrick please sanity check.