### PR TITLE
restart: allow restart from a different checkpoint

### DIFF
--- a/doc/cug.tex
+++ b/doc/cug.tex
@@ -5990,17 +5990,19 @@ suite initial cycle point, or at the next valid point for the task.
 
 \subsubsection{Restart}
 
-A restart starts a suite run from the state recorded at the end of a previous
-run. This allows restarting a suite that was shut down or killed, without
-rerunning tasks that were already completed, or which were already submitted or
-running when the suite went down.
+A restart starts a suite run from the state recorded at a checkpoint, which is
+normally the end of a previous run. This allows restarting a suite that was
+shut down or killed, without rerunning tasks that were already completed, or
+which were already submitted or running when the suite went down.
 \lstset{language=transcript}
 \begin{lstlisting}
-shell$ cylc restart SUITE [STATE_FILE]
+shell$ cylc restart SUITE
 \end{lstlisting}
 For a restart, the scheduler starts by loading each task in its recorded state.
 Any tasks recorded as `submitted' or `running' will be polled automatically to
 determine what happened to them while the suite was down.
+
+See ~\ref{RestartingSuites} for more detail.
 
 \subsubsection{Warm Start}
 
@@ -6268,18 +6270,48 @@ used if necessary (see~\ref{GlobalInitScript}).
 \subsection{Restarting Suites}
 \label{RestartingSuites}
 
-A restarted suite (see \lstinline=cylc restart --help=) is initialized from the
-previous recorded suite state so that it can carry on from wherever it got to
-before being shut down or killed.
+A restarted suite (see \lstinline=cylc restart --help=) is initialized from a
+previous recorded checkpoint, which is normally the end of a previous run, so
+that it can carry on from wherever it got to before being shut down or killed.
 
-Tasks that were recorded in the submitted or running states are now
-automatically polled on restart, to see if they are still submitted
-(e.g. waiting in a PBS batch queue or similar), still running, or if they
-finished (succeeded or failed) while the suite was down.
+\subsubsection{Restart Suite from Latest}
+
+A normal restart is easy. Simply invoke the \lstinline=cylc restart= command
+with the suite name:
+
+\lstset{language=transcript}
+\begin{lstlisting}
+shell$ cylc restart SUITE
+\end{lstlisting}
+
+\subsubsection{Restart Suite from a Check Point}
+
+You can use the \lstinline=cylc ls-checkpoints= command to identify the
+checkpoint to use to restart a suite. (See also
+\lstinline=cylc ls-checkpoints --help=.)
+The checkpoint ID 0 (zero) is always used for latest state of the suite. The
+checkpoint IDs of non-latest states are positive integers starting from 1, and
+incremented each time a new checkpoint is stored.
+
+Once you have identified the checkpoint to use, invoke the
+\lstinline=cylc restart= command with the suite name and the
+\lstinline@--checkpoint=CHECKPOINT@ option:
+
+\lstset{language=transcript}
+\begin{lstlisting}
+shell$ cylc restart --checkpoint=CHECKPOINT-ID SUITE
+\end{lstlisting}
+
+\subsubsection{Behaviour of Tasks on Suite Restart}
+
+Tasks that were recorded in the submitted or running states are automatically
+polled on restart, to see if they are still submitted (e.g. waiting in a PBS
+batch queue or similar), still running, or if they finished (succeeded or
+failed) while the suite was down.
 
 Tasks recorded in the failed state at shutdown are not automatically
-resubmitted on restarting the suite, in case the underlying problem has
-not been addressed yet.
+resubmitted on restarting the suite, in case the underlying problem has not
+been addressed yet.
 
 \subsection{Task States}
 

--- a/doc/cug.tex
+++ b/doc/cug.tex
@@ -6284,14 +6284,20 @@ with the suite name:
 shell$ cylc restart SUITE
 \end{lstlisting}
 
+It will restart the suite from the latest checkpoint.
+
 \subsubsection{Restart Suite from a Check Point}
 
 You can use the \lstinline=cylc ls-checkpoints= command to identify the
 checkpoint to use to restart a suite. (See also
 \lstinline=cylc ls-checkpoints --help=.)
-The checkpoint ID 0 (zero) is always used for latest state of the suite. The
-checkpoint IDs of non-latest states are positive integers starting from 1, and
-incremented each time a new checkpoint is stored.
+
+The checkpoint ID 0 (zero) is always used for latest state of the suite, which
+is updated continuously as the suite progresses. The checkpoint IDs of
+non-latest states are positive integers starting from 1, and incremented each
+time a new checkpoint is stored. Currently a suite will automatically stores
+checkpoints before and after reloads, and on restarts (using the latest
+checkpoints before the restarts).
 
 Once you have identified the checkpoint to use, invoke the
 \lstinline=cylc restart= command with the suite name and the
@@ -6301,6 +6307,8 @@ Once you have identified the checkpoint to use, invoke the
 \begin{lstlisting}
 shell$ cylc restart --checkpoint=CHECKPOINT-ID SUITE
 \end{lstlisting}
+
+It will restart the suite from the specified checkpoint.
 
 \subsubsection{Behaviour of Tasks on Suite Restart}
 

--- a/doc/siterc.tex
+++ b/doc/siterc.tex
@@ -39,10 +39,6 @@ Number of process pool worker processes used to execute shell commands
 \item {\em default:} None (number of processor cores on the suite host)
 \end{myitemize}
 
-\subsubsection{state dump rolling archive length}
-
-Obsolete. This setting is no longer used.
-
 \subsubsection{disable interactive command prompts}
 
 Commands that intervene in running suites can be made to ask for

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -336,6 +336,7 @@ def upg(cfg, descr):
             ['test battery', 'directives', batch_sys_name + ' directives'],
             ['test battery', 'batch systems', batch_sys_name, 'directives'])
     u.obsolete('6.4.1', ['test battery', 'directives'])
+    u.obsolete('6.11.0', ['state dump rolling archive length'])
     u.deprecate('6.11.0', ['cylc', 'event hooks'], ['cylc', 'events'])
     for key in SPEC['cylc']['events']:
         u.deprecate(

--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -1118,8 +1118,15 @@ been defined for this suite""").inform()
 
     def startsuite(self, bt, window, coldstart_rb, warmstart_rb, restart_rb,
                    entry_point_string, stop_point_string_entry,
-                   statedump_entry, optgroups, mode_live_rb, mode_sim_rb,
+                   checkpoint_entry, optgroups, mode_live_rb, mode_sim_rb,
                    mode_dum_rb, hold_cb, holdpoint_entry):
+        """Call back for "Run Suite" dialog box.
+
+        Build "cylc run/restart" command from dialog box options and entries,
+        and run the command.
+        Destroy the dialog box.
+        Reset connection.
+        """
 
         command = 'cylc run ' + self.cfg.template_vars_opts
         options = ''
@@ -1139,6 +1146,9 @@ been defined for this suite""").inform()
             command += ' --mode=simulation'
         elif mode_dum_rb.get_active():
             command += ' --mode=dummy'
+
+        if method == 'restart' and checkpoint_entry.get_text():
+            command += ' --checkpoint=' + checkpoint_entry.get_text()
 
         point_string = ''
         if method != 'restart':
@@ -1163,10 +1173,6 @@ been defined for this suite""").inform()
 
         command += ' ' + options + ' ' + self.cfg.suite + ' ' + point_string
         print command
-
-        if method == 'restart':
-            if statedump_entry.get_text():
-                command += ' ' + statedump_entry.get_text()
 
         try:
             subprocess.Popen([command], shell=True)
@@ -1996,13 +2002,16 @@ shown here in the state they were in at the time of triggering.''')
         vbox.pack_start(nhbox)
 
         is_box = gtk.HBox()
-        label = gtk.Label('[State Dump FILE]')
+        label = gtk.Label('Restart checkpoint')
         is_box.pack_start(label, True)
-        statedump_entry = gtk.Entry()
-        statedump_entry.set_text('state')
-        statedump_entry.set_sensitive(False)
-        label.set_sensitive(False)
-        is_box.pack_start(statedump_entry, True)
+        checkpoint_entry = gtk.Entry()
+        if self.updater is not None and self.updater.stop_summary is not None:
+            checkpoint_entry.set_sensitive(True)
+            label.set_sensitive(True)
+        else:
+            checkpoint_entry.set_sensitive(False)
+            label.set_sensitive(False)
+        is_box.pack_start(checkpoint_entry, True)
         vbox.pack_start(is_box)
 
         coldstart_rb.connect(
@@ -2050,7 +2059,7 @@ shown here in the state they were in at the time of triggering.''')
         start_button = gtk.Button("_Start")
         start_button.connect("clicked", self.startsuite, window, coldstart_rb,
                              warmstart_rb, restart_rb, point_string_entry,
-                             stop_point_string_entry, statedump_entry,
+                             stop_point_string_entry, checkpoint_entry,
                              optgroups, mode_live_rb, mode_sim_rb,
                              mode_dum_rb, hold_cb, holdpoint_entry)
 

--- a/lib/cylc/rundb.py
+++ b/lib/cylc/rundb.py
@@ -639,8 +639,8 @@ class CylcSuiteDAO(object):
         prepare an insert into the checkpoint_id table the event and the
         current time.
 
-        If other_daos is a specified, it should a list of CylcSuiteDAO objects.
-        The logic will prepare insertion of the same items into the
+        If other_daos is a specified, it should be a list of CylcSuiteDAO
+        objects.  The logic will prepare insertion of the same items into the
         *_checkpoints tables of these DAOs as well.
         """
         id_ = 1

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -524,28 +524,31 @@ conditions; see `cylc conditions`.
 
     def load_tasks_for_restart(self):
         """Load tasks for restart."""
-        self.pri_dao.select_suite_params(self._load_suite_params)
-        self.pri_dao.select_broadcast_states(self._load_broadcast_states)
-        self.pri_dao.select_task_pool_for_restart(self._load_task_pool)
+        self.pri_dao.select_suite_params(
+            self._load_suite_params, self.options.checkpoint)
+        self.pri_dao.select_broadcast_states(
+            self._load_broadcast_states, self.options.checkpoint)
+        self.pri_dao.select_task_pool_for_restart(
+            self._load_task_pool, self.options.checkpoint)
         self.pool.poll_task_jobs()
 
     def _load_broadcast_states(self, row_idx, row):
         """Load a setting in the previous broadcast states."""
         if row_idx == 0:
-            print "LOADING broadcast states"
+            OUT.info("LOADING broadcast states")
         point, namespace, key, value = row
         BroadcastServer.get_inst().load_state(point, namespace, key, value)
-        print BROADCAST_LOAD_FMT.strip() % {
+        OUT.info(BROADCAST_LOAD_FMT.strip() % {
             "change": BROADCAST_LOAD_PREFIX,
             "point": point,
             "namespace": namespace,
             "key": key,
-            "value": value}
+            "value": value})
 
     def _load_suite_params(self, row_idx, row):
         """Load previous initial/final cycle point."""
         if row_idx == 0:
-            print "LOADING suite parameters"
+            OUT.info("LOADING suite parameters")
         key, value = row
         for key_str, self_attr, option_ignore_attr in [
                 ("initial", "start_point", "ignore_start_point"),

--- a/lib/cylc/scheduler_cli.py
+++ b/lib/cylc/scheduler_cli.py
@@ -96,7 +96,7 @@ def parse_commandline(is_restart):
     if is_restart:
         parser.add_option(
             "--checkpoint",
-            help="Use specified instead of latest checkpoint to restart",
+            help="Use specified checkpoint to restart",
             metavar="CHECKPOINT", action="store", dest="checkpoint")
 
         parser.add_option(

--- a/lib/cylc/scheduler_cli.py
+++ b/lib/cylc/scheduler_cli.py
@@ -95,6 +95,11 @@ def parse_commandline(is_restart):
 
     if is_restart:
         parser.add_option(
+            "--checkpoint",
+            help="Use specified instead of latest checkpoint to restart",
+            metavar="CHECKPOINT", action="store", dest="checkpoint")
+
+        parser.add_option(
             "--ignore-final-cycle-point",
             help=(
                 "Ignore the final cycle point in the suite run database. " +
@@ -125,8 +130,7 @@ def parse_commandline(is_restart):
         "--until",
         help=("Shut down after all tasks have PASSED " +
               "this cycle point."),
-        metavar="CYCLE_POINT", action="store",
-        dest="final_point_string")
+        metavar="CYCLE_POINT", action="store", dest="final_point_string")
 
     parser.add_option(
         "--hold",

--- a/tests/restart/19-checkpoint.t
+++ b/tests/restart/19-checkpoint.t
@@ -1,0 +1,41 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2016 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test restart from a checkpoint before a reload
+. "$(dirname "$0")/test_header"
+
+set_test_number 4
+
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+cp -p 'suite.rc' 'suite1.rc'
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+
+# Suite reloads+inserts new task to mess up prerequisites - suite should stall
+suite_run_fail "${TEST_NAME_BASE}-run" cylc run "${SUITE_NAME}" --debug
+# Restart should stall in exactly the same way
+suite_run_fail "${TEST_NAME_BASE}-restart-1" \
+    cylc restart "${SUITE_NAME}" --debug
+
+# Restart from a checkpoint before the reload should allow the suite to proceed
+# normally.
+cp -p 'suite1.rc' 'suite.rc'
+suite_run_ok "${TEST_NAME_BASE}-restart-2" \
+    cylc restart "${SUITE_NAME}" --checkpoint=1 --debug --reference-test
+
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/restart/19-checkpoint/reference.log
+++ b/tests/restart/19-checkpoint/reference.log
@@ -1,0 +1,5 @@
+2016-10-10T14:01:04Z INFO - Initial point: 2016
+2016-10-10T14:01:04Z INFO - Final point: 2020
+2016-10-10T14:01:05Z INFO - [t1.2018] -triggered off ['t1.2017']
+2016-10-10T14:01:08Z INFO - [t1.2019] -triggered off ['t1.2018']
+2016-10-10T14:01:11Z INFO - [t1.2020] -triggered off ['t1.2019']

--- a/tests/restart/19-checkpoint/suite.rc
+++ b/tests/restart/19-checkpoint/suite.rc
@@ -1,0 +1,33 @@
+#!jinja2
+[cylc]
+    UTC mode=True
+    cycle point format = %Y
+    [[events]]
+        abort on stalled = True
+        abort on inactivity = True
+        inactivity = P1M
+[scheduling]
+    initial cycle point = 2016
+    final cycle point = 2020
+    [[dependencies]]
+        [[[P1Y]]]
+            graph=t1[-P1Y] => t1
+[runtime]
+    [[t1]]
+        script = """
+if [[ "${CYLC_TASK_CYCLE_POINT}" == '2017' ]]; then
+    cylc broadcast "${CYLC_SUITE_NAME}" -p '2017' -n 't1' --set='script=true'
+    cylc hold "${CYLC_SUITE_NAME}"
+    sleep 1
+    (cd "${CYLC_SUITE_DEF_PATH}"; cp -p 'suite2.rc' 'suite.rc')
+    cylc reload "${CYLC_SUITE_NAME}"
+    while ! grep -q 'Reload completed' ${CYLC_SUITE_LOG_DIR}/log; do
+        sleep 1  # make sure reload completes
+    done
+    cylc insert "${CYLC_SUITE_NAME}" 't2.2017'
+    sleep 1
+    cylc release "${CYLC_SUITE_NAME}"
+fi
+"""
+        [[[job]]]
+            execution time limit = PT15S

--- a/tests/restart/19-checkpoint/suite2.rc
+++ b/tests/restart/19-checkpoint/suite2.rc
@@ -1,0 +1,19 @@
+#!jinja2
+[cylc]
+    UTC mode=True
+    cycle point format = %Y
+    [[events]]
+        abort on stalled = True
+        abort on inactivity = True
+        inactivity = P1M
+[scheduling]
+    initial cycle point = 2016
+    final cycle point = 2020
+    [[dependencies]]
+        [[[P1Y]]]
+            graph=t2[-P1Y] => t1 => t2
+[runtime]
+    [[t1]]
+        script = true
+    [[t2]]
+        script = false


### PR DESCRIPTION
Command line option and GUI entry box updated to allow restart from a
different checkpoint.

Equivalence of #2033, but for 6.11.x. @hjoliver @arjclark please review.