### PR TITLE
Fix new graph parser bug (PR to 6.11.1)

### DIFF
--- a/lib/cylc/graph_parser.py
+++ b/lib/cylc/graph_parser.py
@@ -317,10 +317,13 @@ class GraphParser(object):
             n_info = []
             expr = left
             for name, offset, trig in info:
-                offset = offset or ''
                 if not trig:
                     trig = self.__class__.TRIG_SUCCEED
-                    this = r'\b%s\b%s(?!:)' % (name, re.escape(offset))
+                    if offset:
+                        this = r'\b%s\b%s(?!:)' % (name, re.escape(offset))
+                    else:
+                        this = r'\b%s\b(?![\[:])' % name
+
                     that = name + offset + trig
                     expr = re.sub(this, that, expr)
                 n_info.append((name, offset, trig))

--- a/tests/events/25-held-not-stalled/suite.rc
+++ b/tests/events/25-held-not-stalled/suite.rc
@@ -1,5 +1,6 @@
 [cylc]
     [[events]]
+        abort on inactivity = False
         abort on stalled = True
         inactivity handler = cylc release '%(suite)s'
         inactivity = PT5S

--- a/tests/validate/59-offset-no-offset.t
+++ b/tests/validate/59-offset-no-offset.t
@@ -1,0 +1,39 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2016 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# GitHub PR #2002 - validation of "foo | foo[-P1D] => bar" was failing because
+# the explicit ':succeed' trigger was being substituted before the offset
+# instead of after, creating an invalid trigger expression.
+
+. "$(dirname "$0")/test_header"
+
+set_test_number 1
+
+cat >'suite.rc' <<'__SUITE_RC__'
+[scheduling]
+    initial cycle point = 2010
+[[dependencies]]
+    [[[P1D]]]
+        graph = foo | foo[-P1D] => bar
+[runtime]
+    [[root]]
+        script = true
+__SUITE_RC__
+
+run_ok "${TEST_NAME_BASE}" cylc validate 'suite.rc'
+
+exit


### PR DESCRIPTION
First PR targeting the new 6.11.x branch.

Conditional expression processing is failing if the same task name appears in an expression with and without a cycle point offset, e.g.:

```
graph = foo | foo[-P1D] => bar
```

(NIWA has an operational suite with this sort of construct in it).

```
cylc val test
2016-09-17T23:23:01Z ERROR - name 'foo_colon_succeed_leftsquarebracket__minus_P1D_rightsquarebracket_' is not defined
'"(foo_colon_succeed | foo_colon_succeed_leftsquarebracket__minus_P1D_rightsquarebracket_)"'
'ERROR, bar: invalid trigger expression.'
```

This shows the problem is that the explicit `:succeed` trigger is getting substituted in before the offset `foo:succeed[-P1D]` instead of after it `foo[-P1D]:succeed`. (only if the same name occurs with and without an offset in the same expression).

This PR branch includes two commits merged to master since 6.11.0 as well: #1999 and #2000. Both affect only the test battery.

I'll make a copy of the branch for a PR to master as well.
