### PR TITLE
cylc print: always descend at top level

### DIFF
--- a/lib/cylc/suite_srv_files_mgr.py
+++ b/lib/cylc/suite_srv_files_mgr.py
@@ -325,13 +325,15 @@ To see if %(suite)s is running on '%(host)s:%(port)s':
         from cylc.cfgspec.globalcfg import GLOBAL_CFG
         run_d = GLOBAL_CFG.get_host_item('run directory')
         results = []
-        skip_names = [
-            "log", "share", "work", self.DIR_BASE_SRV, self.FILE_BASE_SUITE_RC]
         for dirpath, dnames, fnames in os.walk(run_d, followlinks=True):
-            # Don't descent further if it looks like a suite directory
-            if any([name in dnames or name in fnames for name in skip_names]):
+            # Always descend for top directory, but
+            # don't descend further if it has a:
+            # * .service/
+            # * cylc-suite.db: (pre-cylc-7 suites don't have ".service/").
+            if dirpath != run_d and (
+                    self.DIR_BASE_SRV in dnames or "cylc-suite.db" in fnames):
                 dnames[:] = []
-            # Choose only suites with info file and matching filter
+            # Choose only suites with .service and matching filter
             reg = os.path.relpath(dirpath, run_d)
             path = os.path.join(dirpath, self.DIR_BASE_SRV)
             if (not self._locate_item(self.FILE_BASE_SOURCE, path) or

--- a/tests/lib/bash/test_header
+++ b/tests/lib/bash/test_header
@@ -1,7 +1,7 @@
 #!/bin/bash
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
 # Copyright (C) 2008-2017 NIWA
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/tests/registration/01-no-skip1.t
+++ b/tests/registration/01-no-skip1.t
@@ -15,9 +15,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test cylc suite registration
+# Test cylc print doesn't skip special names at root level,
+# e.g. "~/cylc-run/work"
 . "$(dirname "$0")/test_header"
-set_test_number 7
+set_test_number 3
 
 init_suite "${TEST_NAME_BASE}" <<'__SUITE_RC__'
 title = the quick brown fox
@@ -28,21 +29,15 @@ title = the quick brown fox
     [[a,b,c]]
         script = true
 __SUITE_RC__
-
-run_ok "${TEST_NAME_BASE}-register" cylc register "${SUITE_NAME}"
-exists_ok "${SUITE_RUN_DIR}/.service/passphrase"
-
-run_ok "${TEST_NAME_BASE}-get-dir" cylc get-directory "${SUITE_NAME}"
-
-cd .. # necessary so the suite is being validated via the database not filepath
-run_ok "${TEST_NAME_BASE}-val" cylc validate "${SUITE_NAME}"
-cd "${OLDPWD}"
+RUND="$(cylc get-global-config --print-run-dir)"
+ln -sf "${SUITE_NAME}" "${RUND}/work"
 
 run_ok "${TEST_NAME_BASE}-print" cylc print
 contains_ok "${TEST_NAME_BASE}-print.stdout" <<__OUT__
-${SUITE_NAME} | the quick brown fox | ${TEST_DIR}/${SUITE_NAME}
+work | the quick brown fox | ${TEST_DIR}/${SUITE_NAME}
 __OUT__
 cmp_ok "${TEST_NAME_BASE}-print.stderr" <'/dev/null'
 
+rm -f "${RUND}/work"
 purge_suite "${SUITE_NAME}"
 exit

--- a/tests/registration/basic/suite.rc
+++ b/tests/registration/basic/suite.rc
@@ -1,7 +1,0 @@
-title = "the quick brown fox"
-[scheduling]
-    [[dependencies]]
-        graph = "a => b => c"
-[runtime]
-    [[a,b,c]]
-        script = true


### PR DESCRIPTION
Allow listing to descend at the top level, regardless of items in the directory.