### PR TITLE
Fix edge case reset outputs

### DIFF
--- a/lib/cylc/task_state.py
+++ b/lib/cylc/task_state.py
@@ -382,7 +382,7 @@ class TaskState(object):
         else:
             self.submission_timer_timeout = None
             self.execution_timer_timeout = None
-            self.set_state(self.hold_swap)
+            self.reset_state(self.hold_swap)
 
     def set_state(self, status, loglvl=DEBUG):
         """Set, log and record task status (normal change, not forced - don't

--- a/tests/hold-release/20-reset-waiting-output.t
+++ b/tests/hold-release/20-reset-waiting-output.t
@@ -1,0 +1,28 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test reset succeeded task to waiting will reset its outputs.
+# https://github.com/cylc/cylc/issues/2115
+. "$(dirname "$0")/test_header"
+set_test_number 2
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+run_ok "${TEST_NAME_BASE}" cylc run --reference-test --debug "${SUITE_NAME}"
+
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/hold-release/20-reset-waiting-output/reference.log
+++ b/tests/hold-release/20-reset-waiting-output/reference.log
@@ -1,0 +1,5 @@
+2016-10-10T14:01:04Z INFO - Initial point: 1
+2016-10-10T14:01:04Z INFO - Final point: 1
+2016-10-10T14:01:05Z INFO - [t1.1] -triggered off []
+2016-10-10T14:01:08Z INFO - [t2.1] -triggered off ['t1.1']
+2016-10-10T14:01:11Z INFO - [t3.1] -triggered off ['t2.1']

--- a/tests/hold-release/20-reset-waiting-output/suite.rc
+++ b/tests/hold-release/20-reset-waiting-output/suite.rc
@@ -1,0 +1,43 @@
+#!jinja2
+[cylc]
+    [[events]]
+        abort on stalled = True
+        abort on inactivity = True
+        inactivity = P1M
+[scheduling]
+    [[dependencies]]
+        graph="t1 => t2 => t3"
+[runtime]
+    [[t1]]
+        script = """
+cylc hold "${CYLC_SUITE_NAME}"
+LOG="${CYLC_SUITE_LOG_DIR}/log"
+while ! grep -qF 'INFO - Command succeeded: hold_suite()' "${LOG}"; do
+    sleep 1  # make sure hold completes
+done
+cylc reset --state='succeeded' "${CYLC_SUITE_NAME}" 't2.1'
+while ! grep -qF \
+    "INFO - Command succeeded: reset_task_states([u't2.1'], state=succeeded)" \
+    "${LOG}"
+do
+    sleep 1  # make sure reset succeeded completes
+done
+cylc reset --state='waiting' "${CYLC_SUITE_NAME}" 't2.1'
+while ! grep -qF \
+    "INFO - Command succeeded: reset_task_states([u't2.1'], state=waiting)" \
+    "${LOG}"
+do
+    sleep 1  # make sure reset waiting completes
+done
+cylc release "${CYLC_SUITE_NAME}"
+"""
+        [[[job]]]
+            execution time limit = PT50S
+        [[[events]]]
+            failed handler = cylc release '%(suite)s'
+
+    [[t2]]
+        script = sleep 10; touch "${CYLC_SUITE_RUN_DIR}/t2.done"
+    [[t3]]
+        # This will fail if t3.1 starts together with t2.1
+        script = test -e "${CYLC_SUITE_RUN_DIR}/t2.done"

--- a/tests/restart/19-checkpoint/suite.rc
+++ b/tests/restart/19-checkpoint/suite.rc
@@ -16,6 +16,7 @@
 [runtime]
     [[t1]]
         script = """
+wait "${CYLC_TASK_MESSAGE_STARTED_PID}" 2>/dev/null || true
 if [[ "${CYLC_TASK_CYCLE_POINT}" == '2017' ]]; then
     cylc broadcast "${CYLC_SUITE_NAME}" -p '2017' -n 't1' --set='script=true'
     cylc hold "${CYLC_SUITE_NAME}"


### PR DESCRIPTION
On suite hold, reset a task to succeeded then reset to waiting. On suite
release, its dependent would run immediately before this fix.

Fix #2115.