### PR TITLE
Graph parser: fix bad succeed substitution

### DIFF
--- a/lib/cylc/graph_parser.py
+++ b/lib/cylc/graph_parser.py
@@ -320,7 +320,7 @@ class GraphParser(object):
                 offset = offset or ''
                 if not trig:
                     trig = self.__class__.TRIG_SUCCEED
-                    this = r'\b%s\b%s' % (name, re.escape(offset))
+                    this = r'\b%s\b%s(?!:)' % (name, re.escape(offset))
                     that = name + offset + trig
                     expr = re.sub(this, that, expr)
                 n_info.append((name, offset, trig))

--- a/tests/validate/58-succeed-sub.t
+++ b/tests/validate/58-succeed-sub.t
@@ -1,0 +1,36 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2016 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# In graph lines where we have multiple triggers of the same task, ensure
+# :succeed does not get substituted to symbols that already have a trigger.
+
+. "$(dirname "$0")/test_header"
+
+set_test_number 1
+
+cat >'suite.rc' <<'__SUITE_RC__'
+[scheduling]
+[[dependencies]]
+graph = foo:fail | (foo & bar:fail) => something
+[runtime]
+[[root]]
+script = true
+__SUITE_RC__
+
+run_ok "${TEST_NAME_BASE}" cylc validate 'suite.rc'
+
+exit


### PR DESCRIPTION
If an LHS contained `foo` and `foo:fail`, `foo:fail` would be modified
to `foo:succeed:fail` incorrectly. This change fixes the problem.

@hjoliver @arjclark please review.