### PR TITLE
Upgrade mixed syntax

### DIFF
--- a/lib/cylc/cfgspec/suite.py
+++ b/lib/cylc/cfgspec/suite.py
@@ -464,33 +464,32 @@ def upg(cfg, descr):
         ['scheduling', 'special tasks', 'external-triggered'],
         ['scheduling', 'special tasks', 'external-trigger'],
     )
-    for key in SPEC['cylc']['events']:
-        u.deprecate(
-            '6.11.0', ['cylc', 'event hooks', key], ['cylc', 'events', key])
-    u.deprecate('6.11.0', ['cylc', 'event hooks'])
-    for key in SPEC['runtime']['__MANY__']['events']:
-        u.deprecate(
-            '6.11.0',
-            ['runtime', '__MANY__', 'event hooks', key],
-            ['runtime', '__MANY__', 'events', key])
-    u.deprecate('6.11.0', ['runtime', '__MANY__', 'event hooks'])
+    u.deprecate(
+        '6.11.0', ['cylc', 'event hooks'], ['cylc', 'events'])
     u.deprecate(
         '6.11.0',
-        ['runtime', '__MANY__', 'job submission', 'method'],
+        ['runtime', '__MANY__', 'event hooks'],
+        ['runtime', '__MANY__', 'events'])
+    u.deprecate(
+        '6.11.0',
+        ['runtime', '__MANY__', 'job submission'],
+        ['runtime', '__MANY__', 'job'])
+    u.deprecate(
+        '6.11.0',
+        ['runtime', '__MANY__', 'job', 'method'],
         ['runtime', '__MANY__', 'job', 'batch system'])
     u.deprecate(
         '6.11.0',
-        ['runtime', '__MANY__', 'job submission', 'command template'],
+        ['runtime', '__MANY__', 'job', 'command template'],
         ['runtime', '__MANY__', 'job', 'batch submit command template'])
     u.deprecate(
         '6.11.0',
-        ['runtime', '__MANY__', 'job submission', 'shell'],
+        ['runtime', '__MANY__', 'job', 'shell'],
         ['runtime', '__MANY__', 'job', 'shell'])
     u.deprecate(
         '6.11.0',
-        ['runtime', '__MANY__', 'job submission', 'retry delays'],
+        ['runtime', '__MANY__', 'job', 'retry delays'],
         ['runtime', '__MANY__', 'job', 'submission retry delays'])
-    u.deprecate('6.11.0', ['runtime', '__MANY__', 'job submission'])
     u.deprecate(
         '6.11.0',
         ['runtime', '__MANY__', 'retry delays'],
@@ -504,13 +503,6 @@ def upg(cfg, descr):
         ['runtime', '__MANY__', 'execution polling intervals'],
         ['runtime', '__MANY__', 'job', 'execution polling intervals'])
     u.upgrade()
-    if 'cylc' in cfg and 'event hooks' in cfg['cylc']:
-        del cfg['cylc']['event hooks']
-    if 'runtime' in cfg:
-        for section in cfg['runtime'].values():
-            for key in ['event hooks', 'job submission']:
-                if key in section:
-                    del section[key]
 
 
 class RawSuiteConfig(config):

--- a/lib/parsec/upgrade.py
+++ b/lib/parsec/upgrade.py
@@ -121,6 +121,15 @@ class upgrader(object):
         else:
             i = -1
             nkeys = upg['new']
+            if nkeys is None:  # No new keys defined.
+                for m in many:
+                    exp_upgs.append({
+                        'old': pre + [m] + post,
+                        'new': None,
+                        'cvt': upg['cvt'],
+                        'silent': upg['silent'],
+                    })
+                return exp_upgs
             npre = []
             npost = []
             for k in nkeys:

--- a/tests/deprecations/00-all.t
+++ b/tests/deprecations/00-all.t
@@ -41,10 +41,11 @@ cmp_ok val.out <<__END__
  * (6.4.0) [runtime][foo, cat, dog][dummy mode][command scripting] -> [runtime][foo, cat, dog][dummy mode][script] - value unchanged
  * (6.5.0) [scheduling][special tasks][clock-triggered] -> [scheduling][special tasks][clock-trigger] - value unchanged
  * (6.5.0) [scheduling][special tasks][external-triggered] -> [scheduling][special tasks][external-trigger] - value unchanged
- * (6.11.0) [runtime][foo, cat, dog][event hooks][retry handler] -> [runtime][foo, cat, dog][events][retry handler] - value unchanged
- * (6.11.0) [runtime][foo, cat, dog][job submission][method] -> [runtime][foo, cat, dog][job][batch system] - value unchanged
- * (6.11.0) [runtime][foo, cat, dog][job submission][command template] -> [runtime][foo, cat, dog][job][batch submit command template] - value unchanged
- * (6.11.0) [runtime][foo, cat, dog][job submission][retry delays] -> [runtime][foo, cat, dog][job][submission retry delays] - value unchanged
+ * (6.11.0) [runtime][foo, cat, dog][event hooks] -> [runtime][foo, cat, dog][events] - value unchanged
+ * (6.11.0) [runtime][foo, cat, dog][job submission] -> [runtime][foo, cat, dog][job] - value unchanged
+ * (6.11.0) [runtime][foo, cat, dog][job][method] -> [runtime][foo, cat, dog][job][batch system] - value unchanged
+ * (6.11.0) [runtime][foo, cat, dog][job][command template] -> [runtime][foo, cat, dog][job][batch submit command template] - value unchanged
+ * (6.11.0) [runtime][foo, cat, dog][job][retry delays] -> [runtime][foo, cat, dog][job][submission retry delays] - value unchanged
  * (6.11.0) [runtime][foo, cat, dog][retry delays] -> [runtime][foo, cat, dog][job][execution retry delays] - value unchanged
  * (6.11.0) [runtime][foo, cat, dog][submission polling intervals] -> [runtime][foo, cat, dog][job][submission polling intervals] - value unchanged
  * (6.11.0) [runtime][foo, cat, dog][execution polling intervals] -> [runtime][foo, cat, dog][job][execution polling intervals] - value unchanged


### PR DESCRIPTION
Closes #2094 

**Note:** #2094 was reported with 6.11.2, I can backport this if we are planning another 6.11.x release.

**1) Fixes a problem in the `upgrader` class** whereby the following config:

```
[runtime]
    [[foo]]
        [[[job submission]]]
            zarquon = True
```

Would fail to be caught by this upgrader:
```
u = upgrader(cfg, descr)
u.obsolete(
    '7.0.0',
    ['runtime', '__MANY__', 'job', 'zarquon'])
u.upgrade()
```

Old behaviour:

```
$ cylc validate .
Illegal item: [runtime][foo][job]zarquon
```

New behaviour:

```

[osanders@eld668 temp2]$ cylc validate --verbose .
...
WARNING: deprecated items were automatically upgraded in 'suite definition':
 * (7.0.0) [runtime][foo][job][zarquon] - DELETED (OBSOLETE)
...
Valid for cylc-7.0.0-dirty
```

**2. Fixes upgrading of mixed-syntax `job submission`/`job` sections**

The following config ...

```
...
[runtime]
    [[foo]]
        command scripting = sleep 5  # old
        [[[job submission]]]         # old
            batch system = at        # new
            retry delays = PT1M      # old
        [[[event hooks]]]            # old
            failed handler = true    # old/new
```

Will now parse correctly:

```
$ cylc get-config --sparse . -i [runtime]
[[root]]
[[foo]]
    script = sleep 5
    [[[events]]]
        failed handler = true
    [[[job]]]
        batch system = at
        submission retry delays = PT1M
```
With the following notices from `validate`:
```
[osanders@eld668 temp2]$ cylc validate --verbose --verbose .
...
WARNING: deprecated items were automatically upgraded in 'suite definition':
 * (6.4.0) [runtime][foo][command scripting] -> [runtime][foo][script] - value unchanged
 * (6.11.0) [runtime][foo][event hooks] -> [runtime][foo][events] - value unchanged
 * (6.11.0) [runtime][foo][job submission] -> [runtime][foo][job] - value unchanged
 * (6.11.0) [runtime][foo][job][retry delays] -> [runtime][foo][job][submission retry delays] - value
...
Valid for cylc-7.0.0-dirty
```
*Caveat: the deprecation warning now reads `[runtime][foo][job][retry delays]` rather than `[runtime][foo][job submission][retry delays]`* which could be a little cryptic.

**3) Upgrade section headings rather than the settings within them** (in cylc/cfgspec/suite.py)

e.g. upgrade [event handlers] to [events] rather than upgrading [event handlers]failed handler to [events]failed handler then [event handlers]xyz to [events]xyz ...

@arjclark @matthewrmshin @hjoliver Whoever's around please debate / review.