### PR TITLE
Make UTC mode True by default.

### DIFF
--- a/doc/cug.tex
+++ b/doc/cug.tex
@@ -2636,8 +2636,8 @@ Graph section heading can also be used with integer cycling see
 Date-time cycling information is made up of a starting {\em date-time}, an
 {\em interval}, and an optional {\em limit}.
 
-The time is assumed to be in the local time zone unless you set
-\lstinline=[cylc]cycle point time zone= or \lstinline=[cylc]UTC mode=. The
+The time is assumed to be in UTC unless you set
+\lstinline=[cylc]cycle point time zone= or \lstinline=[cylc]UTC mode=false. The
 calendar is assumed to be the proleptic Gregorian calendar unless you set
 \lstinline=[scheduling]cycling mode=.
 

--- a/doc/suiterc.tex
+++ b/doc/suiterc.tex
@@ -79,8 +79,8 @@ expensive real tasks during suite development.
 \subsubsection[UTC mode]{ [cylc] \textrightarrow UTC mode}
 \label{UTC-mode}
 
-Cylc runs off the suite host's system clock by default. This item allows
-you to run the suite in UTC even if the system clock is set to local time.
+Cylc runs in UTC by default even if the host is using a local time. This item
+allows you to run the suite using the host's system clock.
 Clock-trigger tasks will trigger when the current UTC time is equal to
 their cycle point date-time plus offset; other time values used, reported,
 or logged by the suite daemon will usually also be in UTC. The default for
@@ -88,7 +88,7 @@ this can be set at the site level (see ~\ref{SiteUTCMode}).
 
 \begin{myitemize}
     \item {\em type:} boolean
-    \item {\em default:} False, unless overridden at site level.
+    \item {\em default:} True, unless overridden at site level.
 \end{myitemize}
 
 \subsubsection[cycle point format]{ [cylc] \textrightarrow cycle point format}

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -59,7 +59,7 @@ SPEC = {
     },
 
     'cylc': {
-        'UTC mode': vdr(vtype='boolean', default=False),
+        'UTC mode': vdr(vtype='boolean', default=True),
         'health check interval': vdr(
             vtype='interval', default=DurationFloat(600)),
         'task event mail interval': vdr(

--- a/tests/cylc-trigger/03-edit-run.t
+++ b/tests/cylc-trigger/03-edit-run.t
@@ -39,7 +39,7 @@ sed -i 's/^--- original $/--- original/; s/^+++ edited $/+++ edited/' $DIFF_LOG
 cmp_ok $DIFF_LOG - <<__END__
 --- original
 +++ edited
-@@ -124,7 +124,7 @@
+@@ -125,7 +125,7 @@
  echo
  
  # SCRIPT:

--- a/tests/jobscript/00-torture/foo.ref-jobfile
+++ b/tests/jobscript/00-torture/foo.ref-jobfile
@@ -68,6 +68,7 @@ export CYLC_SUITE_PORT=
 export CYLC_SUITE_RUN_DIR_ON_SUITE_HOST=
 export CYLC_UTC=
 export CYLC_VERBOSE=
+export TZ=UTC
 
 export CYLC_SUITE_DEF_PATH=
 export CYLC_SUITE_RUN_DIR=


### PR DESCRIPTION
So, pretty much all our suites end up having the line `UTC mode = true` put in them (I'm actually yet to see one where it isn't). Rather than have every suite have to have this line and/or rely on a site config that sets this to default for everyone there (at which point a suite will need the `mode = true` putting in anyway if it is to be shared with someone running on a different site where it isn't necessarily configured that way centrally) its probably best to just make it the default once and for all.

@cylc/core - flagging this up in case there are any objections to this (I know we've discussed doing this in past).