### PR TITLE
gscan: new -a and -o OWNER-PATTERN options

### DIFF
--- a/bin/cylc-gscan
+++ b/bin/cylc-gscan
@@ -24,32 +24,70 @@ hosts.
 To customize themes copy $CYLC_DIR/conf/gcylcrc/gcylc.rc.eg to
 $HOME/.cylc/gcylc.rc and follow the instructions in the file."""
 
-from cylc.option_parsers import CylcOptionParser as COP
-
-parser = COP(__doc__, argdoc=[])
-
-parser.add_option("--host",
-                  help="Host names to monitor (override site default).",
-                  metavar="HOST", action="append",
-                  dest="hosts")
-parser.add_option("--poll-interval",
-                  help="Polling interval (time between updates) in seconds",
-                  type="int", metavar="SECONDS", dest="interval")
-parser.add_option(
-    "-n", "--name",
-    metavar="PATTERN",
-    help="List suites with name matching PATTERN (regular expression). "
-         "Defaults to any name. Can be used multiple times.",
-    action="append", dest="patterns_name", default=[])
-
-options, args = parser.parse_args()
+import sys
+if "--use-ssh" in sys.argv[1:]:
+    sys.argv.remove("--use-ssh")
+    from cylc.remote import remrun
+    if remrun().execute():
+        sys.exit(0)
 
 import gtk
 import warnings
 warnings.filterwarnings('ignore', 'use the new', Warning)
 
 from cylc.gui.gscan import ScanApp
+from cylc.option_parsers import CylcOptionParser as COP
+from cylc.owner import USER
 
-ScanApp(hosts=options.hosts, owner=options.owner,
-        poll_interval=options.interval, name=options.patterns_name)
-gtk.main()
+
+def main():
+    """Implement "cylc gscan"."""
+    parser = COP(
+        __doc__,
+        comms=True,
+        noforce=True,
+        argdoc=[(
+            "[HOSTS ...]", "Hosts to scan instead of the configured hosts.")])
+    parser.add_option(
+        "-a", "--all", "--all-suites",
+        help="List all suites found on all scanned hosts (the default is "
+             "just your own suites).",
+        action="store_true", default=False, dest="all_suites")
+    parser.add_option(
+        "-n", "--name",
+        metavar="PATTERN",
+        help="List suites with name matching PATTERN (regular expression). "
+             "Defaults to any name. Can be used multiple times.",
+        action="append", dest="patterns_name", default=[])
+    parser.add_option(
+        "-o", "--suite-owner",
+        metavar="PATTERN",
+        help="List suites with owner matching PATTERN (regular expression). "
+             "Defaults to just your own suites. Can be used multiple times.",
+        action="append", dest="patterns_owner", default=[])
+    parser.add_option(
+        "--comms-timeout", metavar="SEC",
+        help="Set a timeout for network connections "
+             "to each running suite. The default is 5 seconds.",
+        action="store", default=None, dest="comms_timeout")
+    parser.add_option(
+        "--poll-interval",
+        help="Polling interval (time between updates) in seconds",
+        type="int", metavar="SECONDS", dest="interval")
+    options, args = parser.parse_args()
+
+    if options.all_suites:
+        options.patterns_owner = [r".*"]
+    elif not options.patterns_owner:
+        options.patterns_owner = [USER]
+    ScanApp(
+        hosts=args,
+        patterns_name=options.patterns_name,
+        patterns_owner=options.patterns_owner,
+        comms_timeout=options.comms_timeout,
+        poll_interval=options.interval)
+    gtk.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/cylc-scan
+++ b/bin/cylc-scan
@@ -130,7 +130,7 @@ def main():
         action="store_true", default=False, dest="print_ports")
 
     parser.add_option(
-        "--comms-timeout", "--pyro-timeout", metavar="SEC",
+        "--comms-timeout", metavar="SEC",
         help="Set a timeout for network connections "
              "to each running suite. The default is 5 seconds.",
         action="store", default=None, dest="comms_timeout")

--- a/doc/gscanrc.tex
+++ b/doc/gscanrc.tex
@@ -36,7 +36,7 @@ displayed.
 
 \begin{myitemize}
 \item {\em type:} string (a list of one or more view names)
-\item {\em legal values:} ``host'', ``status'', ``suite'',  ``title'',
+\item {\em legal values:} ``host'', ``owner'', ``status'', ``suite'',  ``title'',
         ``updated''
 \item {\em default:} ``status'', ``suite''
 \item {\em example:} \lstinline@columns = suite, title, status@

--- a/lib/cylc/cfgspec/gscan.py
+++ b/lib/cylc/cfgspec/gscan.py
@@ -33,27 +33,40 @@ SPEC = {
 }
 
 
-class gscanconfig(config):
+class GScanConfig(config):
+    """Configuration for "gscan"."""
+
+    COL_GROUP = "Group"
+    COL_HOST = "Host"
+    COL_OWNER = "Owner"
+    COL_SUITE = "Suite"
+    COL_TITLE = "Title"
+    COL_UPDATED = "Updated"
+    COL_STATUS = "Status"
+    COLS_DEFAULT = (COL_SUITE.lower(), COL_STATUS.lower())
+    COLS = [col.lower() for col in (
+        COL_GROUP, COL_HOST, COL_OWNER, COL_SUITE, COL_TITLE, COL_UPDATED,
+        COL_STATUS)]
 
     def check(self):
+        """Custom configuration check."""
         cfg = self.get(sparse=True)
         if 'columns' in cfg:
             for column in cfg['columns']:
-                if column not in ['host', 'suite', 'title', 'updated',
-                                  'status']:
-                    print >> sys.stderr, ("WARNING: illegal column name "
-                                          "'" + column + "'")
+                if column not in self.COLS:
+                    print >> sys.stderr, (
+                        "WARNING: illegal column name '%s'" % column)
                     cfg['columns'].remove(column)
-            if len(cfg['columns']) < 1:
-                print >> sys.stderr, ('WARNING: at least one column must be '
-                                      'specified, defaulting to "suite, '
-                                      'status"')
-                cfg['columns'] = ['suite', 'status']
+            if not cfg['columns']:
+                print >> sys.stderr, (
+                    'WARNING: at least one column must be specified,' +
+                    ' defaulting to "%s, %s"' % self.COLS_DEFAULT)
+                cfg['columns'] = list(self.COLS_DEFAULT)
 
 
 gsfg = None
 if not gsfg:
-    gsfg = gscanconfig(SPEC)
+    gsfg = GScanConfig(SPEC)
     if os.access(USER_FILE, os.F_OK | os.R_OK):
         try:
             gsfg.loadcfg(USER_FILE, 'user config')

--- a/lib/cylc/gui/scanutil.py
+++ b/lib/cylc/gui/scanutil.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2016 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Scan utilities for "cylc gscan" and "cylc gpanel"."""
+
+import os
+import signal
+from subprocess import Popen, PIPE, STDOUT
+import sys
+from time import time
+
+import gtk
+
+from cylc.cfgspec.gcylc import gcfg
+import cylc.flags
+from cylc.gui.legend import ThemeLegendWindow
+from cylc.gui.util import get_icon
+from cylc.network import (
+    KEY_NAME, KEY_OWNER, KEY_STATES, KEY_UPDATE_TIME)
+from cylc.network.port_scan import scan_all
+from cylc.version import CYLC_VERSION
+from cylc.wallclock import get_unix_time_from_time_string as timestr_to_seconds
+
+
+DURATION_EXPIRE_STOPPED = 600.0
+KEY_PORT = "port"
+
+
+def get_scan_menu(suite_keys,
+                  theme_name, set_theme_func,
+                  has_stopped_suites, clear_stopped_suites_func,
+                  scanned_hosts, change_hosts_func,
+                  update_now_func, start_func,
+                  program_name, extra_items=None, owner=None,
+                  is_stopped=False):
+    """Return a right click menu for scan GUIs.
+
+    suite_keys should be a list of (host, owner, suite) tuples (if any).
+    theme_name should be the name of the current theme.
+    set_theme_func should be a function accepting a new theme name.
+    has_stopped_suites should be a boolean denoting currently
+    stopped suites.
+    clear_stopped_suites should be a function with no arguments that
+    removes stopped suites from the current view.
+    scanned_hosts should be a list of currently scanned suite hosts.
+    change_hosts_func should be a function accepting a new list of
+    suite hosts to scan.
+    update_now_func should be a function with no arguments that
+    forces an update now or soon.
+    start_func should be a function with no arguments that
+    re-activates idle GUIs.
+    program_name should be a string describing the parent program.
+    extra_items (keyword) should be a list of extra menu items to add
+    to the right click menu.
+    owner (keyword) should be the owner of the suites, if not the
+    current user.
+    is_stopped (keyword) denotes whether the GUI is in an inactive
+    state.
+
+    """
+    menu = gtk.Menu()
+
+    if is_stopped:
+        switch_on_item = gtk.ImageMenuItem("Activate")
+        img = gtk.image_new_from_stock(gtk.STOCK_YES, gtk.ICON_SIZE_MENU)
+        switch_on_item.set_image(img)
+        switch_on_item.show()
+        switch_on_item.connect("button-press-event",
+                               lambda b, e: start_func())
+        menu.append(switch_on_item)
+
+    # Construct gcylc launcher items for each relevant suite.
+    for host, owner, suite in suite_keys:
+        gcylc_item = gtk.ImageMenuItem("Launch gcylc: %s - %s@%s" % (
+            suite.replace('_', '__'), owner, host))
+        img = gtk.image_new_from_stock("gcylc", gtk.ICON_SIZE_MENU)
+        gcylc_item.set_image(img)
+        gcylc_item._connect_args = (host, owner, suite)
+        gcylc_item.connect(
+            "button-press-event",
+            lambda b, e: launch_gcylc(b._connect_args))
+        gcylc_item.show()
+        menu.append(gcylc_item)
+    if suite_keys:
+        sep_item = gtk.SeparatorMenuItem()
+        sep_item.show()
+        menu.append(sep_item)
+
+    if extra_items is not None:
+        for item in extra_items:
+            menu.append(item)
+        sep_item = gtk.SeparatorMenuItem()
+        sep_item.show()
+        menu.append(sep_item)
+
+    # Construct theme chooser items (same as cylc.gui.app_main).
+    theme_item = gtk.ImageMenuItem('Theme')
+    img = gtk.image_new_from_stock(gtk.STOCK_SELECT_COLOR, gtk.ICON_SIZE_MENU)
+    theme_item.set_image(img)
+    theme_item.set_sensitive(not is_stopped)
+    thememenu = gtk.Menu()
+    theme_item.set_submenu(thememenu)
+    theme_item.show()
+
+    theme_items = {}
+    theme = "default"
+    theme_items[theme] = gtk.RadioMenuItem(label=theme)
+    thememenu.append(theme_items[theme])
+    theme_items[theme].theme_name = theme
+    for theme in gcfg.get(['themes']):
+        if theme == "default":
+            continue
+        theme_items[theme] = gtk.RadioMenuItem(
+            group=theme_items['default'], label=theme)
+        thememenu.append(theme_items[theme])
+        theme_items[theme].theme_name = theme
+
+    # set_active then connect, to avoid causing an unnecessary toggle now.
+    theme_items[theme_name].set_active(True)
+    for theme in gcfg.get(['themes']):
+        theme_items[theme].show()
+        theme_items[theme].connect(
+            'toggled',
+            lambda i: (i.get_active() and set_theme_func(i.theme_name)))
+
+    menu.append(theme_item)
+    theme_legend_item = gtk.MenuItem("Show task state key")
+    theme_legend_item.show()
+    theme_legend_item.set_sensitive(not is_stopped)
+    theme_legend_item.connect(
+        "button-press-event",
+        lambda b, e: ThemeLegendWindow(None, gcfg.get(['themes', theme_name]))
+    )
+    menu.append(theme_legend_item)
+    sep_item = gtk.SeparatorMenuItem()
+    sep_item.show()
+    menu.append(sep_item)
+
+    # Construct a trigger update item.
+    update_now_item = gtk.ImageMenuItem("Update Now")
+    img = gtk.image_new_from_stock(gtk.STOCK_REFRESH, gtk.ICON_SIZE_MENU)
+    update_now_item.set_image(img)
+    update_now_item.show()
+    update_now_item.set_sensitive(not is_stopped)
+    update_now_item.connect("button-press-event",
+                            lambda b, e: update_now_func())
+    menu.append(update_now_item)
+
+    # Construct a clean stopped suites item.
+    clear_item = gtk.ImageMenuItem("Clear Stopped Suites")
+    img = gtk.image_new_from_stock(gtk.STOCK_CLEAR, gtk.ICON_SIZE_MENU)
+    clear_item.set_image(img)
+    clear_item.show()
+    clear_item.set_sensitive(has_stopped_suites)
+    clear_item.connect("button-press-event",
+                       lambda b, e: clear_stopped_suites_func())
+    menu.append(clear_item)
+
+    # Construct a configure scanned hosts item.
+    hosts_item = gtk.ImageMenuItem("Configure Hosts")
+    img = gtk.image_new_from_stock(gtk.STOCK_PREFERENCES, gtk.ICON_SIZE_MENU)
+    hosts_item.set_image(img)
+    hosts_item.show()
+    hosts_item.connect(
+        "button-press-event",
+        lambda b, e: _launch_hosts_dialog(scanned_hosts, change_hosts_func))
+    menu.append(hosts_item)
+
+    sep_item = gtk.SeparatorMenuItem()
+    sep_item.show()
+    menu.append(sep_item)
+
+    # Construct an about dialog item.
+    info_item = gtk.ImageMenuItem("About")
+    img = gtk.image_new_from_stock(gtk.STOCK_ABOUT, gtk.ICON_SIZE_MENU)
+    info_item.set_image(img)
+    info_item.show()
+    info_item.connect(
+        "button-press-event",
+        lambda b, e: _launch_about_dialog(program_name, scanned_hosts)
+    )
+    menu.append(info_item)
+    return menu
+
+
+def _launch_about_dialog(program_name, hosts):
+    """Launch a modified version of the app_main.py About dialog."""
+    hosts_text = "Hosts monitored: " + ", ".join(hosts)
+    comments_text = hosts_text
+    about = gtk.AboutDialog()
+    if gtk.gtk_version[0] == 2 and gtk.gtk_version[1] >= 12:
+        # set_program_name() was added in PyGTK 2.12
+        about.set_program_name(program_name)
+    else:
+        comments_text = program_name + "\n" + hosts_text
+
+    about.set_version(CYLC_VERSION)
+    about.set_copyright("Copyright (C) 2008-2016 NIWA")
+    about.set_comments(comments_text)
+    about.set_icon(get_icon())
+    about.run()
+    about.destroy()
+
+
+def _launch_hosts_dialog(existing_hosts, change_hosts_func):
+    """Launch a dialog for configuring the suite hosts to scan.
+
+    Arguments:
+    existing_hosts should be a list of currently scanned host names.
+    change_hosts_func should be a function accepting a new list of
+    host names to scan.
+
+    """
+    dialog = gtk.Dialog()
+    dialog.set_icon(get_icon())
+    dialog.vbox.set_border_width(5)
+    dialog.set_title("Configure suite hosts")
+    dialog.add_button(gtk.STOCK_CANCEL, gtk.RESPONSE_CANCEL)
+    dialog.add_button(gtk.STOCK_OK, gtk.RESPONSE_OK)
+    label = gtk.Label("Enter a comma-delimited list of suite hosts to scan")
+    label.show()
+    label_hbox = gtk.HBox()
+    label_hbox.pack_start(label, expand=False, fill=False)
+    label_hbox.show()
+    entry = gtk.Entry()
+    entry.set_text(", ".join(existing_hosts))
+    entry.connect("activate", lambda e: dialog.response(gtk.RESPONSE_OK))
+    entry.show()
+    dialog.vbox.pack_start(label_hbox, expand=False, fill=False, padding=5)
+    dialog.vbox.pack_start(entry, expand=False, fill=False, padding=5)
+    response = dialog.run()
+    if response == gtk.RESPONSE_OK:
+        new_hosts = [h.strip() for h in entry.get_text().split(",")]
+        change_hosts_func(new_hosts)
+    dialog.destroy()
+
+
+def launch_gcylc(key):
+    """Launch gcylc for a given suite and host."""
+    host, owner, suite = key
+    args = ["--host=" + host, "--user=" + owner, suite]
+
+    # Get version of suite
+    f_null = open(os.devnull, "w")
+    if cylc.flags.debug:
+        stderr = sys.stderr
+        args = ["--debug"] + args
+    else:
+        stderr = f_null
+    command = ["cylc", "get-suite-version"] + args
+    proc = Popen(command, stdout=PIPE, stderr=stderr)
+    suite_version = proc.communicate()[0].strip()
+    proc.wait()
+
+    # Run correct version of "cylc gui", provided that "admin/cylc-wrapper" is
+    # installed.
+    env = None
+    if suite_version != CYLC_VERSION:
+        env = dict(os.environ)
+        env["CYLC_VERSION"] = suite_version
+    command = ["cylc", "gui"] + args
+    if cylc.flags.debug:
+        stdout = sys.stdout
+        stderr = sys.stderr
+        Popen(command, env=env, stdout=stdout, stderr=stderr)
+    else:
+        stdout = f_null
+        stderr = STDOUT
+        Popen(["nohup"] + command, env=env, stdout=stdout, stderr=stderr)
+
+
+def update_suites_info(
+        hosts=None, timeout=None, owner_pattern=None, name_pattern=None,
+        prev_results=None):
+    """Return mapping of suite info by host, owner and suite name.
+
+    hosts - hosts to scan, or the default set in the site/user global.rc
+    timeout - communication timeout
+    owner_pattern - return only suites with owners matching this compiled re
+    name_pattern - return only suites with names matching this compiled re
+    prev_results - previous results returned by this function
+
+    Return a dict of the form: {(host, owner, name): suite_info, ...}
+
+    where each "suite_info" is a dict with keys:
+        KEY_GROUP - group name of suite
+        KEY_OWNER - suite owner name
+        KEY_PORT - suite port, for runninig suites only
+        KEY_STATES - suite state
+        KEY_STATES:cycle - states by cycle
+        KEY_TASKS_BY_STATE - tasks by state
+        KEY_TITLE - suite title
+        KEY_UPDATE_TIME - last update time of suite
+    """
+    results = {}
+    for host, port, result in scan_all(hosts=hosts, timeout=timeout):
+        if (name_pattern and not name_pattern.match(result[KEY_NAME]) or
+                owner_pattern and not owner_pattern.match(result[KEY_OWNER])):
+            continue
+        try:
+            result[KEY_PORT] = port
+            result[KEY_UPDATE_TIME] = int(float(result[KEY_UPDATE_TIME]))
+            results[(host, result[KEY_OWNER], result[KEY_NAME])] = result
+        except (KeyError, TypeError, ValueError):
+            pass
+    expire_threshold = time() - DURATION_EXPIRE_STOPPED
+    for (host, owner, name), prev_result in prev_results.items():
+        if ((host, owner, name) in results or
+                host not in hosts or
+                owner_pattern and not owner_pattern.match(owner) or
+                name_pattern and not name_pattern.match(name)):
+            # OK if suite already in current results set.
+            # Don't bother if:
+            # * previous host not in current hosts list
+            # * previous owner does not match current owner pattern
+            # * previous suite name does not match current name pattern
+            continue
+        if prev_result.get(KEY_PORT):
+            # A previously running suite is no longer running.
+            # Get suite info with "cat-state", if possible, and include in the
+            # results set.
+            try:
+                prev_result = _update_stopped_suite_info((host, owner, name))
+            except (IndexError, TypeError, ValueError):
+                continue
+        if prev_result.get(KEY_UPDATE_TIME, 0) > expire_threshold:
+            results[(host, owner, name)] = prev_result
+    return results
+
+
+def _update_stopped_suite_info(key):
+    """Return a map like cylc scan --raw for states and last update time."""
+    host, owner, suite = key
+    cmd = ["cylc", "ls-checkpoint"]
+    if host:
+        cmd.append("--host=" + host)
+    if owner:
+        cmd.append("--user=" + owner)
+    if cylc.flags.debug:
+        stderr = sys.stderr
+        cmd.append("--debug")
+    else:
+        stderr = PIPE
+    cmd += [suite, "0"]  # checkpoint 0 is latest checkpoint
+    result = {}
+    try:
+        proc = Popen(cmd, stderr=stderr, stdout=PIPE, preexec_fn=os.setpgrp)
+    except OSError:
+        return result
+    else:
+        out, err = proc.communicate()
+        if proc.wait():  # non-zero return code
+            if cylc.flags.debug:
+                sys.stderr.write(err)
+            return result
+    finally:
+        if proc.poll() is None:
+            try:
+                os.killpg(proc.pid, signal.SIGTERM)
+            except OSError:
+                pass
+    cur = None
+    for line in out.splitlines():
+        if not line.strip():
+            continue
+        if line.startswith("#"):
+            cur = line
+        elif cur == "# CHECKPOINT ID (ID|TIME|EVENT)":
+            result = {
+                KEY_UPDATE_TIME: timestr_to_seconds(line.split("|")[1]),
+                KEY_STATES: ({}, {})}
+        elif cur == "# TASK POOL (CYCLE|NAME|SPAWNED|STATUS)":
+            point, _, _, state = line.split("|")
+            # Total count of a state
+            result[KEY_STATES][0].setdefault(state, 0)
+            result[KEY_STATES][0][state] += 1
+            # Count of a state per cycle
+            try:
+                point = int(point)  # Allow integer sort, if possible
+            except ValueError:
+                pass
+            result[KEY_STATES][1].setdefault(point, {})
+            result[KEY_STATES][1][point].setdefault(state, 0)
+            result[KEY_STATES][1][point][state] += 1
+    return result

--- a/lib/cylc/network/__init__.py
+++ b/lib/cylc/network/__init__.py
@@ -33,6 +33,15 @@ COMMS_LOG_OBJ_NAME = 'log'
 COMMS_STATE_OBJ_NAME = 'state'
 COMMS_TASK_MESSAGE_OBJ_NAME = 'message'
 
+KEY_DESCRIPTION = "description"
+KEY_GROUP = "group"
+KEY_NAME = "name"
+KEY_OWNER = "owner"
+KEY_STATES = "states"
+KEY_TASKS_BY_STATE = "tasks-by-state"
+KEY_TITLE = "title"
+KEY_UPDATE_TIME = "update-time"
+
 # Ordered privilege levels for authenticated users.
 PRIVILEGE_LEVELS = [
     "identity",

--- a/lib/cylc/network/https/suite_identifier_server.py
+++ b/lib/cylc/network/https/suite_identifier_server.py
@@ -18,14 +18,18 @@
 
 # A minimal server/client pair to allow client programs to identify
 # what suite is running at a given cylc port - by suite name and owner.
+"""HTTPS server-side identification interface."""
 
+import cherrypy
+
+from cylc.config import SuiteConfig
 import cylc.flags
+from cylc.network import (
+    KEY_DESCRIPTION, KEY_GROUP, KEY_NAME, KEY_OWNER, KEY_STATES,
+    KEY_TASKS_BY_STATE, KEY_TITLE, KEY_UPDATE_TIME)
 from cylc.network.https.base_server import BaseCommsServer
 from cylc.network.https.suite_state_server import StateSummaryServer
 from cylc.network import access_priv_ok
-from cylc.config import SuiteConfig
-
-import cherrypy
 
 
 class SuiteIdServer(BaseCommsServer):
@@ -51,17 +55,16 @@ class SuiteIdServer(BaseCommsServer):
         self.report("identify")
         result = {}
         if access_priv_ok(self, "identity"):
-            result['name'] = self.name
-            result['owner'] = self.owner
+            result[KEY_NAME] = self.name
+            result[KEY_OWNER] = self.owner
         if access_priv_ok(self, "description"):
             config = SuiteConfig.get_inst()
-            result['title'] = config.cfg['title']
-            result['description'] = config.cfg['description']
-            result['group'] = config.cfg['group']
+            result[KEY_TITLE] = config.cfg[KEY_TITLE]
+            result[KEY_DESCRIPTION] = config.cfg[KEY_DESCRIPTION]
+            result[KEY_GROUP] = config.cfg[KEY_GROUP]
         if access_priv_ok(self, "state-totals"):
-            result['states'] = StateSummaryServer.get_inst().get_state_totals()
-            result['update-time'] = (
-                StateSummaryServer.get_inst().get_summary_update_time())
-            result['tasks-by-state'] = (
-                StateSummaryServer.get_inst().get_tasks_by_state())
+            summary_server = StateSummaryServer.get_inst()
+            result[KEY_STATES] = summary_server.get_state_totals()
+            result[KEY_UPDATE_TIME] = summary_server.get_summary_update_time()
+            result[KEY_TASKS_BY_STATE] = summary_server.get_tasks_by_state()
         return result


### PR DESCRIPTION
Can now filter by suite owners.
Display host column by default, if scanning multiple hosts.
New owner column, display by default if scanning other users.
Refactor:
* Results dict key now a tuple of (host, owner, suite) - as multiple
  users can run suites with the same names on the same hosts.
* Remove unnecessary logic, e.g. pointless class inheritance, multiple caching of previous results, etc.
* Can now use the data structure returned by port scan without fiddling.
* Use `cylc ls-checkpoint` instead of `cylc cat-state` to get info for
  a stopped suite.
* Moved shared functions between `cylc.gui.gpanel` and `cylc.gui.gscan`
  to a separate module `cylc.gui.scanutil`.

Close #1625.