### PR TITLE
Fix background OSError handling

### DIFF
--- a/lib/cylc/batch_sys_handlers/background.py
+++ b/lib/cylc/batch_sys_handlers/background.py
@@ -78,7 +78,7 @@ class BgCommandHandler(object):
             # subprocess.Popen has a bad habit of not setting the
             # filename of the executable when it raises an OSError.
             if not exc.filename:
-                exc.filename = command[0]
+                exc.filename = "nohup"
             return (1, None, str(exc))
         else:
             return (0, "%d\n" % (proc.pid), None)


### PR DESCRIPTION
(Bug discovered while running a busy suite - when the OS refuses to fork any more process for the current user, causing an OSError. On error handling, the logic is wrong because `command` is not defined.)

@hjoliver please review.