### PR TITLE
cylc gui: fix None error on job log display

### DIFF
--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -2218,6 +2218,8 @@ shown here in the state they were in at the time of triggering.''')
                 local_job_log_dir = os.path.join(itask_log_dir, submit_num_str)
                 for filename in ["job", "job-activity.log"]:
                     filenames.append(os.path.join(local_job_log_dir, filename))
+                if job_user_at_host is None:
+                    continue
                 if '@' in job_user_at_host:
                     job_user, job_host = job_user_at_host.split('@', 1)
                 else:

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -663,7 +663,8 @@ conditions; see `cylc conditions`.
                 # TODO - just poll for outputs in the job status file.
                 itask.state.outputs.set_all_completed()
 
-            itask.summary['job_hosts'][int(submit_num)] = user_at_host
+            if user_at_host:
+                itask.summary['job_hosts'][int(submit_num)] = user_at_host
             OUT.info("\n+ %s.%s %s" % (name, cycle, status))
             self.pool.add_to_runahead_pool(itask)
 


### PR DESCRIPTION
Occasionally, we can be in a state where a task's job `user@host` is not
yet set. The pop up job log viewer can die because of this. This fixes
the issue.

@hjoliver please review.

Equivalence of #2015. Address #2012 for 6.11.x.