### PR TITLE
cylc.config: improve q iter logic

### DIFF
--- a/tests/restart/19-checkpoint.t
+++ b/tests/restart/19-checkpoint.t
@@ -26,16 +26,18 @@ cp -p 'suite.rc' 'suite1.rc'
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
 
 # Suite reloads+inserts new task to mess up prerequisites - suite should stall
-suite_run_fail "${TEST_NAME_BASE}-run" cylc run "${SUITE_NAME}" --debug
+suite_run_fail "${TEST_NAME_BASE}-run" \
+    timeout 120 cylc run "${SUITE_NAME}" --debug
 # Restart should stall in exactly the same way
 suite_run_fail "${TEST_NAME_BASE}-restart-1" \
-    cylc restart "${SUITE_NAME}" --debug
+    timeout 60 cylc restart "${SUITE_NAME}" --debug
 
 # Restart from a checkpoint before the reload should allow the suite to proceed
 # normally.
 cp -p 'suite1.rc' 'suite.rc'
 suite_run_ok "${TEST_NAME_BASE}-restart-2" \
-    cylc restart "${SUITE_NAME}" --checkpoint=1 --debug --reference-test
+    timeout 120 cylc restart "${SUITE_NAME}" \
+    --checkpoint=1 --debug --reference-test
 
 purge_suite "${SUITE_NAME}"
 exit


### PR DESCRIPTION
This should prevent the `RuntimeError: dictionary changed size during iteration` issue. Note: I am unable to repeat the issue on Python 2.7.12 (on Ubuntu 16.04). In his report, the user said he was on Python 2.7.10.

However, on Python 3, a loop such as this one:

```python
x = {1:2, 2:4, 3:6}
for key, value in x.items():
    if key == 3:
        del x[key]
```
will definitely give:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: dictionary changed size during iteration
```

(Was something back ported to Python 2.7.10, but removed again on Python 2.7.12?)