### PR TITLE
Travis CI config update - run the whole test battery.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,8 +57,8 @@ install:
     # Install dependencies
     - sudo apt-get install build-essential
     - sudo apt-get install at python-pip python-dev graphviz libgraphviz-dev python-gtk2-dev
-      #- pip install -r requirements.txt
     - pip install Jinja2
+    # Pygraphviz needs special treatment to avoid an error from "from . import release"
     - pip install pygraphviz --install-option="--include-path=/usr/include/graphviz" --install-option="--library-path=/usr/lib/graphviz/"
     - pip install pep8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,11 @@ before_install:
     # Make sure Cylc is in PATH when running jobs
     - echo "export PATH=$PWD/bin:\$PATH" >> ~/.bashrc
 
+    # Custom diff command to ignore Xlib errors (xvfb has not RANDR extension).
+    - echo "export CYLC_TEST_DIFF_CMD='diff -I Xlib'" >> ~/.bashrc 
+
     # Load our new environment
     - source ~/.bashrc
-
 
 # These commands are run before the test
 install: 
@@ -54,20 +56,17 @@ install:
 
     # Install dependencies
     - sudo apt-get install build-essential
-    - sudo apt-get install at python-pip python-dev libgraphviz-dev # python-gtk2-dev
-    - pip install -r requirements.txt
+    - sudo apt-get install at python-pip python-dev graphviz libgraphviz-dev python-gtk2-dev
+      #- pip install -r requirements.txt
+    - pip install Jinja2
+    - pip install pygraphviz --install-option="--include-path=/usr/include/graphviz" --install-option="--library-path=/usr/lib/graphviz/"
+    - pip install pep8
 
 # Run tests
 script: 
-    # TESTS defines what tests to run
-    # The following failures appear to be artefacts of running on Travis
-    # lib/parsec/tests  - Cannot find 'validate' library in lib/parsec
-    # tests/cylcers     - Requires GTK for graphing
-    # tests/restart/04-running.t - Fails only in some runs (timeout?)
-    - TESTS=$(find . -name *.t -type f -not -path '*/cyclers/*' -not -path '*/parsec/*' -not -path '*/restart/04-running.t')
-    - cylc test-battery $TESTS -- -j 1
+    - xvfb-run -a cylc test-battery -j 5
 
 # Check output (more useful if you narrow down what tests get run)
 after_script:
-    - for file in $(find $HOME/cylc-run -type f); do echo; echo "== $file =="; cat $file; done
+    - for file in $(find $HOME/cylc-run/*/log/{job,suite}/*err -type f); do echo; echo "== $file =="; cat $file; done
     - for file in $(find /tmp/cylc-tests-$USER -type f); do echo; echo "== $file =="; cat $file; done

--- a/lib/cylc/gui/updater_dot.py
+++ b/lib/cylc/gui/updater_dot.py
@@ -127,8 +127,9 @@ class DotUpdater(threading.Thread):
             # iso cycle points
             self.point_strings.sort()
 
-        use_def_order = (self.cfg.use_defn_order and self.updater.ns_defn_order
-                         and self.defn_order_on)
+        use_def_order = (
+            self.cfg.use_defn_order and self.updater.ns_defn_order and
+            self.defn_order_on)
 
         if not self.should_group_families:
             # Display the full task list.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-Jinja2
-pygraphviz

--- a/tests/database/00-simple.t
+++ b/tests/database/00-simple.t
@@ -26,8 +26,11 @@ suite_run_ok "${TEST_NAME_BASE}-run" cylc run --debug "${SUITE_NAME}"
 DB_FILE="$(cylc get-global-config '--print-run-dir')/${SUITE_NAME}/cylc-suite.db"
 
 NAME='schema.out'
+ORIG="${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/${NAME}"
+SORTED_ORIG="sorted-${NAME}"
 sqlite3 "${DB_FILE}" ".schema" | env LANG='C' sort >"${NAME}"
-cmp_ok "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/${NAME}" "${NAME}"
+env LANG='C' sort "${ORIG}" > "${SORTED_ORIG}"
+cmp_ok "${SORTED_ORIG}" "${NAME}"
 
 NAME='select-suite-params.out'
 sqlite3 "${DB_FILE}" 'SELECT key,value FROM suite_params ORDER BY key' \

--- a/tests/ext-trigger/00-satellite/suite.rc
+++ b/tests/ext-trigger/00-satellite/suite.rc
@@ -28,7 +28,7 @@ until triggered by an external system."""
     UTC mode = True
     [[reference test]]
         required run mode = live
-        live mode suite timeout = PT1M
+        live mode suite timeout = PT2M
 
 [scheduling]
     cycling mode = integer

--- a/tests/pre-initial/warm-insert/suite.rc
+++ b/tests/pre-initial/warm-insert/suite.rc
@@ -3,7 +3,7 @@
     [[event hooks]]
         stalled handler = cylc reset %(suite)s foo -s ready
     [[reference test]]
-        live mode suite timeout=PT1M
+        live mode suite timeout=PT2M
 
 [scheduling]
     initial cycle point = 20100101T0000Z


### PR DESCRIPTION
Follow-up (after a bit of a delay!) to #1137.  This gets the whole test battery passing on Travis CI, include graphing and related tests that require GTK import and an X environment (I'm using Xvfb).  Only platform-specific tests get skipped, and four tests that need mail functionality.  @ScottWales - maybe you could take a quick look at this in case I've done anything silly?

(For @cylc/core - Travis CI set-up is very easy, just log in to www.travis-ci.org with GitHub credentials and allow access to your cylc fork), then any commit pushed to GitHub will cause the test battery to run.  I may have to separately configure it to respond to pull requests on the master repo, once this PR is merged...)