### PR TITLE
Fix error on missing quote in suite.rc %include

### DIFF
--- a/lib/parsec/include.py
+++ b/lib/parsec/include.py
@@ -107,7 +107,7 @@ def inline(lines, dir, file, for_grep=False, for_edit=False, viewcfg={},
         if m:
             q1, match, q2 = m.groups()
             if q1 and (q1 != q2):
-                raise IncludeFileError("ERROR, mismatched quotes: " + line)
+                raise ParsecError("ERROR, mismatched quotes: " + line)
             inc = os.path.join(dir, match)
             if inc not in done:
                 if single or for_edit:

--- a/tests/validate/61-include-missing-quote.t
+++ b/tests/validate/61-include-missing-quote.t
@@ -1,0 +1,33 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Error message for missing quote in include statement
+
+. "$(dirname "$0")/test_header"
+
+set_test_number 2
+
+cat >'suite.rc' <<'__SUITE_RC__'
+%include 'foo.rc
+__SUITE_RC__
+
+run_fail "${TEST_NAME_BASE}" cylc validate 'suite.rc'
+cmp_ok "${TEST_NAME_BASE}.stderr" <<'__ERR__'
+ERROR, mismatched quotes: %include 'foo.rc
+__ERR__
+
+exit


### PR DESCRIPTION
`IncludeFileError` is not defined anywhere.

Reported by @kaday.