### PR TITLE
#2154: Fix r-click sub-menu in graph view

### DIFF
--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -1247,6 +1247,18 @@ been defined for this suite""").inform()
                              is_graph_view=False):
         """Return the default menu for a list of tasks."""
 
+        # NOTE: we have to respond to 'button-release-event' rather than
+        # 'activate' in order for sub-menus to work in the graph-view.
+        # sub_menu_connect should be used in preference to item.connect
+        # to handle this
+
+        if is_graph_view:
+            sub_menu_connect = lambda item, x, y, z: \
+                item.connect('button-release-event', x, y, z)
+        else:
+            sub_menu_connect = lambda item, x, y, z: \
+                item.connect('activate', x, None, y, z)
+
         if type(task_is_family) is bool:
             task_is_family = [task_is_family] * len(task_ids)
         if (type(task_ids) is not list or type(t_states) is not list or
@@ -1297,7 +1309,7 @@ been defined for this suite""").inform()
 
                 # NOTE: we have to respond to 'button-release-event' rather
                 # than 'activate' in order for sub-menus to work in the
-                # graph-view.
+                # graph-view so use sub_menu_connect instead of item.connect
 
                 for key, filename in [
                         ('job script', 'job'),
@@ -1307,12 +1319,7 @@ been defined for this suite""").inform()
                     item.set_image(gtk.image_new_from_stock(
                         gtk.STOCK_DND, gtk.ICON_SIZE_MENU))
                     view_menu.append(item)
-                    if is_graph_view:
-                        item.connect('button-release-event',
-                                     self.view_task_info,
-                                     task_ids[0], filename)
-                    else:
-                        item.connect('activate', self.view_task_info, None,
+                    sub_menu_connect(item, self.view_task_info,
                                      task_ids[0], filename)
                     item.set_sensitive(
                         t_states[0] in TASK_STATUSES_WITH_JOB_SCRIPT)
@@ -1425,37 +1432,23 @@ been defined for this suite""").inform()
 
         # NOTE: we have to respond to 'button-release-event' rather
         # than 'activate' in order for sub-menus to work in the
-        # graph-view.
+        # graph-view so use sub_menu_connect instead of item.connect
 
         reset_ready_item = gtk.ImageMenuItem('"%s"' % TASK_STATUS_READY)
         reset_img = gtk.image_new_from_stock(
             gtk.STOCK_CONVERT, gtk.ICON_SIZE_MENU)
         reset_ready_item.set_image(reset_img)
         reset_menu.append(reset_ready_item)
-
-        if is_graph_view:
-            reset_ready_item.connect(
-                'button-release-event', self.reset_task_state,
-                task_ids, TASK_STATUS_READY)
-        else:
-            reset_ready_item.connect(
-                'activate', self.reset_task_state, None,
-                task_ids, TASK_STATUS_READY)
+        sub_menu_connect(reset_ready_item, self.reset_task_state,
+                         task_ids, TASK_STATUS_READY)
 
         reset_waiting_item = gtk.ImageMenuItem('"%s"' % TASK_STATUS_WAITING)
         reset_img = gtk.image_new_from_stock(
             gtk.STOCK_CONVERT, gtk.ICON_SIZE_MENU)
         reset_waiting_item.set_image(reset_img)
         reset_menu.append(reset_waiting_item)
-
-        if is_graph_view:
-            reset_waiting_item.connect(
-                'button-release-event', self.reset_task_state,
-                task_ids, TASK_STATUS_WAITING)
-        else:
-            reset_waiting_item.connect(
-                'activate', self.reset_task_state, None,
-                task_ids, TASK_STATUS_WAITING)
+        sub_menu_connect(reset_waiting_item, self.reset_task_state,
+                         task_ids, TASK_STATUS_WAITING)
 
         reset_succeeded_item = gtk.ImageMenuItem(
             '"%s"' % TASK_STATUS_SUCCEEDED)
@@ -1463,30 +1456,16 @@ been defined for this suite""").inform()
                                              gtk.ICON_SIZE_MENU)
         reset_succeeded_item.set_image(reset_img)
         reset_menu.append(reset_succeeded_item)
-
-        if is_graph_view:
-            reset_succeeded_item.connect(
-                'button-release-event', self.reset_task_state,
-                task_ids, TASK_STATUS_SUCCEEDED)
-        else:
-            reset_succeeded_item.connect(
-                'activate', self.reset_task_state, None,
-                task_ids, TASK_STATUS_SUCCEEDED)
+        sub_menu_connect(reset_succeeded_item, self.reset_task_state,
+                         task_ids, TASK_STATUS_SUCCEEDED)
 
         reset_failed_item = gtk.ImageMenuItem('"%s"' % TASK_STATUS_FAILED)
         reset_img = gtk.image_new_from_stock(gtk.STOCK_CONVERT,
                                              gtk.ICON_SIZE_MENU)
         reset_failed_item.set_image(reset_img)
         reset_menu.append(reset_failed_item)
-
-        if is_graph_view:
-            reset_failed_item.connect(
-                'button-release-event', self.reset_task_state,
-                task_ids, TASK_STATUS_FAILED)
-        else:
-            reset_failed_item.connect(
-                'activate', self.reset_task_state, None,
-                task_ids, TASK_STATUS_FAILED)
+        sub_menu_connect(reset_failed_item, self.reset_task_state,
+                         task_ids, TASK_STATUS_FAILED)
 
         spawn_item = gtk.ImageMenuItem('Force spawn')
         img = gtk.image_new_from_stock(gtk.STOCK_ADD, gtk.ICON_SIZE_MENU)

--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -1243,21 +1243,21 @@ been defined for this suite""").inform()
             self._popup_logview(task_id, task_state_summary, choice)
         return False
 
+    def connect_right_click_sub_menu(self, is_graph_view, item, x, y, z):
+        """Handle right-clicks in sub-menus"""
+        if is_graph_view:
+            item.connect('button-release-event', x, y, z)
+        else:
+            item.connect('activate', x, None, y, z)
+
     def get_right_click_menu(self, task_ids, t_states, task_is_family=False,
                              is_graph_view=False):
         """Return the default menu for a list of tasks."""
 
         # NOTE: we have to respond to 'button-release-event' rather than
         # 'activate' in order for sub-menus to work in the graph-view.
-        # sub_menu_connect should be used in preference to item.connect
-        # to handle this
-
-        if is_graph_view:
-            sub_menu_connect = lambda item, x, y, z: \
-                item.connect('button-release-event', x, y, z)
-        else:
-            sub_menu_connect = lambda item, x, y, z: \
-                item.connect('activate', x, None, y, z)
+        # connect_right_click_sub_menu should be used in preference to
+        # item.connect to handle this
 
         if type(task_is_family) is bool:
             task_is_family = [task_is_family] * len(task_ids)
@@ -1309,7 +1309,8 @@ been defined for this suite""").inform()
 
                 # NOTE: we have to respond to 'button-release-event' rather
                 # than 'activate' in order for sub-menus to work in the
-                # graph-view so use sub_menu_connect instead of item.connect
+                # graph-view so use connect_right_click_sub_menu instead of
+                # item.connect
 
                 for key, filename in [
                         ('job script', 'job'),
@@ -1319,8 +1320,9 @@ been defined for this suite""").inform()
                     item.set_image(gtk.image_new_from_stock(
                         gtk.STOCK_DND, gtk.ICON_SIZE_MENU))
                     view_menu.append(item)
-                    sub_menu_connect(item, self.view_task_info,
-                                     task_ids[0], filename)
+                    self.connect_right_click_sub_menu(is_graph_view, item,
+                                                      self.view_task_info,
+                                                      task_ids[0], filename)
                     item.set_sensitive(
                         t_states[0] in TASK_STATUSES_WITH_JOB_SCRIPT)
 
@@ -1331,13 +1333,9 @@ been defined for this suite""").inform()
                     item.set_image(gtk.image_new_from_stock(
                         gtk.STOCK_DND, gtk.ICON_SIZE_MENU))
                     view_menu.append(item)
-                    if is_graph_view:
-                        item.connect('button-release-event',
-                                     self.view_task_info,
-                                     task_ids[0], filename)
-                    else:
-                        item.connect('activate', self.view_task_info, None,
-                                     task_ids[0], filename)
+                    self.connect_right_click_sub_menu(is_graph_view, item,
+                                                      self.view_task_info,
+                                                      task_ids[0], filename)
                     item.set_sensitive(
                         t_states[0] in TASK_STATUSES_WITH_JOB_LOGS)
 
@@ -1432,23 +1430,26 @@ been defined for this suite""").inform()
 
         # NOTE: we have to respond to 'button-release-event' rather
         # than 'activate' in order for sub-menus to work in the
-        # graph-view so use sub_menu_connect instead of item.connect
+        # graph-view so use connect_right_click_sub_menu instead of
+        # item.connect
 
         reset_ready_item = gtk.ImageMenuItem('"%s"' % TASK_STATUS_READY)
         reset_img = gtk.image_new_from_stock(
             gtk.STOCK_CONVERT, gtk.ICON_SIZE_MENU)
         reset_ready_item.set_image(reset_img)
         reset_menu.append(reset_ready_item)
-        sub_menu_connect(reset_ready_item, self.reset_task_state,
-                         task_ids, TASK_STATUS_READY)
+        self.connect_right_click_sub_menu(is_graph_view, reset_ready_item,
+                                          self.reset_task_state, task_ids,
+                                          TASK_STATUS_READY)
 
         reset_waiting_item = gtk.ImageMenuItem('"%s"' % TASK_STATUS_WAITING)
         reset_img = gtk.image_new_from_stock(
             gtk.STOCK_CONVERT, gtk.ICON_SIZE_MENU)
         reset_waiting_item.set_image(reset_img)
         reset_menu.append(reset_waiting_item)
-        sub_menu_connect(reset_waiting_item, self.reset_task_state,
-                         task_ids, TASK_STATUS_WAITING)
+        self.connect_right_click_sub_menu(is_graph_view, reset_waiting_item,
+                                          self.reset_task_state, task_ids,
+                                          TASK_STATUS_WAITING)
 
         reset_succeeded_item = gtk.ImageMenuItem(
             '"%s"' % TASK_STATUS_SUCCEEDED)
@@ -1456,16 +1457,18 @@ been defined for this suite""").inform()
                                              gtk.ICON_SIZE_MENU)
         reset_succeeded_item.set_image(reset_img)
         reset_menu.append(reset_succeeded_item)
-        sub_menu_connect(reset_succeeded_item, self.reset_task_state,
-                         task_ids, TASK_STATUS_SUCCEEDED)
+        self.connect_right_click_sub_menu(is_graph_view, reset_succeeded_item,
+                                          self.reset_task_state, task_ids,
+                                          TASK_STATUS_SUCCEEDED)
 
         reset_failed_item = gtk.ImageMenuItem('"%s"' % TASK_STATUS_FAILED)
         reset_img = gtk.image_new_from_stock(gtk.STOCK_CONVERT,
                                              gtk.ICON_SIZE_MENU)
         reset_failed_item.set_image(reset_img)
         reset_menu.append(reset_failed_item)
-        sub_menu_connect(reset_failed_item, self.reset_task_state,
-                         task_ids, TASK_STATUS_FAILED)
+        self.connect_right_click_sub_menu(is_graph_view, reset_failed_item,
+                                          self.reset_task_state, task_ids,
+                                          TASK_STATUS_FAILED)
 
         spawn_item = gtk.ImageMenuItem('Force spawn')
         img = gtk.image_new_from_stock(gtk.STOCK_ADD, gtk.ICON_SIZE_MENU)

--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -1230,7 +1230,7 @@ been defined for this suite""").inform()
         self.gcapture_windows.append(foo)
         foo.run()
 
-    def view_task_info(self, w, task_id, choice):
+    def view_task_info(self, w, e, task_id, choice):
         try:
             task_state_summary = self.updater.full_state_summary[task_id]
         except KeyError:
@@ -1243,7 +1243,8 @@ been defined for this suite""").inform()
             self._popup_logview(task_id, task_state_summary, choice)
         return False
 
-    def get_right_click_menu(self, task_ids, t_states, task_is_family=False):
+    def get_right_click_menu(self, task_ids, t_states, task_is_family=False,
+                             is_graph_view=False):
         """Return the default menu for a list of tasks."""
 
         if type(task_is_family) is bool:
@@ -1294,8 +1295,9 @@ been defined for this suite""").inform()
                 view_item.set_submenu(view_menu)
                 menu.append(view_item)
 
-                # NOTE: we have to respond to 'button-press-event' rather than
-                # 'activate' in order for sub-menus to work in the graph-view.
+                # NOTE: we have to respond to 'button-release-event' rather
+                # than 'activate' in order for sub-menus to work in the
+                # graph-view.
 
                 for key, filename in [
                         ('job script', 'job'),
@@ -1305,8 +1307,13 @@ been defined for this suite""").inform()
                     item.set_image(gtk.image_new_from_stock(
                         gtk.STOCK_DND, gtk.ICON_SIZE_MENU))
                     view_menu.append(item)
-                    item.connect('activate', self.view_task_info,
-                                 task_ids[0], filename)
+                    if is_graph_view:
+                        item.connect('button-release-event',
+                                     self.view_task_info,
+                                     task_ids[0], filename)
+                    else:
+                        item.connect('activate', self.view_task_info, None,
+                                     task_ids[0], filename)
                     item.set_sensitive(
                         t_states[0] in TASK_STATUSES_WITH_JOB_SCRIPT)
 
@@ -1317,8 +1324,13 @@ been defined for this suite""").inform()
                     item.set_image(gtk.image_new_from_stock(
                         gtk.STOCK_DND, gtk.ICON_SIZE_MENU))
                     view_menu.append(item)
-                    item.connect('activate', self.view_task_info,
-                                 task_ids[0], filename)
+                    if is_graph_view:
+                        item.connect('button-release-event',
+                                     self.view_task_info,
+                                     task_ids[0], filename)
+                    else:
+                        item.connect('activate', self.view_task_info, None,
+                                     task_ids[0], filename)
                     item.set_sensitive(
                         t_states[0] in TASK_STATUSES_WITH_JOB_LOGS)
 
@@ -1411,21 +1423,39 @@ been defined for this suite""").inform()
         reset_item.set_submenu(reset_menu)
         menu.append(reset_item)
 
+        # NOTE: we have to respond to 'button-release-event' rather
+        # than 'activate' in order for sub-menus to work in the
+        # graph-view.
+
         reset_ready_item = gtk.ImageMenuItem('"%s"' % TASK_STATUS_READY)
         reset_img = gtk.image_new_from_stock(
             gtk.STOCK_CONVERT, gtk.ICON_SIZE_MENU)
         reset_ready_item.set_image(reset_img)
         reset_menu.append(reset_ready_item)
-        reset_ready_item.connect(
-            'activate', self.reset_task_state, task_ids, TASK_STATUS_READY)
+
+        if is_graph_view:
+            reset_ready_item.connect(
+                'button-release-event', self.reset_task_state,
+                task_ids, TASK_STATUS_READY)
+        else:
+            reset_ready_item.connect(
+                'activate', self.reset_task_state, None,
+                task_ids, TASK_STATUS_READY)
 
         reset_waiting_item = gtk.ImageMenuItem('"%s"' % TASK_STATUS_WAITING)
         reset_img = gtk.image_new_from_stock(
             gtk.STOCK_CONVERT, gtk.ICON_SIZE_MENU)
         reset_waiting_item.set_image(reset_img)
         reset_menu.append(reset_waiting_item)
-        reset_waiting_item.connect(
-            'activate', self.reset_task_state, task_ids, TASK_STATUS_WAITING)
+
+        if is_graph_view:
+            reset_waiting_item.connect(
+                'button-release-event', self.reset_task_state,
+                task_ids, TASK_STATUS_WAITING)
+        else:
+            reset_waiting_item.connect(
+                'activate', self.reset_task_state, None,
+                task_ids, TASK_STATUS_WAITING)
 
         reset_succeeded_item = gtk.ImageMenuItem(
             '"%s"' % TASK_STATUS_SUCCEEDED)
@@ -1433,16 +1463,30 @@ been defined for this suite""").inform()
                                              gtk.ICON_SIZE_MENU)
         reset_succeeded_item.set_image(reset_img)
         reset_menu.append(reset_succeeded_item)
-        reset_succeeded_item.connect(
-            'activate', self.reset_task_state, task_ids, TASK_STATUS_SUCCEEDED)
+
+        if is_graph_view:
+            reset_succeeded_item.connect(
+                'button-release-event', self.reset_task_state,
+                task_ids, TASK_STATUS_SUCCEEDED)
+        else:
+            reset_succeeded_item.connect(
+                'activate', self.reset_task_state, None,
+                task_ids, TASK_STATUS_SUCCEEDED)
 
         reset_failed_item = gtk.ImageMenuItem('"%s"' % TASK_STATUS_FAILED)
         reset_img = gtk.image_new_from_stock(gtk.STOCK_CONVERT,
                                              gtk.ICON_SIZE_MENU)
         reset_failed_item.set_image(reset_img)
         reset_menu.append(reset_failed_item)
-        reset_failed_item.connect(
-            'activate', self.reset_task_state, task_ids, TASK_STATUS_FAILED)
+
+        if is_graph_view:
+            reset_failed_item.connect(
+                'button-release-event', self.reset_task_state,
+                task_ids, TASK_STATUS_FAILED)
+        else:
+            reset_failed_item.connect(
+                'activate', self.reset_task_state, None,
+                task_ids, TASK_STATUS_FAILED)
 
         spawn_item = gtk.ImageMenuItem('Force spawn')
         img = gtk.image_new_from_stock(gtk.STOCK_ADD, gtk.ICON_SIZE_MENU)
@@ -1717,7 +1761,7 @@ shown here in the state they were in at the time of triggering.''')
                 return
         self.put_comms_command('spawn_tasks', items=task_ids)
 
-    def reset_task_state(self, b, task_ids, state):
+    def reset_task_state(self, b, e, task_ids, state):
         """Reset the state of a task/family."""
         if type(task_ids) is not list:
             task_ids = [task_ids]

--- a/lib/cylc/gui/view_graph.py
+++ b/lib/cylc/gui/view_graph.py
@@ -193,8 +193,9 @@ Dependency graph suite control interface.
                 if task_id not in self.t.state_summary:
                     return False
                 t_state = self.t.state_summary[task_id]['state']
-            default_menu = self.get_right_click_menu(
-                [task_id], [t_state], task_is_family=[is_fam])
+            default_menu = self.get_right_click_menu([task_id], [t_state],
+                                                     task_is_family=[is_fam],
+                                                     is_graph_view=True)
             dm_kids = default_menu.get_children()
             for item in reversed(dm_kids[:2]):
                 # Put task name and URL at the top.


### PR DESCRIPTION
Closes #2154

Not the nicest of solutions, but this maintains as much functionality as possible by using the "activate" event in submenus for non "graph" views and using the "button-release-event" event for the sub-menus when in "graph" view. The only detectable difference to the user will be that "enter"/"return" won't do anything in r-click sub-menus for the graph view.

@matthewrmshin @oliver-sanders - please review and manually test carefully