### PR TITLE
Fix remote kill after reload

### DIFF
--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -183,6 +183,7 @@ class Scheduler(object):
 
         self.suite_env = {}
         self.suite_task_env = {}
+        self.task_event_handler_env = {}
         self.contact_data = None
 
         self.do_process_tasks = False
@@ -1252,7 +1253,7 @@ conditions; see `cylc conditions`.
 
         # Make [cylc][environment] available to task event handlers in worker
         # processes,
-        TaskProxy.event_handler_env = cenv
+        self.task_event_handler_env = cenv
         # and to suite event handlers in this process.
         for var, val in cenv.items():
             os.environ[var] = val
@@ -1782,8 +1783,8 @@ conditions; see `cylc conditions`.
                     # Run custom event handlers on their own
                     if env is None:
                         env = dict(os.environ)
-                        if TaskProxy.event_handler_env:
-                            env.update(TaskProxy.event_handler_env)
+                        if self.task_event_handler_env:
+                            env.update(self.task_event_handler_env)
                     SuiteProcPool.get_inst().put_command(
                         SuiteProcContext(
                             key, try_timer.ctx.cmd, env=env, shell=True,

--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -176,7 +176,7 @@ class TaskProxy(object):
                  "MANAGE_JOB_LOGS_TRY_DELAYS", "NN",
                  "LOGGING_LVL_OF", "RE_MESSAGE_TIME", "TABLE_TASK_JOBS",
                  "TABLE_TASK_EVENTS", "TABLE_TASK_STATES", "POLLED_INDICATOR",
-                 "event_handler_env", "stop_sim_mode_job_submission", "tdef",
+                 "stop_sim_mode_job_submission", "tdef",
                  "submit_num", "validate_mode", "message_queue", "point",
                  "cleanup_cutoff", "identity", "has_spawned",
                  "point_as_seconds", "stop_point", "manual_trigger",
@@ -226,7 +226,6 @@ class TaskProxy(object):
 
     POLLED_INDICATOR = "(polled)"
 
-    event_handler_env = {}
     stop_sim_mode_job_submission = False
 
     def __init__(
@@ -372,12 +371,21 @@ class TaskProxy(object):
             if pre_reload_inst.state.status in TASK_STATUSES_ACTIVE:
                 self.log(WARNING, "job is active with pre-reload settings")
             # Retain some state from my pre suite-reload predecessor.
-            self.has_spawned = pre_reload_inst.has_spawned
-            self.summary = pre_reload_inst.summary
-            self.try_timers = pre_reload_inst.try_timers
             self.submit_num = pre_reload_inst.submit_num
+            self.has_spawned = pre_reload_inst.has_spawned
+            self.manual_trigger = pre_reload_inst.manual_trigger
+            self.is_manual_submit = pre_reload_inst.is_manual_submit
+            self.summary = pre_reload_inst.summary
+            self.local_job_file_path = pre_reload_inst.local_job_file_path
+            self.try_timers = pre_reload_inst.try_timers
+            self.event_handler_try_timers = (
+                pre_reload_inst.event_handler_try_timers)
             self.db_inserts_map = pre_reload_inst.db_inserts_map
             self.db_updates_map = pre_reload_inst.db_updates_map
+            self.task_host = pre_reload_inst.task_host
+            self.task_owner = pre_reload_inst.task_owner
+            self.job_vacated = pre_reload_inst.job_vacated
+            self.poll_timers = pre_reload_inst.poll_timers
             # Retain status of outputs.
             for msg, oid in pre_reload_inst.state.outputs.completed.items():
                 self.state.outputs.completed[msg] = oid
@@ -732,7 +740,7 @@ class TaskProxy(object):
             TaskJobLogsRetrieveContext(
                 self.JOB_LOGS_RETRIEVE,  # key
                 self.JOB_LOGS_RETRIEVE,  # ctx_type
-                self.user_at_host,
+                user_at_host,
                 self._get_host_conf("retrieve job logs max size"),  # max_size
             ),
             retry_delays)

--- a/tests/reload/19-remote-kill.t
+++ b/tests/reload/19-remote-kill.t
@@ -1,0 +1,44 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test reload then kill remote running task.
+CYLC_TEST_IS_GENERIC=false
+. "$(dirname "$0")/test_header"
+TEST_HOST=$(cylc get-global-config -i '[test battery]remote host' 2>'/dev/null')
+if [[ -z "${TEST_HOST}" ]]; then
+    skip_all '"[test battery]remote host": not defined'
+fi
+
+set_test_number 3
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+run_ok "${TEST_NAME_BASE}-validate" \
+    cylc validate --set="CYLC_TEST_HOST=${TEST_HOST}" "${SUITE_NAME}"
+suite_run_fail "${TEST_NAME_BASE}-run" \
+    cylc run --debug --reference-test \
+    --set="CYLC_TEST_HOST=${TEST_HOST}" \
+     "${SUITE_NAME}"
+sqlite3 "${SUITE_RUN_DIR}/.service/db" \
+    'SELECT cycle,name,run_status FROM task_jobs' >'db.out'
+cmp_ok 'db.out' <<'__OUT__'
+1|foo|1
+1|bar|0
+__OUT__
+
+purge_suite_remote "${TEST_HOST}" "${SUITE_NAME}"
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/reload/19-remote-kill/reference.log
+++ b/tests/reload/19-remote-kill/reference.log
@@ -1,0 +1,4 @@
+2016-07-08T14:53:12+01 INFO - Initial point: 1
+2016-07-08T14:53:12+01 INFO - Final point: 1
+2016-07-08T14:53:12+01 INFO - [foo.1] -triggered off []
+2016-07-08T14:53:19+01 INFO - [bar.1] -triggered off ['foo.1']

--- a/tests/reload/19-remote-kill/suite.rc
+++ b/tests/reload/19-remote-kill/suite.rc
@@ -1,0 +1,32 @@
+#!Jinja2
+[cylc]
+   [[events]]
+       abort on stalled = True
+   [[reference test]]
+       live mode suite timeout = PT1M
+       required run mode = live
+       expected task failures = foo.1
+[scheduling]
+    [[dependencies]]
+        graph="foo:start => bar"
+
+[runtime]
+    [[bar]]
+        script="""
+wait "${CYLC_TASK_MESSAGE_STARTED_PID}" 2>/dev/null || true
+cylc reload "${CYLC_SUITE_NAME}"
+LOG="${CYLC_SUITE_LOG_DIR}/log"
+while ! grep -q 'Reload completed' "${LOG}"; do
+    sleep 1  # make sure reload completes
+done
+cylc kill "${CYLC_SUITE_NAME}" 'foo.1'
+while ! grep -qF '[foo.1] -job(01) killed' "${LOG}"; do
+    sleep 1  # make sure reload completes
+done
+"""
+        [[[job]]]
+            execution time limit = PT1M
+    [[foo]]
+        script=sleep 61
+        [[[remote]]]
+            host = {{CYLC_TEST_HOST}}


### PR DESCRIPTION
Looks like `itask.task_owner` and `itask.task_host` are lost after a reload. I'll raise a simpler back port for 6.11.x as well.