### PR TITLE
Remove get_unix_time_from_time_string bottleneck and fix non-Gregorian logging times

### DIFF
--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -846,7 +846,8 @@ class TaskProxy(object):
             self.log(
                 INFO, 'submit_method_id=' + self.summary['submit_method_id'])
         self.log(INFO, 'submission succeeded')
-        now = get_current_time_string()
+        now = time.time()
+        now_string = get_time_string_from_unix_time(now)
         self.db_updates_map[self.TABLE_TASK_JOBS].append({
             "time_submit_exit": now,
             "submit_status": 0,
@@ -857,9 +858,8 @@ class TaskProxy(object):
             if self.__class__.stop_sim_mode_job_submission:
                 self.state.set_ready_to_submit()
             else:
-                self.summary['started_time'] = float(
-                    get_unix_time_from_time_string(now))
-                self.summary['started_time_string'] = now
+                self.summary['started_time'] = now
+                self.summary['started_time_string'] = now_string
                 self.state.set_executing()
             return
 
@@ -868,9 +868,8 @@ class TaskProxy(object):
         self.summary['finished_time'] = None
         self.summary['finished_time_string'] = None
 
-        self.summary['submitted_time'] = float(
-            get_unix_time_from_time_string(now))
-        self.summary['submitted_time_string'] = now
+        self.summary['submitted_time'] = now
+        self.summary['submitted_time_string'] = now_string
         self.summary['latest_message'] = TASK_STATUS_SUBMITTED
         self.setup_event_handlers("submitted", 'job submitted',
                                   db_event='submission succeeded')

--- a/tests/cylc.wallclock/00-single.t
+++ b/tests/cylc.wallclock/00-single.t
@@ -1,0 +1,56 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2016 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Unit test parts of lib/cylc/wallclock.py.
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 7
+export PYTHONPATH=$CYLC_DIR/lib:$PYTHONPATH
+
+# Arguments: TEST_NAME TIME_STRING EXPECTED_UNIX_TIME CALENDAR_IS_360
+function test_get_unix_time_from_time_string () {
+    run_ok $1 python <<__PYTHON__
+from cylc.wallclock import get_unix_time_from_time_string
+
+if $4:
+    from isodatetime.data import CALENDAR
+    CALENDAR.set_mode(CALENDAR.MODE_360)
+assert(get_unix_time_from_time_string('$2') == $3)
+__PYTHON__
+}
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-get_unix_time_from_time_string-greg-1
+test_get_unix_time_from_time_string $TEST_NAME '2016-09-08T09:09:00+01' 1473322140 False
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-get_unix_time_from_time_string-greg-2
+test_get_unix_time_from_time_string $TEST_NAME '2016-09-08T08:09:00Z' 1473322140 False
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-get_unix_time_from_time_string-greg-3
+test_get_unix_time_from_time_string $TEST_NAME '2016-09-07T20:09:00-12' 1473322140 False
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-get_unix_time_from_time_string-360-1
+test_get_unix_time_from_time_string $TEST_NAME '2016-09-08T09:09:00+01' 1473322140 True
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-get_unix_time_from_time_string-360-2
+test_get_unix_time_from_time_string $TEST_NAME '2016-09-08T08:09:00Z' 1473322140 True
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-get_unix_time_from_time_string-360-3
+test_get_unix_time_from_time_string $TEST_NAME '2016-09-07T20:09:00-12' 1473322140 True
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-get_unix_time_from_time_string-360-31-1
+test_get_unix_time_from_time_string $TEST_NAME '2016-08-31T18:09:00+01' 1472663340 True
+exit

--- a/tests/cylc.wallclock/test_header
+++ b/tests/cylc.wallclock/test_header
@@ -1,0 +1,1 @@
+../lib/bash/test_header


### PR DESCRIPTION
This supercedes #1974.

`get_unix_time_from_time_string` had become a major performance bottleneck due to
initialisation of the `TimePointParser` on every function call.

This change reduces the amount of calls to the function, uses a pre-initialised parser, and
uses `datetime` where possible. The use of `datetime` also fixes the non-Gregorian calendar issues reported in #1974. It's now very fast when the time_string input is in UTC, and still less than half a millisecond per call for non-UTC time strings.

@matthewrmshin, @hjoliver please review.