### PR TITLE
cylc validate: fix demoted info concat

### DIFF
--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -947,9 +947,9 @@ class SuiteConfig(object):
             self.runtime['parents'][name] = pts
 
         if cylc.flags.verbose and demoted:
-            log_msg = "First parent(s) demoted to secondary:"
+            log_msg = "First parent(s) demoted to secondary:\n"
             for n, p in demoted.items():
-                log_msg += " +", p, "as parent of '" + n + "'"
+                log_msg += " + %s as parent of '%s'\n" % (p, n)
             OUT_IF_DEF.info(log_msg)
 
         c3 = C3(self.runtime['parents'])


### PR DESCRIPTION
Getting this trace back on a suite.

```
Traceback (most recent call last):
  File "/home/matt/cylc.git/bin/cylc-validate", line 134, in <module>
    main()
  File "/home/matt/cylc.git/bin/cylc-validate", line 82, in main
    mem_log_func=profiler.log_memory)
  File "/home/matt/cylc.git/lib/cylc/config.py", line 134, in get_inst
    vis_start_string, vis_stop_string, mem_log_func)
  File "/home/matt/cylc.git/lib/cylc/config.py", line 340, in __init__
    self.compute_family_tree()
  File "/home/matt/cylc.git/lib/cylc/config.py", line 952, in compute_family_tree
    log_msg += " +", p, "as parent of '" + n + "'"
TypeError: cannot concatenate 'str' and 'tuple' objects
```

Looks like the `,` before and after `p` are turning right hand side into a tuple.

@hjoliver please review.