### PR TITLE
Fix submitted/running task owner/host on restart

### DIFF
--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -614,16 +614,14 @@ conditions; see `cylc conditions`.
         else:
             if status in (TASK_STATUS_SUBMITTED, TASK_STATUS_RUNNING):
                 itask.state.set_prerequisites_all_satisfied()
-                # update the task proxy with submit ID etc.
-                itask.user_at_host = user_at_host
-                self.old_user_at_host_set.add(itask.user_at_host)
-                if itask.user_at_host is None:
-                    itask.user_at_host = "localhost"
-                # update timers in case regular polling is configured for itask
-                if '@' in itask.user_at_host:
-                    host = itask.user_at_host.split('@', 1)[1]
-                else:
-                    host = itask.user_at_host
+                # update the task proxy with user@host
+                try:
+                    itask.task_owner, itask.task_host = user_at_host.split(
+                        "@", 1)
+                except ValueError:
+                    itask.task_owner = None
+                    itask.task_host = user_at_host
+                self.old_user_at_host_set.add(user_at_host)
 
             elif status in (TASK_STATUS_SUBMIT_FAILED, TASK_STATUS_FAILED):
                 itask.state.set_prerequisites_all_satisfied()

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -1549,20 +1549,25 @@ class TaskPool(object):
             if (itask.task_host, itask.task_owner) not in auth_itasks:
                 auth_itasks[(itask.task_host, itask.task_owner)] = []
             auth_itasks[(itask.task_host, itask.task_owner)].append(itask)
-        for auth, itasks in sorted(auth_itasks.items()):
+        for (host, owner), itasks in sorted(auth_itasks.items()):
             cmd = ["cylc", cmd_key]
             if cylc.flags.debug:
                 cmd.append("--debug")
-            host, owner = auth
-            for key, value, test_func in [
-                    ('host', host, is_remote_host),
-                    ('user', owner, is_remote_user)]:
-                if test_func(value):
-                    cmd.append('--%s=%s' % (key, value))
-                    kwargs[key] = value
+            try:
+                if is_remote_host(host):
+                    cmd.append("--host=%s" % (host))
+                    kwargs["host"] = host
+            except IOError:
+                # Bad host, run the command any way, command will fail and
+                # callback will deal with it
+                cmd.append("--host=%s" % (host))
+                kwargs["host"] = host
+            if is_remote_user(owner):
+                cmd.append("--user=%s" % (owner))
+                kwargs["user"] = owner
             cmd.append("--")
             cmd.append(GLOBAL_CFG.get_derived_host_item(
-                self.suite_name, 'suite job log directory', host, owner))
+                self.suite_name, "suite job log directory", host, owner))
             job_log_dirs = []
             for itask in sorted(itasks, key=lambda itask: itask.identity):
                 job_log_dirs.append(itask.get_job_log_path())

--- a/tests/restart/26-remote-kill.t
+++ b/tests/restart/26-remote-kill.t
@@ -15,25 +15,33 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test re-run event handler on restart.
+# Test stop with a remote running task, restart, kill the task.
+CYLC_TEST_IS_GENERIC=false
 . "$(dirname "$0")/test_header"
-set_test_number 7
+export CYLC_TEST_HOST="$( \
+    cylc get-global-config -i '[test battery]remote host' 2>'/dev/null')"
+if [[ -z "${CYLC_TEST_HOST}" ]]; then
+    skip_all '"[test battery]remote host": not defined'
+fi
+set_test_number 5
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
-SUITED="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}"
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
 suite_run_ok "${TEST_NAME_BASE}-run" cylc run "${SUITE_NAME}" --debug
-sqlite3 "${SUITED}/log/db" \
-    'SELECT COUNT(*) FROM task_action_timers WHERE ctx_key_pickle GLOB "*event-handler-00*"' \
-    >"${TEST_NAME_BASE}-db-n-entries"
-cmp_ok "${TEST_NAME_BASE}-db-n-entries" <<<'1'
-suite_run_ok "${TEST_NAME_BASE}-restart" cylc restart "${SUITE_NAME}" --debug
-cmp_ok "${SUITED}/file" <<'__TEXT__'
-1
-2
-__TEXT__
-grep_ok 'LOADING task action timers' "${SUITED}/log/suite/out"
-grep_ok "+ t01\\.1 (('event-handler-00', 'succeeded'), 1)" "${SUITED}/log/suite/out"
-
+sqlite3 "${SUITE_RUN_DIR}/log/db" \
+    'SELECT status FROM task_pool WHERE cycle=="1" AND NAME=="t1"' \
+    >'t1-status.out'
+cmp_ok 't1-status.out' <<<'running'
+run_ok "${TEST_NAME_BASE}-restart" cylc restart "${SUITE_NAME}"
+# Ensure suite has started
+poll ! test -f "${SUITE_RUN_DIR}/.service/contact"
+cylc kill "${SUITE_NAME}" 't1.1'
+# Ensure suite has completed
+poll test -f "${SUITE_RUN_DIR}/.service/contact"
+sqlite3 "${SUITE_RUN_DIR}/log/db" \
+    'SELECT status FROM task_pool WHERE cycle=="1" AND NAME=="t1"' \
+    >'t1-status.out'
+cmp_ok 't1-status.out' <<<'failed'
+purge_suite_remote "${CYLC_TEST_HOST}" "${SUITE_NAME}"
 purge_suite "${SUITE_NAME}"
 exit

--- a/tests/restart/26-remote-kill/suite.rc
+++ b/tests/restart/26-remote-kill/suite.rc
@@ -1,0 +1,18 @@
+#!jinja2
+[cylc]
+    UTC mode = True
+    cycle point format = %Y
+    [[events]]
+        abort on stalled = True
+        abort on inactivity = True
+        inactivity = P6M
+[scheduling]
+    [[dependencies]]
+        graph = t1
+[runtime]
+    [[t1]]
+        script = sleep 300
+        [[[events]]]
+            started handler = cylc stop --now --now '%(suite)s'
+        [[[remote]]]
+            host = {{environ["CYLC_TEST_HOST"]}}


### PR DESCRIPTION
Ensure that `itask.task_owner` and `itask.task_host` are set on restart.
Previously, it only set `itask.user_at_host` which was not enough for
job management commands such as poll/kill.

Remove `TaskProxy.user_at_host` as an attribute, as it duplicates the
functionality of `TaskProxy.task_owner` and `TaskProxy.task_host` and
confuses matter.

Also fix diagnostic log after successful kill - it should not say retry
after P0Y.