### PR TITLE
Update state summary on runahead release.

### DIFF
--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -1367,7 +1367,8 @@ conditions; see `cylc conditions`.
                 self.do_update_state_summary = True
 
             self.process_command_queue()
-            self.pool.release_runahead_tasks()
+            if self.pool.release_runahead_tasks():
+                self.do_update_state_summary = True
             proc_pool.handle_results_async()
 
             # External triggers must be matched now. If any are matched pflag

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -279,7 +279,7 @@ class TaskPool(object):
 
     def release_runahead_tasks(self):
         """Release tasks from the runahead pool to the main pool.
-        
+
         Return True if any tasks are released, else False.
         """
 

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -281,7 +281,7 @@ class TaskPool(object):
         """Release tasks from the runahead pool to the main pool."""
 
         if not self.runahead_pool:
-            return
+            return False
 
         # Any finished tasks can be released immediately (this can happen at
         # restart when all tasks are initially loaded into the runahead pool).
@@ -311,7 +311,7 @@ class TaskPool(object):
             points.append(point)
 
         if not points:
-            return
+            return False
 
         # Get the earliest point with unfinished tasks.
         runahead_base_point = min(points)
@@ -362,10 +362,13 @@ class TaskPool(object):
                     )
             self._prev_runahead_base_point = runahead_base_point
 
+        released = False
         for point, itask_id_map in self.runahead_pool.items():
             if point <= latest_allowed_point:
                 for itask in itask_id_map.values():
                     self.release_runahead_task(itask)
+                    released = True
+        return released
 
     def release_runahead_task(self, itask):
         """Release itask to the appropriate queue in the active pool."""

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -278,7 +278,10 @@ class TaskPool(object):
         return True
 
     def release_runahead_tasks(self):
-        """Release tasks from the runahead pool to the main pool."""
+        """Release tasks from the runahead pool to the main pool.
+        
+        Return True if any tasks are released, else False.
+        """
 
         if not self.runahead_pool:
             return False

--- a/tests/runahead/06-release-update.t
+++ b/tests/runahead/06-release-update.t
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test that the state summary is updated when runahead tasks are released.
-# GitHub
+# GitHub #1981
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 set_test_number 3

--- a/tests/runahead/06-release-update.t
+++ b/tests/runahead/06-release-update.t
@@ -1,0 +1,42 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2016 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test that the state summary is updated when runahead tasks are released.
+# GitHub
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 3
+#-------------------------------------------------------------------------------
+install_suite $TEST_NAME_BASE release-update
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-validate
+run_ok $TEST_NAME cylc validate $SUITE_NAME
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-check-states
+cylc run $SUITE_NAME
+sleep 10
+cylc dump -t $SUITE_NAME | awk '{print $1 $3}' > log
+cmp_ok log - << __END__
+bar,succeeded,
+bar,waiting,
+foo,waiting,
+__END__
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-stop
+run_ok $TEST_NAME cylc stop --max-polls=10 --interval=6 $SUITE_NAME
+#-------------------------------------------------------------------------------
+purge_suite $SUITE_NAME

--- a/tests/runahead/release-update/suite.rc
+++ b/tests/runahead/release-update/suite.rc
@@ -1,0 +1,18 @@
+[cylc]
+    cycle point format = %Y
+    [[events]]
+        inactivity = PT1M
+        abort on inactivity = True
+[scheduling]
+    initial cycle point = now
+    final cycle point = +P1Y
+    max active cycle points = 1
+    [[special tasks]]
+        clock-trigger = foo(P0Y)
+    [[dependencies]]
+        [[[P1Y]]]
+            graph = """foo => bar
+                bar[-P1Y] => bar""" # (or sequential bar)
+[runtime]
+    [[root]]
+        script = /bin/true


### PR DESCRIPTION
Currently the suite state summary does not get updated immediately when runahead tasks are released to the main pool, if nothing else is happening at the time.  This becomes apparent if you have an inter-cycle trigger, and a pending clock-trigger, and set `max active cycles = 1`.   A test suite that does this:

```
[cylc]
    cycle point format = %Y
[scheduling]
    initial cycle point = now
    max active cycle points = 1
    [[special tasks]]
        clock-trigger = foo(P0Y)
    [[dependencies]]
        [[[P1Y]]]
            graph = """foo => bar
                bar[-P1Y] => bar""" # (or sequential bar)
[runtime]
    [[root]]
        script = sleep 5
```

When the second `foo` is waiting for 1 year real time, there will be no waiting tasks visible in the GUI (or `cylc dump`) even though they have been released to the main pool.  A `cylc nudge` will make them appear (by causing a state summary update).

This change fixes the problem.