### PR TITLE
Profiling option for validation too.

### DIFF
--- a/bin/cylc-validate
+++ b/bin/cylc-validate
@@ -37,6 +37,7 @@ from cylc.config import SuiteConfig, SuiteConfigError
 from cylc.prerequisite import TriggerExpressionError
 from cylc.task_proxy import TaskProxy
 from cylc.templatevars import load_template_vars
+from cylc.profiler import Profiler
 
 
 def main():
@@ -61,7 +62,14 @@ def main():
         help="Don't write out the processed suite definition.",
         action="store_true", default=False, dest="nowrite")
 
+    parser.add_option(
+        "--profile", help="Output profiling (performance) information",
+        action="store_true", default=False, dest="profile_mode")
+
     (options, args) = parser.parse_args()
+
+    profiler = Profiler(options.profile_mode)
+    profiler.start()
 
     suite, suiterc = parser.get_suite()
 
@@ -70,7 +78,8 @@ def main():
         load_template_vars(options.templatevars, options.templatevars_file),
         cli_initial_point_string=options.ict,
         validation=True, strict=options.strict,
-        write_proc=not options.nowrite)
+        write_proc=not options.nowrite,
+        mem_log_func=profiler.log_memory)
 
     # Instantiate tasks and force evaluation of trigger expressions.
     # (Taken from config.py to avoid circular import problems.)
@@ -117,6 +126,7 @@ def main():
             print "  + " + itask.identity + " ok"
 
     print "Valid for cylc-" + CYLC_VERSION
+    profiler.stop()
 
 
 if __name__ == "__main__":

--- a/lib/cylc/profiler.py
+++ b/lib/cylc/profiler.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2016 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Cylc memory and performance profiling."""
+
+import os
+import sys
+import cProfile
+import StringIO
+import pstats
+from subprocess import call, Popen, PIPE
+
+
+class Profiler(object):
+    """Wrap cProfile, pstats, and memory logging, for performance profiling."""
+
+    def __init__(self, enabled=False):
+        """Initialize cProfile."""
+        self.enabled = enabled
+        if enabled:
+            self.prof = cProfile.Profile()
+        else:
+            self.prof = None
+
+    def start(self):
+        """Start profiling."""
+        if not self.enabled:
+            return
+        self.prof.enable()
+
+    def stop(self):
+        """Stop profiling and print stats."""
+        if not self.enabled:
+            return
+        self.prof.disable()
+        string_stream = StringIO.StringIO()
+        stats = pstats.Stats(self.prof, stream=string_stream)
+        stats.sort_stats('cumulative')
+        stats.print_stats()
+        print string_stream.getvalue()
+
+    def log_memory(self, message):
+        """Print a message to standard out with the current memory usage."""
+        if not self.enabled:
+            return
+        proc = Popen(["ps", "h", "-orss", str(os.getpid())], stdout=PIPE)
+        memory = int(proc.communicate()[0])
+        print "PROFILE: Memory: %d KiB: %s" % (memory, message)


### PR DESCRIPTION
Factor out cProfile, pstats, and memory logging code, and enable profiling of validation as well as scheduler.  (motivation: performance testing on #1953)

@matthewrmshin - please review/assign (one is probably enough for this).