### PR TITLE
Self-documenting comms layer

### DIFF
--- a/lib/cylc/network/https/daemon.py
+++ b/lib/cylc/network/https/daemon.py
@@ -128,7 +128,7 @@ def _ws_init(service_inst, *args, **kwargs):
         cherrypy.config['server.ssl_private_key'] = service_inst.pkey
     else:
         sys.stderr.write("WARNING: no HTTPS support: cannot import OpenSSL\n")
-    cherrypy.config['log.screen'] = None
+    #cherrypy.config['log.screen'] = None
     key = binascii.hexlify(os.urandom(16))
     cherrypy.config.update({
         'tools.auth_digest.on': True,

--- a/lib/cylc/network/https/daemon.py
+++ b/lib/cylc/network/https/daemon.py
@@ -128,7 +128,7 @@ def _ws_init(service_inst, *args, **kwargs):
         cherrypy.config['server.ssl_private_key'] = service_inst.pkey
     else:
         sys.stderr.write("WARNING: no HTTPS support: cannot import OpenSSL\n")
-    #cherrypy.config['log.screen'] = None
+    cherrypy.config['log.screen'] = None
     key = binascii.hexlify(os.urandom(16))
     cherrypy.config.update({
         'tools.auth_digest.on': True,

--- a/lib/cylc/network/https/ext_trigger_server.py
+++ b/lib/cylc/network/https/ext_trigger_server.py
@@ -45,8 +45,22 @@ class ExtTriggerServer(BaseCommsServer):
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def put(self, event_message, event_id):
-        """Server-side external event trigger interface."""
+        """Put a new external trigger event.
 
+        Example usage:
+
+        *    /put?event_message=new+sat+X+data+avail&event=passX12334a
+
+        See 'cylc ext-trigger'.
+
+        Args:
+
+        * event_message - string
+            External trigger message string
+        * event_id - string
+            Unique ID of the event.
+
+        """
         check_access_priv(self, 'full-control')
         self.report("ext_trigger")
         self.queue.put((event_message, event_id))

--- a/lib/cylc/network/https/suite_broadcast_server.py
+++ b/lib/cylc/network/https/suite_broadcast_server.py
@@ -45,6 +45,7 @@ class BroadcastServer(BaseCommsServer):
     Examples:
     self.settings['*']['root'] = {'environment': {'FOO': 'bar'}}
     self.settings['20100808T06Z']['root'] = {'command scripting': 'stuff'}
+
     """
 
     _INSTANCE = None
@@ -121,6 +122,16 @@ class BroadcastServer(BaseCommsServer):
             not_from_client=False):
         """Add new broadcast settings (server side interface).
 
+        Kwargs:
+
+        * point_strings - list
+            List of applicable cycle points for these settings. Can
+            be ['*'] to cover all cycle points.
+        * namespaces - list
+            List of applicable namespaces. Can also be ["root"].
+        * settings - list
+            List of setting key value dictionaries to apply.
+
         Return a tuple (modified_settings, bad_options) where:
           modified_settings is list of modified settings in the form:
             [("20200202", "foo", {"command scripting": "true"}, ...]
@@ -182,7 +193,15 @@ class BroadcastServer(BaseCommsServer):
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def get(self, task_id=None):
-        """Retrieve all broadcast variables that target a given task ID."""
+        """Retrieve all broadcast variables that target a given task ID.
+
+        Kwargs:
+
+        * task_id - string or None
+            If given, return the broadcasts set for this task_id.
+            If None, return all currently set broadcasts.
+
+        """
         check_access_priv(self, 'full-read')
         self.report('broadcast_get')
         if task_id == "None":
@@ -210,7 +229,15 @@ class BroadcastServer(BaseCommsServer):
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def expire(self, cutoff=None):
-        """Clear all settings targeting cycle points earlier than cutoff."""
+        """Clear all settings targeting cycle points earlier than cutoff.
+
+        Kwargs:
+
+        * cutoff - string or None
+            If cutoff is a point string, expire all broadcasts < cutoff
+            If cutoff is None, expire all broadcasts.
+
+        """
         point_strings = []
         cutoff_point = None
         if cutoff is not None:
@@ -231,6 +258,18 @@ class BroadcastServer(BaseCommsServer):
     def clear(self, point_strings=None, namespaces=None, cancel_settings=None):
         """Clear settings globally, or for listed namespaces and/or points.
 
+        Accepts a JSON payload or kwargs containing:
+
+        * point_strings - list or None
+            List of target point strings to clear. None or empty list means
+            clear all point strings.
+        * namespaces - list or None
+            List of target namespaces. None or empty list means clear all
+            namespaces.
+        * cancel_settings - list or NOne
+            List of particular settings to clear. None or empty list means
+            clear all settings.
+
         Return a tuple (modified_settings, bad_options), where:
         * modified_settings is similar to the return value of the "put" method,
           but for removed settings.
@@ -242,6 +281,7 @@ class BroadcastServer(BaseCommsServer):
           * namespaces: a list of bad namespaces.
           * cancel: a list of tuples. Each tuple contains the keys of a bad
             setting.
+
         """
 
         if hasattr(cherrypy.request, "json"):

--- a/lib/cylc/network/https/suite_broadcast_server.py
+++ b/lib/cylc/network/https/suite_broadcast_server.py
@@ -122,6 +122,13 @@ class BroadcastServer(BaseCommsServer):
             not_from_client=False):
         """Add new broadcast settings (server side interface).
 
+        Example URL:
+
+        * /put (plus JSON payload)
+
+        Usually accepts a JSON payload formatted as the kwargs dict
+        would be for this method.
+
         Kwargs:
 
         * point_strings - list
@@ -130,11 +137,15 @@ class BroadcastServer(BaseCommsServer):
         * namespaces - list
             List of applicable namespaces. Can also be ["root"].
         * settings - list
-            List of setting key value dictionaries to apply.
+            List of setting key value dictionaries to apply. For
+            example, [{"pre-script": "sleep 10"}].
+        * not_from_client - boolean
+            If True, do not attempt to read in JSON - use keyword
+            arguments instead. If False (default), read in JSON.
 
         Return a tuple (modified_settings, bad_options) where:
           modified_settings is list of modified settings in the form:
-            [("20200202", "foo", {"command scripting": "true"}, ...]
+            [("20200202", "foo", {"script": "true"}, ...]
           bad_options is as described in the docstring for self.clear().
         """
         check_access_priv(self, 'full-control')
@@ -195,10 +206,17 @@ class BroadcastServer(BaseCommsServer):
     def get(self, task_id=None):
         """Retrieve all broadcast variables that target a given task ID.
 
+        Example URLs:
+
+        * /get
+        * /get?task_id=:failed
+        * /get?task_id=20200202T0000Z/*
+        * /get?task_id=foo.20101225T0600Z
+
         Kwargs:
 
         * task_id - string or None
-            If given, return the broadcasts set for this task_id.
+            If given, return the broadcasts set for this task_id spec.
             If None, return all currently set broadcasts.
 
         """
@@ -231,6 +249,11 @@ class BroadcastServer(BaseCommsServer):
     def expire(self, cutoff=None):
         """Clear all settings targeting cycle points earlier than cutoff.
 
+        Example URLs:
+
+        * /expire
+        * /expire?cutoff=20100504T1200Z
+
         Kwargs:
 
         * cutoff - string or None
@@ -258,7 +281,10 @@ class BroadcastServer(BaseCommsServer):
     def clear(self, point_strings=None, namespaces=None, cancel_settings=None):
         """Clear settings globally, or for listed namespaces and/or points.
 
-        Accepts a JSON payload or kwargs containing:
+        Usually accepts a JSON payload formatted as the kwargs dict
+        would be for this method.
+
+        Kwargs:
 
         * point_strings - list or None
             List of target point strings to clear. None or empty list means

--- a/lib/cylc/network/https/suite_command_server.py
+++ b/lib/cylc/network/https/suite_command_server.py
@@ -38,6 +38,15 @@ class SuiteCommandServer(BaseCommsServer):
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def set_stop_cleanly(self, kill_active_tasks=False):
+        """Command to stop the suite after current active tasks finish.
+
+        Kwargs:
+
+        * kill_active_tasks - boolean
+            If kill_active_tasks is True, kill all current tasks before
+            stopping.
+
+        """
         if isinstance(kill_active_tasks, basestring):
             kill_active_tasks = ast.literal_eval(kill_active_tasks)
         return self._put("set_stop_cleanly",
@@ -46,6 +55,17 @@ class SuiteCommandServer(BaseCommsServer):
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def stop_now(self, terminate=False):
+        """Command to stop the suite right now, orphaning current active tasks.
+
+        By default, wait for event handlers to finish.
+
+        Kwargs:
+
+        * terminate - boolean
+            If terminate is True, terminate without waiting for event
+            handlers to finish.
+
+        """
         if isinstance(terminate, basestring):
             terminate = ast.literal_eval(terminate)
         return self._put("stop_now", None, {"terminate": terminate})

--- a/lib/cylc/network/https/suite_command_server.py
+++ b/lib/cylc/network/https/suite_command_server.py
@@ -40,6 +40,11 @@ class SuiteCommandServer(BaseCommsServer):
     def set_stop_cleanly(self, kill_active_tasks=False):
         """Command to stop the suite after current active tasks finish.
 
+        Example URLs:
+
+        * /set_stop_cleanly
+        * /set_stop_cleanly?kill_active_tasks=True
+
         Kwargs:
 
         * kill_active_tasks - boolean
@@ -59,6 +64,11 @@ class SuiteCommandServer(BaseCommsServer):
 
         By default, wait for event handlers to finish.
 
+        Example URLs:
+
+        * /stop_now
+        * /stop_now?terminate=True
+
         Kwargs:
 
         * terminate - boolean
@@ -73,134 +83,415 @@ class SuiteCommandServer(BaseCommsServer):
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def set_stop_after_point(self, point_string):
+        """Command to stop the suite after a cycle point.
+
+        Example URL:
+
+        * /set_stop_after_point?point_string=20101225T0000Z
+
+        Args:
+
+        * point_string - string
+            point_string should be a valid cycle point for the suite.
+
+        """
         return self._put("set_stop_after_point", (point_string,))
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def set_stop_after_clock_time(self, datetime_string):
+        """Command to stop the suite after a wallclock time has been reached.
+
+        Example URL:
+
+        * /set_stop_after_clock_time?datetime_string=2016-11-01T15:43+11
+
+        Args:
+
+        * datetime_string - string
+            datetime_string should be a valid ISO 8601 date-time.
+
+        """
         return self._put("set_stop_after_clock_time", (datetime_string,))
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def set_stop_after_task(self, task_id):
+        """Command to stop the suite after a particular task succeeds.
+
+        Example URL:
+
+        * /set_stop_after_task?task_id=foo.20160101T0000Z
+
+        Args:
+
+        * task_id - string
+            task_id should be the task whose success triggers a shut
+            down.
+
+        """
         return self._put("set_stop_after_task", (task_id,))
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def release_suite(self):
+        """Command to release or unpause the suite from a held state.
+
+        Example URL:
+
+        * /release_suite
+
+        """
         return self._put("release_suite", None)
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
-    def release_tasks(self, items):
-        if not isinstance(items, list):
-            items = [items]
-        return self._put("release_tasks", (items,))
+    def release_tasks(self, task_ids):
+        """Command to release particular tasks from a held state.
+
+        Example URL:
+
+        * /release_tasks?task_ids=foo.20160101T0000Z&task_ids=20160201T0000Z%2F%2A
+
+        Args:
+
+        * task_ids - list or string
+            task_ids should be either a single task id spec or a list of
+            task id spec to release.
+
+        """
+        if not isinstance(task_ids, list):
+            task_ids = [task_ids]
+        return self._put("release_tasks", (task_ids,))
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def remove_cycle(self, point_string, spawn=False):
+        """Command to remove a cycle point from the suite.
+
+        Example URL:
+
+        * /remove_cycle?point_string=20160101T0000Z
+        * /remove_cycle?point_string=20161225T0632+13&spawn=True
+
+        Args:
+
+        * point_string - string
+            point_string should be the cycle point to remove.
+
+        Kwargs:
+
+        * spawn - boolean
+            spawn, if True, allows the removed tasks in that cycle
+            point to spawn their successors.
+
+        """
         spawn = ast.literal_eval(spawn)
         return self._put("remove_cycle", (point_string,), {"spawn": spawn})
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
-    def remove_tasks(self, items, spawn=False):
+    def remove_tasks(self, task_ids, spawn=False):
+        """Command to remove a particular task or tasks from the suite.
+
+        Example URL:
+
+        * /release_tasks?task_ids=foo.20160101T0000Z&task_ids=20160201T0000Z%2F%2A
+
+        Args:
+
+        * task_ids - list or string
+            task_ids should either be a string of a task id spec to remove
+            or a list of task id specs to remove.
+
+        Kwargs:
+
+        * spawn - boolean
+            spawn, if True, allows the removed task or tasks to spawn
+            their successors.
+
+        """
         spawn = ast.literal_eval(spawn)
-        if not isinstance(items, list):
-            items = [items]
-        return self._put("remove_tasks", (items,), {"spawn": spawn})
+        if not isinstance(task_ids, list):
+            task_ids = [task_ids]
+        return self._put("remove_tasks", (task_ids,), {"spawn": spawn})
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def hold_suite(self):
+        """Command to hold (pause) a suite.
+
+        Example URL:
+
+        * /hold_suite
+
+        """
         return self._put("hold_suite", None)
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def hold_after_point_string(self, point_string):
+        """Command to hold a suite after a cycle point.
+
+        Example URL:
+
+        * /hold_after_point_string?point_string=20160101T0000Z
+
+        Args:
+
+        * point_string - string
+            point_string should be the cycle point to hold the suite
+            after.
+
+        """
         return self._put("hold_after_point_string", (point_string,))
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
-    def hold_tasks(self, items):
-        if not isinstance(items, list):
-            items = [items]
-        return self._put("hold_tasks", (items,))
+    def hold_tasks(self, task_ids):
+        """Command to hold or pause a particular task or tasks.
+
+        Example URLs:
+
+        * /hold_tasks?task_ids=foo.%2A
+        * /hold_tasks?task_ids=foo.2&task_ids=bar.1
+
+        Args:
+
+        * task_ids - list or string
+            task_ids should either be a string of a task id spec to hold
+            or a list of task id specs to hold.
+
+        """
+        if not isinstance(task_ids, list):
+            task_ids = [task_ids]
+        return self._put("hold_tasks", (task_ids,))
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def set_runahead(self, interval=None):
+        """Command to set or reset the suite runahead limit.
+
+        Example URLs:
+
+        * /set_runahead
+        * /set_runahead?interval=PT6H
+
+        Kwargs:
+
+        * interval - ISO 8601 duration string or None
+            interval should be a string like 'PT36H' to set this as the
+            suite runahead limit or None to clear the suite runahead
+            limit.
+
+        """
         interval = ast.literal_eval(interval)
         return self._put("set_runahead", None, {"interval": interval})
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def set_verbosity(self, level):
+        """Command to set the suite logging verbosity.
+
+        Example URL:
+
+        * /set_verbosity?level=DEBUG
+
+        Args:
+
+        * level - string
+            level should be the new suite logging level - one of 'INFO',
+            'NORMAL', 'WARNING', 'ERROR', 'CRITICAL', 'DEBUG'.
+
+        """
         return self._put("set_verbosity", (level,))
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
-    def reset_task_states(self, items, state=None):
-        if not isinstance(items, list):
-            items = [items]
-        return self._put("reset_task_states", (items,), {"state": state})
+    def reset_task_states(self, task_ids, state):
+        """Command to reset the state of a particular task or tasks.
+
+        Example URL:
+
+        * /reset_task_states?task_ids=foo.1&state=waiting
+
+        Args:
+
+        * task_ids - list or string
+            task_ids should either be a string of a task id spec to reset
+            or a list of task id specs to reset.
+        * state - string
+            state should be the destination state e.g. 'waiting' or
+            'succeeded'.
+
+        """
+        if not isinstance(task_ids, list):
+            task_ids = [task_ids]
+        return self._put("reset_task_states", (task_ids,), {"state": state})
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
-    def trigger_tasks(self, items):
-        if not isinstance(items, list):
-            items = [items]
-        items = [str(item) for item in items]
-        return self._put("trigger_tasks", (items,))
+    def trigger_tasks(self, task_ids):
+        """Command to trigger a particular task or tasks.
+
+        Example URLs:
+
+        * /trigger_tasks?task_ids=foo.20160101T0000Z
+        * /trigger_tasks?task_ids=foo.1&task_ids=bar.1
+        * /trigger_tasks?task_ids=:failed
+
+        Args:
+
+        * task_ids - list or string
+            task_ids should either be a string of a task id spec to trigger
+            or a list of task id specs to trigger.
+
+        """
+        if not isinstance(task_ids, list):
+            task_ids = [task_ids]
+        task_ids = [str(item) for item in task_ids]
+        return self._put("trigger_tasks", (task_ids,))
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
-    def dry_run_tasks(self, items):
-        if not isinstance(items, list):
-            items = [items]
-        return self._put("dry_run_tasks", (items,))
+    def dry_run_tasks(self, task_ids):
+        """Command to dry run a particular task or tasks.
+
+        Example URLs:
+
+        * /dry_run_tasks?task_ids=foo.1
+
+        This generates job files but does not submit them - e.g. for
+        an edit run.
+
+        Args:
+
+        * task_ids - list or string
+            task_ids should either be a string of a task id spec to dry
+            run or a list of task id specs to dry run.
+
+        """
+        if not isinstance(task_ids, list):
+            task_ids = [task_ids]
+        return self._put("dry_run_tasks", (task_ids,))
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def nudge(self):
+        """Command to nudge cylc task processing in case of stuck suites.
+
+        Example URL:
+
+        * /nudge
+
+        """
         return self._put("nudge", None)
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
-    def insert_tasks(self, items, stop_point_string=None):
-        if not isinstance(items, list):
-            items = [items]
+    def insert_tasks(self, task_ids, stop_point_string=None):
+        """Command to insert a task or tasks.
+
+        Example URLs:
+
+        * /insert_tasks?task_ids=foo.20160101
+        * /insert_tasks?task_ids=foo.20160101&stop_point_string=20161225
+
+        Args:
+
+        * task_ids - list or string
+            task_ids should either be a string of a task id spec to insert
+            or a list of task id specs to insert.
+
+        Kwargs:
+
+        * stop_point_string - string or None
+            stop_point_string, if given, sets a stop cycle point for
+            the task or tasks that they will not spawn beyond.
+
+        """
+        if not isinstance(task_ids, list):
+            task_ids = [task_ids]
         if stop_point_string == "None":
             stop_point_string = None
-        return self._put("insert_tasks", (items,),
+        return self._put("insert_tasks", (task_ids,),
                          {"stop_point_string": stop_point_string})
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def reload_suite(self):
+        """Command to reload the suite definition from files.
+
+        Example URLs:
+
+        * /reload_suite
+
+        """
         return self._put("reload_suite", None)
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
-    def poll_tasks(self, items=None):
-        if items is not None and not isinstance(items, list):
-            items = [items]
-        return self._put("poll_tasks", (items,))
+    def poll_tasks(self, task_ids=None):
+        """Command to poll particular tasks or all in the suite.
+
+        Example URL:
+
+        * /poll_tasks
+        * /poll_tasks?task_ids=foo.20160101
+
+        Kwargs:
+
+        * task_ids - list or string or None
+            task_ids, if None, implies that all tasks should be polled.
+            task_ids can also either be a string of a task id spec to
+            poll or a list of task id specs to poll.
+
+        """
+        if task_ids is not None and not isinstance(task_ids, list):
+            task_ids = [task_ids]
+        return self._put("poll_tasks", (task_ids,))
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
-    def kill_tasks(self, items):
-        if not isinstance(items, list):
-            items = [items]
-        return self._put("kill_tasks", (items,))
+    def kill_tasks(self, task_ids):
+        """Command to kill a task or tasks.
+
+        Example URLs:
+
+        * /kill_tasks?task_ids=foo.1&task_ids=bar.1
+        * /kill_tasks?task_ids=:running
+
+        Args:
+
+        * task_ids - list or string
+            task_ids should either be a string of a task id spec to kill
+            or a list of task id specs to insert.
+
+        """
+        if not isinstance(task_ids, list):
+            task_ids = [task_ids]
+        return self._put("kill_tasks", (task_ids,))
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
-    def spawn_tasks(self, items):
-        if not isinstance(items, list):
-            items = [items]
-        return self._put("kill_tasks", (items,))
+    def spawn_tasks(self, task_ids):
+        """Command to spawn the successors of a task or tasks.
+
+        Example URLs:
+
+        * /spawn_tasks?task_ids=foo.1&task_ids=bar.1
+        * /spawn_tasks?task_ids=FOO
+
+        Args:
+
+        * task_ids - list or string
+            task_ids should either be a string of a task id spec to spawn
+            or a list of task id specs to spawn.
+
+        """
+        if not isinstance(task_ids, list):
+            task_ids = [task_ids]
+        return self._put("spawn_tasks", (task_ids,))
 
     def _put(self, command, command_args, command_kwargs=None):
         if command_args is None:

--- a/lib/cylc/network/https/suite_identifier_server.py
+++ b/lib/cylc/network/https/suite_identifier_server.py
@@ -48,6 +48,13 @@ class SuiteIdServer(BaseCommsServer):
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def identify(self):
+        """Provide key identity information about the suite.
+
+        Example URL:
+
+        * /identify
+
+        """
         self.report("identify")
         result = {}
         if access_priv_ok(self, "identity"):

--- a/lib/cylc/network/https/suite_info_server.py
+++ b/lib/cylc/network/https/suite_info_server.py
@@ -36,16 +36,44 @@ class SuiteInfoServer(BaseCommsServer):
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def ping_suite(self):
+        """Return True if the suite is alive!
+
+        Example URL:
+
+        * /ping_suite
+
+        """
         return self._put("ping_suite", None)
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def get_cylc_version(self):
+        """Return the cylc version used to run this suite."""
         return self._put("get_cylc_version", None)
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def ping_task(self, task_id, exists_only=False):
+        """Return True if task exists and is running.
+
+        Example URL:
+
+        * /ping_task?task_id=foo.1
+        * /ping_task?task_id=foo.2&exists_only=True
+
+        Args:
+
+        * task_id - string
+            task_id should be the task to ping.
+
+        Kwargs:
+
+        * exists_only - boolean
+            exists_only, if True, means that the task
+            does not need to be running for this method
+            to return True - it only needs to exist.
+
+        """
         if isinstance(exists_only, basestring):
             exists_only = ast.literal_eval(exists_only)
         return self._put("ping_task", (task_id,),
@@ -54,21 +82,60 @@ class SuiteInfoServer(BaseCommsServer):
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def get_task_jobfile_path(self, task_id):
+        """Return the path to the task job script for task_id.
+
+        Example URL:
+
+        * /get_task_jobfile_path?task_id=foo.1
+
+        Args:
+
+        * task_id - string
+            task_id should be the task to get the job file for.
+
+        """
         return self._put("get_task_jobfile_path", (task_id,))
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def get_suite_info(self):
+        """Return a dict with key-values for suite title and description.
+
+        Example URL:
+
+        * /get_suite_info
+
+        """
         return self._put("get_suite_info", None)
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def get_task_info(self, name):
+        """Return a dict with key-values for task title and description.
+
+        Example URL:
+
+        * /get_task_info?name=foo
+
+        """
         return self._put("get_task_info", (name,))
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def get_all_families(self, exclude_root=False):
+        """Return a list of all families.
+
+        Example URLs:
+
+        * /get_all_families
+        * /get_all_families?exclude_root=True
+
+        Kwargs:
+
+        * exclude_root - boolean
+            if exclude_root is True, do not include 'root' in the list.
+
+        """
         if isinstance(exclude_root, basestring):
             exclude_root = ast.literal_eval(exclude_root)
         return self._put("get_all_families", None,
@@ -77,11 +144,31 @@ class SuiteInfoServer(BaseCommsServer):
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def get_first_parent_descendants(self):
+        """Return a dict of families (keys) vs descendant lists (values).
+
+        Example URL:
+
+        * /get_first_parent_descendants
+
+        """
         return self._put("get_first_parent_descendants", None)
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
-    def get_first_parent_ancestors(self, pruned=None):
+    def get_first_parent_ancestors(self, pruned=False):
+        """Return a dict of families (keys) vs ancestor lists (values).
+
+        Example URL:
+
+        * /get_first_parent_ancestors
+        * /get_first_parent_ancestors?pruned=True
+
+        Kwargs:
+
+        * pruned - boolean
+            If True, prune non-task namespaces from ancestors dict.
+
+        """
         if isinstance(pruned, basestring):
             pruned = ast.literal_eval(pruned)
         return self._put("get_first_parent_ancestors", None,
@@ -93,6 +180,37 @@ class SuiteInfoServer(BaseCommsServer):
                       group_nodes=None, ungroup_nodes=None,
                       ungroup_recursive=False, group_all=False,
                       ungroup_all=False):
+        """Return a list of graph edges for this suite.
+
+        Example URLs:
+
+        * /get_graph_raw?start_point_string=20160101T0000Z&stop_point_string=20160501T0000Z
+        * /get_graph_raw?start_point_string=10&stop_point_string=20&group_all=True
+
+        Args:
+
+        * start_point_string - string
+            This should be the cycle point to begin graphing with.
+        * stop_point_string - string
+            This should be the cycle point to end graphing with.
+
+        Kwargs:
+
+        * group_nodes - list or None
+            This should be the list of custom nodes to 'group up'.
+        * ungroup_nodes - list or None
+            This should be the list of custom nodes to 'ungroup'.
+        * ungroup_recursive - boolean
+            If True and ungroup_nodes is given, recursively ungroup
+            those nodes.
+        * group_all - boolean
+            If True, group all tasks and families up to the highest
+            non-root level possible.
+        * ungroup_all - boolean
+            If True, ungroup all families so that only task edges are
+            present.
+
+        """
         if isinstance(group_nodes, basestring):
             group_nodes = ast.literal_eval(group_nodes)
         if isinstance(ungroup_nodes, basestring):
@@ -115,6 +233,20 @@ class SuiteInfoServer(BaseCommsServer):
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def get_task_requisites(self, name, point_string):
+        """Get task requisites for task name at point_string.
+
+        Example URL:
+
+        * /get_task_requisites?name=foo&point_string=20161201T0000Z
+
+        Args:
+
+        * name - string
+            name of the task, excluding cycle point
+        * point_string - string
+            cycle point of the task.
+
+        """
         return self._put("get_task_requisites", (name, point_string))
 
     def _put(self, command, command_args, command_kwargs=None):

--- a/lib/cylc/network/https/suite_log_server.py
+++ b/lib/cylc/network/https/suite_log_server.py
@@ -49,7 +49,26 @@ class SuiteLogServer(BaseCommsServer):
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def get_err_content(self, prev_size, max_lines):
-        """Return the content and new size of the error file."""
+        """Return the content and new size of the suite error file.
+
+        Returns a list of most recent error file lines and the new size
+        of the file, only if the size is different from prev_size.
+
+        Example URL:
+
+        * /get_err_content?prev_size=4824&max_lines=10
+
+        Args:
+
+        * prev_size - integer
+            If prev_size matches the err file size, return zero content
+            and prev_size ([], prev_size).
+
+        * max_lines - integer
+            If the suite error file has changed size, return up to the
+            last max_lines lines of error file.
+
+        """
         check_access_priv(self, 'full-read')
         self.report("get_err_content")
         prev_size = int(prev_size)

--- a/lib/cylc/network/https/suite_state_server.py
+++ b/lib/cylc/network/https/suite_state_server.py
@@ -193,7 +193,13 @@ class StateSummaryServer(BaseCommsServer):
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def get_state_summary(self):
-        """Return the global, task, and family summary data structures."""
+        """Return the global, task, and family summary data structures.
+
+        Example URL:
+
+        * /get_state_summary
+
+        """
         check_access_priv(self, 'full-read')
         self.report('get_state_summary')
         if not self.first_update_completed:
@@ -203,7 +209,13 @@ class StateSummaryServer(BaseCommsServer):
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def get_summary_update_time(self):
-        """Return the last time the summaries were changed (Unix time)."""
+        """Return the last time the summaries were changed (Unix time).
+
+        Example URL:
+
+        * /get_summary_update_time
+
+        """
         check_access_priv(self, 'state-totals')
         self.report('get_state_summary_update_time')
         if not self.first_update_completed:
@@ -213,8 +225,17 @@ class StateSummaryServer(BaseCommsServer):
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def get_tasks_by_state(self):
-        """Returns a dictionary containing lists of tasks by state in the form:
-        {state: [(most_recent_time_string, task_name, point_string), ...]}."""
+        """Returns a dictionary containing lists of tasks by state.
+        
+        The dictionary is in the form:
+        {state:
+         [(most_recent_time_string, task_name, point_string), ...]}.
+
+        Example URL:
+
+        * /get_tasks_by_state
+
+        """
         check_access_priv(self, 'state-totals')
 
         # Get tasks.

--- a/lib/cylc/network/https/task_msg_server.py
+++ b/lib/cylc/network/https/task_msg_server.py
@@ -33,6 +33,24 @@ class TaskMessageServer(BaseCommsServer):
     @cherrypy.expose
     @cherrypy.tools.json_out()
     def put(self, task_id, priority, message):
+        """Notify the suite daemon of a task message.
+
+        Example URL:
+
+        * /put?task_id=foo.1&priority=NORMAL&message=foo.1+succeeded
+
+        Args:
+
+        * task_id - string
+            task_id should be the task that originates the message.
+        * priority - string
+            priority should be NORMAL, WARNING, or CRITICAL
+        * message - string
+            message should usually be a known output message for the
+            task (e.g. to indicate that the task succeeded). It can
+            also be a custom message.
+
+        """
         check_access_priv(self, 'full-control')
         self.report('task_message')
         self.queue.put((task_id, priority, str(message)))

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -1812,7 +1812,7 @@ To see if %(suite)s is running on '%(host)s:%(port)s':
         """Dry-run tasks, e.g. edit run."""
         return self.pool.dry_run_task(items)
 
-    def command_reset_task_states(self, items, state=None):
+    def command_reset_task_states(self, items, state):
         """Reset the state of tasks."""
         return self.pool.reset_task_states(items, state)
 

--- a/tests/comms.api/00-broadcast.t
+++ b/tests/comms.api/00-broadcast.t
@@ -1,0 +1,161 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2016 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test authentication - privilege 'identity'.
+
+. $(dirname $0)/test_header
+
+if ! wget --version 1>'/dev/null' 2>&1; then
+    skip_all '"wget" command not available'
+fi
+
+set_test_number 6
+
+install_suite "${TEST_NAME_BASE}" basic
+
+TEST_NAME="${TEST_NAME_BASE}-validate"
+run_ok "${TEST_NAME}" cylc validate "${SUITE_NAME}"
+
+cylc run "${SUITE_NAME}"
+unset CYLC_CONF_PATH
+
+# Wait for first task 'foo' to fail.
+cylc suite-state "${SUITE_NAME}" --task=foo --status=failed --cycle=1 \
+    --interval=1 --max-polls=10 || exit 1
+
+PORT=$(cylc ping -v "${SUITE_NAME}" | cut -d':' -f 2)
+SUITE_RUN_DIR="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}"
+if grep -q "^WARNING: no HTTPS support" "${SUITE_RUN_DIR}/log/suite/err"; then
+    URL="http://localhost:${PORT}"
+else
+    URL="https://localhost:${PORT}"
+fi
+
+TEST_NAME="${TEST_NAME_BASE}-wget-json"
+export http_proxy= https_proxy=
+run_ok "${TEST_NAME}" wget "$URL/broadcast/index?form=json" --no-check-certificate --user=cylc \
+    --password=$(cat "${TEST_DIR}/${SUITE_NAME}/passphrase") -O index
+TEST_NAME="${TEST_NAME_BASE}-print-json"
+run_ok "${TEST_NAME}" python -c "import json, pprint, sys; pprint.pprint(json.loads(sys.stdin.read()))" <index
+cmp_ok "${TEST_NAME}.stdout" <<__OUT__
+[{u'argdoc': u'(point_strings=None, namespaces=None, cancel_settings=None)',
+  u'doc': u'Clear settings globally, or for listed namespaces and/or points.\n\nAccepts a JSON payload or kwargs containing:\n\n* point_strings - list or None\n    List of target point strings to clear. None or empty list means\n    clear all point strings.\n* namespaces - list or None\n    List of target namespaces. None or empty list means clear all\n    namespaces.\n* cancel_settings - list or NOne\n    List of particular settings to clear. None or empty list means\n    clear all settings.\n\nReturn a tuple (modified_settings, bad_options), where:\n* modified_settings is similar to the return value of the "put" method,\n  but for removed settings.\n* bad_options is a dict in the form:\n      {"point_strings": ["20020202", ..."], ...}\n  The dict is only populated if there are options not associated with\n  previous broadcasts. The keys can be:\n  * point_strings: a list of bad point strings.\n  * namespaces: a list of bad namespaces.\n  * cancel: a list of tuples. Each tuple contains the keys of a bad\n    setting.',
+  u'name': u'clear'},
+ {u'argdoc': u'(cutoff=None)',
+  u'doc': u'Clear all settings targeting cycle points earlier than cutoff.\n\nKwargs:\n\n* cutoff - string or None\n    If cutoff is a point string, expire all broadcasts < cutoff\n    If cutoff is None, expire all broadcasts.',
+  u'name': u'expire'},
+ {u'argdoc': u'(task_id=None)',
+  u'doc': u'Retrieve all broadcast variables that target a given task ID.\n\nKwargs:\n\n* task_id - string or None\n    If given, return the broadcasts set for this task_id.\n    If None, return all currently set broadcasts.',
+  u'name': u'get'},
+ {u'argdoc': u"(form='html')",
+  u'doc': u"Return the methods (=sub-urls) within this class.\n\nExample URL:\n\n* https://host:port/CLASS/\n\nKwargs:\n\n* form - string\n    form can be either 'html' (default) or 'json' for easily\n    machine readable output.",
+  u'name': u'index'},
+ {u'argdoc': u'(point_strings=None, namespaces=None, settings=None, not_from_client=False)',
+  u'doc': u'Add new broadcast settings (server side interface).\n\nKwargs:\n\n* point_strings - list\n    List of applicable cycle points for these settings. Can\n    be [\'*\'] to cover all cycle points.\n* namespaces - list\n    List of applicable namespaces. Can also be ["root"].\n* settings - list\n    List of setting key value dictionaries to apply.\n\nReturn a tuple (modified_settings, bad_options) where:\n  modified_settings is list of modified settings in the form:\n    [("20200202", "foo", {"command scripting": "true"}, ...]\n  bad_options is as described in the docstring for self.clear().',
+  u'name': u'put'}]
+__OUT__
+
+TEST_NAME="${TEST_NAME_BASE}-wget-html"
+run_ok "${TEST_NAME}" wget "$URL/broadcast/index" --no-check-certificate --user=cylc \
+    --password=$(cat "${TEST_DIR}/${SUITE_NAME}/passphrase") -O "${TEST_NAME_BASE}-index.html"
+cmp_ok "${TEST_NAME_BASE}-index.html" <<__OUT__
+<html><head>
+<title>Cylc Comms API for BroadcastServer</title></head>
+<h1>BroadcastServer</h1>
+<h2>clear</h2>
+<p>clear(point_strings=None, namespaces=None, cancel_settings=None)</p>
+<pre>Clear settings globally, or for listed namespaces and/or points.
+
+Accepts a JSON payload or kwargs containing:
+
+* point_strings - list or None
+    List of target point strings to clear. None or empty list means
+    clear all point strings.
+* namespaces - list or None
+    List of target namespaces. None or empty list means clear all
+    namespaces.
+* cancel_settings - list or NOne
+    List of particular settings to clear. None or empty list means
+    clear all settings.
+
+Return a tuple (modified_settings, bad_options), where:
+* modified_settings is similar to the return value of the "put" method,
+  but for removed settings.
+* bad_options is a dict in the form:
+      {"point_strings": ["20020202", ..."], ...}
+  The dict is only populated if there are options not associated with
+  previous broadcasts. The keys can be:
+  * point_strings: a list of bad point strings.
+  * namespaces: a list of bad namespaces.
+  * cancel: a list of tuples. Each tuple contains the keys of a bad
+    setting.</pre>
+<h2>expire</h2>
+<p>expire(cutoff=None)</p>
+<pre>Clear all settings targeting cycle points earlier than cutoff.
+
+Kwargs:
+
+* cutoff - string or None
+    If cutoff is a point string, expire all broadcasts < cutoff
+    If cutoff is None, expire all broadcasts.</pre>
+<h2>get</h2>
+<p>get(task_id=None)</p>
+<pre>Retrieve all broadcast variables that target a given task ID.
+
+Kwargs:
+
+* task_id - string or None
+    If given, return the broadcasts set for this task_id.
+    If None, return all currently set broadcasts.</pre>
+<h2>index</h2>
+<p>index(form='html')</p>
+<pre>Return the methods (=sub-urls) within this class.
+
+Example URL:
+
+* https://host:port/CLASS/
+
+Kwargs:
+
+* form - string
+    form can be either 'html' (default) or 'json' for easily
+    machine readable output.</pre>
+<h2>put</h2>
+<p>put(point_strings=None, namespaces=None, settings=None, not_from_client=False)</p>
+<pre>Add new broadcast settings (server side interface).
+
+Kwargs:
+
+* point_strings - list
+    List of applicable cycle points for these settings. Can
+    be ['*'] to cover all cycle points.
+* namespaces - list
+    List of applicable namespaces. Can also be ["root"].
+* settings - list
+    List of setting key value dictionaries to apply.
+
+Return a tuple (modified_settings, bad_options) where:
+  modified_settings is list of modified settings in the form:
+    [("20200202", "foo", {"command scripting": "true"}, ...]
+  bad_options is as described in the docstring for self.clear().</pre>
+</html>
+__OUT__
+
+# Stop and purge the suite.
+cylc stop --max-polls=10 --interval=1 "${SUITE_NAME}"
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/comms.api/00-broadcast.t
+++ b/tests/comms.api/00-broadcast.t
@@ -53,19 +53,19 @@ TEST_NAME="${TEST_NAME_BASE}-print-json"
 run_ok "${TEST_NAME}" python -c "import json, pprint, sys; pprint.pprint(json.loads(sys.stdin.read()))" <index
 cmp_ok "${TEST_NAME}.stdout" <<__OUT__
 [{u'argdoc': u'(point_strings=None, namespaces=None, cancel_settings=None)',
-  u'doc': u'Clear settings globally, or for listed namespaces and/or points.\n\nAccepts a JSON payload or kwargs containing:\n\n* point_strings - list or None\n    List of target point strings to clear. None or empty list means\n    clear all point strings.\n* namespaces - list or None\n    List of target namespaces. None or empty list means clear all\n    namespaces.\n* cancel_settings - list or NOne\n    List of particular settings to clear. None or empty list means\n    clear all settings.\n\nReturn a tuple (modified_settings, bad_options), where:\n* modified_settings is similar to the return value of the "put" method,\n  but for removed settings.\n* bad_options is a dict in the form:\n      {"point_strings": ["20020202", ..."], ...}\n  The dict is only populated if there are options not associated with\n  previous broadcasts. The keys can be:\n  * point_strings: a list of bad point strings.\n  * namespaces: a list of bad namespaces.\n  * cancel: a list of tuples. Each tuple contains the keys of a bad\n    setting.',
+  u'doc': u'Clear settings globally, or for listed namespaces and/or points.\n\nUsually accepts a JSON payload formatted as the kwargs dict\nwould be for this method.\n\nKwargs:\n\n* point_strings - list or None\n    List of target point strings to clear. None or empty list means\n    clear all point strings.\n* namespaces - list or None\n    List of target namespaces. None or empty list means clear all\n    namespaces.\n* cancel_settings - list or NOne\n    List of particular settings to clear. None or empty list means\n    clear all settings.\n\nReturn a tuple (modified_settings, bad_options), where:\n* modified_settings is similar to the return value of the "put" method,\n  but for removed settings.\n* bad_options is a dict in the form:\n      {"point_strings": ["20020202", ..."], ...}\n  The dict is only populated if there are options not associated with\n  previous broadcasts. The keys can be:\n  * point_strings: a list of bad point strings.\n  * namespaces: a list of bad namespaces.\n  * cancel: a list of tuples. Each tuple contains the keys of a bad\n    setting.',
   u'name': u'clear'},
  {u'argdoc': u'(cutoff=None)',
-  u'doc': u'Clear all settings targeting cycle points earlier than cutoff.\n\nKwargs:\n\n* cutoff - string or None\n    If cutoff is a point string, expire all broadcasts < cutoff\n    If cutoff is None, expire all broadcasts.',
+  u'doc': u'Clear all settings targeting cycle points earlier than cutoff.\n\nExample URLs:\n\n* /expire\n* /expire?cutoff=20100504T1200Z\n\nKwargs:\n\n* cutoff - string or None\n    If cutoff is a point string, expire all broadcasts < cutoff\n    If cutoff is None, expire all broadcasts.',
   u'name': u'expire'},
  {u'argdoc': u'(task_id=None)',
-  u'doc': u'Retrieve all broadcast variables that target a given task ID.\n\nKwargs:\n\n* task_id - string or None\n    If given, return the broadcasts set for this task_id.\n    If None, return all currently set broadcasts.',
+  u'doc': u'Retrieve all broadcast variables that target a given task ID.\n\nExample URLs:\n\n* /get\n* /get?task_id=:failed\n* /get?task_id=20200202T0000Z/*\n* /get?task_id=foo.20101225T0600Z\n\nKwargs:\n\n* task_id - string or None\n    If given, return the broadcasts set for this task_id spec.\n    If None, return all currently set broadcasts.',
   u'name': u'get'},
  {u'argdoc': u"(form='html')",
   u'doc': u"Return the methods (=sub-urls) within this class.\n\nExample URL:\n\n* https://host:port/CLASS/\n\nKwargs:\n\n* form - string\n    form can be either 'html' (default) or 'json' for easily\n    machine readable output.",
   u'name': u'index'},
  {u'argdoc': u'(point_strings=None, namespaces=None, settings=None, not_from_client=False)',
-  u'doc': u'Add new broadcast settings (server side interface).\n\nKwargs:\n\n* point_strings - list\n    List of applicable cycle points for these settings. Can\n    be [\'*\'] to cover all cycle points.\n* namespaces - list\n    List of applicable namespaces. Can also be ["root"].\n* settings - list\n    List of setting key value dictionaries to apply.\n\nReturn a tuple (modified_settings, bad_options) where:\n  modified_settings is list of modified settings in the form:\n    [("20200202", "foo", {"command scripting": "true"}, ...]\n  bad_options is as described in the docstring for self.clear().',
+  u'doc': u'Add new broadcast settings (server side interface).\n\nExample URL:\n\n* /put (plus JSON payload)\n\nUsually accepts a JSON payload formatted as the kwargs dict\nwould be for this method.\n\nKwargs:\n\n* point_strings - list\n    List of applicable cycle points for these settings. Can\n    be [\'*\'] to cover all cycle points.\n* namespaces - list\n    List of applicable namespaces. Can also be ["root"].\n* settings - list\n    List of setting key value dictionaries to apply. For\n    example, [{"pre-script": "sleep 10"}].\n* not_from_client - boolean\n    If True, do not attempt to read in JSON - use keyword\n    arguments instead. If False (default), read in JSON.\n\nReturn a tuple (modified_settings, bad_options) where:\n  modified_settings is list of modified settings in the form:\n    [("20200202", "foo", {"script": "true"}, ...]\n  bad_options is as described in the docstring for self.clear().',
   u'name': u'put'}]
 __OUT__
 
@@ -80,7 +80,10 @@ cmp_ok "${TEST_NAME_BASE}-index.html" <<__OUT__
 <p>clear(point_strings=None, namespaces=None, cancel_settings=None)</p>
 <pre>Clear settings globally, or for listed namespaces and/or points.
 
-Accepts a JSON payload or kwargs containing:
+Usually accepts a JSON payload formatted as the kwargs dict
+would be for this method.
+
+Kwargs:
 
 * point_strings - list or None
     List of target point strings to clear. None or empty list means
@@ -107,6 +110,11 @@ Return a tuple (modified_settings, bad_options), where:
 <p>expire(cutoff=None)</p>
 <pre>Clear all settings targeting cycle points earlier than cutoff.
 
+Example URLs:
+
+* /expire
+* /expire?cutoff=20100504T1200Z
+
 Kwargs:
 
 * cutoff - string or None
@@ -116,10 +124,17 @@ Kwargs:
 <p>get(task_id=None)</p>
 <pre>Retrieve all broadcast variables that target a given task ID.
 
+Example URLs:
+
+* /get
+* /get?task_id=:failed
+* /get?task_id=20200202T0000Z/*
+* /get?task_id=foo.20101225T0600Z
+
 Kwargs:
 
 * task_id - string or None
-    If given, return the broadcasts set for this task_id.
+    If given, return the broadcasts set for this task_id spec.
     If None, return all currently set broadcasts.</pre>
 <h2>index</h2>
 <p>index(form='html')</p>
@@ -138,6 +153,13 @@ Kwargs:
 <p>put(point_strings=None, namespaces=None, settings=None, not_from_client=False)</p>
 <pre>Add new broadcast settings (server side interface).
 
+Example URL:
+
+* /put (plus JSON payload)
+
+Usually accepts a JSON payload formatted as the kwargs dict
+would be for this method.
+
 Kwargs:
 
 * point_strings - list
@@ -146,11 +168,15 @@ Kwargs:
 * namespaces - list
     List of applicable namespaces. Can also be ["root"].
 * settings - list
-    List of setting key value dictionaries to apply.
+    List of setting key value dictionaries to apply. For
+    example, [{"pre-script": "sleep 10"}].
+* not_from_client - boolean
+    If True, do not attempt to read in JSON - use keyword
+    arguments instead. If False (default), read in JSON.
 
 Return a tuple (modified_settings, bad_options) where:
   modified_settings is list of modified settings in the form:
-    [("20200202", "foo", {"command scripting": "true"}, ...]
+    [("20200202", "foo", {"script": "true"}, ...]
   bad_options is as described in the docstring for self.clear().</pre>
 </html>
 __OUT__

--- a/tests/comms.api/basic/suite.rc
+++ b/tests/comms.api/basic/suite.rc
@@ -1,0 +1,14 @@
+title = Authentication test suite.
+description = Stalls when the first task fails.
+[cylc]
+    [[events]]
+        timeout = PT30S
+        abort on timeout = True
+[scheduling]
+    [[dependencies]]
+        graph = foo => bar
+[runtime]
+    [[foo]]
+        script = /bin/false
+    [[bar]]
+        script = /bin/true

--- a/tests/comms.api/test_header
+++ b/tests/comms.api/test_header
@@ -1,0 +1,1 @@
+../lib/bash/test_header


### PR DESCRIPTION
A rough sketch of self-documentation capability for the comms layer. Each exposed method is introspected and is used to generate a page for each sub-url (e.g. all the `/broadcast/*` server methods are exposed by going to the root `/broadcast/` page).

I'm putting this up as an example for discussion really - there is definitely a better way of presenting this out there. If we're being really wild, there must be some kind of auto-generation of HTML forms based on input metadata for the parameters...
