### PR TITLE
port scan inactivity timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ install:
 # Run tests
 script: 
     # Custom diff command to ignore Xlib errors (xvfb has not RANDR extension).
-    - export CYLC_TEST_DIFF_CMD='diff -I Xlib'
+    - export CYLC_TEST_DIFF_CMD='diff -I Xlib -u'
     # Only run the generic tests on Travis CI.
     - export CYLC_TEST_RUN_PLATFORM=false
     # Run tests with virtual frame buffer for X support.

--- a/bin/cylc-scan
+++ b/bin/cylc-scan
@@ -132,8 +132,8 @@ def main():
     parser.add_option(
         "--comms-timeout", "--pyro-timeout", metavar="SEC",
         help="Set a timeout for network connections "
-             "to running suites. The default is 60 seconds.",
-        action="store", default=60, dest="comms_timeout")
+             "to each running suite. The default is 5 seconds.",
+        action="store", default=None, dest="comms_timeout")
 
     parser.add_option(
         "--old", "--old-format",
@@ -207,26 +207,10 @@ def main():
         state_legend = state_legend.rstrip()
 
     skip_one = True
-    for result in scan_all(args, options.db, options.comms_timeout):
-        host, scan_result = result
-        try:
-            port, suite_identity = scan_result
-        except ValueError:
-            # Back-compat (<= 6.5.0 no title or state totals).
-            port, name, owner = scan_result
-            if not (re.match(pattern_name, name) and
-                    re.match(pattern_owner, owner)):
-                continue
-            if options.old_format:
-                print name, owner, host, port
-            elif options.raw_format:
-                print "%s|%s|%s|port|%s" % (name, owner, host, port)
-            else:
-                print "%s %s@%s:%s" % (name, owner, host, port)
-            continue
-        else:
-            name = suite_identity['name']
-            owner = suite_identity['owner']
+    for host, port, suite_identity in scan_all(
+            args, options.db, options.comms_timeout):
+        name = suite_identity['name']
+        owner = suite_identity['owner']
 
         if not (re.match(pattern_name, name) and
                 re.match(pattern_owner, owner)):

--- a/lib/cylc/gui/dbchooser.py
+++ b/lib/cylc/gui/dbchooser.py
@@ -112,15 +112,9 @@ class db_updater(threading.Thread):
 
         # Scan for running suites
         choices = []
-        for host, scan_result in scan_all(timeout=self.timeout):
-            try:
-                port, suite_identity = scan_result
-            except ValueError:
-                # Back-compat <= 6.5.0
-                port, name, owner = scan_result
-            else:
-                name = suite_identity['name']
-                owner = suite_identity['owner']
+        for host, port, suite_identity in scan_all(timeout=self.timeout):
+            name = suite_identity['name']
+            owner = suite_identity['owner']
             if is_remote_user(owner):
                 continue  # current user only
             auth = "%s:%d" % (host, port)

--- a/lib/cylc/gui/gscan.py
+++ b/lib/cylc/gui/gscan.py
@@ -52,8 +52,7 @@ KEY_UPDATE_TIME = "update-time"
 def get_hosts_suites_info(hosts, timeout=None, owner=None):
     """Return a dictionary of hosts, suites, and their properties."""
     host_suites_map = {}
-    for host, (port, result) in scan_all(
-            hosts=hosts, timeout=timeout):
+    for host, port, result in scan_all(hosts=hosts, timeout=timeout):
         if owner and owner != result.get(KEY_OWNER):
             continue
         if host not in host_suites_map:

--- a/lib/cylc/network/__init__.py
+++ b/lib/cylc/network/__init__.py
@@ -70,6 +70,16 @@ class ConnectionDeniedError(ConnectionError):
         return self.MESSAGE % (self.args[0], self.args[1], self.args[2])
 
 
+class ConnectionTimeout(ConnectionError):
+
+    """An error raised on connection timeout."""
+
+    MESSAGE = "Connection timeout: %s: %s"
+
+    def __str__(self):
+        return self.MESSAGE % (self.args[0], self.args[1])
+
+
 def access_priv_ok(server_obj, required_privilege_level):
     """Return True if a client is allowed access to info from server_obj.
 

--- a/tests/cylc-scan/02-sigstop.t
+++ b/tests/cylc-scan/02-sigstop.t
@@ -1,0 +1,42 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2016 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "cylc scan" on suite suspended with SIGSTOP
+. "$(dirname "$0")/test_header"
+set_test_number 4
+create_test_globalrc
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+run_ok "${TEST_NAME_BASE}-run" cylc run --hold "${SUITE_NAME}"
+SUITE_PID=$(awk '/\+ PID: / {print $3}' "${TEST_NAME_BASE}-run.stdout")
+SUITE_PORT=$(awk '/\+ Port: / {print $3}' "${TEST_NAME_BASE}-run.stdout")
+# Suspend the suite, simulate Ctrl-Z
+sleep 1
+kill -SIGSTOP "${SUITE_PID}"
+sleep 1
+run_ok "${TEST_NAME_BASE}-scan" cylc scan 'localhost'
+contains_ok "${TEST_NAME_BASE}-scan.stderr" <<__ERR__
+WARNING, scan timed out, no result for the following:
+  localhost:${SUITE_PORT}
+__ERR__
+# Tell the suite to continue
+kill -SIGCONT "${SUITE_PID}"
+sleep 1
+cylc stop --max-polls=5 --interval=2 "${SUITE_NAME}"
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/cylc-scan/02-sigstop/suite.rc
+++ b/tests/cylc-scan/02-sigstop/suite.rc
@@ -1,0 +1,6 @@
+[scheduling]
+    [[dependencies]]
+        graph = t1
+[runtime]
+    [[t1]]
+        script = true


### PR DESCRIPTION
Manage custom process pool instead of using `mutliprocess.Pool`.
This allows the logic to terminate processes with hanging connections - about 10 seconds of inactivity.
Report each `host:port` that causes a process to hang or has timed out connection.

Also:
* Default connection timeout reduced to 5 seconds - a long time for modern intra-network traffic.
* Child processes are used as workers.
  Each worker runs a loop to receive messages from main process to scan the next `host:port`.
  Previously, each process pool job scans all ports (in range) of a host.
* Single UUID for all jobs.
* Remove cylc 6.5 compatibility logic.
  Cylc 7 port scan does not work with cylc 6 suites any way.
* Improve returned data structure.