### PR TITLE
tests: hold-release-12: improve stability

### DIFF
--- a/tests/hold-release/12-hold-then-retry/suite.rc
+++ b/tests/hold-release/12-hold-then-retry/suite.rc
@@ -16,9 +16,6 @@ t-submit-retry-able:submit => t-hold
 [runtime]
     [[t-hold]]
         script = """
-# Silently kill off t-submit-retry-able
-T_ST_FILE="$(dirname "$0")/../../t-submit-retry-able/NN/job.status"
-atrm "$(awk -F= '$1 == "CYLC_BATCH_SYS_JOB_ID" {print $2}' "${T_ST_FILE}")"
 # Hold the suite
 cylc hold "${CYLC_SUITE_NAME}"
 timeout 15 my-log-grepper 'Command succeeded: hold_suite'
@@ -28,10 +25,6 @@ cylc poll "${CYLC_SUITE_NAME}" 't-submit-retry-able'
 rm -f "${CYLC_SUITE_RUN_DIR}/file"
 timeout 15 my-log-grepper '[t-retry-able.1] -retrying => held'
 timeout 15 my-log-grepper '[t-submit-retry-able.1] -submit-retrying => held'
-# No need to delay run in submit-retry
-cylc broadcast "${CYLC_SUITE_NAME}" \
-    -p '1' -n 't-submit-retry-able' \
-    -s '[job]batch submit command template=at now'
 # Release the suite
 cylc release "${CYLC_SUITE_NAME}"
 timeout 15 my-log-grepper '[t-retry-able.1] -held => retrying'
@@ -39,21 +32,23 @@ timeout 15 my-log-grepper '[t-submit-retry-able.1] -held => submit-retrying'
 """
     [[t-retry-able]]
         script = """
-if ((CYLC_TASK_TRY_NUMBER == 1)); then
+if ((CYLC_TASK_SUBMIT_NUMBER == 1)); then
     touch "${CYLC_SUITE_RUN_DIR}/file"
     while [[ -e "${CYLC_SUITE_RUN_DIR}/file" ]]; do
         sleep 1
     done
     false
-else
-    :
 fi
 """
         [[[job]]]
             execution retry delays = PT5S
     [[t-submit-retry-able]]
+        env-script = """
+if ((CYLC_TASK_SUBMIT_NUMBER == 1)); then
+    trap '' EXIT
+    exit
+fi
+"""
         script = true
         [[[job]]]
-            batch system = at
-            batch submit command template = at now + 1 minute
             submission retry delays = PT5S


### PR DESCRIPTION
Remove dependency on `at`.
Less time driven. More event driven.

This test has started failing randomly in my environment and in Travis CI in at least 2 occasions. I believe removing the dependency on `at` and the broadcast should make it more robust.

Note: Instead of `t-hold` silently killing `t-submit-retry-able`, `t-submit-retry-able` will now silently exit (before it says `started`) on 1st submit.

@arjclark please sanity check.