### PR TITLE
get-config: fixed --python option

### DIFF
--- a/lib/parsec/OrderedDict.py
+++ b/lib/parsec/OrderedDict.py
@@ -105,16 +105,3 @@ class OrderedDictWithDefaults(OrderedDict):
     def __nonzero__(self):
         """Include any default keys in the nonzero calculation."""
         return bool(self.keys())
-
-    def __repr__(self):
-        """User-friendly-ish representation of defaults and others."""
-        non_default_items = []
-        non_default_keys = list(self)
-        for key in non_default_keys:
-            non_default_items.append((key, self[key]))
-        default_items = []
-        for key in getattr(self, 'defaults_', []):
-            if key not in non_default_keys:
-                default_items.append((key, self[key]))
-        repr_map = {"": non_default_items, "defaults_": default_items}
-        return "<" + type(self).__name__ + "(" + repr(repr_map) + ")>\n"

--- a/tests/cylc-get-config/00-simple.t
+++ b/tests/cylc-get-config/00-simple.t
@@ -18,7 +18,7 @@
 # Test cylc get-config
 . "$(dirname "$0")/test_header"
 #-------------------------------------------------------------------------------
-set_test_number 15
+set_test_number 19
 #-------------------------------------------------------------------------------
 init_suite "${TEST_NAME_BASE}" "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/suite.rc"
 #-------------------------------------------------------------------------------
@@ -55,6 +55,17 @@ sort ${TEST_NAME}.stdout > stdout.1
 sort "$TEST_SOURCE_DIR/$TEST_NAME_BASE/section2.stdout" > stdout.2
 cmp_ok stdout.1 stdout.2
 cmp_ok $TEST_NAME.stderr - </dev/null
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-python
+run_ok $TEST_NAME cylc get-config --python --sparse $SUITE_NAME
+run_ok $TEST_NAME-parse-config python -c "
+import sys
+from parsec.OrderedDict import OrderedDictWithDefaults
+with open(sys.argv[1], 'r') as file_:
+    print eval(file_.read())
+" "$TEST_NAME.stdout"
+cmp_ok "$TEST_NAME-parse-config.stdout" "$TEST_NAME.stdout"
+cmp_ok "$TEST_NAME-parse-config.stderr" /dev/null
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME
 exit


### PR DESCRIPTION
Closes #2073 

Removed the 'un-helpfull' `__repr__` in `OrderedDictWithDefaults` which was preventing its output from being parsable.