### PR TITLE
Fix documentation guide link in the INSTALL.md file

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Cylc Installation
 
-**See [The Cylc User Guide](https://cylc.github.io/cylc/#documentation) for
+**See [The Cylc User Guide](https://cylc.github.io/cylc/documentation.html) for
 detailed instructions.**
 
 Note: *to run distributed suites cylc must be installed on task hosts as well as suite


### PR DESCRIPTION
Was going to install cylc again on a new notebook, but the documentation link is actually going to the project home page. I think that's the correct URL.

Thanks

ps: the site changed since the last time I accessed it, and it's looking great. Kudos!