### PR TITLE
Fix hanging warm insert stall test

### DIFF
--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -69,7 +69,7 @@ from cylc.wallclock import (
 from cylc.task_state import (
     TaskState, TASK_STATUSES_ALL, TASK_STATUSES_RESTRICTED,
     TASK_STATUSES_WITH_JOB_SCRIPT, TASK_STATUSES_WITH_JOB_LOGS,
-    TASK_STATUSES_TRIGGERABLE, TASK_STATUSES_POLLABLE, TASK_STATUSES_KILLABLE,
+    TASK_STATUSES_TRIGGERABLE, TASK_STATUSES_ACTIVE,
     TASK_STATUS_WAITING, TASK_STATUS_READY,
     TASK_STATUS_RUNNING, TASK_STATUS_SUCCEEDED, TASK_STATUS_FAILED)
 
@@ -1355,7 +1355,7 @@ been defined for this suite""").inform()
         menu.append(poll_item)
         poll_item.connect('activate', self.poll_task, task_ids)
         poll_item.set_sensitive(
-            all([t_state in TASK_STATUSES_POLLABLE for t_state in t_states])
+            all([t_state in TASK_STATUSES_ACTIVE for t_state in t_states])
         )
 
         menu.append(gtk.SeparatorMenuItem())
@@ -1367,7 +1367,7 @@ been defined for this suite""").inform()
         menu.append(kill_item)
         kill_item.connect('activate', self.kill_task, task_ids)
         kill_item.set_sensitive(
-            all([t_state in TASK_STATUSES_KILLABLE for t_state in t_states])
+            all([t_state in TASK_STATUSES_ACTIVE for t_state in t_states])
         )
 
         # Separator.

--- a/lib/cylc/task_state.py
+++ b/lib/cylc/task_state.py
@@ -86,20 +86,32 @@ TASK_STATUSES_CAN_RESET_TO = set([
     TASK_STATUS_FAILED
 ])
 
-# Task statuses that are killable.
-TASK_STATUSES_KILLABLE = set([
-    TASK_STATUS_SUBMITTED,
-    TASK_STATUS_RUNNING
+# Task statuses that are final.
+TASK_STATUSES_FINAL = set([
+    TASK_STATUS_EXPIRED,
+    TASK_STATUS_SUCCEEDED,
+    TASK_STATUS_FAILED,
+    TASK_STATUS_SUBMIT_FAILED,
 ])
 
-# Task statuses that are externally active.
-TASK_STATUSES_ACTIVE = TASK_STATUSES_KILLABLE
-
-# Task statuses that are pollable.
-TASK_STATUSES_POLLABLE = set([
-    TASK_STATUS_SUBMITTED,
-    TASK_STATUS_RUNNING
+# Task statuses that are to be externally active
+TASK_STATUSES_TO_BE_ACTIVE = set([
+    TASK_STATUS_QUEUED,
+    TASK_STATUS_READY,
+    TASK_STATUS_SUBMIT_RETRYING,
+    TASK_STATUS_RETRYING,
 ])
+
+# Task statuses that are externally active, i.e. pollable and killable
+TASK_STATUSES_ACTIVE = set([
+    TASK_STATUS_SUBMITTED,
+    TASK_STATUS_RUNNING,
+])
+
+# Task statuses in which tasks cannot be considered stalled
+TASK_STATUSES_NOT_STALLED = (
+    TASK_STATUSES_ACTIVE | TASK_STATUSES_TO_BE_ACTIVE |
+    set([TASK_STATUS_HELD]))
 
 # Task statuses that can be manually triggered.
 TASK_STATUSES_TRIGGERABLE = set([

--- a/tests/pre-initial/warm-insert-stall/suite.rc
+++ b/tests/pre-initial/warm-insert-stall/suite.rc
@@ -1,13 +1,15 @@
 [cylc]
-    UTC mode = true
-    [[event hooks]]
-        abort on stalled = true
+    UTC mode = True
+    [[events]]
+        abort on inactivity = True
+        abort on stalled = True
+        inactivity = PT1M
     [[reference test]]
-        live mode suite timeout=PT1M
+        live mode suite timeout = PT1M
 
 [scheduling]
     initial cycle point = 20100101T0000Z
-    final cycle point   = 20100102T0000Z
+    final cycle point = 20100102T0000Z
     [[dependencies]]
         [[[T00, T06, T12, T18]]]
             graph = foo[-PT6H] => foo
@@ -16,7 +18,9 @@
 
 [runtime]
     [[root]]
-        script = sleep 5
+        script = true
     [[foo]]
     [[inserter]]
-        script = cylc insert $CYLC_SUITE_NAME foo.20100101T1200Z --stop-point=20100101T1200Z
+        script = """
+cylc insert "${CYLC_SUITE_NAME}" 'foo.20100101T1200Z' --stop-point='20100101T1200Z'
+"""


### PR DESCRIPTION
The test hanged when the insert happened quite late in the suite. A task
would be `held` beyond the stop point. The stall check would always
return False if any task were in the `held` state, so the suite did not
stall, and did not trigger the stall abort logic.

In the fix, we will ignore tasks that are beyond the stop point in the
stall checking logic.

I have also:
* Added `TASK_STATUS_SUBMIT_RETRYING` to the list of non-stalling statuses.
* Added `TASK_STATUS_EXPIRED` to the list of final statuses.
* Changed `sleep 5` to `true` for a faster turn around of the suite in the no-longer failing test.
* Done some minor refactor to reduce repeated logic.

@hjoliver @arjclark please review/reassign.