### PR TITLE
Auto insert on reload

### DIFF
--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -884,6 +884,7 @@ conditions; see `cylc conditions`.
         add = set(self.config.get_task_name_list()) - old_tasks
         for task in add:
             LOG.warning("Added task: '%s'" % (task,))
+        self.pool.new_tasks.update(add)
 
         self.configure_suite_environment()
         if self.gen_reference_log or self.reference_test_mode:
@@ -1376,6 +1377,9 @@ To see if %(suite)s is running on '%(host)s:%(port)s':
             if self.pool.do_reload:
                 self.pool.reload_taskdefs()
                 self.do_update_state_summary = True
+
+            if self.pool.new_tasks:
+                self.pool.auto_insert()
 
             self.process_command_queue()
             if self.pool.release_runahead_tasks():


### PR DESCRIPTION
**Not for merge**

Addresses #774 

This is a messy, part-baked implementation of auto-insert for tasks added through a suite reload:
- It determines whether a task can be inserted by forming a graph leading back to tasks currently in the task pool and assessing their status.
- The cycle point to insert the new task is that of the task pool task(s) that it leads to / hangs off adjusted for inter-cycle dependence extracted from config.edges (i.e. `foo[-PT6H] => bar`)
- If the new task is a graph isolate (its sub graph does not connect to anything from pre-reload) then the cycle point is taken to be the earliest point on the tasks sequence at or after the oldest active cycle point.
- If a task downstream of a new task has completed then the new task **will not** be inserted _(at this cycle point)_
- If a task upstream of a new task has succeeded then the new task **will** be inserted
- If a task upstream of a new task has failed and the dependency relationship is for a failed state (`foo:fail => bar`) then task **will** be inserted, else it **will not**.

I've been testing with the following suite:

``` ini
[scheduling]
    initial cycle point = 2000-01-01T00
    [[dependencies]]
        [[[T12]]]
            graph = d[-P1D] => a => b => c:fail => d
[runtime]
    [[root]]
        script = sleep 1
    [[a, b, d]]
    [[c]]
        script = fail
```

Reloading with:

``` ini
[scheduling]
    initial cycle point = 2000-01-01T00
    [[dependencies]]
        [[[T12]]]
            graph = """
                d[-P1D] => a => b => c:failed => d
                new_1 => a => new_2
                new_3 => new_4 & new_5
                new_4 & new_5 => b
                b => new_6 & new_7
                new_6 & new_7 => new_8
                new_9 => c
                c:fail => new_10
                new_11[-PT6H] => d
            """
        [[[T06]]]
            graph = new_11
        [[[T18]]]
            graph = d[-PT6H] => new_12
        [[[T00]]]
            graph = new_13 => new_14
[runtime]
    [[root]]
        script = sleep 1
    [[a, b, d]]
    [[c]]
        script = fail
```

@hjoliver @arjclark:
- Is this behaviour what you would expect?
- Should we auto insert by default or should it be a command line option?
