### PR TITLE
Fix #1929 configuration upgrade logic

### DIFF
--- a/lib/cylc/cfgspec/suite.py
+++ b/lib/cylc/cfgspec/suite.py
@@ -496,19 +496,16 @@ def upg(cfg, descr):
         ['scheduling', 'special tasks', 'external-triggered'],
         ['scheduling', 'special tasks', 'external-trigger'],
     )
-    u.deprecate('6.10.3', ['cylc', 'event hooks'], ['cylc', 'events'])
     for key in SPEC['cylc']['events']:
         u.deprecate(
             '6.10.3', ['cylc', 'event hooks', key], ['cylc', 'events', key])
-    u.deprecate(
-        '6.10.3',
-        ['runtime', '__MANY__', 'event hooks'],
-        ['runtime', '__MANY__', 'events'])
+    u.deprecate('6.10.3', ['cylc', 'event hooks'])
     for key in SPEC['runtime']['__MANY__']['events']:
         u.deprecate(
             '6.10.3',
             ['runtime', '__MANY__', 'event hooks', key],
             ['runtime', '__MANY__', 'events', key])
+    u.deprecate('6.10.3', ['runtime', '__MANY__', 'event hooks'])
     u.deprecate(
         '6.10.3',
         ['runtime', '__MANY__', 'job submission', 'method'],
@@ -525,10 +522,7 @@ def upg(cfg, descr):
         '6.10.3',
         ['runtime', '__MANY__', 'job submission', 'retry delays'],
         ['runtime', '__MANY__', 'job', 'submission retry delays'])
-    u.deprecate(
-        '6.10.3',
-        ['runtime', '__MANY__', 'job submission'],
-        ['runtime', '__MANY__', 'job'])
+    u.deprecate('6.10.3', ['runtime', '__MANY__', 'job submission'])
     u.deprecate(
         '6.10.3',
         ['runtime', '__MANY__', 'retry delays'],
@@ -542,6 +536,13 @@ def upg(cfg, descr):
         ['runtime', '__MANY__', 'execution polling intervals'],
         ['runtime', '__MANY__', 'job', 'execution polling intervals'])
     u.upgrade()
+    if 'cylc' in cfg and 'event hooks' in cfg['cylc']:
+        del cfg['cylc']['event hooks']
+    if 'runtime' in cfg:
+        for section in cfg['runtime'].values():
+            for key in ['event hooks', 'job submission']:
+                if key in section:
+                    del section[key]
 
     # Force pre cylc-6 "cycling = Yearly" type suites to the explicit
     # dependency heading form for which backward compatibility is provided:


### PR DESCRIPTION
#1929 upgrade logic is causing issues. (I think it is caused by an ordering problem not revealed by my previous tests.)

Old configuration sections need to be deprecated with no new settings then removed.