### PR TITLE
Improve logic for adding cylc lib to sys.path

### DIFF
--- a/bin/cylc
+++ b/bin/cylc
@@ -22,11 +22,12 @@ import sys
 
 def prelude():
     """Ensure cylc library is at the front of "sys.path"."""
-    lib = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), '..', 'lib')
-    if lib in sys.path:
-        sys.path.remove(lib)
-    sys.path.insert(0, lib)
+    lib = os.path.normpath(os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), '..', 'lib'))
+    if sys.path[0:1] != [lib]:
+        if lib in sys.path:
+            sys.path.remove(lib)
+        sys.path.insert(0, lib)
 
 
 prelude()

--- a/lib/cylc/__init__.py
+++ b/lib/cylc/__init__.py
@@ -37,7 +37,7 @@ def environ_init(argv0=None):
         if cylc_dir != os.getenv('CYLC_DIR', ''):
             os.environ['CYLC_DIR'] = cylc_dir
 
-        cylc_dir_lib = os.path.join(cylc_dir, 'lib')
+        cylc_dir_lib = os.path.normpath(os.path.join(cylc_dir, 'lib'))
         my_lib = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
         if cylc_dir_lib == my_lib:
             dirs = []
@@ -49,6 +49,11 @@ def environ_init(argv0=None):
             dirs.append(os.getenv('CYLC_SUITE_DEF_PATH'))
         environ_path_add(dirs)
         environ_path_add([cylc_dir_lib], 'PYTHONPATH')
+        # Ensure cylc library is at the front of "sys.path".
+        if sys.path[0:1] != [cylc_dir_lib]:
+            if cylc_dir_lib in sys.path:
+                sys.path.remove(cylc_dir_lib)
+            sys.path.insert(0, cylc_dir_lib)
 
     # Python output buffering delays appearance of stdout and stderr
     # when output is not directed to a terminal (this occurred when

--- a/tests/restart/19-checkpoint/suite.rc
+++ b/tests/restart/19-checkpoint/suite.rc
@@ -24,6 +24,7 @@ if [[ "${CYLC_TASK_CYCLE_POINT}" == '2017' ]]; then
     while ! grep -qF 'INFO - Command succeeded: hold_suite()' "${LOG}"; do
         sleep 1  # make sure hold completes
     done
+    sleep 2
     (cd "${CYLC_SUITE_DEF_PATH}"; cp -p 'suite2.rc' 'suite.rc')
     cylc reload "${CYLC_SUITE_NAME}"
     while ! grep -q 'Reload completed' "${LOG}"; do


### PR DESCRIPTION
Using `cylc validate` as an example, the sequence of event is a bit like this:

1. `bin/cylc` is invoked.
2. `prelude` in `bin/cylc` puts bundled `lib` in front of `sys.path`.
3. `bin/cylc` imports `cylc`.
4. `environ_init` in `lib/cylc/__init__.py` puts bundled `lib` in front of `PYTHONPATH`.
5. *After this change, `environ_init` in `lib/cylc/__init__.py` puts bundled `lib` in front of `sys.path` as well.*
6. `bin/cylc` invokes `bin/cylc-validate`.
7. `bin/cylc-validate` imports `cylc`.
8. `environ_init` in `lib/cylc/__init__.py` puts bundled `lib` in front of `PYTHONPATH`.
9. *After this change, `environ_init` in `lib/cylc/__init__.py` puts bundled `lib` in front of `sys.path` as well.*