### PR TITLE
Configurable event mail footer

### DIFF
--- a/doc/siterc.tex
+++ b/doc/siterc.tex
@@ -904,6 +904,8 @@ of which can be found under ~\ref{SuiteEventHandling}:
 
 \subparagraph[mail events]{[cylc] \textrightarrow [[events]] \textrightarrow mail events}
 
+\subparagraph[mail footer]{[cylc] \textrightarrow [[events]] \textrightarrow mail footer}
+
 \subparagraph[mail from]{[cylc] \textrightarrow [[events]] \textrightarrow mail from}
 
 \subparagraph[mail smtp]{[cylc] \textrightarrow [[events]] \textrightarrow mail smtp}

--- a/doc/suiterc.tex
+++ b/doc/suiterc.tex
@@ -329,6 +329,26 @@ Specify the suite events for which notification emails should be sent.
     \item {\em example:} \lstinline@handler = startup, shutdown, timeout@
 \end{myitemize}
 
+\paragraph[mail footer]{[cylc] \textrightarrow [[events]] \textrightarrow mail footer}
+
+Specify a string or string template to insert to footers of notification emails
+for both suite events and task events.
+
+A template string may have any or all of these patterns which will be
+substituted with actual values:
+\begin{myitemize}
+    \item \%(host)s: suite host name
+    \item \%(port)s: suite port number
+    \item \%(owner)s: suite owner name
+    \item \%(suite)s: suite name
+\end{myitemize}
+
+\begin{myitemize}
+    \item {\em type:} 
+    \item {\em default:} (none)
+    \item {\em example:} \lstinline@mail footer = see: http://localhost/%(owner)s/notes-on/%(suite)s/@
+\end{myitemize}
+
 \paragraph[mail from]{[cylc] \textrightarrow [[events]] \textrightarrow mail from}
 
 Specify an alternate \lstinline=from:= email address for suite event notifications.

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -78,6 +78,7 @@ SPEC = {
             'mail from': vdr(vtype='string'),
             'mail smtp': vdr(vtype='string'),
             'mail to': vdr(vtype='string'),
+            'mail footer': vdr(vtype='string'),
             'startup handler': vdr(vtype='string_list', default=[]),
             'timeout handler': vdr(vtype='string_list', default=[]),
             'inactivity handler': vdr(vtype='string_list', default=[]),

--- a/lib/cylc/cfgspec/suite.py
+++ b/lib/cylc/cfgspec/suite.py
@@ -258,6 +258,7 @@ SPEC = {
             'mail from': vdr(vtype='string'),
             'mail smtp': vdr(vtype='string'),
             'mail to': vdr(vtype='string'),
+            'mail footer': vdr(vtype='string'),
         },
         'simulation mode': {
             'disable suite event hooks': vdr(vtype='boolean', default=True),

--- a/tests/events/09-task-event-mail.t
+++ b/tests/events/09-task-event-mail.t
@@ -20,11 +20,14 @@
 if ! mail -V 2>'/dev/null'; then
     skip_all '"mail" command not available'
 fi
-set_test_number 5
+set_test_number 3
 mock_smtpd_init
 OPT_SET=
 if [[ "${TEST_NAME_BASE}" == *-globalcfg ]]; then
     create_test_globalrc "" "
+[cylc]
+    [[events]]
+        mail footer = see: http://localhost/stuff/%(owner)s/%(suite)s/
 [task events]
     mail events = failed, retry, succeeded
     mail smtp = ${TEST_SMTPD_HOST}"
@@ -39,9 +42,13 @@ run_ok "${TEST_NAME_BASE}-validate" \
 suite_run_ok "${TEST_NAME_BASE}-run" \
     cylc run --reference-test --debug ${OPT_SET} "${SUITE_NAME}"
 
-grep_ok 'Subject: \[1 task(s) retry\]' "${TEST_SMTPD_LOG}"
-grep_ok 'Subject: \[1 task(s) succeeded\]' "${TEST_SMTPD_LOG}"
-grep_ok '^1/t1/\(01: retry\|02: succeeded\)' "${TEST_SMTPD_LOG}"
+contains_ok "${TEST_SMTPD_LOG}" <<__LOG__
+task 1: 1/t1/01
+task event: retry
+task 1: 1/t1/02
+task event: succeeded
+see: http://localhost/stuff/${USER}/${SUITE_NAME}/
+__LOG__
 
 purge_suite "${SUITE_NAME}"
 mock_smtpd_kill

--- a/tests/events/09-task-event-mail/suite.rc
+++ b/tests/events/09-task-event-mail/suite.rc
@@ -3,6 +3,10 @@
 title=Task Event Mail
 
 [cylc]
+{% if GLOBALCFG is not defined %}
+    [[events]]
+        mail footer = see: http://localhost/stuff/%(owner)s/%(suite)s/
+{% endif %}{# not GLOBALCFG is not defined #}
     [[reference test]]
         live mode suite timeout=PT1M
 

--- a/tests/events/18-suite-event-mail/suite.rc
+++ b/tests/events/18-suite-event-mail/suite.rc
@@ -6,6 +6,7 @@ title=Suite Event Mail
     [[events]]
 {% if GLOBALCFG is not defined %}
         mail events = startup, shutdown
+        mail footer = see: http://localhost/stuff/%(owner)s/%(suite)s/
         mail smtp = {{MAIL_SMTP}}
 {% endif %}{# not GLOBALCFG is not defined #}
     [[reference test]]


### PR DESCRIPTION
Allow a configurable event mail footer setting (suite or global) to be
added to all event mails. The new setting, although specified at the
suite level, will apply to both suite events and task events.

Move task event handler logic from `cylc.task_pool` to `cylc.scheduler`
for easier access to suite variables.

Close #2022. (This change should be appropriate to replace what we currently have for `rose suite-hook --mail`.)

@hjoliver @arjclark please review.