### PR TITLE
Fix: initial cycle point = "now"

### DIFF
--- a/lib/cylc/cfgspec/suite.py
+++ b/lib/cylc/cfgspec/suite.py
@@ -56,10 +56,10 @@ def _coerce_cycletime(value, keys, _):
     """Coerce value to a cycle point."""
     if not value:
         return None
+    value = _strip_and_unquote(keys, value)
     if value == "now":
         # Handle this later in config.py when the suite UTC mode is known.
         return value
-    value = _strip_and_unquote(keys, value)
     if re.match(r"\d+$", value):
         # Could be an old date-time cycle point format, or integer format.
         return value

--- a/tests/validate/58-icp-quoted-now.t
+++ b/tests/validate/58-icp-quoted-now.t
@@ -1,0 +1,39 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2016 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Quoted "now" for initial cycle point was failing.
+
+. "$(dirname "$0")/test_header"
+
+set_test_number 1
+
+cat >'suite.rc' <<'__SUITE_RC__'
+[cylc]
+    cycle point format = %Y%m%d
+[scheduling]
+    initial cycle point = "now"
+    [[dependencies]]
+        [[[P1D]]]
+            graph = t1
+[runtime]
+    [[t1]]
+        script = true
+__SUITE_RC__
+
+run_ok "${TEST_NAME_BASE}" cylc validate 'suite.rc'
+
+exit


### PR DESCRIPTION
Previously, quotes were stripped too late.

@arjclark @oliver-sanders please review.

Issue reported via: https://groups.google.com/forum/?fromgroups#!topic/cylc/-WtAc13IoTg