### PR TITLE
suite stop logic improvement

### DIFF
--- a/bin/cylc-stop
+++ b/bin/cylc-stop
@@ -89,8 +89,13 @@ def main():
 
     parser.add_option(
         "-n", "--now",
-        help="Shut down immediately, orphaning currently active tasks.",
-        action="store_true", default=False, dest="now")
+        help=(
+            "Shut down without waiting for active tasks to complete." +
+            " If this option is specified once," +
+            " wait for task event handler, job poll/kill to complete." +
+            " If this option is specified more than once," +
+            " tell the suite to terminate immediately."),
+        action="count", default=0, dest="now")
 
     parser.add_option(
         "-w", "--wall-clock", metavar="STOP",
@@ -130,25 +135,27 @@ def main():
             }
         )
 
-    method = None
     if options.wall_clock:
-        method = 'set_stop_after_clock_time'
-        prompt_text = 'Set shutdown at wall clock %s' % options.wall_clock
-        shutdown_arg = options.wall_clock
-    elif shutdown_at:
+        prompt(
+            'Set shutdown at wall clock %s for %s' % (
+                options.wall_clock, suite),
+            options.force)
+        pclient.put_command('set_stop_after_clock_time', options.wall_clock)
+    elif shutdown_at and TaskID.is_valid_id(shutdown_arg):
         # STOP argument detected
-        if TaskID.is_valid_id(shutdown_arg):
-            # is a task ID
-            method = 'set_stop_after_task'
-            prompt_text = 'Set shutdown after task %s' % shutdown_arg
-        else:
-            # not a task ID, may be a cycle point
-            method = 'set_stop_after_point'
-            prompt_text = 'Set shutdown at cycle point %s' % shutdown_arg
-
-    if method:
-        prompt(prompt_text + ' for ' + suite, options.force)
-        pclient.put_command(method, shutdown_arg)
+        prompt(
+            'Set shutdown after task %s for %s' % (shutdown_arg, suite),
+            options.force)
+        pclient.put_command('set_stop_after_task', shutdown_arg)
+    elif shutdown_at:
+        # not a task ID, may be a cycle point
+        prompt(
+            'Set shutdown at cycle point %s for %s' % (shutdown_arg, suite),
+            options.force)
+        pclient.put_command('set_stop_after_point', shutdown_arg)
+    elif options.now > 1:
+        prompt('Shut down and terminate %s now' % suite, options.force)
+        pclient.put_command('stop_now', True)
     elif options.now:
         prompt('Shut down %s now' % suite, options.force)
         pclient.put_command('stop_now')

--- a/lib/cylc/exceptions.py
+++ b/lib/cylc/exceptions.py
@@ -24,6 +24,7 @@ class CylcError(Exception):
         message - what the problem is.
     """
     def __init__(self, msg):
+        Exception.__init__(self, msg)
         self.msg = msg
 
     def __str__(self):

--- a/tests/hold-release/13-ready-restart/suite.rc
+++ b/tests/hold-release/13-ready-restart/suite.rc
@@ -26,7 +26,7 @@ bar
         script = """
 # Stop the suite as soon as job file of "foo-1" is in the ready state
 timeout 1m my-file-poll "${CYLC_SUITE_RUN_DIR}/log/job/1/foo-1/NN/job"
-cylc stop --now --max-polls=10 --interval=1 "${CYLC_SUITE_NAME}"
+cylc stop --now --now --max-polls=10 --interval=1 "${CYLC_SUITE_NAME}"
 # Restart the suite on hold
 cylc restart --hold "${CYLC_SUITE_NAME}"
 timeout 1m my-log-grepper 'Held on start-up (no tasks will be submitted)'

--- a/tests/shutdown/07-task-fail.t
+++ b/tests/shutdown/07-task-fail.t
@@ -1,0 +1,38 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2016 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test task event handler runs after "abort if any task fails".
+. "$(dirname "$0")/test_header"
+
+set_test_number 5
+
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+suite_run_fail "${TEST_NAME_BASE}-run" cylc run --no-detach "${SUITE_NAME}"
+LOGD="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/log"
+grep_ok 'INFO - Suite shutting down .* - AUTOMATIC(ON-TASK-FAILURE)' \
+    "${LOGD}/suite/log"
+JLOGD="${LOGD}/job/1/t1/01"
+# Check that t1.1 event handler runs
+run_ok "${TEST_NAME_BASE}-activity-log" \
+    grep -q -F \
+    "[(('event-handler-00', 'failed'), 1) out] Unfortunately t1.1 failed" \
+    "${JLOGD}/job-activity.log"
+# Check that t2.1 did not run
+exists_fail "${LOGD}/1/t2"
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/shutdown/07-task-fail/suite.rc
+++ b/tests/shutdown/07-task-fail/suite.rc
@@ -1,0 +1,17 @@
+[cylc]
+    abort if any task fails = True
+    [[events]]
+        abort on timeout = True
+        timeout = PT1M
+
+[scheduling]
+    [[dependencies]]
+        graph = t1:finish => t2
+
+[runtime]
+    [[t1]]
+        script = false
+        [[[events]]]
+            failed handler = echo 'Unfortunately %(id)s %(event)s'
+    [[t2]]
+        script = true

--- a/tests/shutdown/08-now1.t
+++ b/tests/shutdown/08-now1.t
@@ -1,0 +1,41 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2016 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "cylc stop --now" will wait for event handler.
+. "$(dirname "$0")/test_header"
+
+set_test_number 6
+
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+suite_run_ok "${TEST_NAME_BASE}-run" cylc run --no-detach "${SUITE_NAME}"
+LOGD="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/log"
+grep_ok 'INFO - Suite shutting down .* - REQUEST(NOW)' "${LOGD}/suite/log"
+JLOGD="${LOGD}/job/1/t1/01"
+# Check that t1.1 event handler runs
+run_ok "${TEST_NAME_BASE}-activity-log-succeeded" \
+    grep -q -F \
+    "[(('event-handler-00', 'succeeded'), 1) out] Well done t1.1 succeeded" \
+    "${JLOGD}/job-activity.log"
+run_ok "${TEST_NAME_BASE}-activity-log-started" \
+    grep -q -F \
+    "[(('event-handler-00', 'started'), 1) out] Hello t1.1 started" \
+    "${JLOGD}/job-activity.log"
+# Check that t2.1 did not run
+exists_fail "${LOGD}/job/1/t2"
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/shutdown/08-now1/suite.rc
+++ b/tests/shutdown/08-now1/suite.rc
@@ -1,0 +1,17 @@
+[cylc]
+    [[events]]
+        abort on timeout = True
+        timeout = PT1M
+
+[scheduling]
+    [[dependencies]]
+        graph = t1:finish => t2
+
+[runtime]
+    [[t1]]
+        script = sleep 1 && cylc stop --now "${CYLC_SUITE_NAME}"
+        [[[events]]]
+            started handler = sleep 10 && echo 'Hello %(id)s %(event)s'
+            succeeded handler = echo 'Well done %(id)s %(event)s'
+    [[t2]]
+        script = true

--- a/tests/shutdown/09-now2.t
+++ b/tests/shutdown/09-now2.t
@@ -1,0 +1,42 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2016 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "cylc stop --now --now".
+. "$(dirname "$0")/test_header"
+
+set_test_number 7
+
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+suite_run_ok "${TEST_NAME_BASE}-run" cylc run --no-detach "${SUITE_NAME}"
+LOGD="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/log"
+grep_ok 'INFO - Suite shutting down .* - REQUEST(NOW-NOW)' "${LOGD}/suite/log"
+grep_ok 'WARNING - t1.1: orphaned task (running)' "${LOGD}/suite/log"
+JLOGD="${LOGD}/job/1/t1/01"
+# Check that t1.1 event handler runs
+run_fail "${TEST_NAME_BASE}-activity-log-succeeded" \
+    grep -q -F \
+    "[(('event-handler-00', 'succeeded'), 1) out] Well done t1.1 succeeded" \
+    "${JLOGD}/job-activity.log"
+run_fail "${TEST_NAME_BASE}-activity-log-started" \
+    grep -q -F \
+    "[(('event-handler-00', 'started'), 1) out] Hello t1.1 started" \
+    "${JLOGD}/job-activity.log"
+# Check that t2.1 did not run
+exists_fail "${LOGD}/job/1/t2"
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/shutdown/09-now2/suite.rc
+++ b/tests/shutdown/09-now2/suite.rc
@@ -1,0 +1,22 @@
+[cylc]
+    [[events]]
+        abort on timeout = True
+        timeout = PT1M
+
+[scheduling]
+    [[dependencies]]
+        graph = t1:finish => t2
+
+[runtime]
+    [[t1]]
+        script = """
+sleep 1
+cylc stop --now --now "${CYLC_SUITE_NAME}"
+trap '' EXIT
+exit
+"""
+        [[[events]]]
+            started handler = sleep 10 && echo 'Hello %(id)s %(event)s'
+            succeeded handler = echo 'Well done %(id)s %(event)s'
+    [[t2]]
+        script = true


### PR DESCRIPTION
Internal refactor:
* Group stop logic towards the end of the main loop.
* Remove unnecessary attribute variables.
* Rename methods and variables for internal consistency.
* Generate reference log with filter (https://github.com/cylc/cylc/pull/1892#issuecomment-227383351).

Improve diagnostic:
* Improve orphaned tasks warnings - list orphaned tasks and their states.
* Improve labelling of shut down reasons.

Wait for event handlers to complete:
* On shut down due to task failures.
* On `cylc stop --now`.

Terminate immediately on `cylc stop --now --now`.

Partially address #1282. (Recording event handlers progress in suite DB and running left over event handlers on restart will be done in a separate PR.)