### PR TITLE
Fixed traceback.

### DIFF
--- a/lib/cylc/gui/gscan.py
+++ b/lib/cylc/gui/gscan.py
@@ -1055,7 +1055,7 @@ class ScanAppUpdater(BaseScanUpdater):
             return ['<i>Cannot connect to suite.</i>']
 
         # Append "And x more" to list if required.
-        temp = [(dt, tn, ps) for (dt, tn, ps) in tasks if dt is None]
+        temp = [[dt, tn, ps] for (dt, tn, ps) in tasks if dt is None]
         suffix = []
         if temp:
             tasks.remove(temp[0])


### PR DESCRIPTION
Closes #2061.

Traceback was caused by the feature that reports "And <N> more" at the bottom of the tooltip text when hovering over task status icons.

@arjclark Please review