### PR TITLE
travis: re-run failed tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ script:
     # Only run the generic tests on Travis CI.
     - export CYLC_TEST_RUN_PLATFORM=false
     # Run tests with virtual frame buffer for X support.
-    - xvfb-run -a cylc test-battery -j 5
+    - xvfb-run -a cylc test-battery --state=save -j 5 || (echo -e "\n\nRerunning Failed Tests...\n\n"; cylc test-battery --state=save,failed -j 5)
 
 # Check output (more useful if you narrow down what tests get run)
 after_script:


### PR DESCRIPTION
Travis-ci: re-run any failed tests as we have done in rose (https://github.com/metomi/rose/pull/1999).

Example with failed test (see bottom of file):
https://travis-ci.org/metomi/rose/builds/172332817