### PR TITLE
Deprecate cylc 5 cycling syntax

### DIFF
--- a/examples/polling/suite.rc
+++ b/examples/polling/suite.rc
@@ -20,5 +20,5 @@ as the suite runs, filtering for the word 'poll'.
             # stay 'submitted' for up to a minute:
             batch submit command template = at now + 1 minutes
             # configure submission and execution polling:
-            submission polling intervals = 0.1
-            execution polling intervals = 0.2, 2*0.3, 0.1
+            submission polling intervals = PT6S
+            execution polling intervals = PT12S, 2*PT18S, PT6S

--- a/lib/cylc/cfgspec/suite.py
+++ b/lib/cylc/cfgspec/suite.py
@@ -475,6 +475,22 @@ def upg(cfg, descr):
         ['visualization', 'final cycle point'],
         converter(
             lambda x: x, 'changed naming to reflect non-date-time cycling'))
+    u.deprecate(
+        '6.0.0',
+        ['scheduling', 'cycling']
+    )
+    u.deprecate(
+        '6.0.0',
+        ['scheduling', 'special tasks', 'sequential']
+    )
+    u.deprecate(
+        '6.0.0',
+        ['scheduling', 'special tasks', 'start-up']
+    )
+    u.deprecate(
+        '6.0.0',
+        ['scheduling', 'special tasks', 'cold-start']
+    )
     u.obsolete('6.0.0', ['cylc', 'job submission'])
     u.obsolete('6.0.0', ['cylc', 'event handler submission'])
     u.obsolete('6.0.0', ['cylc', 'poll and kill command submission'])

--- a/lib/cylc/syntax_flags.py
+++ b/lib/cylc/syntax_flags.py
@@ -18,9 +18,14 @@
 
 """Global syntax flags used in cylc"""
 
+import sys
 
 VERSION_PREV = "pre-cylc-6"  # < cylc-6
 VERSION_NEW = "post-cylc-6"  # cylc 6 +
+
+DEPRECATED_SYNTAX_WARNING = {
+    VERSION_PREV: "WARNING: pre cylc 6 syntax is deprecated: {0}\n"
+}
 
 
 class SyntaxVersion(object):
@@ -28,6 +33,7 @@ class SyntaxVersion(object):
     """Store the syntax version used in the suite.rc."""
     VERSION_REASON = None
     VERSION = None
+    WARNING_MESSAGES = set()
 
 
 class SyntaxVersionError(ValueError):
@@ -53,3 +59,9 @@ def set_syntax_version(version, message):
         SyntaxVersion.VERSION_REASON = message
     elif SyntaxVersion.VERSION != version:
         raise SyntaxVersionError(version, message)
+    if SyntaxVersion.VERSION in DEPRECATED_SYNTAX_WARNING:
+        warning = (
+            DEPRECATED_SYNTAX_WARNING[SyntaxVersion.VERSION].format(message))
+        if warning not in SyntaxVersion.WARNING_MESSAGES:
+            sys.stderr.write(warning)
+            SyntaxVersion.WARNING_MESSAGES.add(warning)

--- a/tests/cyclers/34-implicit-back-compat.t
+++ b/tests/cyclers/34-implicit-back-compat.t
@@ -27,6 +27,10 @@ run_ok $TEST_NAME cylc validate $SUITE_NAME
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-cmp
 cmp_ok $TEST_NAME_BASE-validate.stderr <<__ERR__
+WARNING: pre cylc 6 syntax is deprecated: integer interval: [cylc][reference test]live mode suite timeout = 30
+WARNING: pre cylc 6 syntax is deprecated: initial/final cycle point format: CCYYMMDDhh
+WARNING: pre cylc 6 syntax is deprecated: [scheduling][[dependencies]][[[00]]]: old-style cycling
+WARNING: pre cylc 6 syntax is deprecated: graphnode foo[T-24]: old-style offset
 WARNING, foo: not explicitly defined in dependency graphs (deprecated)
 __ERR__
 #-------------------------------------------------------------------------------

--- a/tests/cylc-5to6/00-simple-start-up.t
+++ b/tests/cylc-5to6/00-simple-start-up.t
@@ -19,12 +19,11 @@
 # TODO - another test for nested file inclusion
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
-set_test_number 5
+set_test_number 6
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-validate
 run_ok "$TEST_NAME" cylc validate $SUITE_NAME
-cat "$TEST_NAME.stderr" >&2
 sed -n '/REPLACING .* DEPENDENCIES/,/^"""/p' "$TEST_NAME.stdout" \
     >"$TEST_NAME.dep-replace"
 cmp_ok "$TEST_NAME.dep-replace" <<'__DEP_INFO__'
@@ -43,6 +42,35 @@ cold_foo => foo_twelves
 cold_foo[^] => foo_dawn
 """
 __DEP_INFO__
+contains_ok "$TEST_NAME.stderr" <<'__STDERR__'
+WARNING: pre cylc 6 syntax is deprecated: integer interval: [cylc][reference test]live mode suite timeout = 120
+WARNING: pre cylc 6 syntax is deprecated: integer interval: [cylc][reference test]dummy mode suite timeout = 60.0
+WARNING: pre cylc 6 syntax is deprecated: integer interval: [cylc][reference test]simulation mode suite timeout = 60
+WARNING: pre cylc 6 syntax is deprecated: integer interval: [cylc][events]timeout = 1440
+WARNING: pre cylc 6 syntax is deprecated: integer interval for [scheduling]runahead limit = 6
+WARNING: pre cylc 6 syntax is deprecated: integer interval: [runtime][root][suite state polling]interval = 5
+WARNING: pre cylc 6 syntax is deprecated: integer interval: [runtime][root][events]execution timeout = 180
+WARNING: pre cylc 6 syntax is deprecated: integer interval: [runtime][root][events]submission timeout = 360
+WARNING: pre cylc 6 syntax is deprecated: integer interval: [runtime][root][job]submission retry delays = 5
+WARNING: pre cylc 6 syntax is deprecated: integer interval: [runtime][root][job]execution retry delays = 0.5
+WARNING: pre cylc 6 syntax is deprecated: integer interval: [runtime][root][job]execution retry delays = 10
+WARNING: pre cylc 6 syntax is deprecated: integer interval: [runtime][root][job]execution retry delays = 30
+WARNING: pre cylc 6 syntax is deprecated: integer interval: [runtime][root][job]execution retry delays = 60
+WARNING: pre cylc 6 syntax is deprecated: integer interval: [runtime][root][job]execution retry delays = 180
+WARNING: pre cylc 6 syntax is deprecated: integer interval: [runtime][root][job]execution retry delays = 1440
+WARNING: pre cylc 6 syntax is deprecated: initial/final cycle point format: CCYYMMDDhh
+WARNING: pre cylc 6 syntax is deprecated: [scheduling][[dependencies]][[[0]]]: old-style cycling
+WARNING: pre cylc 6 syntax is deprecated: [scheduling][[dependencies]][[[6]]]: old-style cycling
+WARNING: pre cylc 6 syntax is deprecated: [scheduling][[dependencies]][[[Daily(20131231 ,2)]]]: old-style cycling
+WARNING: pre cylc 6 syntax is deprecated: [scheduling][[dependencies]][[[Monthly(201402,1)]]]: old-style cycling
+WARNING: pre cylc 6 syntax is deprecated: [scheduling][[dependencies]][[[Yearly( 2010 , 3 )]]]: old-style cycling
+WARNING: pre cylc 6 syntax is deprecated: [scheduling][[dependencies]][[[12]]]: old-style cycling
+WARNING: pre cylc 6 syntax is deprecated: start-up tasks: cold_foo
+WARNING: pre cylc 6 syntax is deprecated: graphnode foo_midnight[T-24]: old-style offset
+WARNING: pre cylc 6 syntax is deprecated: graphnode foo_dawn[T-24]: old-style offset
+WARNING: pre cylc 6 syntax is deprecated: graphnode foo_m[T-2]: old-style offset
+WARNING: pre cylc 6 syntax is deprecated: graphnode foo_twelves[T-12]: old-style offset
+__STDERR__
 #-------------------------------------------------------------------------------
 # Run the convert-suggest-tool.
 TEST_NAME=$TEST_NAME_BASE-5to6

--- a/tests/lib/bash/test_header
+++ b/tests/lib/bash/test_header
@@ -284,7 +284,7 @@ function graph_suite() {
     local SUITE_NAME="${1}"
     local OUTPUT_FILE="${2}"
     shift 2
-    cylc graph --reference "${SUITE_NAME}" "$@" >"${OUTPUT_FILE}"
+    cylc graph --reference "${SUITE_NAME}" "$@" >"${OUTPUT_FILE}" 2>/dev/null
 }
 
 function init_suite() {

--- a/tests/repeated-items/00-one.t
+++ b/tests/repeated-items/00-one.t
@@ -26,20 +26,22 @@ TEST_NAME=$TEST_NAME_BASE-validate
 run_ok $TEST_NAME cylc validate $SUITE_NAME
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-a
-cylc get-config -i title $SUITE_NAME > a.txt
+cylc get-config -i title $SUITE_NAME >a.txt 2>/dev/null
 cmp_ok a.txt <<'__END'
 the quick brown fox
 __END
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-b
-cylc get-config -i '[scheduling][dependencies]graph' $SUITE_NAME > b.txt
+cylc get-config -i '[scheduling][dependencies]graph' $SUITE_NAME >b.txt \
+    2>/dev/null
 cmp_ok b.txt <<'__END'
 foo => bar
 bar => baz
 __END
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-c
-cylc get-config -i '[scheduling][dependencies][0]graph' $SUITE_NAME > c.txt
+cylc get-config -i '[scheduling][dependencies][0]graph' $SUITE_NAME >c.txt \
+    2>/dev/null
 cmp_ok c.txt <<'__END'
 cfoo => cbar
 cbar => cbaz
@@ -48,19 +50,19 @@ dbar => dbaz
 __END
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-d
-cylc get-config -i '[runtime][FOO]title' $SUITE_NAME > d.txt
+cylc get-config -i '[runtime][FOO]title' $SUITE_NAME >d.txt 2>/dev/null
 cmp_ok d.txt <<'__END'
 the quick brown fox
 __END
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-e
-cylc get-config -i '[runtime][FOO]description' $SUITE_NAME > e.txt
+cylc get-config -i '[runtime][FOO]description' $SUITE_NAME >e.txt 2>/dev/null
 cmp_ok e.txt <<'__END'
 jumped over the lazy dog
 __END
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-f
-cylc get-config -i '[runtime][FOO][environment]' $SUITE_NAME > f.txt
+cylc get-config -i '[runtime][FOO][environment]' $SUITE_NAME >f.txt 2>/dev/null
 cmp_ok f.txt <<'__END'
 VAR1 = the quick brown fox
 __END

--- a/tests/special/04-clock-triggered.t
+++ b/tests/special/04-clock-triggered.t
@@ -23,25 +23,25 @@ set_test_number 4
 install_suite $TEST_NAME_BASE clock
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-validate
-run_ok $TEST_NAME cylc validate $SUITE_NAME -s START=$(date +%Y%m%d%H) \
-    -s HOUR=$(date +%H) -s UTC_MODE=False -s OFFSET=0 -s TIMEOUT=0.2
+run_ok $TEST_NAME cylc validate $SUITE_NAME -s START=$(date +%Y%m%dT%H) \
+    -s HOUR=$(date +%H) -s UTC_MODE=False -s OFFSET=PT0S -s TIMEOUT=PT12S
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-run-now
-run_ok $TEST_NAME cylc run --debug $SUITE_NAME -s START=$(date +%Y%m%d%H) \
-    -s HOUR=$(date +%H) -s UTC_MODE=False -s OFFSET=0 -s TIMEOUT=0.2
+run_ok $TEST_NAME cylc run --debug $SUITE_NAME -s START=$(date +%Y%m%dT%H) \
+    -s HOUR=$(date +%H) -s UTC_MODE=False -s OFFSET=PT0S -s TIMEOUT=PT12S
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-run-past
-NOW=$(date +%Y%m%d%H)
+NOW=$(date +%Y%m%dT%H)
 START=$(cylc cycle-point $NOW --offset-hour=-10)
-HOUR=$(cylc cycle-point $NOW --offset-hour=-10 --print-hour)
+HOUR="$(cylc cycle-point $NOW --offset-hour=-10 --print-hour)"
 run_ok $TEST_NAME cylc run --debug $SUITE_NAME -s START=$START -s HOUR=$HOUR \
-    -s UTC_MODE=False -s OFFSET=0 -s TIMEOUT=1
+    -s UTC_MODE=False -s OFFSET=PT0S -s TIMEOUT=PT1M
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-run-later
-NOW=$(date +%Y%m%d%H)
+NOW=$(date +%Y%m%dT%H)
 START=$(cylc cycle-point $NOW --offset-hour=10)
 HOUR=$(cylc cycle-point $NOW --offset-hour=10 --print-hour)
 run_fail $TEST_NAME cylc run --debug $SUITE_NAME -s START=$START \
-    -s HOUR=$HOUR -s UTC_MODE=False -s OFFSET=0 -s TIMEOUT=0.2
+    -s HOUR=$HOUR -s UTC_MODE=False -s OFFSET=PT0S -s TIMEOUT=PT12S
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/special/05-clock-triggered-utc.t
+++ b/tests/special/05-clock-triggered-utc.t
@@ -24,17 +24,17 @@ install_suite $TEST_NAME_BASE clock
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-validate
 run_ok $TEST_NAME cylc validate $SUITE_NAME -s START=$(date -u +%Y%m%dT%H00)Z \
-    -s HOUR=T$(date -u +%H) -s UTC_MODE=True -s OFFSET=PT0M -s TIMEOUT=PT0.2M
+    -s HOUR=$(date -u +%H) -s UTC_MODE=True -s OFFSET=PT0M -s TIMEOUT=PT0.2M
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-run-now
 run_ok $TEST_NAME cylc run --debug $SUITE_NAME \
-    -s START=$(date -u +%Y%m%dT%H00)Z -s HOUR=T$(date -u +%H) \
+    -s START=$(date -u +%Y%m%dT%H00)Z -s HOUR=$(date -u +%H) \
     -s UTC_MODE=True -s OFFSET=PT0M -s TIMEOUT=PT1M
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-run-past
 NOW=$(date -u +%Y%m%dT%H00)Z
 START=$(cylc cycle-point $NOW --offset-hour=-10)
-HOUR=T$(cylc cycle-point $NOW --offset-hour=-10 --print-hour)
+HOUR=$(cylc cycle-point $NOW --offset-hour=-10 --print-hour)
 run_ok $TEST_NAME cylc run --debug $SUITE_NAME -s START=$START -s HOUR=$HOUR \
      -s UTC_MODE=True -s OFFSET=PT0M -s TIMEOUT=PT0.2M
 #-------------------------------------------------------------------------------

--- a/tests/special/06-clock-triggered-iso.t
+++ b/tests/special/06-clock-triggered-iso.t
@@ -24,16 +24,16 @@ install_suite $TEST_NAME_BASE clock
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-validate
 run_ok $TEST_NAME cylc validate $SUITE_NAME -s START=$(date +%Y%m%dT%H%z) \
-    -s HOUR=T$(date +%H) -s UTC_MODE=False -s OFFSET=PT0M -s TIMEOUT=PT0.2M
+    -s HOUR=$(date +%H) -s UTC_MODE=False -s OFFSET=PT0M -s TIMEOUT=PT0.2M
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-run-now
 run_ok $TEST_NAME cylc run --debug $SUITE_NAME -s START=$(date +%Y%m%dT%H%z) \
-    -s HOUR=T$(date +%H) -s UTC_MODE=False -s OFFSET=PT0M -s TIMEOUT=PT0.2M
+    -s HOUR=$(date +%H) -s UTC_MODE=False -s OFFSET=PT0M -s TIMEOUT=PT0.2M
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-run-past
 NOW=$(date +%Y%m%dT%H)
 START=$(cylc cycle-point $NOW --offset-hour=-10)$(date +%z)
-HOUR=T$(cylc cycle-point $NOW --offset-hour=-10 --print-hour)
+HOUR=$(cylc cycle-point $NOW --offset-hour=-10 --print-hour)
 run_ok $TEST_NAME cylc run --debug $SUITE_NAME -s START=$START -s HOUR=$HOUR \
     -s UTC_MODE=False -s OFFSET=PT0M -s TIMEOUT=PT1M
 #-------------------------------------------------------------------------------

--- a/tests/special/08-clock-triggered-0.t
+++ b/tests/special/08-clock-triggered-0.t
@@ -25,23 +25,23 @@ install_suite $TEST_NAME_BASE clock
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-validate
 run_ok $TEST_NAME cylc validate $SUITE_NAME -s START=$(date +%Y%m%dT%H%z) \
-    -s HOUR=T$(date +%H) -s UTC_MODE=False -s TIMEOUT=PT0.2M
+    -s HOUR=$(date +%H) -s UTC_MODE=False -s TIMEOUT=PT0.2M
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-run-now
 run_ok $TEST_NAME cylc run --debug $SUITE_NAME -s START=$(date +%Y%m%dT%H%z) \
-    -s HOUR=T$(date +%H) -s UTC_MODE=False -s TIMEOUT=PT0.2M
+    -s HOUR=$(date +%H) -s UTC_MODE=False -s TIMEOUT=PT0.2M
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-run-past
 NOW=$(date +%Y%m%dT%H)
 START=$(cylc cycle-point $NOW --offset-hour=-10)$(date +%z)
-HOUR=T$(cylc cycle-point $NOW --offset-hour=-10 --print-hour)
+HOUR=$(cylc cycle-point $NOW --offset-hour=-10 --print-hour)
 run_ok $TEST_NAME cylc run --debug $SUITE_NAME -s START=$START -s HOUR=$HOUR \
     -s UTC_MODE=False -s TIMEOUT=PT1M
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-run-later
 NOW=$(date +%Y%m%dT%H)
 START=$(cylc cycle-point $NOW --offset-hour=10)$(date +%z)
-HOUR=T$(cylc cycle-point $NOW --offset-hour=10 --print-hour)
+HOUR=$(cylc cycle-point $NOW --offset-hour=10 --print-hour)
 run_fail $TEST_NAME cylc run --debug $SUITE_NAME -s START=$START \
     -s HOUR=$HOUR -s UTC_MODE=False -s TIMEOUT=PT0.2M
 #-------------------------------------------------------------------------------

--- a/tests/special/clock/suite.rc
+++ b/tests/special/clock/suite.rc
@@ -10,7 +10,7 @@
     [[special tasks]]
         clock-triggered = clock{% if OFFSET is defined %}({{OFFSET}}){% endif %}
     [[dependencies]]
-        [[[{{HOUR}}]]]
+        [[[T{{HOUR}}]]]
             graph = "clock"
 [runtime]
     [[clock]]


### PR DESCRIPTION
We should add deprecation warnings for the nearly-2-years-old cylc 5 syntax.