### PR TITLE
gscan: removed possible weakness

### DIFF
--- a/lib/cylc/gui/gscan.py
+++ b/lib/cylc/gui/gscan.py
@@ -687,7 +687,10 @@ class ScanApp(object):
         # tasks.
         dot_offset, dot_width = tuple(column.cell_get_position(
             column.get_cell_renderers()[2]))
-        cell_index = ((cell_x - dot_offset) // dot_width) + 1
+        try:
+            cell_index = ((cell_x - dot_offset) // dot_width) + 1
+        except ZeroDivisionError:
+            return False
         if cell_index >= 0:
             # NOTE: TreeViewColumn.get_cell_renderers() does not always return
             # cell renderers for the correct row.


### PR DESCRIPTION
The code shouldn't fail but I think it can in strange situations where GTK PixBuffRenderers register as having no width during settup?
To remove the potential for errors I've stuck it in a try catch.

@arjclark Please review / assign if you like.