### PR TITLE
t: restart-19: attempt to fix hang

### DIFF
--- a/tests/restart/19-checkpoint/suite.rc
+++ b/tests/restart/19-checkpoint/suite.rc
@@ -36,6 +36,6 @@ if [[ "${CYLC_TASK_CYCLE_POINT}" == '2017' ]]; then
 fi
 """
         [[[job]]]
-            execution time limit = PT15S
+            execution time limit = PT50S
         [[[events]]]
             failed handler = cylc release '%(suite)s'


### PR DESCRIPTION
I suspect that the suite hangs because `t1.2017` times out too quickly for it to call `cylc release`. Let's see if this change fixes it or not.