### PR TITLE
Ensure that Unix time is always Gregorian

### DIFF
--- a/lib/cylc/wallclock.py
+++ b/lib/cylc/wallclock.py
@@ -19,7 +19,7 @@
 
 from datetime import datetime, timedelta
 
-from isodatetime.data import Duration
+from isodatetime.data import CALENDAR, Duration
 from isodatetime.parsers import TimePointParser
 from isodatetime.timezone import (
     get_local_time_zone_format, get_local_time_zone)
@@ -212,7 +212,15 @@ def get_unix_time_from_time_string(time_string):
     """Convert a time string into a unix timestamp."""
     parser = TimePointParser()
     time_point = parser.parse(time_string)
-    return time_point.get("seconds_since_unix_epoch")
+    # Unix time is always Gregorian
+    prev_calendar_mode = CALENDAR.mode
+    if prev_calendar_mode != CALENDAR.MODE_GREGORIAN:
+        CALENDAR.set_mode(CALENDAR.MODE_GREGORIAN)
+    try:
+        return time_point.get("seconds_since_unix_epoch")
+    finally:
+        if prev_calendar_mode != CALENDAR.mode:
+            CALENDAR.set_mode(prev_calendar_mode)
 
 
 def get_seconds_as_interval_string(seconds):


### PR DESCRIPTION
Otherwise, on e.g. 31st of a month (wall clock date time), a suite on
the 360day calendar will fail.

This breakage was introduced by #1925, although #1925 is not the root cause.

Today, (31 August), I am getting this traceback:

```
Traceback (most recent call last):
  File "/home/matt/cylc.git/bin/cylc-run", line 31, in <module>
    main(is_restart=False)
  File "/home/matt/cylc.git/lib/cylc/scheduler_cli.py", line 71, in main
    scheduler.start()
  File "/home/matt/cylc.git/lib/cylc/scheduler.py", line 283, in start
    self.run()
  File "/home/matt/cylc.git/lib/cylc/scheduler.py", line 1429, in run
    self.pool.process_queued_task_messages()
  File "/home/matt/cylc.git/lib/cylc/task_pool.py", line 1028, in process_queued_task_messages
    itask.process_incoming_message(priority, message)
  File "/home/matt/cylc.git/lib/cylc/task_proxy.py", line 1402, in process_incoming_message
    get_unix_time_from_time_string(event_time))
  File "/home/matt/cylc.git/lib/cylc/wallclock.py", line 215, in get_unix_time_from_time_string
    return time_point.get("seconds_since_unix_epoch")
  File "/home/matt/cylc.git/lib/isodatetime/data.py", line 996, in get
    self - reference_timepoint).get_days_and_seconds()
  File "/home/matt/cylc.git/lib/isodatetime/data.py", line 1334, in __sub__
    my_year, my_day_of_year = self.get_ordinal_date()
  File "/home/matt/cylc.git/lib/isodatetime/data.py", line 914, in get_ordinal_date
    self.day_of_month)
  File "/home/matt/cylc.git/lib/isodatetime/data.py", line 1851, in get_ordinal_date_from_calendar_date
    day_of_month))
ValueError: Bad calendar date: 2016-08-31
```

@benfitzpatrick @hjoliver please review, sanity check or reassign.