### PR TITLE
Improve stall logic in presence of clock trigger

### DIFF
--- a/lib/cylc/task_state.py
+++ b/lib/cylc/task_state.py
@@ -109,9 +109,7 @@ TASK_STATUSES_ACTIVE = set([
 ])
 
 # Task statuses in which tasks cannot be considered stalled
-TASK_STATUSES_NOT_STALLED = (
-    TASK_STATUSES_ACTIVE | TASK_STATUSES_TO_BE_ACTIVE |
-    set([TASK_STATUS_HELD]))
+TASK_STATUSES_NOT_STALLED = TASK_STATUSES_ACTIVE | TASK_STATUSES_TO_BE_ACTIVE
 
 # Task statuses that can be manually triggered.
 TASK_STATUSES_TRIGGERABLE = set([

--- a/lib/cylc/task_state.py
+++ b/lib/cylc/task_state.py
@@ -249,8 +249,8 @@ class TaskState(object):
         self.db_update_status = db_update_status
         self.log = log
 
-        self._is_satisfied = False
-        self._suicide_is_satisfied = False
+        self._is_satisfied = None
+        self._suicide_is_satisfied = None
 
         # Prerequisites.
         self.prerequisites = []

--- a/tests/events/32-stall-despite-clock-trig.t
+++ b/tests/events/32-stall-despite-clock-trig.t
@@ -1,0 +1,35 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test stall does not wait for unrelated clock trigger.
+. "$(dirname "$0")/test_header"
+set_test_number 3
+
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+run_fail "${TEST_NAME_BASE}-run" timeout 60 cylc run --debug "${SUITE_NAME}"
+sed -n 's/^.* WARNING - //p' "${SUITE_RUN_DIR}/log/suite/log" \
+    >"${SUITE_RUN_DIR}/log/suite/log.edited"
+TODAY="$(date -u '+%Y%m%d')"
+contains_ok "${SUITE_RUN_DIR}/log/suite/log.edited" <<__OUT__
+suite stalled
+Unmet prerequisites for t3.${TODAY}:
+ * t2.${TODAY} succeeded
+__OUT__
+
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/events/32-stall-despite-clock-trig/suite.rc
+++ b/tests/events/32-stall-despite-clock-trig/suite.rc
@@ -1,0 +1,22 @@
+#!jinja2
+[cylc]
+    UTC mode = True
+    cycle point format = %Y%m%d
+    [[events]]
+        abort on stalled = True
+        abort on inactivity = True
+        inactivity = PT5M
+[scheduling]
+    initial cycle point = now
+    [[special tasks]]
+        clock-trigger = t1(P0D)
+    [[dependencies]]
+        [[[P1D]]]
+            graph=t3[-P1D] => t1 => t2 => t3
+[runtime]
+    [[t1]]
+        script = true
+    [[t2]]
+        script = false
+    [[t3]]
+        script = true


### PR DESCRIPTION
Before this change, if the suite has any clock triggered tasks, the
suite will wait for all clock triggered times to reach before considering
the suite as stalled, even if the clock triggered tasks can never be
triggered due to dependencies issues.

With this change, the suite will treat waiting clock triggered tasks
with unsatisfied dependencies the same as other waiting tasks with
unsatisfied dependencies. However, it will consider a clock triggered
task as an *active* task if it has its dependencies satisfied but is
only waiting for the clock triggered time.

The change allows the stalled event to be raised as soon as the
following conditions are satisfied:
* There is no activity after one main loop.
* The task pool is left with only inactive tasks.
  * Active tasks are those that are not pending outputs of other tasks.
* The task pool has inactive tasks with unsatisfied dependencies.

The problem is reported by @dpmatthews and should be well illustrated by the suite of the new test.