### PR TITLE
1825.slot task proxy

### DIFF
--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -598,7 +598,6 @@ conditions; see `cylc conditions`.
             elif status in (TASK_STATUS_SUBMITTED, TASK_STATUS_RUNNING):
                 itask.state.set_prerequisites_all_satisfied()
                 # update the task proxy with submit ID etc.
-                itask.try_number = try_num
                 itask.user_at_host = user_at_host
                 self.old_user_at_host_set.add(itask.user_at_host)
                 if itask.user_at_host is None:

--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -168,6 +168,27 @@ class TaskProxy(object):
     # if execution retries are configured; and is passed to task
     # environments to allow changed behaviour after previous failures.
 
+    # Memory optimization - constrain possible attributes to this list.
+    __slots__ = ["JOB_LOG_FMT_1", "JOB_LOG_FMT_M", "CUSTOM_EVENT_HANDLER",
+                 "EVENT_MAIL", "HEAD_MODE_LOCAL", "HEAD_MODE_REMOTE",
+                 "JOB_FILE_BASE", "JOB_KILL", "JOB_LOGS_RETRIEVE", "JOB_POLL",
+                 "JOB_SUBMIT", "MANAGE_JOB_LOGS_TRY_DELAYS", "NN",
+                 "LOGGING_LVL_OF", "RE_MESSAGE_TIME", "TABLE_TASK_JOBS",
+                 "TABLE_TASK_EVENTS", "TABLE_TASK_STATES", "POLLED_INDICATOR",
+                 "event_handler_env", "stop_sim_mode_job_submission", "tdef",
+                 "submit_num", "validate_mode", "message_queue", "point",
+                 "cleanup_cutoff", "identity", "has_spawned",
+                 "point_as_seconds", "stop_point", "manual_trigger",
+                 "is_manual_submit", "summary", "local_job_file_path",
+                 "retries_configured", "run_try_state", "sub_try_state",
+                 "event_handler_try_states",
+                 "execution_time_limit_poll_try_state", "db_inserts_map",
+                 "db_updates_map", "suite_name", "task_host", "task_owner",
+                 "user_at_host", "job_vacated", "submission_poll_timer",
+                 "execution_poll_timer", "event_hooks", "sim_mode_run_length",
+                 "delayed_start_str", "delayed_start", "expire_time_str",
+                 "expire_time", "state", "log"]
+
     # Format string for single line output
     JOB_LOG_FMT_1 = "%(timestamp)s [%(cmd_key)s %(attr)s] %(mesg)s"
     # Format string for multi-line output

--- a/lib/cylc/task_state.py
+++ b/lib/cylc/task_state.py
@@ -164,6 +164,14 @@ class TaskStateError(ValueError):
 class TaskState(object):
     """Task status and utilities."""
 
+    # Memory optimization - constrain possible attributes to this list.
+    __slots__ = ["_STATUS_MAP", "status", "identity", "db_events_insert",
+                 "db_update_status", "log", "_recalc_satisfied",
+                 "_is_satisfied", "_suicide_is_satisfied", "prerequisites",
+                 "suicide_prerequisites", "external_triggers", "outputs",
+                 "kill_failed", "hold_on_retry", "_state_pre_hold", "run_mode",
+                 "submission_timer_timeout", "execution_timer_timeout"]
+
     # Associate status names with other properties.
     _STATUS_MAP = {
         TASK_STATUS_RUNAHEAD: {


### PR DESCRIPTION
Closes #1825 

 * Applies slotting to the TaskProxy class
 * Also applies it to TaskState
 * removes a redundant `itask.try_number` assignment from `scheduler.py` (not used anywhere)

@matthewrmshin @hjoliver please review.