### PR TITLE
Add `--icp=CYCLE_POINT` option for various commands

### DIFF
--- a/bin/cylc-diff
+++ b/bin/cylc-diff
@@ -115,7 +115,7 @@ def prdict(dct, arrow='<', section='', level=0, diff=False, nested=False):
 
 def main():
     parser = COP(
-        __doc__, jset=True, prep=True, twosuites=True,
+        __doc__, jset=True, prep=True, icp=True,
         argdoc=[('SUITE1', 'Suite name or path'),
                 ('SUITE2', 'Suite name or path')])
 
@@ -135,10 +135,13 @@ def main():
     template_vars = load_template_vars(
         options.templatevars, options.templatevars_file)
     config1 = SuiteConfig.get_inst(
-        suite1, suite1rc, template_vars).cfg
+        suite1, suite1rc, template_vars,
+        cli_initial_point_string=options.icp).cfg
+    SuiteConfig._FORCE = True
     print "Parsing %s (%s)" % (suite2, suite2rc)
     config2 = SuiteConfig.get_inst(
-        suite2, suite2rc, template_vars, is_reload=True).cfg
+        suite2, suite2rc, template_vars,
+        cli_initial_point_string=options.icp, is_reload=True).cfg
 
     if config1 == config2:
         print "Suite definitions %s and %s are identical" % (suite1, suite2)

--- a/bin/cylc-get-suite-config
+++ b/bin/cylc-get-suite-config
@@ -65,7 +65,7 @@ from cylc.templatevars import load_template_vars
 
 
 def main():
-    parser = COP(__doc__, jset=True, prep=True)
+    parser = COP(__doc__, jset=True, prep=True, icp=True)
 
     parser.add_option(
         "-i", "--item", metavar="[SEC...]ITEM",
@@ -119,7 +119,8 @@ def main():
 
     config = SuiteConfig(
         suite, suiterc,
-        load_template_vars(options.templatevars, options.templatevars_file))
+        load_template_vars(options.templatevars, options.templatevars_file),
+        cli_initial_point_string=options.icp)
     if options.tasks:
         for task in config.get_task_name_list():
             print prefix + task

--- a/bin/cylc-graph-diff
+++ b/bin/cylc-graph-diff
@@ -17,7 +17,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 set -eu
 
-usage() {
+_clean() {
+    if [[ -n "${DIFF_FILES:-}" ]]; then
+        rm -f ${DIFF_FILES:-}
+    fi
+}
+
+_usage() {
   cat <<'__USAGE__'
 Usage: cylc graph-diff [OPTIONS] SUITE1 SUITE2 -- [GRAPH_OPTIONS_ARGS]
 
@@ -40,7 +46,7 @@ for ARG in "$@"; do
     if [[ "$ARG" == '--' ]]; then
         break
     elif [[ "$ARG" == '--help' ]]; then
-        usage
+        _usage
         exit 0
     elif [[ "$ARG" == "-g" ]]; then
         GRAPHICAL_DIFF=true
@@ -57,14 +63,16 @@ for ARG in "$@"; do
     fi
 done
 if (( NUM_SUITES != 2 )); then
-    usage >&2
+    _usage >&2
     exit 1
 fi
 
+trap _clean EXIT
+trap _clean ERR
 DIFF_FILES=""
 for SUITE in $SUITES; do
     FILE=$(mktemp -t "$(tr '/' '.' <<<"${SUITE}").graph.ref.XXXX")
-    cylc graph --reference "$@" $SUITE >$FILE
+    cylc graph --reference "${SUITE}" "$@" >$FILE
     DIFF_FILES="$DIFF_FILES $FILE"
 done
 

--- a/bin/cylc-insert
+++ b/bin/cylc-insert
@@ -57,7 +57,7 @@ def main():
     parser.add_option(
         "--stop-point", "--remove-point",
         help="Optional hold/stop cycle point for inserted task.",
-        metavar="POINT", action="store", dest="stop_point_string")
+        metavar="CYCLE_POINT", action="store", dest="stop_point_string")
     parser.add_option(
         "--no-check", help="Add task even if the provided cycle point is not "
         "valid for the given task.", action="store_true", default=False)

--- a/bin/cylc-list
+++ b/bin/cylc-list
@@ -41,7 +41,7 @@ from cylc.templatevars import load_template_vars
 
 def main():
 
-    parser = COP(__doc__, jset=True, prep=True)
+    parser = COP(__doc__, jset=True, prep=True, icp=True)
 
     parser.add_option(
         "-a", "--all-tasks",
@@ -113,7 +113,8 @@ def main():
 
     config = SuiteConfig(
         suite, suiterc,
-        load_template_vars(options.templatevars, options.templatevars_file))
+        load_template_vars(options.templatevars, options.templatevars_file),
+        cli_initial_point_string=options.icp)
     if options.tree:
         config.print_first_parent_tree(
             pretty=options.box, titles=options.titles)

--- a/bin/cylc-submit
+++ b/bin/cylc-submit
@@ -60,7 +60,7 @@ from cylc.templatevars import load_template_vars
 
 def commandline_parser():
     parser = COP(
-        __doc__, jset=True,
+        __doc__, jset=True, icp=True,
         argdoc=[("REG", "Suite name"),
                 ("TASK", "Target task (" + TaskID.SYNTAX + ")")])
 
@@ -103,7 +103,8 @@ def main():
     # load suite config
     config = SuiteConfig.get_inst(
         suite, suiterc,
-        load_template_vars(options.templatevars, options.templatevars_file))
+        load_template_vars(options.templatevars, options.templatevars_file),
+        cli_initial_point_string=options.icp)
 
     # No TASK EVENT HOOKS are set for the submit command because there is
     # no scheduler instance watching for task failure etc.

--- a/bin/cylc-validate
+++ b/bin/cylc-validate
@@ -43,12 +43,7 @@ from cylc.profiler import Profiler
 
 def main():
 
-    parser = COP(__doc__, jset=True, prep=True)
-
-    parser.add_option(
-        "--icp",
-        help="Set an initial cycle point to validate against. This "
-             "may be required if the suite does not supply one.")
+    parser = COP(__doc__, jset=True, prep=True, icp=True)
 
     parser.add_option(
         "--strict",

--- a/lib/cylc/cylc_xdot.py
+++ b/lib/cylc/cylc_xdot.py
@@ -46,6 +46,7 @@ class CylcDotViewerCommon(xdot.DotWindow):
             self.suiterc = SuiteConfig(
                 self.suite, self.file, self.template_vars,
                 is_reload=is_reload, collapsed=collapsed,
+                cli_initial_point_string=self.start_point_string,
                 vis_start_string=self.start_point_string,
                 vis_stop_string=self.stop_point_string)
         except Exception, x:

--- a/tests/cylc-diff/03-icp.t
+++ b/tests/cylc-diff/03-icp.t
@@ -1,0 +1,89 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test for "cylc diff --icp=CYCLE_POINT".
+. "$(dirname "$0")/test_header"
+
+set_test_number 3
+
+init_suite "${TEST_NAME_BASE}-1" <<'__SUITE_RC__'
+[cylc]
+    UTC mode = True
+[scheduling]
+    [[dependencies]]
+        [[[R1]]]
+            graph = foo => bar
+[runtime]
+    [[foo, bar]]
+        script = true
+__SUITE_RC__
+SUITE_NAME1="${SUITE_NAME}"
+init_suite "${TEST_NAME_BASE}-2" <<'__SUITE_RC__'
+[cylc]
+    UTC mode = True
+[scheduling]
+    [[dependencies]]
+        [[[R1]]]
+            graph = food => barley
+[runtime]
+    [[food, barley]]
+        script = true
+__SUITE_RC__
+SUITE_NAME2="${SUITE_NAME}"
+
+run_ok "${TEST_NAME_BASE}" \
+    cylc diff --icp=2020 "${SUITE_NAME1}" "${SUITE_NAME2}"
+cmp_ok "${TEST_NAME_BASE}.stdout" <<__OUT__
+Parsing ${SUITE_NAME1} (${TEST_DIR}/${SUITE_NAME1}/suite.rc)
+Parsing ${SUITE_NAME2} (${TEST_DIR}/${SUITE_NAME2}/suite.rc)
+Suite definitions ${SUITE_NAME1} and ${SUITE_NAME2} differ
+
+2 items only in ${SUITE_NAME1} (<)
+
+   [runtime] [[foo]]
+ <   script = true
+
+   [runtime] [[bar]]
+ <   script = true
+
+2 items only in ${SUITE_NAME2} (>)
+
+   [runtime] [[food]]
+ >   script = true
+
+   [runtime] [[barley]]
+ >   script = true
+
+3 common items differ ${SUITE_NAME1}(<) ${SUITE_NAME2}(>)
+
+   [scheduling] [[queues]] [[[default]]]
+ <   members = ['foo', 'bar']
+ >   members = ['food', 'barley']
+
+   [scheduling] [[dependencies]] [[[R1]]]
+ <   graph = foo => bar
+ >   graph = food => barley
+
+   [visualization] [[node groups]]
+ <   root = ['root', 'foo', 'bar']
+ >   root = ['root', 'food', 'barley']
+__OUT__
+cmp_ok "${TEST_NAME_BASE}.stderr" <'/dev/null'
+
+purge_suite "${SUITE_NAME1}"
+purge_suite "${SUITE_NAME2}"
+exit

--- a/tests/cylc-diff/04-icp-2.t
+++ b/tests/cylc-diff/04-icp-2.t
@@ -1,0 +1,90 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test for "cylc diff --icp=CYCLE_POINT", override.
+. "$(dirname "$0")/test_header"
+
+set_test_number 3
+
+init_suite "${TEST_NAME_BASE}-1" <<'__SUITE_RC__'
+[cylc]
+    UTC mode = True
+[scheduling]
+    [[dependencies]]
+        [[[R1]]]
+            graph = foo => bar
+[runtime]
+    [[foo, bar]]
+        script = true
+__SUITE_RC__
+SUITE_NAME1="${SUITE_NAME}"
+init_suite "${TEST_NAME_BASE}-2" <<'__SUITE_RC__'
+[cylc]
+    UTC mode = True
+[scheduling]
+    initial cycle point = 2016
+    [[dependencies]]
+        [[[R1]]]
+            graph = food => barley
+[runtime]
+    [[food, barley]]
+        script = true
+__SUITE_RC__
+SUITE_NAME2="${SUITE_NAME}"
+
+run_ok "${TEST_NAME_BASE}" \
+    cylc diff --icp=2020 "${SUITE_NAME1}" "${SUITE_NAME2}"
+cmp_ok "${TEST_NAME_BASE}.stdout" <<__OUT__
+Parsing ${SUITE_NAME1} (${TEST_DIR}/${SUITE_NAME1}/suite.rc)
+Parsing ${SUITE_NAME2} (${TEST_DIR}/${SUITE_NAME2}/suite.rc)
+Suite definitions ${SUITE_NAME1} and ${SUITE_NAME2} differ
+
+2 items only in ${SUITE_NAME1} (<)
+
+   [runtime] [[foo]]
+ <   script = true
+
+   [runtime] [[bar]]
+ <   script = true
+
+2 items only in ${SUITE_NAME2} (>)
+
+   [runtime] [[food]]
+ >   script = true
+
+   [runtime] [[barley]]
+ >   script = true
+
+3 common items differ ${SUITE_NAME1}(<) ${SUITE_NAME2}(>)
+
+   [scheduling] [[queues]] [[[default]]]
+ <   members = ['foo', 'bar']
+ >   members = ['food', 'barley']
+
+   [scheduling] [[dependencies]] [[[R1]]]
+ <   graph = foo => bar
+ >   graph = food => barley
+
+   [visualization] [[node groups]]
+ <   root = ['root', 'foo', 'bar']
+ >   root = ['root', 'food', 'barley']
+__OUT__
+cmp_ok "${TEST_NAME_BASE}.stderr" <'/dev/null'
+
+purge_suite "${SUITE_NAME1}"
+purge_suite "${SUITE_NAME2}"
+exit

--- a/tests/cylc-get-config/03-icp.t
+++ b/tests/cylc-get-config/03-icp.t
@@ -1,0 +1,42 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test for "cylc get-config --icp=CYCLE_POINT".
+. "$(dirname "$0")/test_header"
+
+set_test_number 3
+
+init_suite "${TEST_NAME_BASE}" <<'__SUITE_RC__'
+[cylc]
+    UTC mode = True
+[scheduling]
+    [[dependencies]]
+        [[[R1]]]
+            graph = foo => bar
+[runtime]
+    [[foo, bar]]
+        script = true
+__SUITE_RC__
+
+run_ok "${TEST_NAME_BASE}" cylc get-config --icp=20200101T0000Z "${SUITE_NAME}"
+contains_ok "${TEST_NAME_BASE}.stdout" <<__OUT__
+    initial cycle point = 20200101T0000Z
+__OUT__
+cmp_ok "${TEST_NAME_BASE}.stderr" <'/dev/null'
+
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/cylc-graph-diff/01-icp.t
+++ b/tests/cylc-graph-diff/01-icp.t
@@ -1,0 +1,63 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test for "cylc graph-diff SUITE1 SUITE2 -- ICP".
+. "$(dirname "$0")/test_header"
+
+set_test_number 3
+
+init_suite "${TEST_NAME_BASE}-1" <<'__SUITE_RC__'
+[cylc]
+    UTC mode = True
+[scheduling]
+    [[dependencies]]
+        [[[R1]]]
+            graph = foo => bar
+[runtime]
+    [[foo, bar]]
+        script = true
+__SUITE_RC__
+SUITE_NAME1="${SUITE_NAME}"
+init_suite "${TEST_NAME_BASE}-2" <<'__SUITE_RC__'
+[cylc]
+    UTC mode = True
+[scheduling]
+    [[dependencies]]
+        [[[R1]]]
+            graph = food => barley
+[runtime]
+    [[food, barley]]
+        script = true
+__SUITE_RC__
+SUITE_NAME2="${SUITE_NAME}"
+
+run_fail "${TEST_NAME_BASE}" \
+    cylc graph-diff "${SUITE_NAME1}" "${SUITE_NAME2}" --  '20200101T0000Z'
+contains_ok "${TEST_NAME_BASE}.stdout" <<__OUT__
+-edge "foo.20200101T0000Z" "bar.20200101T0000Z" solid
++edge "food.20200101T0000Z" "barley.20200101T0000Z" solid
+ graph
+-node "bar.20200101T0000Z" "bar\n20200101T0000Z" unfilled box black
+-node "foo.20200101T0000Z" "foo\n20200101T0000Z" unfilled box black
++node "barley.20200101T0000Z" "barley\n20200101T0000Z" unfilled box black
++node "food.20200101T0000Z" "food\n20200101T0000Z" unfilled box black
+__OUT__
+cmp_ok "${TEST_NAME_BASE}.stderr" <'/dev/null'
+
+purge_suite "${SUITE_NAME1}"
+purge_suite "${SUITE_NAME2}"
+exit

--- a/tests/cylc-list/01-icp.t
+++ b/tests/cylc-list/01-icp.t
@@ -1,0 +1,43 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test for "cylc list --icp=CYCLE_POINT".
+. "$(dirname "$0")/test_header"
+
+set_test_number 3
+
+init_suite "${TEST_NAME_BASE}" <<'__SUITE_RC__'
+[cylc]
+    UTC mode = True
+[scheduling]
+    [[dependencies]]
+        [[[R1]]]
+            graph = foo => bar
+[runtime]
+    [[foo, bar]]
+        script = true
+__SUITE_RC__
+
+run_ok "${TEST_NAME_BASE}" cylc list --icp=20200101T0000Z "${SUITE_NAME}"
+cmp_ok "${TEST_NAME_BASE}.stdout" <<__OUT__
+bar
+foo
+__OUT__
+cmp_ok "${TEST_NAME_BASE}.stderr" <'/dev/null'
+
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/jobscript/09-icp.t
+++ b/tests/jobscript/09-icp.t
@@ -1,0 +1,43 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test for "cylc jobscript --icp=CYCLE_POINT".
+. "$(dirname "${0}")/test_header"
+
+set_test_number 3
+init_suite "${TEST_NAME_BASE}" <<'__SUITE_RC__'
+[cylc]
+    UTC mode = True
+[scheduling]
+    [[dependencies]]
+        [[[R1]]]
+            graph = foo
+[runtime]
+    [[foo]]
+        script = true
+__SUITE_RC__
+
+run_ok "${TEST_NAME_BASE}" \
+    cylc jobscript --icp=20200101T0000Z "${SUITE_NAME}" 'foo.20200101T0000Z'
+contains_ok "${TEST_NAME_BASE}.stdout" <<__OUT__
+export CYLC_SUITE_INITIAL_CYCLE_POINT=20200101T0000Z
+__OUT__
+cmp_ok "${TEST_NAME_BASE}.stderr" <<__ERR__
+Task Job Script Generated: ${SUITE_RUN_DIR}/log/job/20200101T0000Z/foo/01/job
+__ERR__
+purge_suite "${SUITE_NAME}"
+exit


### PR DESCRIPTION
Allow initial cycle point to be specified if missing from `suite.rc`.

Close #1000.