### PR TITLE
cylc profile-battery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ conf/*/*.rc.processed
 # suite passphrases
 passphrase
 
+# profiling
+.profiling

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ used for non-cycling systems.
 
 ### Copyright and Terms of Use
 
-Copyright (C) 2008-2016 [NIWA](https://www.niwa.co.nz)
+Copyright (C) 2008-2017 [NIWA](https://www.niwa.co.nz)
  
 Cylc is free software: you can redistribute it and/or modify it under the terms
 of the GNU General Public License as published by the Free Software Foundation,

--- a/bin/cylc
+++ b/bin/cylc
@@ -253,6 +253,7 @@ hook_commands['check-triggering'] = ['check-triggering']
 
 admin_commands = OrderedDict()
 admin_commands['test-battery'] = ['test-battery']
+admin_commands['profile-battery'] = ['profile-battery']
 admin_commands['import-examples'] = ['import-examples']
 admin_commands['upgrade-run-dir'] = ['upgrade-run-dir']
 admin_commands['check-software'] = ['check-software']
@@ -371,6 +372,7 @@ Command CATEGORIES:"""
 comsum = OrderedDict()
 # admin
 comsum['test-battery'] = 'Run a battery of self-diagnosing test suites'
+comsum['profile-battery'] = 'Run a battery of profiling tests'
 comsum['import-examples'] = 'Import example suites your suite run directory'
 comsum['upgrade-run-dir'] = 'Upgrade a pre-cylc-6 suite run directory'
 comsum['check-software'] = 'Check required software is installed.'

--- a/bin/cylc-profile-battery
+++ b/bin/cylc-profile-battery
@@ -1,0 +1,945 @@
+#!/usr/bin/env python
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Orchestrates experiments to profile the performance of cylc at different
+versions."""
+
+import glob
+import hashlib
+import itertools
+import json
+import optparse
+import os
+import random
+import shutil
+import sys
+import tempfile
+import time
+
+# Write out floats to one decimal place only.
+from json import encoder
+encoder.FLOAT_REPR = lambda o: format(o, '.1f')
+
+import cylc.profiling as prof
+from cylc.profiling.analysis import (make_table, print_table, plot_results)
+import cylc.profiling.git as git
+
+RUN_DOC = r"""cylc profile-battery [-e [EXPERIMENT ...]] [-v [VERSION ...]]
+
+Run profiling experiments against different versions of cylc. A list of
+experiments can be specified after the -e flag, if not provided the experiment
+"complex" will be chosen. A list of versions to profile against can be
+specified after the -v flag, if not provided the current version will be used.
+
+Experiments are stored in dev/profile-experiments, user experiments can be
+stored in .profiling/experiments. Experiments are specified without the file
+extension, experiments in .profiling/ will be chosen before those in dev/.
+
+IMPORTANT: See dev/profile-experiments/example for an experiment template with
+further details.
+
+Versions are any valid git identifiers i.e. tags, branches, commits. To compare
+results to different cylc versions either:
+    * Supply cylc profile-battery with a complete list of the versions you wish
+      to profile, it will then provide the option to checkout the required
+      versions automatically.
+    * Checkout each version manually running cylc profile-battery against only
+      one version at a time. Once all results have been gathered you can then
+      run cylc profile-battery with a complete list of versions.
+
+Profiling will save results to .profiling/results.json where they can be used
+for future comparisons. To list profiling results run:
+    * cylc profile-battery --ls  # list all results
+    * cylc profile-battery --ls -e experiment  # list all results for
+                                               # experiment "experiment".
+    * cylc profile-battery --ls --delete -v  6.1.2  # Delete all results for
+                                                    # version 6.1.2 (prompted).
+
+If matplotlib and numpy are installed profiling generates plots which are
+saved to .profiling/plots or presented in an interactive window using the -i
+flag.
+
+Results are stored along with a checksum for the experiment file. When an
+experiment file is changed previous results are maintained, future results will
+be stored separately. To copy results from an older version of an experiment
+into those from the current one run:
+    * cylc profile-battery --promote experiment@checksum
+NOTE: At present results cannot be analysed without the experiment file so old
+results must be "copied" in this way to be re-used.
+
+The results output contain only a small number of metrics, to see a full list
+of results use the --full option.
+"""
+
+
+def create_profile_directory():
+    """Creates a directory for storing results and user experiments in."""
+    profile_dir = os.path.join(prof.CYLC_DIR, prof.PROFILE_DIR_NAME)
+    os.mkdir(profile_dir)
+    os.mkdir(os.path.join(profile_dir, prof.PROFILE_PLOT_DIR_NAME))
+    os.mkdir(os.path.join(profile_dir, prof.USER_EXPERIMENT_DIR_NAME))
+    print 'creating', os.path.join(profile_dir, prof.PROFILE_FILE_NAME)
+    with open(os.path.join(profile_dir, prof.PROFILE_FILE_NAME),
+              'w+') as profile_file:
+        profile_file.write('{}')
+
+
+def parse_args():
+    """Parse command line arguments for this script."""
+    def multi_arg_callback(option, _, value, parser):
+        """Allows an unkonwn number of arguments to be passed as an option."""
+        assert value is None
+        value = []
+        for arg in parser.rargs:
+            if arg[0] == '-':
+                break
+            value.append(arg)
+        del parser.rargs[:len(value)]
+        setattr(parser.values, option.dest, value)
+
+    parser = optparse.OptionParser(RUN_DOC)
+    parser.add_option('-e', '--experiments',
+                      help='Specify list of experiments to run.',
+                      dest='experiments', callback=multi_arg_callback,
+                      action='callback')
+    parser.add_option('-v', '--versions',
+                      help='Specify cylc versions to profile. Git tags, ' +
+                      'branches, commits are all valid.',
+                      dest='versions', callback=multi_arg_callback,
+                      action='callback')
+    parser.add_option('-i', '--interactive', action='store_true',
+                      help='Open any plots in interactive window rather '
+                      'saving them to files.', default=False)
+    parser.add_option('-p', '--no-plots', action='store_true', default=False,
+                      help='Don\'t generate any plots.')
+    parser.add_option('--ls', '--list-results', action='store_true',
+                      default=False, help='List all stored results. ' +
+                      'Experiments and versions to list can be specified ' +
+                      'using --experiments and --versions.')
+    parser.add_option('--delete', action='store_true', default=False,
+                      help='Delete stored results (to be used in ' +
+                      'combination with --list-results).')
+    parser.add_option('--yes', '-y', action='store_true', default=False,
+                      help='Answer yes to any user input. Will check-out '
+                      'cylc versions as required.')
+    parser.add_option('--full-results', '--full', action='store_true',
+                      default=False, help='Display all gathered metrics.')
+    parser.add_option('--lobf-order', dest='lobf_order', help='The order (int)'
+                      'of the line of best fit to be drawn. 0 for no lobf, '
+                      '1 for linear, 2 for quadratic ect.', default=2,
+                      type='int')
+    parser.add_option('--promote', type='str', help='Promote results from an '
+                      'older version of an experiment to the current version. '
+                      'To be used when making non-functional changes to an '
+                      'experiment.')
+    parser.add_option('--test', action='store_true', default=False,
+                      help='For development purposes, run experiment without '
+                      'saving results and regardless of any prior runs.')
+    opts, _ = parser.parse_args()
+
+    # Defaults for experiments and versions if we are not in list mode.
+    if not (opts.ls or opts.delete):
+        if not opts.experiments:
+            opts.experiments = ["complex"]
+        if not opts.versions:
+            opts.versions = ["HEAD"]
+    else:
+        if not opts.experiments:
+            opts.experiments = []
+        if not opts.versions:
+            opts.versions = []
+
+    return opts
+
+
+def get_results():
+    """Return data from the results file."""
+    if not os.path.exists(os.path.join(prof.CYLC_DIR, prof.PROFILE_DIR_NAME,
+                                       prof.PROFILE_FILE_NAME)):
+        # Profile file does not exist, create it.
+        create_profile_directory()
+        return {}
+    else:
+        # Profile file exists, git list of results contained.
+        profile_file_path = os.path.join(prof.CYLC_DIR, prof.PROFILE_DIR_NAME,
+                                         prof.PROFILE_FILE_NAME)
+        with open(profile_file_path, 'r') as profile_file:
+            try:
+                profile_results = json.load(profile_file)
+            except ValueError as exc:
+                print exc
+                sys.exit('ERROR: Could not read "%s". Check that it is valid'
+                         ' JSON or delete the file.' % profile_file_path)
+        return profile_results
+
+
+def get_result_keys():
+    """Return a list of (version_id, experiment_id,) tuples."""
+    profile_results = get_results()
+    result_keys = []
+    for version_id, experiment_ids in profile_results.iteritems():
+        result_keys.extend([(version_id, experiment_id) for experiment_id
+                            in experiment_ids.keys()])
+    return result_keys
+
+
+def get_schedule(versions, experiments, test=False):
+    """Determine which experiments to run with which versions.
+
+    Return:
+        tuple - (schedule, experiments_to_run)
+            - schedule (dict) - Dictionary of cylc version ids containing lists
+              of the experiments to run for each.
+            - experiments_to_run (set) - Set of (version_id, experiment_id)
+              tuples of the experiments to run.
+    """
+    experiment_keys = itertools.product(
+        [version['id'] for version in versions],
+        [experiment['id'] for experiment in experiments])
+    result_keys = get_result_keys()
+
+    # Exclude any previously acquired results so that experiments are not run
+    # twice.
+    if test:
+        # Don't exclude experiments if in "test" mode.
+        experiments_to_run = set(experiment_keys)
+    else:
+        experiments_to_run = set(experiment_keys) - set(result_keys)
+
+    ret = {}
+    for version_id, experiment_id in experiments_to_run:
+        if version_id not in ret:
+            ret[version_id] = []
+        for experiment in experiments:
+            if experiment_id == experiment['id']:
+                ret[version_id].append(experiment)
+                break
+    return ret, set([item[1] for item in experiments_to_run])
+
+
+def get_versions(version_names):
+    """Produces a list of version objects from a list of cylc version names."""
+    versions = []
+    for version_name in version_names:
+        version_id = git.describe(version_name)
+        if version_id:
+            versions.append({
+                'name': version_name,
+                'id': version_id
+            })
+        else:
+            sys.exit('ERROR: cylc version "%s" not reccognised' % version_name)
+    return versions
+
+
+def get_checksum(file_path, chunk_size=4096):
+    """Returns a hash of a file."""
+    hash_ = hashlib.sha256()
+    with open(file_path, 'rb') as file_:
+        for chunk in iter(lambda: file_.read(chunk_size), b""):
+            hash_.update(chunk)
+        return hash_.hexdigest()[:15]
+
+
+def load_experiment_config(experiment_file):
+    """Returns a dictionary containing the contents of the experiment file."""
+    with open(experiment_file, 'r') as file_:
+        try:
+            ret = json.load(file_)
+        except ValueError as exc:
+            sys.exit('ERROR: Invalid JSON in experiment file"{0}"\n{1}'.format(
+                experiment_file, exc))
+
+    # Prepend CYLC_DIR to suite definition paths if they aren't provided as
+    # absolute paths.
+    try:
+        for run in ret['runs']:
+            if not os.path.isabs(os.path.expanduser(run['suite dir'])):
+                run['suite dir'] = os.path.join(prof.CYLC_DIR,
+                                                run['suite dir'])
+            run['suite dir'] = os.path.realpath(run['suite dir'])
+    except KeyError as exc:
+        print exc
+        sys.exit('Error: Experiment definition not complete.')
+
+    # Apply defaults.
+    for run in ret['runs']:
+        if 'repeats' not in run:
+            run['repeats'] = 0
+        if 'options' not in run:
+            run['options'] = []
+    if 'profile modes' not in ret:
+        ret['profile modes'] = prof.DEFAULT_PROFILE_MODES
+    if 'analysis' not in ret:
+        ret['analysis'] = 'single'
+
+    return ret
+
+
+def install_experiments(experiment_ids, experiments, install_dir,
+                        checkout_required=False):
+    """Install experiments with the provided ids as necessary."""
+    codicil_path = os.path.join(prof.CYLC_DIR, prof.EXPERIMENTS_PATH,
+                                'profile-simulation', 'suite.rc')
+    install_sdir = os.path.join(install_dir, 'suites')
+    os.mkdir(install_sdir)
+
+    install_modes = {
+        'copy': shutil.copyfile,
+        'symlink': os.symlink
+    }
+
+    # Determine which suites require installation.
+    suite_dirs = {}
+    for experiment_id in experiment_ids:
+        experiment = None
+        for exp in experiments:
+            if exp['id'] == experiment_id:
+                experiment = exp
+                break
+        if not experiment:
+            raise Exception('Could not find experiment definition.')
+        append_codicil = ('mode' in experiment['config'] and
+                          experiment['config']['mode'] == 'profile-simulation')
+        for run in experiment['config']['runs']:
+            sdir = os.path.realpath(run['suite dir'])
+            # Is suite within the cylc repository.
+            in_cylc_repo = (
+                sdir.startswith(os.path.realpath(prof.CYLC_DIR)) and not
+                sdir.startswith(os.path.realpath(os.path.join(
+                    prof.CYLC_DIR,
+                    prof.PROFILE_DIR_NAME))))
+            if not append_codicil and not (in_cylc_repo and checkout_required):
+                # Don't install suite unless:
+                # - We are in profile-battery mode
+                # - The suite is in the cylc repo and we need to checkout
+                #   another cylc version
+                continue
+            if in_cylc_repo:
+                install_mode = install_modes['copy']
+            else:
+                install_mode = install_modes['symlink']
+            key = (sdir, append_codicil,)
+            if sdir not in suite_dirs:
+                new_sdir = os.path.join(install_sdir, str(random.random())[2:])
+                os.mkdir(new_sdir)
+                suite_dirs[key] = {'install dir': new_sdir, 'runs': [run],
+                                   'install fcn': install_mode}
+            else:
+                suite_dirs[key]['runs'].append(run)
+
+    # Install suites.
+    dont_symlink = ['passphrase', 'ssl.cert', 'ssl.pem', 'suite.rc.processed']
+    for key in suite_dirs:
+        sdir, append_codicil = key
+        install_dir = suite_dirs[key]['install dir']
+        install_fcn = suite_dirs[key]['install fcn']
+        # Symlink / copy files as appropriate
+        for filepath in glob.glob(os.path.join(sdir, '*')):
+            filename = os.path.basename(filepath)
+            if filename in dont_symlink:
+                continue
+            dest = os.path.join(install_dir, filename)
+            if append_codicil and filename == 'suite.rc':
+                # Symlink the suite.rc file as suite.rc-orig.
+                install_fcn(filepath, dest + '-orig')
+            else:
+                # Symlink suite files / directories.
+                install_fcn(filepath, dest)
+        # Include suite.rc-orig and codicil.rc if in profile-simulation mode.
+        if append_codicil:
+            install_fcn(codicil_path, os.path.join(install_dir, 'codicil.rc'))
+            with open(os.path.join(install_dir, 'suite.rc'), 'a') as suite_rc:
+                suite_rc.write('#!jinja2\n'
+                               '{% include "suite.rc-orig" %}\n'
+                               '{% include "codicil.rc" %}')
+
+    # Update experiments to installation directories.
+    for sdir, append_codicil in suite_dirs:
+        key = (sdir, append_codicil,)
+        for run in suite_dirs[key]['runs']:
+            print 'installing suite "%s" => "%s"' % (
+                sdir, suite_dirs[key]['install dir'])
+            run['suite dir'] = suite_dirs[key]['install dir']
+
+
+def get_experiments(experiment_names):
+    """Returns a dictionary of experiment names against experiment ids (which
+    contain a checksum)."""
+    experiments = []
+    for experiment_name in experiment_names:
+        file_name = experiment_name + '.json'
+        # Look for experiment file in the users experiment directory.
+        file_path = os.path.join(prof.CYLC_DIR, prof.PROFILE_DIR_NAME,
+                                 prof.USER_EXPERIMENT_DIR_NAME, file_name)
+        if not os.path.exists(file_path):
+            # Look for experiment file in built-in experiment directory.
+            file_path = os.path.join(prof.CYLC_DIR, prof.EXPERIMENTS_PATH,
+                                     file_name)
+            if not os.path.exists(file_path):
+                # Could not find experiment file in either path. Exit!
+                print 'ERROR: Could not find experiment file for "%s"' % (
+                    experiment_name)
+                experiments.append({'name': experiment_name,
+                                    'id': 'Invalid',
+                                    'file': None})
+                continue
+        config = load_experiment_config(file_path)
+        experiments.append({
+            'name': experiment_name,
+            'id': '{0}@{1}'.format(experiment_name, get_checksum(file_path)),
+            'file': file_path,
+            'config': config
+        })
+    return experiments
+
+
+def print_manual_scheme(versions, experiments, all_versions=None):
+    """Writes a list of bash commands to run in order to perform profing
+    without automation of checkout out cylc versions."""
+    # TODO: Generate from schedule.
+    if all_versions:
+        ver = ' '.join([version['id'] for version in all_versions])
+    else:
+        ver = ' '.join([version['id'] for version in versions])
+    exp = ' '.join([experiment['name'] for experiment in experiments])
+    for version in versions:
+        print '\t$ git checkout ' + version['id']
+        print '\t$ cylc profile-battery --experiments ' + exp
+    print ('\t$ cylc profile-battery --versions {versions} --experiments '
+           '{experiments}'.format(versions=ver, experiments=exp))
+
+
+def determine_action(schedule, versions, experiments, non_interactive=False):
+    """Determines whether it is necessary to checkout differnet cylc
+    version(s).
+
+    Prompts user as to whether they want to use automated
+    checkout and if so for what.
+    """
+    # Determine which versions need to be checked out.
+    current_version = git.describe('HEAD')
+    other_versions = []
+    for version_id in schedule:
+        if version_id != current_version:
+            for version in versions:
+                if version_id == version['id']:
+                    other_versions.append(version)
+
+    # Check for potential incompatability with PROFILE_MODE_CYLC.
+    temp = []
+    for experiment in experiments:
+        for mode in experiment['config']['profile modes']:
+            if prof.PROFILE_MODES[mode] != prof.PROFILE_MODE_CYLC:
+                continue
+            for version_id in schedule:
+                if not git.is_ancestor_commit(prof.CYLC_PROFILING_COMMIT,
+                                              version_id):
+                    for version in versions:
+                        if version['id'] == version_id:
+                            temp.append(version)
+        if temp and not non_interactive:
+            print('WARNING: You are trying to use the "cylc" profile mode with'
+                  ' versions of cylc which predate the profiling module '
+                  'namely:')
+            print '\t', ' '.join([version['name'] for version in temp])
+            print('\nTo profile these versions you will need to back port the '
+                  'profiling module as well as some of the memory '
+                  'checkpointing in the main loop.\n')
+            usr = None
+            while usr not in ['y', 'n']:
+                usr = raw_input('proceed? (y/n): ')
+            if usr == 'n':
+                sys.exit('Profiling aborted by user.')
+            print
+
+    # Prompt user over using automated checkout.
+    to_checkout = []
+    if other_versions and not non_interactive:
+        manual_versions = []
+        automatic_only_versions = []
+        for version in other_versions:
+            if git.is_ancestor_commit(prof.PROFILE_COMMIT, version['id']):
+                manual_versions.append(version)
+            else:
+                automatic_only_versions.append(version)
+
+        print ('To perform profiling different cylc versions will need to be '
+               'checked out. I can checkout and profile versions '
+               'automatically.')
+        print ('If using the automatic checkout system ensure that there are '
+               'no un-commited changes before proceeding and do not make '
+               'any changes to the local repository whist the profiling is '
+               'running\n')
+
+        if automatic_only_versions:
+            print ('These versions can only be profiled '
+                   'automatically:\n\t{0}'.format(
+                       ' '.join([version['name'] for version in
+                                 automatic_only_versions])
+                   ))
+        if manual_versions:
+            print ('These versions you can profile manually if you '
+                   'prefer:\n\t{0}'.format(
+                       ' '.join([version['name'] for version in
+                                 manual_versions])))
+
+        print
+
+        if manual_versions and not automatic_only_versions:
+            response = None
+            while response not in ['y', 'n']:
+                response = raw_input('Do you want to checkout these versions '
+                                     'automatically? (y/n): ')
+            if response == 'n':
+                print ('You can perform this profiling manually by doing '
+                       'something like:')
+                print_manual_scheme(manual_versions, experiments,
+                                    all_versions=versions)
+                sys.exit('Profiling aborted by user.')
+            else:
+                to_checkout = manual_versions
+        elif manual_versions and automatic_only_versions:
+            response = None
+            while response not in ['some', 'all', 'none']:
+                response = raw_input(
+                    'Which versions should I check out:\n\t'
+                    'Only those which cannot be profiled otherwise (some)\n\t'
+                    'All versions (all)\n\t'
+                    'None (none)\n> ')
+            if response == 'some':
+                print 'The remainder can be profiled by doing something like:'
+                print_manual_scheme(manual_versions, experiments,
+                                    all_versions=versions)
+                to_checkout = automatic_only_versions
+            if response == 'none':
+                print ('Some versions can be profiled manually by doing '
+                       'something like:')
+                print_manual_scheme(manual_versions, experiments,
+                                    all_versions=manual_versions)
+                sys.exit('Profiling aborted by user.')
+            else:
+                to_checkout = manual_versions + automatic_only_versions
+        elif automatic_only_versions:
+            response = None
+            while response not in ['y', 'n']:
+                response = raw_input('Do you want to checkout these versions '
+                                     'automatically? (y/n): ')
+            if response == 'y':
+                to_checkout = automatic_only_versions
+            else:
+                sys.exit('Profiling aborted by user.')
+    if other_versions and non_interactive:
+        to_checkout = other_versions
+    return to_checkout
+
+
+def update_nested_dictionaries(old, new):
+    """Merges entries from new into old (overwrites old with new in the event
+    of a conflict."""
+    old = old.copy()
+    new = new.copy()
+    for key, value in new.iteritems():
+        if key in old:
+            if type(value) is dict:
+                old[key] = update_nested_dictionaries(old[key], new[key])
+            else:
+                old[key] = value
+        else:
+            old[key] = value
+    return old
+
+
+def append_new_results(results):
+    """Append new profiling results to results file."""
+    profile_file_path = os.path.join(prof.CYLC_DIR, prof.PROFILE_DIR_NAME,
+                                     prof.PROFILE_FILE_NAME)
+    try:
+        with open(profile_file_path, 'r') as file_:
+            previous_results = json.load(file_)
+    except IOError as exc:
+        if exc.errno == 2:
+            previous_results = {}
+        else:
+            raise
+
+    ret = update_nested_dictionaries(previous_results, results)
+    os.remove(profile_file_path)
+    with open(profile_file_path, 'w+') as file_:
+        json.dump(ret, file_)
+
+
+def delete_results(result_keys, interactive=False):
+    """Delete results from the results file provided as a list of version_id,
+    experiment_id tuples."""
+    if interactive:
+        usr = None
+        while usr not in ['y', 'n']:
+            usr = raw_input('Delete these results (y/n)? ')
+        if usr != 'y':
+            sys.exit(0)
+
+    results = get_results()
+
+    for version_id, experiment_id in result_keys:
+        try:
+            del results[version_id][experiment_id]
+            if not results[version_id]:
+                del results[version_id]
+        except KeyError:
+            pass
+
+    profile_file_path = os.path.join(prof.CYLC_DIR, prof.PROFILE_DIR_NAME,
+                                     prof.PROFILE_FILE_NAME)
+    os.remove(profile_file_path)
+    with open(profile_file_path, 'w+') as results_file:
+        json.dump(results, results_file)
+
+
+def install_profiler():
+    """Transfer profiling code and resources to a temporary directory to enable
+    different cylc versions to be checked out."""
+    try:
+        # Temp dir to install files to
+        tempdir = tempfile.mkdtemp()
+        print 'Installing profiler to:', tempdir
+
+        shutil.copytree(
+            os.path.join(prof.CYLC_DIR, 'lib', 'cylc', 'profiling'),
+            os.path.join(tempdir, 'tempprofiling')
+        )
+
+        # Append profiling code to $PATH
+        sys.path.insert(0, os.path.join(tempdir))
+        sys.path.insert(0, os.path.join(tempdir, 'tempprofiling'))
+    except Exception as exc:
+        # Slightest hint of trouble => abort.
+        print exc
+        sys.exit('ERROR: Problem installing profiling.')
+    return tempdir
+
+
+def run_schedule(schedule, experiments, versions, exps_to_run,
+                 non_interactive=False, test=False):
+    """Orchestrates profiling the versions/experiments contained in the
+    schedule.
+
+    Args:
+        schedule (dict): A dictionary of cylc version_ids containing lists of
+            experiments to run for each.
+        experiments (list): List of experiment dicts.
+        versions (list): List of version dicts.
+        exps_to_run (set): Set of (version_id, experiment_id) tuples for the
+            experiments to run.
+        non_interactive (bool - optional): If True prompting is disabled.
+        test (bool - optional): If True all experiments will be run
+            irrespective of any previous results. New results will not be
+            saved.
+
+    Return:
+        bool: True if ALL profiling has been successfull.
+
+    """
+    # Ask the user which versions to profile.
+    other_versions = determine_action(schedule, versions, experiments,
+                                      non_interactive or test)
+
+    # Install profiler if necessary.
+    if other_versions:
+        # Some versions will need to be checked-out. Install the profiling code
+        # outside the working tree then proceed.
+        if git.has_changes_to_be_committed():
+            sys.exit('Please commit any changes before proceeding.')
+        profiler_install_dir = install_profiler()
+        try:
+            from tempprofiling.profile import profile
+            from tempprofiling.git import (
+                checkout, has_changes_to_be_committed, GitCheckoutError)
+        except ImportError:
+            shutil.rmtree(profiler_install_dir, ignore_errors=True)
+            sys.exit('ERROR: Failed to install profiler.')
+    else:
+        # No cylc versions need to be checkout-out.
+        from cylc.profiling.profile import profile
+        profiler_install_dir = tempfile.mkdtemp()
+
+    # Install experiments as necessary
+    install_experiments(exps_to_run, experiments, profiler_install_dir,
+                        checkout_required=True if other_versions else False)
+
+    # Run profiling.
+    results, checkout_count, success = profile(schedule)
+
+    # Delete profiler and experiments if created.
+    if success:
+        shutil.rmtree(profiler_install_dir, ignore_errors=True)
+
+    # Append results to results file.
+    if not test:
+        append_new_results(results)
+
+    # Return git repo to original location (if changed).
+    if checkout_count > 0:
+        try:
+            if git.has_changes_to_be_committed():
+                raise GitCheckoutError()
+            checkout(r'@{-%d}' % checkout_count, delete_pyc=True)
+        except GitCheckoutError:
+            print ('ERROR: Could not checkout git repo to original location. '
+                   r'\n\t$ git checkout @{-%d}' % checkout_count)
+
+    # Stop here if profiling was un-successfull.
+    if not success:
+        print ('ERROR: Some experiments failed to run, no plotting will be '
+               'attempted.')
+
+    return success
+
+
+def run_analysis(experiments, versions, interactive=False,
+                 quick_analysis=True, lobf_order=2, plot=True):
+    """Runs analysis over the results already acquired.
+
+    Args:
+        versions (list): List of version dicts.
+        experiments (list): List of experiment dicts.
+        interactive (bool - optional): If True then interractive matplotlib
+            windows will display rather than being rendered to a file.
+        quick_analysis (bool - optional): If True then only a small set of the
+            gathered metrics will be output.
+        lobf_order (int - optional): The polynomial order to be used for
+            generating the lines of best fit on all plots produced.
+        plot (bool - optional): If True then plotting will be performed.
+
+    """
+    # Get results
+    with open(os.path.join(prof.CYLC_DIR,
+                           prof.PROFILE_DIR_NAME,
+                           prof.PROFILE_FILE_NAME), 'r') as profile_file:
+        full_results = json.load(profile_file)
+
+    # Run analysis for each experiment requested.
+    for experiment in experiments:
+        plt_dir = False
+        if not interactive:
+            plt_dir = os.path.join(prof.CYLC_DIR,
+                                   prof.PROFILE_DIR_NAME,
+                                   prof.PROFILE_PLOT_DIR_NAME,
+                                   experiment['name'] + '-' +
+                                   str(int(time.time())))
+            os.makedirs(plt_dir)
+
+        # Print a table of results.
+        print
+        print_table(
+            make_table(full_results, versions, experiment,
+                       quick_analysis=quick_analysis),
+            transpose=not quick_analysis
+        )
+        print
+
+        # Plot results.
+        if not plot:
+            continue
+        plot_results(full_results, versions, experiment, plt_dir,
+                     quick_analysis=quick_analysis, lobf_order=lobf_order)
+        if plt_dir:
+            print ('Results for experiment "{exp}" have been written out to '
+                   '"{dir}"'.format(exp=experiment['name'], dir=plt_dir))
+
+
+def ls(exp_names, ver_names, delete=False):
+    """List all results for the provided experiment and version names.
+
+    Args:
+        delete (bool - optional): If true the user is prompted whether to
+            delete the selected results.
+
+    """
+    results = get_results()  # Get contents of results file.
+    include = {}  # Dict of all results to list, exp_name: exp_id: [ver_id]
+    all_versions = []  # List of all version ids contained in 'include'
+
+    def include_result(experiment_name, experiment_id, version_id):
+        if experiment_name not in include:
+            include[experiment_name] = {}
+        if experiment_id not in include[experiment_name]:
+            include[experiment_name][experiment_id] = []
+        include[experiment_name][experiment_id].append(version_id)
+        if version_id not in all_versions:
+            all_versions.append(version_id)
+
+    if not exp_names and not ver_names:
+        # No experiments or versions specified => list all results.
+        for version_id in results:
+            for experiment_id in results[version_id]:
+                experiment_name = experiment_id.split('@')[0]
+                include_result(experiment_name, experiment_id, version_id)
+    else:
+        # List only specified experiments and versions.
+        version_ids = map(git.describe, ver_names)
+        experiment_ids = set([name for name in exp_names if '@' in name])
+        experiment_names = set(exp_names) - experiment_ids
+
+        for version_id in results:
+            if ver_names and version_id not in version_ids:
+                continue
+            for experiment_id in results[version_id]:
+                experiment_name = experiment_id.split('@')[0]
+                if (not exp_names or (experiment_name in experiment_names or
+                                      experiment_id in experiment_ids)):
+                    include_result(experiment_name, experiment_id, version_id)
+
+    git.order_identifiers_by_date(all_versions)
+
+    experiments = get_experiments(include.keys())
+    current_experiment_ids = []
+    for experiment in experiments:
+        current_experiment_ids.append(experiment['id'])
+
+    table = [['Experiment Name', 'Experiment ID', 'Version ID'],
+             [None, None, None]]
+    for experiment_name in sorted(include):
+        table.append([experiment_name, None, None])
+        for experiment_id in include[experiment_name]:
+            if experiment_id in current_experiment_ids:
+                table.append(['', '* ' + experiment_id, None])
+            else:
+                table.append(['', experiment_id, None])
+            for version_id in all_versions:
+                if version_id in include[experiment_name][experiment_id]:
+                    table.append(['', '', version_id])
+
+    print_table(table)
+
+    if delete:
+        filtered_keys = []
+        for experiment_name in include:
+            for experiment_id in include[experiment_name]:
+                for version_id in include[experiment_name][experiment_id]:
+                    filtered_keys.append((version_id, experiment_id,))
+        delete_results(filtered_keys, interactive=True)
+
+
+def promote(experiment_id, yes=False):
+    """Promote any results for the provided experiment version to the current
+    version."""
+    if '@' not in experiment_id:
+        sys.exit('A version must be supplied to promote an experiment e.g. '
+                 'exp@a1b2c3d4e5')
+    experiment_name, experiment_version = experiment_id.rsplit('@', 1)
+
+    results = get_results()  # Get contents of results file.
+
+    cur_exp_id = get_experiments([experiment_name])[0]['id']
+
+    candidate_versions = []
+    target_versions = []
+    for version in results:
+        for exp_id in results[version]:
+            exp_name, exp_ver = exp_id.rsplit('@', 1)
+            if exp_name != experiment_name:
+                continue
+            if exp_ver == experiment_version:
+                candidate_versions.append(version)
+            elif exp_id == cur_exp_id:
+                target_versions.append(version)
+
+    if not candidate_versions:
+        sys.exit('There are no results for experiment "{experiment_id}".'
+                 ''.format(experiment_id=experiment_id))
+    ls([experiment_name], [])
+    if target_versions:
+        candidate_versions = [version for version in candidate_versions if
+                              version not in target_versions]
+        print
+        print ('Only the results for cylc versions not already profiled in '
+               'the current experiment version will be promoted.')
+    git.order_identifiers_by_date(candidate_versions)
+
+    print
+    print ('Promote the following results for experiment "{name}" at version '
+           '"{candidate}" to the current version "{target}":'.format(
+               name=experiment_name,
+               candidate=experiment_version,
+               target=cur_exp_id.rsplit('@', 1)[1]
+           ))
+    print '\t', ' '.join(candidate_versions)
+
+    if not yes:
+        response = None
+        while response not in ['y', 'n']:
+            response = raw_input('Upgrade these versions? (y/n): ')
+    if yes or response == 'y':
+        # Promote results.
+        try:
+            for version in candidate_versions:
+                results[version][cur_exp_id] = results[version][experiment_id]
+        except KeyError as exc:
+            print exc
+            sys.exit('Unexpected error.')
+        else:
+            append_new_results(results)
+        # Provide option to delete duplicates.
+        ls([experiment_id], candidate_versions, delete=True)
+    else:
+        sys.exit('Aborted, not changes made.')
+
+
+def main():
+    """cylc profile-battery"""
+    opts = parse_args()
+
+    # Promote mode.
+    if opts.promote:
+        promote(opts.promote, opts.yes)
+        sys.exit(0)
+
+    # If in "list" mode print out results then exit.
+    if opts.ls or opts.delete:
+        ls(opts.experiments, opts.versions, delete=opts.delete)
+        sys.exit(0)
+
+    # Generate list of requested experiments and versions.
+    experiments = get_experiments(opts.experiments)
+    versions = get_versions(opts.versions)
+
+    # Order versions.
+    git.order_versions_by_date(versions)
+
+    # Fail in the event that an experiment file cannot be found.
+    if not all([experiment['file'] for experiment in experiments]):
+        sys.exit('Experiment file(s) could not be loaded, profiling aborted.')
+
+    # Run experiments as necessary.
+    schedule, exps_to_run = get_schedule(versions, experiments, test=opts.test)
+    if schedule:
+        if not run_schedule(schedule, experiments, versions, exps_to_run,
+                            opts.yes, opts.test):
+            sys.exit('Profiling failed.')
+
+    # Don't run analysis if in "test" mode.
+    if opts.test:
+        sys.exit(0)
+
+    # Run analysis
+    run_analysis(experiments, versions, opts.interactive,
+                 not opts.full_results, opts.lobf_order,
+                 plot=not opts.no_plots)
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/cylc-profile-battery
+++ b/bin/cylc-profile-battery
@@ -440,31 +440,34 @@ def determine_action(schedule, versions, experiments, non_interactive=False):
                     other_versions.append(version)
 
     # Check for potential incompatability with PROFILE_MODE_CYLC.
-    temp = []
     for experiment in experiments:
-        for mode in experiment['config']['profile modes']:
-            if prof.PROFILE_MODES[mode] != prof.PROFILE_MODE_CYLC:
-                continue
+        if prof.PROFILE_MODE_CYLC in experiment['config']['profile modes']:
+            # Check suitability of profile-mode cylc with this schedule.
+            temp = []
             for version_id in schedule:
                 if not git.is_ancestor_commit(prof.CYLC_PROFILING_COMMIT,
                                               version_id):
                     for version in versions:
                         if version['id'] == version_id:
                             temp.append(version)
-        if temp and not non_interactive:
-            print('WARNING: You are trying to use the "cylc" profile mode with'
-                  ' versions of cylc which predate the profiling module '
-                  'namely:')
-            print '\t', ' '.join([version['name'] for version in temp])
-            print('\nTo profile these versions you will need to back port the '
-                  'profiling module as well as some of the memory '
-                  'checkpointing in the main loop.\n')
-            usr = None
-            while usr not in ['y', 'n']:
-                usr = raw_input('proceed? (y/n): ')
-            if usr == 'n':
-                sys.exit('Profiling aborted by user.')
-            print
+            if temp and not non_interactive:
+                # Profile-mode cylc might not be suitible, warn user.
+                print('WARNING: You are trying to use the "cylc" profile mode '
+                      'with versions of cylc which predate the profiling '
+                      'module namely:\n'
+                      '\t' + ' '.join([version['name'] for version in temp]) +
+                      '\n\nTo profile these versions you will need to back '
+                      'port the profiling module as well as some of the memory'
+                      ' checkpointing in the main loop.\n')
+                usr = None
+                while usr not in ['y', 'n']:
+                    usr = raw_input('proceed? (y/n): ')
+                if usr == 'n':
+                    sys.exit('Profiling aborted by user.')
+                print
+            elif temp:
+                print >> sys.stderr, ('WARNING: You are using profile-mode '
+                                      '"cylc" with older versions of cylc.')
 
     # Prompt user over using automated checkout.
     to_checkout = []

--- a/dev/profile-experiments/busy-validate.json
+++ b/dev/profile-experiments/busy-validate.json
@@ -1,0 +1,62 @@
+{
+    "runs": [
+        {
+           "name": "1",
+           "suite dir": "dev/suites/chains",
+           "options": ["tasks_per_chain=5", "chains=1"],
+           "repeats": 1
+        },
+        {
+           "name": "2",
+           "suite dir": "dev/suites/chains",
+           "options": ["tasks_per_chain=5", "chains=2"],
+           "repeats": 1
+        },
+        {
+           "name": "5",
+           "suite dir": "dev/suites/chains",
+           "options": ["tasks_per_chain=5", "chains=5"],
+           "repeats": 0
+        },
+        {
+           "name": "10",
+           "suite dir": "dev/suites/chains",
+           "options": ["tasks_per_chain=5", "chains=10"],
+           "repeats": 0
+        },
+        {
+           "name": "25",
+           "suite dir": "dev/suites/chains",
+           "options": ["tasks_per_chain=5", "chains=25"],
+           "repeats": 0
+        },
+        {
+           "name": "50",
+           "suite dir": "dev/suites/chains",
+           "options": ["tasks_per_chain=5", "chains=50"],
+           "repeats": 0
+        },
+        {
+           "name": "75",
+           "suite dir": "dev/suites/chains",
+           "options": ["tasks_per_chain=5", "chains=75"],
+           "repeats": 0
+        },
+        {
+           "name": "100",
+           "suite dir": "dev/suites/chains",
+           "options": ["tasks_per_chain=5", "chains=100"],
+           "repeats": 0
+        },
+        {
+           "name": "200",
+           "suite dir": "dev/suites/chains",
+           "options": ["tasks_per_chain=5", "chains=200"],
+           "repeats": 0
+        }
+    ],
+    "profile modes": ["time"],
+    "analysis": "scale",
+    "mode": "validate",
+    "x-axis": "Chains of parallel tasks (X5 tasks per chain X2 cycles)"
+}

--- a/dev/profile-experiments/busy.json
+++ b/dev/profile-experiments/busy.json
@@ -1,0 +1,61 @@
+{
+    "runs": [
+        {
+           "name": "1",
+           "suite dir": "dev/suites/chains",
+           "options": ["tasks_per_chain=5", "chains=1", "batch_system=at"],
+           "repeats": 1
+        },
+        {
+           "name": "2",
+           "suite dir": "dev/suites/chains",
+           "options": ["tasks_per_chain=5", "chains=2", "batch_system=at"],
+           "repeats": 1
+        },
+        {
+           "name": "5",
+           "suite dir": "dev/suites/chains",
+           "options": ["tasks_per_chain=5", "chains=5", "batch_system=at"],
+           "repeats": 0
+        },
+        {
+           "name": "10",
+           "suite dir": "dev/suites/chains",
+           "options": ["tasks_per_chain=5", "chains=10", "batch_system=at"],
+           "repeats": 0
+        },
+        {
+           "name": "25",
+           "suite dir": "dev/suites/chains",
+           "options": ["tasks_per_chain=5", "chains=25", "batch_system=at"],
+           "repeats": 0
+        },
+        {
+           "name": "50",
+           "suite dir": "dev/suites/chains",
+           "options": ["tasks_per_chain=5", "chains=50", "batch_system=at"],
+           "repeats": 0
+        },
+        {
+           "name": "75",
+           "suite dir": "dev/suites/chains",
+           "options": ["tasks_per_chain=5", "chains=75", "batch_system=at"],
+           "repeats": 0
+        },
+        {
+           "name": "100",
+           "suite dir": "dev/suites/chains",
+           "options": ["tasks_per_chain=5", "chains=100", "batch_system=at"],
+           "repeats": 0
+        },
+        {
+           "name": "200",
+           "suite dir": "dev/suites/chains",
+           "options": ["tasks_per_chain=5", "chains=200", "batch_system=at"],
+           "repeats": 0
+        }
+    ],
+    "profile modes": ["time"],
+    "x-axis": "Chains of parallel tasks (X5 tasks per chain X2 cycles)",
+    "analysis": "scale"
+}

--- a/dev/profile-experiments/complex-validate.json
+++ b/dev/profile-experiments/complex-validate.json
@@ -1,0 +1,10 @@
+{
+    "runs": [
+        {
+           "name": "complex suite",
+           "suite dir": "dev/suites/complex"
+        }
+    ],
+    "profile modes": ["time"],
+    "mode": "validate"
+}

--- a/dev/profile-experiments/complex.json
+++ b/dev/profile-experiments/complex.json
@@ -1,0 +1,10 @@
+{
+    "runs": [
+        {
+           "name": "complex suite",
+           "suite dir": "dev/suites/complex",
+           "options": ["batch_system=at", "sleep_time=1"]
+        }
+    ],
+    "profile modes": ["time"]
+}

--- a/dev/profile-experiments/diamond-validate.json
+++ b/dev/profile-experiments/diamond-validate.json
@@ -1,0 +1,49 @@
+{
+    "runs": [
+        {
+           "name": "10",
+           "suite dir": "dev/suites/diamond",
+           "options": ["cycles=5", "tasks=10"],
+           "repeats": 2
+        },
+        {
+           "name": "50",
+           "suite dir": "dev/suites/diamond",
+           "options": ["cycles=5", "tasks=50"],
+           "repeats": 1
+        },
+        {
+           "name": "100",
+           "suite dir": "dev/suites/diamond",
+           "options": ["cycles=5", "tasks=100"],
+           "repeats": 0
+        },
+        {
+           "name": "250",
+           "suite dir": "dev/suites/diamond",
+           "options": ["cycles=5", "tasks=250"],
+           "repeats": 0
+        },
+        {
+           "name": "500",
+           "suite dir": "dev/suites/diamond",
+           "options": ["cycles=5", "tasks=500"],
+           "repeats": 0
+        },
+        {
+           "name": "750",
+           "suite dir": "dev/suites/diamond",
+           "options": ["cycles=5", "tasks=750"],
+           "repeats": 0
+        },
+        {
+           "name": "1000",
+           "suite dir": "dev/suites/diamond",
+           "options": ["cycles=5", "tasks=1000"],
+           "repeats": 0
+        }
+    ],
+    "profile modes": ["time"],
+    "mode": "validate",
+    "analysis": "scale"
+}

--- a/dev/profile-experiments/diamond.json
+++ b/dev/profile-experiments/diamond.json
@@ -1,0 +1,48 @@
+{
+    "runs": [
+        {
+           "name": "10",
+           "suite dir": "dev/suites/diamond",
+           "options": ["cycles=5", "tasks=10", "batch_system=at"],
+           "repeats": 2
+        },
+        {
+           "name": "50",
+           "suite dir": "dev/suites/diamond",
+           "options": ["cycles=5", "tasks=50", "batch_system=at"],
+           "repeats": 1
+        },
+        {
+           "name": "100",
+           "suite dir": "dev/suites/diamond",
+           "options": ["cycles=5", "tasks=100", "batch_system=at"],
+           "repeats": 0
+        },
+        {
+           "name": "250",
+           "suite dir": "dev/suites/diamond",
+           "options": ["cycles=5", "tasks=250", "batch_system=at"],
+           "repeats": 0
+        },
+        {
+           "name": "500",
+           "suite dir": "dev/suites/diamond",
+           "options": ["cycles=5", "tasks=500", "batch_system=at"],
+           "repeats": 0
+        },
+        {
+           "name": "750",
+           "suite dir": "dev/suites/diamond",
+           "options": ["cycles=5", "tasks=750", "batch_system=at"],
+           "repeats": 0
+        },
+        {
+           "name": "1000",
+           "suite dir": "dev/suites/diamond",
+           "options": ["cycles=5", "tasks=1000", "batch_system=at"],
+           "repeats": 0
+        }
+    ],
+    "profile modes": ["time"],
+    "analysis": "scale"
+}

--- a/dev/profile-experiments/example
+++ b/dev/profile-experiments/example
@@ -1,0 +1,59 @@
+# Example of experiment definition (NOTE: json does not support comments)
+
+{
+    # A list of runs where a run represents a particular profiling
+    # configuration. Specify one or more runs as dictionaries.
+    "runs": [
+        {
+            # A name for this run, results will be stored under this name.
+            # If using "analysis = scale" this name should be an integer value
+            # provided as a string (e.g. name = "12")
+            "name": "hello world suite",
+
+            # Path to the suite directory. Relative paths will be prefixed
+            # the path to the cylc working copy.
+            "suite dir": "~/roses/hello_world",
+
+            # For providing jinja2 variables to your suite.rc
+            # --- optional, default=[] ---
+            # NOTE: A convention upheld by profile-battery mode for jinja2
+            #       variables is:
+            #  - `batch_system`: Used for [task][job]batch system = _
+            #  - `sleep_time`: User for [task]script = sleep _
+            "options": ["setting=value", "foo=bar"],
+
+            # Number of REPEATS to perform, if zero the suite will run once,
+            # if one it will run twice!
+            # --- optional, default=0 ---
+            "repeats": 1
+        }
+    ],
+
+    # System(s) to profile code:
+    # - `time`: Profiles the code using /usr/bin/time.
+    # - `cylc`: Runs the code using the --profile option (not available in all
+    #     cylc versions.
+    # --- optional, default=['time'] ---
+    "profile modes": ["time", "cylc"],
+
+    # Type of analysis to perform:
+    # - `single`: For non-scaling experiments.
+    # - `scale`:  For scaling suites.
+    # --- optional, default='single' ---
+    "analysis": "single",
+
+    # cylc run mode:
+    # - `validate`: Profiles with `cylc validate <SUITE>` rather than
+    #     `cylc run <SUITE>`.
+    # - `profile-simulation`: Manually overwrites all script to sleep 1 removes
+    #     any pre/post script, sets host to localhost and job-submission method
+    #     to background then runs `cylc run <SUITE> --mode=live`.
+    # - `<MODE>`:   Profiles `cylc run` with `--mode=<MODE>`.
+    # --- optional, default=None (equivilent to `live`) ---
+    "mode": "profile-simulation",
+
+    # For experiments using analysis=scale, the label for the x-axis of
+    # produced plots.
+    # --- optional, default='Tasks' ---
+    "x-axis": "X axis title"
+}

--- a/dev/profile-experiments/experiment.json
+++ b/dev/profile-experiments/experiment.json
@@ -1,0 +1,9 @@
+{
+    "runs": [
+        {
+           "name": "hello world suite",
+           "suite dir": "~/roses/hello_world"
+        }
+    ],
+    "profile modes": ["time", "cylc"]
+}

--- a/dev/profile-experiments/family-trigger-validate.json
+++ b/dev/profile-experiments/family-trigger-validate.json
@@ -1,0 +1,55 @@
+{
+    "runs": [
+        {
+           "name": "10",
+           "suite dir": "dev/suites/family-triggers",
+           "options": ["batch_system=at", "no_members=10"],
+           "repeats": 3
+        },
+        {
+           "name": "25",
+           "suite dir": "dev/suites/family-triggers",
+           "options": ["batch_system=at", "no_members=20"],
+           "repeats": 2
+        },
+        {
+           "name": "50",
+           "suite dir": "dev/suites/family-triggers",
+           "options": ["batch_system=at", "no_members=50"],
+           "repeats": 1
+        },
+        {
+           "name": "75",
+           "suite dir": "dev/suites/family-triggers",
+           "options": ["batch_system=at", "no_members=75"],
+           "repeats": 0
+        },
+        {
+           "name": "100",
+           "suite dir": "dev/suites/family-triggers",
+           "options": ["batch_system=at", "no_members=100"],
+           "repeats": 0
+        },
+        {
+           "name": "150",
+           "suite dir": "dev/suites/family-triggers",
+           "options": ["batch_system=at", "no_members=150"],
+           "repeats": 0
+        },
+        {
+           "name": "200",
+           "suite dir": "dev/suites/family-triggers",
+           "options": ["batch_system=at", "no_members=200"],
+           "repeats": 0
+        },
+        {
+           "name": "250",
+           "suite dir": "dev/suites/family-triggers",
+           "options": ["batch_system=at", "no_members=250"],
+           "repeats": 0
+        }
+    ],
+    "analysis": "scale",
+    "profile modes": ["time" ],
+    "mode": "validate"
+}

--- a/dev/profile-experiments/hello-world-validate.json
+++ b/dev/profile-experiments/hello-world-validate.json
@@ -1,0 +1,10 @@
+{
+    "runs": [
+        {
+           "name": "run",
+           "suite dir": "dev/suites/hello-world",
+           "repeats": 10
+        }
+    ],
+    "mode": "validate"
+}

--- a/dev/profile-experiments/hello-world.json
+++ b/dev/profile-experiments/hello-world.json
@@ -1,0 +1,9 @@
+{
+    "runs": [
+        {
+           "name": "run",
+           "suite dir": "dev/suites/hello-world",
+           "repeats": 10
+        }
+    ]
+}

--- a/dev/profile-experiments/lazy-validate.json
+++ b/dev/profile-experiments/lazy-validate.json
@@ -1,0 +1,50 @@
+{
+    "runs": [
+        {
+           "name": "10",
+           "suite dir": "dev/suites/chains",
+           "options": ["chains=1", "tasks_per_chain=10"],
+           "repeats": 0
+        },
+        {
+           "name": "50",
+           "suite dir": "dev/suites/chains",
+           "options": ["chains=1", "tasks_per_chain=50"],
+           "repeats": 0
+        },
+        {
+           "name": "100",
+           "suite dir": "dev/suites/chains",
+           "options": ["chains=1", "tasks_per_chain=100"],
+           "repeats": 0
+        },
+        {
+           "name": "250",
+           "suite dir": "dev/suites/chains",
+           "options": ["chains=1", "tasks_per_chain=250"],
+           "repeats": 0
+        },
+        {
+           "name": "500",
+           "suite dir": "dev/suites/chains",
+           "options": ["chains=1", "tasks_per_chain=500"],
+           "repeats": 0
+        },
+        {
+           "name": "750",
+           "suite dir": "dev/suites/chains",
+           "options": ["chains=1", "tasks_per_chain=750"],
+           "repeats": 0
+        },
+        {
+           "name": "1000",
+           "suite dir": "dev/suites/chains",
+           "options": ["chains=1", "tasks_per_chain=1000"],
+           "repeats": 0
+        }
+    ],
+    "profile modes": ["time"],
+    "analysis": "scale",
+    "mode": "validate",
+    "x-axis": "Sequential Tasks (X3 cycles)"
+}

--- a/dev/profile-experiments/lazy.json
+++ b/dev/profile-experiments/lazy.json
@@ -1,0 +1,49 @@
+{
+    "runs": [
+        {
+           "name": "10",
+           "suite dir": "dev/suites/chains",
+           "options": ["chains=1", "tasks_per_chain=10", "batch_system=at"],
+           "repeats": 0
+        },
+        {
+           "name": "50",
+           "suite dir": "dev/suites/chains",
+           "options": ["chains=1", "tasks_per_chain=50", "batch_system=at"],
+           "repeats": 0
+        },
+        {
+           "name": "100",
+           "suite dir": "dev/suites/chains",
+           "options": ["chains=1", "tasks_per_chain=100", "batch_system=at"],
+           "repeats": 0
+        },
+        {
+           "name": "250",
+           "suite dir": "dev/suites/chains",
+           "options": ["chains=1", "tasks_per_chain=250", "batch_system=at"],
+           "repeats": 0
+        },
+        {
+           "name": "500",
+           "suite dir": "dev/suites/chains",
+           "options": ["chains=1", "tasks_per_chain=500", "batch_system=at"],
+           "repeats": 0
+        },
+        {
+           "name": "750",
+           "suite dir": "dev/suites/chains",
+           "options": ["chains=1", "tasks_per_chain=750", "batch_system=at"],
+           "repeats": 0
+        },
+        {
+           "name": "1000",
+           "suite dir": "dev/suites/chains",
+           "options": ["chains=1", "tasks_per_chain=1000", "batch_system=at"],
+           "repeats": 0
+        }
+    ],
+    "profile modes": ["time"],
+    "analysis": "scale",
+    "x-axis": "Sequential Tasks (X2 cycles)"
+}

--- a/dev/profile-experiments/profile-simulation/suite.rc
+++ b/dev/profile-experiments/profile-simulation/suite.rc
@@ -1,0 +1,42 @@
+#!jinja2
+
+# This config get appended to the suite config when profiling with
+# mode=profile-simulation where namespaces is a list of all tasks present in
+# the suite config.
+#
+# The jinja2 variables sleep_time and batch_system can be provided in the
+# options section of an experiment run (e.g. options=["sleep_time=1"]).
+#
+# The jinja2 variable cylc_compat_mode is provided automatically and contains
+# the major version number of the cylc version which will run the suite.
+
+{% if not sleep_time is defined %}
+    {% set sleep_time = '1' %}
+{% endif %}
+{% if not batch_system is defined %}
+    {% set batch_system = 'background' %}
+{% endif %}
+{% if namespaces is string %}
+    {% set namespaces = [namespaces] %}
+{% endif %}
+
+# The runtime to overwrite.
+[runtime]
+{% for namespace in namespaces %}
+    [[{{namespace}}]]
+    {% if cylc_compat_mode is defined and cylc_compat_mode == '6' %}
+        pre-command scripting =
+        command scripting = sleep {{sleep_time}}
+        post-command scripting =
+        [[[job submission]]]
+            method = {{batch_system}}
+    {% else %}
+        pre-script =
+        script = sleep {{sleep_time}}
+        post-script =
+        [[[job]]]
+            batch system = {{batch_system}}
+    {% endif %}
+        [[[remote]]]
+            host = localhost
+{% endfor %}

--- a/dev/profile-experiments/test.json
+++ b/dev/profile-experiments/test.json
@@ -1,0 +1,18 @@
+{
+    "runs": [
+        {
+            "name": "chains",
+            "suite dir": "dev/suites/chains",
+            "repeats": 1,
+            "options": ["batch_system=at", "chains=3", "tasks_per_chain=1"]
+        },
+        {
+            "name": "diamond",
+            "suite dir": "dev/suites/diamond",
+            "options": ["tasks=3", "cycles=1"]
+        }
+    ],
+    "profile modes": ["time", "cylc"],
+    "analysis": "single",
+    "mode": "profile-simulation"
+}

--- a/dev/suites/chains/suite.rc
+++ b/dev/suites/chains/suite.rc
@@ -1,0 +1,44 @@
+#!jinja2
+
+# A suite which runs a <chain_num> parallel chains of <tasks_per_chain> tasks.
+
+# Implemented using jinja2 rather than parameterized tasks to allow for
+# profiling with older cylc versions.
+
+{% if not batch_system is defined %}
+    {% set batch_system = 'background' %}
+{% endif %}
+{% if not chains is defined %}
+    {% set chains = 1 %}
+{% endif %}
+{% if not tasks_per_chain is defined %}
+    {% set tasks_per_chain = 1 %}
+{% endif %}
+
+[scheduling]
+    cycling mode = integer
+    initial cycle point = 1
+    final cycle point = 2
+    [[dependencies]]
+        [[[P1]]]
+            graph = """
+            {% for chain_num in range(chains|int) -%}
+                task_{{chain_num}}_{{tasks_per_chain}}[-P1] => \
+                    task_{{chain_num}}_1
+            {% for task_num in range(1, tasks_per_chain|int) -%}
+                task_{{chain_num}}_{{task_num}} => \
+                    task_{{chain_num}}_{{task_num + 1}}
+            {% endfor -%}
+            {% endfor -%}
+            """
+[runtime]
+    [[root]]
+    {% if cylc_compat_mode is defined and cylc_compat_mode == '6' %}
+        command scripting = true
+        [[[job submission]]]
+            method = {{ batch_system }}
+    {% else %}
+        script = true
+        [[[job]]]
+            batch system = {{ batch_system }}
+    {% endif %}

--- a/dev/suites/complex/suite.rc
+++ b/dev/suites/complex/suite.rc
@@ -1,0 +1,4547 @@
+#!jinja2
+
+# A somewhat complex suite put together for the IS-ENES2 Workshop in Lisbon
+# 2016.
+
+{% if not batch_system is defined %}
+    {% set batch_system = 'background' %}
+{% endif %}
+{% if not sleep_time is defined %}
+    {% set sleep_time = 1 %}
+{% endif %}
+
+title = "Complex Suite Demo"
+description = "This is a super-elaborate obfuscated version of a suite with no Jinja2 to condense it down."
+[cylc]
+    UTC mode = True
+    [[event hooks]]
+        timeout handler = rose suite-hook --mail --shutdown
+        timeout = P1D                       # 1 day.
+[scheduling]
+    initial cycle point = 20150219T00
+    final cycle point = 20150220T00
+    runahead limit = PT6H
+    [[special tasks]]
+        clock-triggered = \
+                          long_start_00(PT2H40M), brief_start_00(PT6H15M), \
+                          long_start_06(PT2H40M), brief_start_06(PT6H15M), \
+                          long_start_12(PT2H40M), brief_start_12(PT6H15M), \
+                          long_start_18(PT2H40M), brief_start_18(PT6H15M), \
+                          long_res_create(-PT1H20M), brief_res_create(PT1H30M), \
+                          ensemble_start_00(PT3H30M), ensemble_start_06(PT3H30M), \
+                          ensemble_start_12(PT3H30M), ensemble_start_18(PT3H30M), \
+                          ensemble_res_create(-PT30M), ensembles_res_create(-PT30M)
+    [[dependencies]]
+        [[[R1]]]
+            graph = """
+                     install_cold
+                     install_cold_mirror
+                     install_cold & longbrief_install_startdata_cold => long_start & brief_start
+                     install_cold & ensemble_install_startdata_cold => ensemble_start
+            """
+        [[[ T00 ]]]
+            graph = """
+                housekeep => archive_logs
+            """
+[runtime]
+    [[root]]
+    {% if cylc_compat_mode is defined and cylc_compat_mode == '6' %}
+        command scripting = sleep {{ sleep_time }}
+        [[[job submission]]]
+            method = {{ batch_system }}
+    {% else %}
+        script = sleep {{ sleep_time }}
+        [[[job]]]
+            batch system = {{ batch_system }}
+    {% endif %}
+    [[HPC]]
+    [[HPC_BACKUP]]
+    [[CORETYPE_PARALLEL]]
+    [[CORETYPE_SHARED]]
+    [[ARCHIVE]]
+        inherit = CORETYPE_SHARED
+    [[INSTALL_COLD]]
+        inherit = CORETYPE_SHARED
+    [[INSTALL_DIAG]]
+    [[LOCAL]]
+    [[OS_RES_CREATE]]
+        inherit = None, HPC, CORETYPE_SHARED
+    [[OS_RES_DELETE]]
+        inherit = None, HPC, CORETYPE_SHARED
+    [[OS_START]]
+        inherit = None, LOCAL
+    [[RETRY_TASK]]
+    [[archive_logs]]
+        inherit = None, LOCAL, ARCHIVE
+    [[housekeep]]
+        inherit = None, LOCAL
+    [[install_cold]]
+        inherit = INSTALL_COLD, HPC
+    [[install_cold_mirror]]
+        inherit = INSTALL_COLD, HPC_BACKUP
+[scheduling]
+    [[dependencies]]
+        [[[ T00 ]]]
+            graph = """
+                long_res_create   => long_start_00   => long_start
+                brief_res_create   => brief_start_00   => brief_start
+                brief_forecast_end => brief_hpc_backup_daily => housekeep
+                long_dispersion_proc_completed => long_dispersion_archive_prep => long_dispersion_archive
+            """
+        [[[ T06 ]]]
+            graph = """
+                brief_forecast[-PT6H]                             => brief_wagtail_look_at_snow & brief_wagtail_look_at_wagtail_ice   \
+                                                               => brief_forecast_redo_daily                              \
+                                                               => brief_forecast
+                brief_start                                      => brief_wagtail_look_at_snow & brief_wagtail_look_at_wagtail_ice
+                brief_start                                      => brief_observations_wagtail_background => brief_observations_wagtail_look_at
+                brief_start                                      => brief_observations_process_wagtail_background => brief_observations_process_wagtail_look_at \
+                                                               => brief_observations_db_stuff_wagtail => brief_archive
+                long_res_create   => long_start_06   => long_start
+                brief_res_create   => brief_start_06   => brief_start
+            """
+        [[[ T12 ]]]
+            graph = """
+                long_res_create   => long_start_12   => long_start
+                brief_res_create   => brief_start_12   => brief_start
+            """
+        [[[ T18 ]]]
+            graph = """
+                long_res_create   => long_start_18   => long_start
+                brief_res_create   => brief_start_18   => brief_start
+            """
+        [[[ T00, T12 ]]]
+            graph = """
+                long_assimilation_look_at_larger                      =>  long_forecast_long
+                long_forecast_long => LONG_OBS_PROCESS_LOOK_AT:succeed-all => long_observations_db_stuff_wagtail => long_archive_long => housekeep
+                long_forecast_long                       => long_verificationmodel_database
+                long_forecast_subjob_tZT                     => long_verificationmodel_database => long_verificationmodel_database_induced
+                long_verificationmodel_database_induced & brief_verificationmodel_database_induced => housekeep
+                long_forecast_long:start                                         \
+                                                 => long_forecast_tA       \
+                                                 => long_forecast_tB       \
+                                                 => long_forecast_tC       \
+                                                 => long_forecast_tD       \
+                                                 => long_forecast_tE       \
+                                                 => long_forecast_tF       \
+                                                 => long_forecast_tG       \
+                                                 => long_forecast_tH       \
+                                                 => long_forecast_tI       \
+                                                 => long_forecast_tB0       \
+                                                 => long_forecast_tB3       \
+                                                 => long_forecast_tB6       \
+                                                 => long_forecast_tB9       \
+                                                 => long_forecast_tBA       \
+                                                 => long_forecast_tBB       \
+                                                 => long_forecast_tJ       \
+                                                 => long_forecast_tBC       \
+                                                 => long_forecast_tBD       \
+                                                 => long_forecast_tBE       \
+                                                 => long_forecast_tC0       \
+                                                 => long_forecast_tC3       \
+                                                 => long_forecast_tC6       \
+                                                 => long_forecast_tK       \
+                                                 => long_forecast_tKA       \
+                                                 => long_forecast_tKB       \
+                                                 => long_forecast_tKC       \
+                                                 => long_forecast_tKD       \
+                                                 => long_forecast_tKE       \
+                                                 => long_forecast_tKF       \
+                                                 => long_forecast_tZA       \
+                                                 => long_forecast_tZB       \
+                                                 => long_forecast_tZC       \
+                                                 => long_forecast_tM       \
+                                                 => long_forecast_tZD       \
+                                                 => long_forecast_tZE       \
+                                                 => long_forecast_tL       \
+                                                 => long_forecast_tZF       \
+                                                 => long_forecast_tZG       \
+                                                 => long_forecast_tZH       \
+                                                 => long_forecast_tN       \
+                                                 => long_forecast_tZI       \
+                                                 => long_forecast_tZJ       \
+                                                 => long_forecast_tZK       \
+                                                 => long_forecast_tZM       \
+                                                 => long_forecast_tZN       \
+                                                 => long_forecast_tZO       \
+                                                 => long_forecast_tO       \
+                                                 => long_forecast_tZP       \
+                                                 => long_forecast_tZQ       \
+                                                 => long_forecast_tZR       \
+                                                 => long_forecast_tZS       \
+                                                 => long_forecast_tZT       \
+                                                 => housekeep
+                long_forecast_long                 => long_forecast_end
+                long_forecast_end & LONG_OBS_PROCESS_LOOK_AT:succeed-all         \
+                                                 => long_res_delete
+                long_forecast_tA             => long_forecast_subjob_tA     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tA           => long_local_preflight_checks
+                long_forecast_subjob_tA           => long_thunderbirds_are_go
+                long_forecast_tB             => long_forecast_subjob_tB     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tB           => long_local_preflight_checks
+                long_forecast_subjob_tB           => long_thunderbirds_are_go
+                long_forecast_tC             => long_forecast_subjob_tC     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tC           => long_local_preflight_checks
+                long_forecast_subjob_tC           => long_thunderbirds_are_go
+                long_forecast_tD             => long_forecast_subjob_tD     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tD           => long_local_preflight_checks
+                long_forecast_subjob_tD           => long_thunderbirds_are_go
+                long_forecast_tE             => long_forecast_subjob_tE     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tE           => long_local_preflight_checks
+                long_forecast_subjob_tE           => long_thunderbirds_are_go
+                long_forecast_tF             => long_forecast_subjob_tF     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tF           => long_local_preflight_checks
+                long_forecast_subjob_tF           => long_thunderbirds_are_go
+                long_forecast_tG             => long_forecast_subjob_tG     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tG           => long_local_preflight_checks
+                long_forecast_subjob_tG           => long_thunderbirds_are_go
+                long_forecast_tH             => long_forecast_subjob_tH     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tH           => long_local_preflight_checks
+                long_forecast_subjob_tH           => long_thunderbirds_are_go
+                long_forecast_tI             => long_forecast_subjob_tI     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tI           => long_local_preflight_checks
+                long_forecast_subjob_tI           => long_thunderbirds_are_go
+                long_forecast_tB0             => long_forecast_subjob_tB0     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tB0           => long_local_preflight_checks
+                long_forecast_subjob_tB0           => long_thunderbirds_are_go
+                long_forecast_tB3             => long_forecast_subjob_tB3     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tB3           => long_local_preflight_checks
+                long_forecast_subjob_tB3           => long_thunderbirds_are_go
+                long_forecast_tB6             => long_forecast_subjob_tB6     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tB6           => long_local_preflight_checks
+                long_forecast_subjob_tB6           => long_thunderbirds_are_go
+                long_forecast_tB9             => long_forecast_subjob_tB9     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tB9           => long_local_preflight_checks
+                long_forecast_subjob_tB9           => long_thunderbirds_are_go
+                long_forecast_tBA             => long_forecast_subjob_tBA     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tBA           => long_local_preflight_checks
+                long_forecast_subjob_tBA           => long_thunderbirds_are_go
+                long_forecast_tBB             => long_forecast_subjob_tBB     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tBB           => long_local_preflight_checks
+                long_forecast_subjob_tBB           => long_thunderbirds_are_go
+                long_forecast_tJ             => long_forecast_subjob_tJ     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tJ           => long_local_preflight_checks
+                long_forecast_subjob_tJ           => long_thunderbirds_are_go
+                long_forecast_tBC             => long_forecast_subjob_tBC     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tBC           => long_thunderbirds_are_go
+                long_forecast_tBD             => long_forecast_subjob_tBD     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tBD           => long_thunderbirds_are_go
+                long_forecast_tBE             => long_forecast_subjob_tBE     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tBE           => long_thunderbirds_are_go
+                long_forecast_tC0             => long_forecast_subjob_tC0     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tC0           => long_thunderbirds_are_go
+                long_forecast_tC3             => long_forecast_subjob_tC3     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tC3           => long_thunderbirds_are_go
+                long_forecast_tC6             => long_forecast_subjob_tC6     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tC6           => long_thunderbirds_are_go
+                long_forecast_tK             => long_forecast_subjob_tK     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tK           => long_thunderbirds_are_go
+                long_forecast_tKA             => long_forecast_subjob_tKA     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tKA           => long_thunderbirds_are_go
+                long_forecast_tKB             => long_forecast_subjob_tKB     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tKB           => long_thunderbirds_are_go
+                long_forecast_tKC             => long_forecast_subjob_tKC     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tKC           => long_thunderbirds_are_go
+                long_forecast_tKD             => long_forecast_subjob_tKD     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tKD           => long_thunderbirds_are_go
+                long_forecast_tKE             => long_forecast_subjob_tKE     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tKE           => long_thunderbirds_are_go
+                long_forecast_tKF             => long_forecast_subjob_tKF     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tKF           => long_thunderbirds_are_go
+                long_forecast_tL             => long_forecast_subjob_tL     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tL           => long_thunderbirds_are_go
+                long_forecast_tZF             => long_forecast_subjob_tZF     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tZF           => long_thunderbirds_are_go
+                long_forecast_tZG             => long_forecast_subjob_tZG     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tZG           => long_thunderbirds_are_go
+                long_forecast_tZH             => long_forecast_subjob_tZH     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tZH           => long_thunderbirds_are_go
+                long_forecast_tZA             => long_forecast_subjob_tZA     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tZA           => long_thunderbirds_are_go
+                long_forecast_tZB             => long_forecast_subjob_tZB     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tZB           => long_thunderbirds_are_go
+                long_forecast_tZC             => long_forecast_subjob_tZC     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tZC           => long_thunderbirds_are_go
+                long_forecast_tM             => long_forecast_subjob_tM     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tM           => long_thunderbirds_are_go
+                long_forecast_tZD             => long_forecast_subjob_tZD     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tZD           => long_thunderbirds_are_go
+                long_forecast_tZE             => long_forecast_subjob_tZE     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tZE           => long_thunderbirds_are_go
+                long_forecast_tL             => long_forecast_subjob_tL     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tL           => long_thunderbirds_are_go
+                long_forecast_tZF             => long_forecast_subjob_tZF     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tZF           => long_thunderbirds_are_go
+                long_forecast_tZG             => long_forecast_subjob_tZG     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tZG           => long_thunderbirds_are_go
+                long_forecast_tZH             => long_forecast_subjob_tZH     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tZH           => long_thunderbirds_are_go
+                long_forecast_tN             => long_forecast_subjob_tN     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tN           => long_thunderbirds_are_go
+                long_forecast_tZI             => long_forecast_subjob_tZI     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tZI           => long_thunderbirds_are_go
+                long_forecast_tZJ             => long_forecast_subjob_tZJ     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tZJ           => long_thunderbirds_are_go
+                long_forecast_tZK             => long_forecast_subjob_tZK     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tZK           => long_thunderbirds_are_go
+                long_forecast_tZM             => long_forecast_subjob_tZM     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tZM           => long_thunderbirds_are_go
+                long_forecast_tZN             => long_forecast_subjob_tZN     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tZN           => long_thunderbirds_are_go
+                long_forecast_tZO             => long_forecast_subjob_tZO     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tZO           => long_thunderbirds_are_go
+                long_forecast_tO             => long_forecast_subjob_tO     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tO           => long_thunderbirds_are_go
+                long_forecast_tZP             => long_forecast_subjob_tZP     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tZP           => long_thunderbirds_are_go
+                long_forecast_tZQ             => long_forecast_subjob_tZQ     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tZQ           => long_thunderbirds_are_go
+                long_forecast_tZR             => long_forecast_subjob_tZR     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tZR           => long_thunderbirds_are_go
+                long_forecast_tZS             => long_forecast_subjob_tZS     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tZS           => long_thunderbirds_are_go
+                long_forecast_tZT             => long_forecast_subjob_tZT     \
+                                                 => long_local & long_bigleftright    \
+                                                  & long_sync_happy            \
+                                                  & long_archive_long
+                long_forecast_subjob_tZT           => long_thunderbirds_are_go
+                long_forecast_tF             => long_dispersion_tF          \
+                                                 => long_dispersion_clock
+                long_forecast_tB6             => long_dispersion_tB6          \
+                                                 => long_dispersion_clock
+                long_forecast_tBD             => long_dispersion_tBD          \
+                                                 => long_dispersion_clock
+                long_forecast_tKA             => long_dispersion_tKA          \
+                                                 => long_dispersion_clock
+                long_forecast_tL             => long_dispersion_tL          \
+                                                 => long_dispersion_clock
+                long_forecast_tZC             => long_dispersion_tZC          \
+                                                 => long_dispersion_clock
+                long_forecast_tZG             => long_dispersion_tZG          \
+                                                 => long_dispersion_clock
+                long_forecast_tZM             => long_dispersion_tZM          \
+                                                 => long_dispersion_clock
+                long_dispersion_clock                     => housekeep
+                long_forecast_tD             => long_dispersion_proc_tD \
+                                                 => long_dispersion_proc_completed
+                long_forecast_tH             => long_dispersion_proc_tH \
+                                                 => long_dispersion_proc_completed
+                long_forecast_tB6             => long_dispersion_proc_tB6 \
+                                                 => long_dispersion_proc_completed
+                long_forecast_tJ             => long_dispersion_proc_tJ \
+                                                 => long_dispersion_proc_completed
+                long_forecast_tC0             => long_dispersion_proc_tC0 \
+                                                 => long_dispersion_proc_completed
+                long_forecast_tKA             => long_dispersion_proc_tKA \
+                                                 => long_dispersion_proc_completed
+                long_forecast_tKE             => long_dispersion_proc_tKE \
+                                                 => long_dispersion_proc_completed
+                long_forecast_tZG             => long_dispersion_proc_tZG \
+                                                 => long_dispersion_proc_completed
+                long_forecast_tZC             => long_dispersion_proc_tZC \
+                                                 => long_dispersion_proc_completed
+                long_forecast_tL             => long_dispersion_proc_tL \
+                                                 => long_dispersion_proc_completed
+                long_forecast_tN             => long_dispersion_proc_tN \
+                                                 => long_dispersion_proc_completed
+                long_forecast_tZM             => long_dispersion_proc_tZM \
+                                                 => long_dispersion_proc_completed
+                long_forecast_tZP             => long_dispersion_proc_tZP \
+                                                 => long_dispersion_proc_completed
+                long_forecast_tZT             => long_dispersion_proc_tZT \
+                                                 => long_dispersion_proc_completed
+                long_dispersion_proc_completed      => long_dispersion_archive_forecast  \
+                                                 => long_dispersion_prune_forecast    \
+                                                 => long_dispersion_housekeep
+                long_forecast_end                  => long_local & long_bigleftright
+                long_forecast_end                  => long_happyland_ingest
+                long_forecast_end                  => long_send_stingray_stingray
+                long_forecast_end                  => long_user_hook
+                long_verificationmodel_database_induced    => long_sync_verification
+           """
+        [[[ T06, T18 ]]]
+            graph = """
+                long_assimilation_look_at_larger                           =>  long_forecast_short
+                long_forecast_short => LONG_OBS_PROCESS_LOOK_AT:succeed-all => long_observations_db_stuff_wagtail => long_archive_short => housekeep
+                long_forecast_short                           => long_verificationmodel_database_short
+                long_forecast_subjob_tC0                           => long_verificationmodel_database_short => long_verificationmodel_database_induced_short
+                long_verificationmodel_database_induced_short & brief_verificationmodel_database_induced => housekeep
+                long_forecast_short:start                                        \
+                                                 => long_forecast_tA       \
+                                                 => long_forecast_tB       \
+                                                 => long_forecast_tC       \
+                                                 => long_forecast_tD       \
+                                                 => long_forecast_tE       \
+                                                 => long_forecast_tF       \
+                                                 => long_forecast_tG       \
+                                                 => long_forecast_tH       \
+                                                 => long_forecast_tI       \
+                                                 => long_forecast_tB0       \
+                                                 => long_forecast_tB3       \
+                                                 => long_forecast_tB6       \
+                                                 => long_forecast_tB9       \
+                                                 => long_forecast_tBA       \
+                                                 => long_forecast_tBB       \
+                                                 => long_forecast_tJ       \
+                                                 => long_forecast_tBC       \
+                                                 => long_forecast_tBD       \
+                                                 => long_forecast_tBE       \
+                                                 => long_forecast_tC0       \
+                                                 => housekeep
+                long_forecast_short                => long_forecast_end
+                long_forecast_end & LONG_OBS_PROCESS_LOOK_AT:succeed-all         \
+                                                 => long_res_delete
+                long_forecast_tA             => long_forecast_subjob_tA     \
+                                                 => long_bigleftright               \
+                                                  & long_sync_happy            \
+                                                  & long_archive_short
+                long_forecast_subjob_tA           => long_local_preflight_checks
+                long_forecast_subjob_tA           => long_thunderbirds_are_go
+                long_forecast_tB             => long_forecast_subjob_tB     \
+                                                 => long_bigleftright               \
+                                                  & long_sync_happy            \
+                                                  & long_archive_short
+                long_forecast_subjob_tB           => long_local_preflight_checks
+                long_forecast_subjob_tB           => long_thunderbirds_are_go
+                long_forecast_tC             => long_forecast_subjob_tC     \
+                                                 => long_bigleftright               \
+                                                  & long_sync_happy            \
+                                                  & long_archive_short
+                long_forecast_subjob_tC           => long_local_preflight_checks
+                long_forecast_subjob_tC           => long_thunderbirds_are_go
+                long_forecast_tD             => long_forecast_subjob_tD     \
+                                                 => long_bigleftright               \
+                                                  & long_sync_happy            \
+                                                  & long_archive_short
+                long_forecast_subjob_tD           => long_local_preflight_checks
+                long_forecast_subjob_tD           => long_thunderbirds_are_go
+                long_forecast_tE             => long_forecast_subjob_tE     \
+                                                 => long_bigleftright               \
+                                                  & long_sync_happy            \
+                                                  & long_archive_short
+                long_forecast_subjob_tE           => long_local_preflight_checks
+                long_forecast_subjob_tE           => long_thunderbirds_are_go
+                long_forecast_tF             => long_forecast_subjob_tF     \
+                                                 => long_bigleftright               \
+                                                  & long_sync_happy            \
+                                                  & long_archive_short
+                long_forecast_subjob_tF           => long_local_preflight_checks
+                long_forecast_subjob_tF           => long_thunderbirds_are_go
+                long_forecast_tG             => long_forecast_subjob_tG     \
+                                                 => long_bigleftright               \
+                                                  & long_sync_happy            \
+                                                  & long_archive_short
+                long_forecast_subjob_tG           => long_local_preflight_checks
+                long_forecast_subjob_tG           => long_thunderbirds_are_go
+                long_forecast_tH             => long_forecast_subjob_tH     \
+                                                 => long_bigleftright               \
+                                                  & long_sync_happy            \
+                                                  & long_archive_short
+                long_forecast_subjob_tH           => long_local_preflight_checks
+                long_forecast_subjob_tH           => long_thunderbirds_are_go
+                long_forecast_tI             => long_forecast_subjob_tI     \
+                                                 => long_bigleftright               \
+                                                  & long_sync_happy            \
+                                                  & long_archive_short
+                long_forecast_subjob_tI           => long_local_preflight_checks
+                long_forecast_subjob_tI           => long_thunderbirds_are_go
+                long_forecast_tB0             => long_forecast_subjob_tB0     \
+                                                 => long_bigleftright               \
+                                                  & long_sync_happy            \
+                                                  & long_archive_short
+                long_forecast_subjob_tB0           => long_local_preflight_checks
+                long_forecast_subjob_tB0           => long_thunderbirds_are_go
+                long_forecast_tB3             => long_forecast_subjob_tB3     \
+                                                 => long_bigleftright               \
+                                                  & long_sync_happy            \
+                                                  & long_archive_short
+                long_forecast_subjob_tB3           => long_local_preflight_checks
+                long_forecast_subjob_tB3           => long_thunderbirds_are_go
+                long_forecast_tB6             => long_forecast_subjob_tB6     \
+                                                 => long_bigleftright               \
+                                                  & long_sync_happy            \
+                                                  & long_archive_short
+                long_forecast_subjob_tB6           => long_local_preflight_checks
+                long_forecast_subjob_tB6           => long_thunderbirds_are_go
+                long_forecast_tB9             => long_forecast_subjob_tB9     \
+                                                 => long_bigleftright               \
+                                                  & long_sync_happy            \
+                                                  & long_archive_short
+                long_forecast_subjob_tB9           => long_local_preflight_checks
+                long_forecast_subjob_tB9           => long_thunderbirds_are_go
+                long_forecast_tBA             => long_forecast_subjob_tBA     \
+                                                 => long_bigleftright               \
+                                                  & long_sync_happy            \
+                                                  & long_archive_short
+                long_forecast_subjob_tBA           => long_local_preflight_checks
+                long_forecast_subjob_tBA           => long_thunderbirds_are_go
+                long_forecast_tBB             => long_forecast_subjob_tBB     \
+                                                 => long_bigleftright               \
+                                                  & long_sync_happy            \
+                                                  & long_archive_short
+                long_forecast_subjob_tBB           => long_local_preflight_checks
+                long_forecast_subjob_tBB           => long_thunderbirds_are_go
+                long_forecast_tJ             => long_forecast_subjob_tJ     \
+                                                 => long_bigleftright               \
+                                                  & long_sync_happy            \
+                                                  & long_archive_short
+                long_forecast_subjob_tJ           => long_local_preflight_checks
+                long_forecast_subjob_tJ           => long_thunderbirds_are_go
+                long_forecast_tBC             => long_forecast_subjob_tBC     \
+                                                 => long_bigleftright               \
+                                                  & long_sync_happy            \
+                                                  & long_archive_short
+                long_forecast_subjob_tBC           => long_thunderbirds_are_go
+                long_forecast_tBD             => long_forecast_subjob_tBD     \
+                                                 => long_bigleftright               \
+                                                  & long_sync_happy            \
+                                                  & long_archive_short
+                long_forecast_subjob_tBD           => long_thunderbirds_are_go
+                long_forecast_tBE             => long_forecast_subjob_tBE     \
+                                                 => long_bigleftright               \
+                                                  & long_sync_happy            \
+                                                  & long_archive_short
+                long_forecast_subjob_tBE           => long_thunderbirds_are_go
+                long_forecast_tC0             => long_forecast_subjob_tC0     \
+                                                 => long_bigleftright               \
+                                                  & long_sync_happy            \
+                                                  & long_archive_short
+                long_forecast_subjob_tC0           => long_thunderbirds_are_go
+                long_forecast_tF             => long_dispersion_tF          \
+                                                 => long_dispersion_clock
+                long_forecast_tB6             => long_dispersion_tB6          \
+                                                 => long_dispersion_clock
+                long_forecast_tBD             => long_dispersion_tBD          \
+                                                 => long_dispersion_clock
+                long_dispersion_clock                     => housekeep
+                long_forecast_tD             => long_dispersion_proc_tD \
+                                                 => long_dispersion_proc_completed
+                long_forecast_tH             => long_dispersion_proc_tH \
+                                                 => long_dispersion_proc_completed
+                long_forecast_tB6             => long_dispersion_proc_tB6 \
+                                                 => long_dispersion_proc_completed
+                long_dispersion_proc_completed      => long_dispersion_prune_forecast    \
+                                                 => long_dispersion_housekeep
+                long_forecast_end                  => long_bigleftright
+                long_forecast_end                  => long_happyland_ingest
+                long_forecast_end                  => long_send_stingray_stingray
+                long_forecast_end                  => long_user_hook
+                long_verificationmodel_database_induced_short => long_sync_verification
+            """
+        [[[ T00, T06, T12, T18 ]]]
+            graph = """
+                long_start[-PT6H] => long_start
+                brief_start[-PT6H] => brief_start
+                brief_forecast_redo_ls_little[-PT6H]   => long_assimilation_look_at_little & brief_assimilation_look_at_little
+                brief_forecast_redo_ls_larger[-PT6H]   => long_assimilation_look_at_larger & brief_assimilation_look_at_larger
+                brief_forecast_redo_ls_screen[-PT6H] => brief_assimilation_look_at_screen
+                brief_start => brief_wagtail_aintree_filter & brief_observations_background_atmos & BRIEF_OBSERVATIONS_PROCESS_BACKGROUND
+                long_start => long_forecast_create_zap_little & long_forecast_create_zap_larger & long_observations_background_atmos & LONG_OBS_PROCESS_BACKGROUND
+                long_forecast_create_zap_little => long_assimilation_create_zap_little => long_assimilation_look_at_little & brief_assimilation_look_at_little
+                long_forecast_create_zap_larger => long_assimilation_create_zap_larger => long_assimilation_look_at_larger & brief_assimilation_look_at_larger
+                brief_wagtail_aintree_filter    => brief_wagtail_forecast_landsim           \
+                                      => brief_wagtail_landsim  \
+                                      => brief_wagtail_filter
+                long_observations_background_atmos                => LONG_OBS_PROCESS_BACKGROUND:succeed-all                     \
+                                                 => long_assimilation_look_at_little                               \
+                                                 => long_assimilation_look_at_larger
+                brief_observations_background_atmos                => BRIEF_OBSERVATIONS_PROCESS_BACKGROUND:succeed-all                     \
+                                                 => brief_assimilation_look_at_little                               \
+                                                 => brief_assimilation_look_at_larger
+                brief_forecast[-PT6H] => brief_wagtail_aintree_filter & brief_observations_background_atmos & long_observations_background_atmos \
+                                         & LONG_OBS_PROCESS_BACKGROUND & BRIEF_OBSERVATIONS_PROCESS_BACKGROUND
+                brief_assimilation_look_at_larger & brief_wagtail_filter => brief_forecast
+                brief_forecast                      => brief_observations_process_look_at_barn_owl \
+                                                 => brief_observations_db_stuff_barn_owl => brief_archive
+                brief_observations_process_look_at_barn_owl => brief_res_delete
+                brief_forecast                      => brief_observations_process_look_at_avocet \
+                                                 => brief_observations_db_stuff_avocet => brief_archive
+                brief_observations_process_look_at_avocet => brief_res_delete
+                brief_forecast                      => brief_observations_process_look_at_chaffinch \
+                                                 => brief_observations_db_stuff_chaffinch => brief_archive
+                brief_observations_process_look_at_chaffinch => brief_res_delete
+                brief_forecast                      => brief_observations_process_look_at_egret \
+                                                 => brief_observations_db_stuff_egret => brief_archive
+                brief_observations_process_look_at_egret => brief_res_delete
+                brief_forecast                      => brief_observations_process_look_at_dipper \
+                                                 => brief_observations_db_stuff_dipper => brief_archive
+                brief_observations_process_look_at_dipper => brief_res_delete
+                brief_forecast                      => brief_observations_process_look_at_gannet \
+                                                 => brief_observations_db_stuff_gannet => brief_archive
+                brief_observations_process_look_at_gannet => brief_res_delete
+                brief_forecast                      => brief_observations_process_look_at_fulmar \
+                                                 => brief_observations_db_stuff_fulmar => brief_archive
+                brief_observations_process_look_at_fulmar => brief_res_delete
+                brief_forecast                      => brief_observations_process_look_at_house_martin \
+                                                 => brief_observations_db_stuff_house_martin => brief_archive
+                brief_observations_process_look_at_house_martin => brief_res_delete
+                brief_forecast                      => brief_observations_process_look_at_iceland_gull \
+                                                 => brief_observations_db_stuff_iceland_gull => brief_archive
+                brief_observations_process_look_at_iceland_gull => brief_res_delete
+                brief_forecast                      => brief_observations_process_look_at_jackdaw \
+                                                 => brief_observations_db_stuff_jackdaw => brief_archive
+                brief_observations_process_look_at_jackdaw => brief_res_delete
+                brief_forecast                      => brief_observations_process_look_at_kestrel \
+                                                 => brief_observations_db_stuff_kestrel => brief_archive
+                brief_observations_process_look_at_kestrel => brief_res_delete
+                brief_forecast                      => brief_observations_process_look_at_lapwing \
+                                                 => brief_observations_db_stuff_lapwing => brief_archive
+                brief_observations_process_look_at_lapwing => brief_res_delete
+                brief_forecast                      => brief_observations_process_look_at_mallard \
+                                                 => brief_observations_db_stuff_mallard => brief_archive
+                brief_observations_process_look_at_mallard => brief_res_delete
+                brief_forecast                      => brief_observations_process_look_at_nightjar \
+                                                 => brief_observations_db_stuff_nightjar => brief_archive
+                brief_observations_process_look_at_nightjar => brief_res_delete
+                brief_forecast                      => brief_observations_process_look_at_osprey \
+                                                 => brief_observations_db_stuff_osprey => brief_archive
+                brief_observations_process_look_at_osprey => brief_res_delete
+                brief_forecast                      => brief_observations_process_look_at_pheasant \
+                                                 => brief_observations_db_stuff_pheasant => brief_archive
+                brief_observations_process_look_at_pheasant => brief_res_delete
+                brief_forecast                      => brief_observations_process_look_at_quail \
+                                                 => brief_observations_db_stuff_quail => brief_archive
+                brief_observations_process_look_at_quail => brief_res_delete
+                brief_forecast                      => brief_observations_process_look_at_raven \
+                                                 => brief_observations_db_stuff_raven => brief_archive
+                brief_observations_process_look_at_raven => brief_res_delete
+                brief_forecast                      => brief_observations_process_look_at_shelduck \
+                                                 => brief_observations_db_stuff_shelduck => brief_archive
+                brief_observations_process_look_at_shelduck => brief_res_delete
+                brief_forecast                      => brief_observations_process_look_at_teal \
+                                                 => brief_observations_db_stuff_teal => brief_archive
+                brief_observations_process_look_at_teal => brief_res_delete
+                brief_forecast                      => brief_observations_process_look_at_velvet_scoter \
+                                                 => brief_observations_db_stuff_velvet_scoter => brief_archive
+                brief_observations_process_look_at_velvet_scoter => brief_res_delete
+                brief_forecast                      => brief_observations_process_look_at_wagtail \
+                                                 => brief_observations_db_stuff_wagtail => brief_archive
+                brief_observations_process_look_at_wagtail => brief_res_delete
+                brief_forecast                      => brief_observations_merge_look_at
+                brief_forecast                      => brief_verificationmodel_database
+                brief_forecast                      => brief_forecast_redo_ls_little & brief_forecast_redo_ls_larger \
+                                                  & brief_forecast_redo_ls_screen                        \
+                                                 => brief_archive
+                brief_observations_background_atmos                => brief_observations_merge_background
+                brief_observations_background_atmos                => brief_observations_process_screen                          \
+                                                 => brief_assimilation_look_at_screen                             \
+                                                 => brief_wagtail_filter
+                brief_observations_merge_background         => brief_observations_merge_look_at  => housekeep
+                brief_forecast_subjob_tC                 => brief_verificationmodel_database => brief_verificationmodel_database_induced
+                brief_archive                       => housekeep
+                LONG_OBS_PROCESS_BACKGROUND:succeed-all => long_bogus_listing
+                BRIEF_OBSERVATIONS_PROCESS_BACKGROUND:succeed-all => brief_bogus_listing
+                brief_forecast:start                                        \
+                                                 => brief_forecast_tA       \
+                                                 => brief_forecast_tB       \
+                                                 => brief_forecast_tC       \
+                                                 => brief_forecast_tD       \
+                                                 => housekeep
+                brief_forecast                      => brief_forecast_end            \
+                                                 => brief_res_delete
+                brief_forecast_tA             => brief_forecast_subjob_tA     \
+                                                 => brief_archive
+                brief_forecast_tB             => brief_forecast_subjob_tB     \
+                                                 => brief_archive
+                brief_forecast_tC             => brief_forecast_subjob_tC     \
+                                                 => brief_archive
+                brief_forecast_tD             => brief_forecast_subjob_tD     \
+                                                 => brief_archive
+                brief_forecast_end                  => brief_user_hook
+                long_forecast_tC            => long_sync_forecast_tC  => housekeep
+                long_forecast_tJ           => long_sync_forecast_tJ => housekeep
+                long_forecast_end           => long_sync_forecast     => housekeep
+                long_forecast_end           => long_sync_main     => housekeep
+                long_sync_happy & long_sync_verification                 => housekeep
+                brief_forecast_end & brief_forecast_tB \
+                                          => brief_sync_forecast     => housekeep
+                brief_forecast_redo_ls_little & brief_forecast_redo_ls_larger & brief_forecast_redo_ls_screen \
+                                          => brief_sync_main     => housekeep
+                brief_forecast_end           => brief_sync_happy       => housekeep
+                brief_verificationmodel_database_induced  => brief_sync_verification      => housekeep
+            """
+[runtime]
+    [[GL]]
+    [[LONG]]
+        inherit = None, GL
+    [[BRIEF]]
+        inherit = None, GL
+    [[COLD_START]]
+        inherit = GL
+    [[OBS_PARALLEL]]
+        inherit = HPC, CORETYPE_PARALLEL
+    [[OBS_SHARED]]
+        inherit = HPC, CORETYPE_SHARED
+    [[SURFACE_PARALLEL]]
+        inherit = HPC, CORETYPE_PARALLEL
+    [[FORECAST_PARALLEL]]
+        inherit = HPC, CORETYPE_PARALLEL
+    [[ASSIMILATION_PARALLEL]]
+        inherit = HPC, CORETYPE_PARALLEL
+    [[VERIFICATIONMODEL_SHARED]]
+        inherit = HPC, CORETYPE_SHARED
+    [[LONG_OBS]]
+        inherit = LONG, INSTALL_DIAG
+    [[BRIEF_OBS]]
+        inherit = BRIEF, INSTALL_DIAG
+    [[LONG_OBS_PROCESS_BACKGROUND]]
+        inherit = LONG_OBS, LONG_OBS_ENVIRONMENT, LONG_RES
+    [[BRIEF_OBSERVATIONS_PROCESS_BACKGROUND]]
+        inherit = BRIEF_OBS, BRIEF_OBS_ENVIRONMENT, BRIEF_RES
+    [[LONG_OBS_PROCESS_LOOK_AT]]
+        inherit = LONG_OBS, LONG_OBS_ENVIRONMENT, LONG_RES
+    [[BRIEF_OBS_PROCESS_LOOK_AT]]
+        inherit = BRIEF_OBS, BRIEF_OBS_ENVIRONMENT, BRIEF_RES
+    [[LONG_OBS_DB_STUFF]]
+        inherit = LONG_OBS, LONG_OBS_ENVIRONMENT, LONG_HPC
+    [[BRIEF_OBS_DB_STUFF]]
+        inherit = BRIEF_OBS, BRIEF_OBS_ENVIRONMENT, BRIEF_HPC
+    [[LONG_OBS_ENVIRONMENT]]
+    [[BRIEF_OBS_ENVIRONMENT]]
+    [[BRIEF_SURFACE_LANDSIM]]
+        inherit = BRIEF
+    [[BRIEF_SURFACE]]
+        inherit = BRIEF
+    [[BRIEF_FORECAST]]
+        inherit = BRIEF, BRIEF_RES
+    [[LONG_FORECAST]]
+        inherit = LONG, LONG_RES
+    [[_MODEL]]
+    [[LONG_FORECAST_SHORT]]
+    [[LONG_FORECAST_LONG]]
+    [[LONGBRIEF_FORECAST_REDO]]
+    [[LONGBRIEF_FORECAST_CREATE_ZAP]]
+        inherit = LONG, HPC, LONG_HPC, CORETYPE_SHARED
+    [[LONGBRIEF_FORECAST_CREATE_ZAP_LITTLE]]
+        inherit = LONGBRIEF_FORECAST_CREATE_ZAP
+    [[LONGBRIEF_FORECAST_CREATE_ZAP_BIGGER]]
+        inherit = LONGBRIEF_FORECAST_CREATE_ZAP
+    [[LONG_ASSIMILATION_ZAP]]
+        inherit = LONG, INSTALL_DIAG, HPC, LONG_HPC
+    [[LONGBRIEF_FORECAST_REDO_LS]]
+        inherit = BRIEF, HPC, BRIEF_HPC, CORETYPE_SHARED
+    [[LONGBRIEF_FORECAST_REDO_LS_LITTLE]]
+        inherit = LONGBRIEF_FORECAST_REDO_LS
+    [[LONGBRIEF_FORECAST_REDO_LS_BIGGER]]
+        inherit = LONGBRIEF_FORECAST_REDO_LS
+    [[LONGBRIEF_FORECAST_REDO_LS_SCREEN]]
+        inherit = LONGBRIEF_FORECAST_REDO_LS
+    [[LONG_ASSIMILATION_LOOK_AT]]
+        inherit = LONG, INSTALL_DIAG, LONG_RES
+    [[BRIEF_ASSIMILATION_LOOK_AT]]
+        inherit = BRIEF, INSTALL_DIAG, BRIEF_RES
+    [[LONGBRIEF_ASSIMILATION_LOOK_AT_LITTLE]]
+    [[LONGBRIEF_ASSIMILATION_LOOK_AT_BIGGER]]
+    [[LONG_HPC]]
+    [[BRIEF_HPC]]
+    [[LONG_RES]]
+        inherit = LONG_HPC
+    [[BRIEF_RES]]
+        inherit = BRIEF_HPC
+    [[long_archive_long, long_archive_short]]
+        inherit = LONG, ARCHIVE, HPC, LONG_HPC, CORETYPE_SHARED
+    [[brief_archive]]
+        inherit = BRIEF, ARCHIVE, HPC, BRIEF_HPC, CORETYPE_SHARED
+    [[longbrief_install_startdata_cold]]
+        inherit = COLD_START, HPC, CORETYPE_SHARED
+    [[brief_start]]
+        inherit = BRIEF, HPC, BRIEF_HPC, CORETYPE_SHARED
+    [[long_start]]
+        inherit = LONG, HPC, LONG_HPC, CORETYPE_SHARED
+    [[long_observations_background_atmos]]
+        inherit = LONG_OBS, OBS_PARALLEL, LONG_RES
+    [[brief_observations_background_atmos]]
+        inherit = BRIEF_OBS, OBS_PARALLEL, BRIEF_RES
+    [[brief_observations_process_background_barn_owl]]
+        inherit = BRIEF_OBSERVATIONS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_process_look_at_barn_owl]]
+        inherit = BRIEF_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_background_barn_owl]]
+        inherit = LONG_OBS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_look_at_barn_owl]]
+        inherit = LONG_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_db_stuff_barn_owl]]
+        inherit = BRIEF_OBS_DB_STUFF, OBS_SHARED
+    [[brief_observations_process_background_avocet]]
+        inherit = BRIEF_OBSERVATIONS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_process_look_at_avocet]]
+        inherit = BRIEF_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_background_avocet]]
+        inherit = LONG_OBS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_look_at_avocet]]
+        inherit = LONG_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_db_stuff_avocet]]
+        inherit = BRIEF_OBS_DB_STUFF, OBS_SHARED
+    [[brief_observations_process_background_chaffinch]]
+        inherit = BRIEF_OBSERVATIONS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_process_look_at_chaffinch]]
+        inherit = BRIEF_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_background_chaffinch]]
+        inherit = LONG_OBS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_look_at_chaffinch]]
+        inherit = LONG_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_db_stuff_chaffinch]]
+        inherit = BRIEF_OBS_DB_STUFF, OBS_SHARED
+    [[brief_observations_process_background_egret]]
+        inherit = BRIEF_OBSERVATIONS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_process_look_at_egret]]
+        inherit = BRIEF_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_background_egret]]
+        inherit = LONG_OBS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_look_at_egret]]
+        inherit = LONG_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_db_stuff_egret]]
+        inherit = BRIEF_OBS_DB_STUFF, OBS_SHARED
+    [[brief_observations_process_background_dipper]]
+        inherit = BRIEF_OBSERVATIONS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_process_look_at_dipper]]
+        inherit = BRIEF_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_background_dipper]]
+        inherit = LONG_OBS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_look_at_dipper]]
+        inherit = LONG_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_db_stuff_dipper]]
+        inherit = BRIEF_OBS_DB_STUFF, OBS_SHARED
+    [[brief_observations_process_background_gannet]]
+        inherit = BRIEF_OBSERVATIONS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_process_look_at_gannet]]
+        inherit = BRIEF_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_background_gannet]]
+        inherit = LONG_OBS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_look_at_gannet]]
+        inherit = LONG_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_db_stuff_gannet]]
+        inherit = BRIEF_OBS_DB_STUFF, OBS_SHARED
+    [[brief_observations_process_background_fulmar]]
+        inherit = BRIEF_OBSERVATIONS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_process_look_at_fulmar]]
+        inherit = BRIEF_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_background_fulmar]]
+        inherit = LONG_OBS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_look_at_fulmar]]
+        inherit = LONG_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_db_stuff_fulmar]]
+        inherit = BRIEF_OBS_DB_STUFF, OBS_SHARED
+    [[brief_observations_process_background_house_martin]]
+        inherit = BRIEF_OBSERVATIONS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_process_look_at_house_martin]]
+        inherit = BRIEF_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_background_house_martin]]
+        inherit = LONG_OBS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_look_at_house_martin]]
+        inherit = LONG_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_db_stuff_house_martin]]
+        inherit = BRIEF_OBS_DB_STUFF, OBS_SHARED
+    [[brief_observations_process_background_iceland_gull]]
+        inherit = BRIEF_OBSERVATIONS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_process_look_at_iceland_gull]]
+        inherit = BRIEF_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_background_iceland_gull]]
+        inherit = LONG_OBS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_look_at_iceland_gull]]
+        inherit = LONG_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_db_stuff_iceland_gull]]
+        inherit = BRIEF_OBS_DB_STUFF, OBS_SHARED
+    [[brief_observations_process_background_jackdaw]]
+        inherit = BRIEF_OBSERVATIONS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_process_look_at_jackdaw]]
+        inherit = BRIEF_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_background_jackdaw]]
+        inherit = LONG_OBS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_look_at_jackdaw]]
+        inherit = LONG_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_db_stuff_jackdaw]]
+        inherit = BRIEF_OBS_DB_STUFF, OBS_SHARED
+    [[brief_observations_process_background_kestrel]]
+        inherit = BRIEF_OBSERVATIONS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_process_look_at_kestrel]]
+        inherit = BRIEF_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_background_kestrel]]
+        inherit = LONG_OBS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_look_at_kestrel]]
+        inherit = LONG_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_db_stuff_kestrel]]
+        inherit = BRIEF_OBS_DB_STUFF, OBS_SHARED
+    [[brief_observations_process_background_lapwing]]
+        inherit = BRIEF_OBSERVATIONS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_process_look_at_lapwing]]
+        inherit = BRIEF_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_background_lapwing]]
+        inherit = LONG_OBS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_look_at_lapwing]]
+        inherit = LONG_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_db_stuff_lapwing]]
+        inherit = BRIEF_OBS_DB_STUFF, OBS_SHARED
+    [[brief_observations_process_background_mallard]]
+        inherit = BRIEF_OBSERVATIONS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_process_look_at_mallard]]
+        inherit = BRIEF_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_background_mallard]]
+        inherit = LONG_OBS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_look_at_mallard]]
+        inherit = LONG_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_db_stuff_mallard]]
+        inherit = BRIEF_OBS_DB_STUFF, OBS_SHARED
+    [[brief_observations_process_background_nightjar]]
+        inherit = BRIEF_OBSERVATIONS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_process_look_at_nightjar]]
+        inherit = BRIEF_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_background_nightjar]]
+        inherit = LONG_OBS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_look_at_nightjar]]
+        inherit = LONG_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_db_stuff_nightjar]]
+        inherit = BRIEF_OBS_DB_STUFF, OBS_SHARED
+    [[brief_observations_process_background_osprey]]
+        inherit = BRIEF_OBSERVATIONS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_process_look_at_osprey]]
+        inherit = BRIEF_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_background_osprey]]
+        inherit = LONG_OBS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_look_at_osprey]]
+        inherit = LONG_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_db_stuff_osprey]]
+        inherit = BRIEF_OBS_DB_STUFF, OBS_SHARED
+    [[brief_observations_process_background_pheasant]]
+        inherit = BRIEF_OBSERVATIONS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_process_look_at_pheasant]]
+        inherit = BRIEF_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_background_pheasant]]
+        inherit = LONG_OBS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_look_at_pheasant]]
+        inherit = LONG_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_db_stuff_pheasant]]
+        inherit = BRIEF_OBS_DB_STUFF, OBS_SHARED
+    [[brief_observations_process_background_quail]]
+        inherit = BRIEF_OBSERVATIONS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_process_look_at_quail]]
+        inherit = BRIEF_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_background_quail]]
+        inherit = LONG_OBS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_look_at_quail]]
+        inherit = LONG_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_db_stuff_quail]]
+        inherit = BRIEF_OBS_DB_STUFF, OBS_SHARED
+    [[brief_observations_process_background_raven]]
+        inherit = BRIEF_OBSERVATIONS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_process_look_at_raven]]
+        inherit = BRIEF_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_background_raven]]
+        inherit = LONG_OBS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_look_at_raven]]
+        inherit = LONG_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_db_stuff_raven]]
+        inherit = BRIEF_OBS_DB_STUFF, OBS_SHARED
+    [[brief_observations_process_background_shelduck]]
+        inherit = BRIEF_OBSERVATIONS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_process_look_at_shelduck]]
+        inherit = BRIEF_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_background_shelduck]]
+        inherit = LONG_OBS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_look_at_shelduck]]
+        inherit = LONG_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_db_stuff_shelduck]]
+        inherit = BRIEF_OBS_DB_STUFF, OBS_SHARED
+    [[brief_observations_process_background_teal]]
+        inherit = BRIEF_OBSERVATIONS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_process_look_at_teal]]
+        inherit = BRIEF_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_background_teal]]
+        inherit = LONG_OBS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_look_at_teal]]
+        inherit = LONG_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_db_stuff_teal]]
+        inherit = BRIEF_OBS_DB_STUFF, OBS_SHARED
+    [[brief_observations_process_background_velvet_scoter]]
+        inherit = BRIEF_OBSERVATIONS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_process_look_at_velvet_scoter]]
+        inherit = BRIEF_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_background_velvet_scoter]]
+        inherit = LONG_OBS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_look_at_velvet_scoter]]
+        inherit = LONG_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_db_stuff_velvet_scoter]]
+        inherit = BRIEF_OBS_DB_STUFF, OBS_SHARED
+    [[brief_observations_process_background_wagtail]]
+        inherit = BRIEF_OBSERVATIONS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_process_look_at_wagtail]]
+        inherit = BRIEF_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_background_wagtail]]
+        inherit = LONG_OBS_PROCESS_BACKGROUND, OBS_PARALLEL, RETRY_TASK
+    [[long_observations_process_look_at_wagtail]]
+        inherit = LONG_OBS_PROCESS_LOOK_AT, OBS_PARALLEL, RETRY_TASK
+    [[brief_observations_db_stuff_wagtail]]
+        inherit = BRIEF_OBS_DB_STUFF, OBS_SHARED
+    [[brief_observations_db_stuff_wagtail]]
+        inherit = BRIEF_OBS_DB_STUFF, OBS_SHARED
+    [[long_observations_db_stuff_wagtail]]
+        inherit = LONG_OBS_DB_STUFF, OBS_SHARED
+    [[brief_observations_process_screen]]
+        inherit = BRIEF_OBS, BRIEF_OBS_ENVIRONMENT, OBS_PARALLEL, BRIEF_RES
+    [[brief_wagtail_filter]]
+        inherit = BRIEF_SURFACE, BRIEF_RES, SURFACE_PARALLEL
+    [[brief_wagtail_look_at_wagtail_ice]]
+        inherit = BRIEF_SURFACE, BRIEF_RES, SURFACE_PARALLEL
+    [[brief_wagtail_forecast_landsim]]
+        inherit = BRIEF_SURFACE, BRIEF_RES, SURFACE_PARALLEL
+    [[brief_wagtail_landsim]]
+        inherit = BRIEF_SURFACE_LANDSIM, BRIEF_SURFACE, HPC
+    [[brief_wagtail_look_at_snow]]
+        inherit = BRIEF_SURFACE, BRIEF_RES, RETRY_TASK, SURFACE_PARALLEL
+    [[brief_wagtail_aintree_filter]]
+        inherit = BRIEF_SURFACE, BRIEF_RES, RETRY_TASK, SURFACE_PARALLEL
+    [[long_forecast_long]]
+        inherit = LONG_FORECAST, FORECAST_PARALLEL, LONG_FORECAST_LONG
+    [[long_forecast_short]]
+        inherit = LONG_FORECAST, FORECAST_PARALLEL, LONG_FORECAST_SHORT
+    [[brief_forecast]]
+        inherit = BRIEF_FORECAST, FORECAST_PARALLEL, _MODEL
+    [[brief_forecast_redo_daily]]
+        inherit = BRIEF_FORECAST, FORECAST_PARALLEL, LONGBRIEF_FORECAST_REDO
+    [[long_assimilation_look_at_little]]
+        inherit = LONG_ASSIMILATION_LOOK_AT, LONGBRIEF_ASSIMILATION_LOOK_AT_LITTLE, ASSIMILATION_PARALLEL
+    [[long_assimilation_look_at_larger]]
+        inherit = LONG_ASSIMILATION_LOOK_AT, LONGBRIEF_ASSIMILATION_LOOK_AT_BIGGER, ASSIMILATION_PARALLEL
+    [[brief_assimilation_look_at_little]]
+        inherit = BRIEF_ASSIMILATION_LOOK_AT, LONGBRIEF_ASSIMILATION_LOOK_AT_LITTLE, ASSIMILATION_PARALLEL
+    [[brief_assimilation_look_at_larger]]
+        inherit = BRIEF_ASSIMILATION_LOOK_AT, LONGBRIEF_ASSIMILATION_LOOK_AT_BIGGER, ASSIMILATION_PARALLEL
+    [[brief_assimilation_look_at_screen]]
+        inherit = BRIEF_ASSIMILATION_LOOK_AT, ASSIMILATION_PARALLEL
+    [[brief_forecast_redo_ls_little]]
+        inherit = LONGBRIEF_FORECAST_REDO_LS_LITTLE, HPC, LONGBRIEF_FORECAST_REDO
+    [[brief_forecast_redo_ls_larger]]
+        inherit = LONGBRIEF_FORECAST_REDO_LS_BIGGER, HPC, LONGBRIEF_FORECAST_REDO
+    [[brief_forecast_redo_ls_screen]]
+        inherit = LONGBRIEF_FORECAST_REDO_LS_SCREEN, HPC, LONGBRIEF_FORECAST_REDO
+    [[long_forecast_create_zap_little]]
+        inherit = LONGBRIEF_FORECAST_CREATE_ZAP_LITTLE
+    [[long_forecast_create_zap_larger]]
+        inherit = LONGBRIEF_FORECAST_CREATE_ZAP_BIGGER
+    [[long_assimilation_create_zap_little]]
+        inherit = LONG_ASSIMILATION_ZAP
+    [[long_assimilation_create_zap_larger]]
+        inherit = LONG_ASSIMILATION_ZAP
+    [[long_verificationmodel_database]]
+        inherit = LONG, LONG_HPC, VERIFICATIONMODEL_SHARED
+    [[long_verificationmodel_database_short]]
+        inherit = LONG, LONG_HPC, VERIFICATIONMODEL_SHARED
+    [[brief_verificationmodel_database]]
+        inherit = BRIEF, BRIEF_HPC, VERIFICATIONMODEL_SHARED
+[runtime]
+    [[LONG_FORECAST_TRIGGER]]
+        inherit = LONG, HPC, CORETYPE_SHARED
+    [[BRIEF_FORECAST_TRIGGER]]
+        inherit = BRIEF, HPC, CORETYPE_SHARED
+    [[LONG_SUBJOB]]
+        inherit = LONG, HPC, LONG_HPC, CORETYPE_SHARED
+    [[BRIEF_SUBJOB]]
+        inherit = BRIEF, HPC, BRIEF_HPC, CORETYPE_SHARED
+    [[LONG_DISPERSION]]
+        inherit = LONG, HPC, LONG_HPC
+    [[LONG_DISPERSION_PROC]]
+        inherit = LONG, HPC, LONG_HPC
+    [[LONG_DISPERSION_ARCHIVING]]
+        inherit = LONG, HPC, LONG_HPC
+    [[LONG_DISPERSION_HOUSEKEEPING]]
+        inherit = LONG, HPC, LONG_HPC
+    [[LONG_MIRROR]]
+        inherit = LONG, HPC, LONG_HPC, CORETYPE_SHARED
+    [[BRIEF_MIRROR]]
+        inherit = BRIEF, HPC, BRIEF_HPC, CORETYPE_SHARED
+    [[long_local_preflight_checks, long_local]]
+        inherit = LONG, HPC, LONG_HPC, CORETYPE_SHARED
+        inherit = LONG, HPC, LONG_HPC
+    [[long_bigleftright]]
+        inherit = LONG, HPC, LONG_HPC, CORETYPE_SHARED
+        inherit = LONG, HPC, LONG_HPC
+    [[long_happyland_ingest]]
+        inherit = LONG, HPC, LONG_HPC, CORETYPE_SHARED
+    [[long_bogus_listing]]
+        inherit = LONG, HPC, LONG_HPC, CORETYPE_SHARED
+    [[brief_bogus_listing]]
+        inherit = BRIEF, HPC, BRIEF_HPC, CORETYPE_SHARED
+    [[long_dispersion_tF]]
+        inherit = LONG_DISPERSION
+    [[long_dispersion_tB6]]
+        inherit = LONG_DISPERSION
+    [[long_dispersion_tBD]]
+        inherit = LONG_DISPERSION
+    [[long_dispersion_tKA]]
+        inherit = LONG_DISPERSION
+    [[long_dispersion_tL]]
+        inherit = LONG_DISPERSION
+    [[long_dispersion_tZC]]
+        inherit = LONG_DISPERSION
+    [[long_dispersion_tZG]]
+        inherit = LONG_DISPERSION
+    [[long_dispersion_tZM]]
+        inherit = LONG_DISPERSION
+    [[long_dispersion_clock]]
+        inherit = LONG_DISPERSION
+    [[long_dispersion_proc_tD]]
+        inherit = LONG_DISPERSION_PROC
+    [[long_dispersion_proc_tH]]
+        inherit = LONG_DISPERSION_PROC
+    [[long_dispersion_proc_tB6]]
+        inherit = LONG_DISPERSION_PROC
+    [[long_dispersion_proc_tJ]]
+        inherit = LONG_DISPERSION_PROC
+    [[long_dispersion_proc_tC0]]
+        inherit = LONG_DISPERSION_PROC
+    [[long_dispersion_proc_tKA]]
+        inherit = LONG_DISPERSION_PROC
+    [[long_dispersion_proc_tKE]]
+        inherit = LONG_DISPERSION_PROC
+    [[long_dispersion_proc_tZG]]
+        inherit = LONG_DISPERSION_PROC
+    [[long_dispersion_proc_tZC]]
+        inherit = LONG_DISPERSION_PROC
+    [[long_dispersion_proc_tL]]
+        inherit = LONG_DISPERSION_PROC
+    [[long_dispersion_proc_tN]]
+        inherit = LONG_DISPERSION_PROC
+    [[long_dispersion_proc_tZM]]
+        inherit = LONG_DISPERSION_PROC
+    [[long_dispersion_proc_tZP]]
+        inherit = LONG_DISPERSION_PROC
+    [[long_dispersion_proc_tZT]]
+        inherit = LONG_DISPERSION_PROC
+    [[long_dispersion_proc_completed]]
+        inherit = LONG_DISPERSION_HOUSEKEEPING
+    [[long_dispersion_archive_prep]]
+        inherit = LONG_DISPERSION_ARCHIVING
+    [[long_dispersion_archive]]
+        inherit = LONG_DISPERSION_ARCHIVING
+    [[long_dispersion_archive_forecast]]
+        inherit = LONG, LOCAL
+    [[long_dispersion_prune_forecast]]
+        inherit = LONG_DISPERSION_HOUSEKEEPING
+    [[long_dispersion_housekeep]]
+        inherit = LONG_DISPERSION_HOUSEKEEPING
+    [[long_thunderbirds_are_go]]
+        inherit = LONG, HPC, LONG_HPC
+    [[long_send_stingray_stingray]]
+        inherit = LONG, HPC, LONG_HPC, CORETYPE_SHARED
+    [[long_sync_main, long_sync_forecast, long_sync_verification]]
+        inherit = LONG_MIRROR
+    [[long_sync_happy]]
+        inherit = LONG_MIRROR
+    [[long_sync_forecast_tC]]
+        inherit = LONG_MIRROR
+    [[long_sync_forecast_tJ]]
+        inherit = LONG_MIRROR
+    [[brief_sync_main, brief_sync_forecast, brief_sync_verification]]
+        inherit = BRIEF_MIRROR
+    [[brief_sync_happy]]
+        inherit = BRIEF_MIRROR
+    [[brief_hpc_backup_daily]]
+        inherit = BRIEF, HPC, BRIEF_HPC, CORETYPE_SHARED
+    [[long_user_hook]]
+        inherit = LONG, HPC, LONG_HPC, CORETYPE_SHARED
+    [[brief_user_hook]]
+        inherit = BRIEF, HPC, BRIEF_HPC, CORETYPE_SHARED
+    [[long_verificationmodel_database_induced]]
+        inherit = LONG, VERIFICATIONMODEL_SHARED
+    [[long_verificationmodel_database_induced_short]]
+        inherit = LONG, VERIFICATIONMODEL_SHARED
+    [[brief_verificationmodel_database_induced]]
+        inherit = BRIEF, VERIFICATIONMODEL_SHARED
+    [[brief_observations_merge_background]]
+        inherit = BRIEF_OBS, OBS_PARALLEL, BRIEF_HPC
+    [[brief_observations_merge_look_at]]
+        inherit = BRIEF_OBS, OBS_PARALLEL, BRIEF_HPC
+    [[brief_observations_wagtail_background, brief_observations_wagtail_look_at]]
+        inherit = BRIEF_OBS, OBS_PARALLEL, BRIEF_HPC
+    [[brief_observations_process_wagtail_background]]
+        inherit = BRIEF_OBS, OBS_PARALLEL, BRIEF_HPC
+    [[brief_observations_process_wagtail_look_at]]
+        inherit = BRIEF_OBS, OBS_PARALLEL, BRIEF_HPC
+    [[long_start_00, long_start_06, long_start_12, long_start_18]]
+        inherit = LONG, OS_START
+    [[brief_start_00, brief_start_06, brief_start_12, brief_start_18]]
+        inherit = BRIEF, OS_START
+    [[long_res_create]]
+        inherit = OS_RES_CREATE, LONG_HPC
+    [[brief_res_create]]
+        inherit = OS_RES_CREATE, BRIEF_HPC
+    [[long_res_delete]]
+        inherit = OS_RES_DELETE, LONG_HPC
+    [[brief_res_delete]]
+        inherit = OS_RES_DELETE, BRIEF_HPC
+    [[long_forecast_tA]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tB]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tC]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tD]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tD]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tE]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tF]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tG]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tH]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tI]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tB0]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tB3]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tB6]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tB9]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tBA]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tBB]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tJ]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tBC]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tBD]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tBE]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tC0]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tC3]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tC6]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tK]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tKA]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tKB]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tKC]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tKD]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tKE]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tKF]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tL]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tZF]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tZG]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tZH]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tZA]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tZB]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tZC]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tM]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tZD]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tZE]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tL]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tZF]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tZG]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tZH]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tN]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tZI]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tZJ]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tZK]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tZM]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tZN]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tZO]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tO]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tZP]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tZQ]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tZR]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tZS]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[long_forecast_tZT]]
+        inherit = LONG_FORECAST_TRIGGER, LONG_HPC
+    [[brief_forecast_tA]]
+        inherit = BRIEF_FORECAST_TRIGGER, BRIEF_HPC
+    [[brief_forecast_tB]]
+        inherit = BRIEF_FORECAST_TRIGGER, BRIEF_HPC
+    [[brief_forecast_tC]]
+        inherit = BRIEF_FORECAST_TRIGGER, BRIEF_HPC
+    [[brief_forecast_tD]]
+        inherit = BRIEF_FORECAST_TRIGGER, BRIEF_HPC
+    [[long_forecast_end]]
+        inherit = LONG_FORECAST_TRIGGER, LOCAL
+    [[brief_forecast_end]]
+        inherit = BRIEF_FORECAST_TRIGGER, LOCAL
+    [[long_forecast_subjob_tA]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tB]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tC]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tD]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tD]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tE]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tF]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tG]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tH]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tI]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tB0]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tB3]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tB6]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tB9]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tBA]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tBB]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tJ]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tBC]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tBD]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tBE]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tC0]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tC3]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tC6]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tK]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tKA]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tKB]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tKC]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tKD]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tKE]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tKF]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tL]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tZF]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tZG]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tZH]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tZA]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tZB]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tZC]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tM]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tZD]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tZE]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tL]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tZF]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tZG]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tZH]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tN]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tZI]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tZJ]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tZK]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tZM]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tZN]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tZO]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tO]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tZP]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tZQ]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tZR]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tZS]]
+        inherit = LONG_SUBJOB
+    [[long_forecast_subjob_tZT]]
+        inherit = LONG_SUBJOB
+    [[brief_forecast_subjob_tA]]
+        inherit = BRIEF_SUBJOB
+    [[brief_forecast_subjob_tB]]
+        inherit = BRIEF_SUBJOB
+    [[brief_forecast_subjob_tC]]
+        inherit = BRIEF_SUBJOB
+    [[brief_forecast_subjob_tD]]
+        inherit = BRIEF_SUBJOB
+[scheduling]
+    [[queues]]
+        [[[ENSEMBLELIMIT]]]
+            limit = 3
+            members = ENSEMBLE_FORECAST_SHRT
+        [[[ENSEMBLEOBSLIMIT]]]
+            limit = 20
+            members = ENSEMBLE_OBS
+    [[dependencies]]
+        [[[ T00 ]]]
+            graph = """
+                ensemble_res_create & ensembles_res_create => ensemble_start_00  => ensemble_start
+            """
+        [[[ T06 ]]]
+            graph = """
+                ensemble_res_create & ensembles_res_create => ensemble_start_06  => ensemble_start
+            """
+        [[[ T12 ]]]
+            graph = """
+                ensemble_res_create & ensembles_res_create => ensemble_start_12  => ensemble_start
+            """
+        [[[ T18 ]]]
+            graph = """
+                ensemble_res_create & ensembles_res_create => ensemble_start_18  => ensemble_start
+            """
+        [[[ T00, T12 ]]]
+            graph = """
+                  ensemble_ens_wiggle              => ensemble_forecast_long_001
+                  ensemble_forecast_long_001      => ensemble_verificationmodel_database
+                  ensemble_forecast_long_001      => ensemble_res_delete
+                ensemble_forecast_long_001        => ensemble_forecast_end
+                ensemble_forecast_long_001:start \
+                                                 => ensemble_forecast_001_tC \
+                                                 => ensemble_forecast_001_tI \
+                                                 => ensemble_forecast_001_tJ \
+                                                 => ensemble_forecast_001_tK \
+                                                 => ensemble_forecast_001_tL \
+                                                 => ensemble_forecast_001_tM \
+                                                 => ensemble_forecast_001_tN \
+                                                 => ensemble_forecast_001_tO \
+                                                 => ensemble_forecast_001_tP \
+                                                 => housekeep
+                ensemble_forecast_001_tC      => ensemble_forecast_subjob_001_tC \
+                                                 => ensemble_forecast_subjob_001_sdfk & ensemble_forecast_subjob_001_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_001 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_001_tI      => ensemble_forecast_subjob_001_tI \
+                                                 => ensemble_forecast_subjob_001_sdfk & ensemble_forecast_subjob_001_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_001 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_001_tJ      => ensemble_forecast_subjob_001_tJ \
+                                                 => ensemble_forecast_subjob_001_sdfk & ensemble_forecast_subjob_001_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_001 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_001_tK      => ensemble_forecast_subjob_001_tK \
+                                                 => ensemble_forecast_subjob_001_sdfk & ensemble_forecast_subjob_001_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_001 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_001_tL      => ensemble_forecast_subjob_001_tL \
+                                                 => ensemble_forecast_subjob_001_sdfk & ensemble_forecast_subjob_001_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_001 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_001_tM      => ensemble_forecast_subjob_001_tM \
+                                                 => ensemble_forecast_subjob_001_sdfk & ensemble_forecast_subjob_001_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_001 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_001_tN      => ensemble_forecast_subjob_001_tN \
+                                                 => ensemble_forecast_subjob_001_sdfk & ensemble_forecast_subjob_001_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_001 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_001_tO      => ensemble_forecast_subjob_001_tO \
+                                                 => ensemble_forecast_subjob_001_sdfk & ensemble_forecast_subjob_001_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_001 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_001_tP      => ensemble_forecast_subjob_001_tP \
+                                                 => ensemble_forecast_subjob_001_sdfk & ensemble_forecast_subjob_001_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_001 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_long_001        => ensemble_forecast_subjob_001_sdfk \
+                                                 => ensemble_local & ensemble_downscale & ensemble_subjob_hook
+                ensemble_forecast_001_tK           => ensemble_forecast_all_tK
+                ensemble_forecast_001_tC            => ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_long_002
+                  ensemble_forecast_long_002      => ensemble_verificationmodel_database
+                  ensemble_forecast_long_002      => ensemble_res_delete
+                ensemble_forecast_long_002        => ensemble_forecast_end
+                ensemble_forecast_long_002:start \
+                                                 => ensemble_forecast_002_tC \
+                                                 => ensemble_forecast_002_tI \
+                                                 => ensemble_forecast_002_tJ \
+                                                 => ensemble_forecast_002_tK \
+                                                 => ensemble_forecast_002_tL \
+                                                 => ensemble_forecast_002_tM \
+                                                 => ensemble_forecast_002_tN \
+                                                 => ensemble_forecast_002_tO \
+                                                 => ensemble_forecast_002_tP \
+                                                 => housekeep
+                ensemble_forecast_002_tC      => ensemble_forecast_subjob_002_tC \
+                                                 => ensemble_forecast_subjob_002_sdfk & ensemble_forecast_subjob_002_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_002 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_002_tI      => ensemble_forecast_subjob_002_tI \
+                                                 => ensemble_forecast_subjob_002_sdfk & ensemble_forecast_subjob_002_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_002 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_002_tJ      => ensemble_forecast_subjob_002_tJ \
+                                                 => ensemble_forecast_subjob_002_sdfk & ensemble_forecast_subjob_002_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_002 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_002_tK      => ensemble_forecast_subjob_002_tK \
+                                                 => ensemble_forecast_subjob_002_sdfk & ensemble_forecast_subjob_002_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_002 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_002_tL      => ensemble_forecast_subjob_002_tL \
+                                                 => ensemble_forecast_subjob_002_sdfk & ensemble_forecast_subjob_002_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_002 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_002_tM      => ensemble_forecast_subjob_002_tM \
+                                                 => ensemble_forecast_subjob_002_sdfk & ensemble_forecast_subjob_002_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_002 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_002_tN      => ensemble_forecast_subjob_002_tN \
+                                                 => ensemble_forecast_subjob_002_sdfk & ensemble_forecast_subjob_002_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_002 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_002_tO      => ensemble_forecast_subjob_002_tO \
+                                                 => ensemble_forecast_subjob_002_sdfk & ensemble_forecast_subjob_002_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_002 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_002_tP      => ensemble_forecast_subjob_002_tP \
+                                                 => ensemble_forecast_subjob_002_sdfk & ensemble_forecast_subjob_002_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_002 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_long_002        => ensemble_forecast_subjob_002_sdfk \
+                                                 => ensemble_local & ensemble_downscale & ensemble_subjob_hook
+                ensemble_forecast_002_tK           => ensemble_forecast_all_tK
+                ensemble_forecast_002_tC            => ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_long_003
+                  ensemble_forecast_long_003      => ensemble_verificationmodel_database
+                  ensemble_forecast_long_003      => ensemble_res_delete
+                ensemble_forecast_long_003        => ensemble_forecast_end
+                ensemble_forecast_long_003:start \
+                                                 => ensemble_forecast_003_tC \
+                                                 => ensemble_forecast_003_tI \
+                                                 => ensemble_forecast_003_tJ \
+                                                 => ensemble_forecast_003_tK \
+                                                 => ensemble_forecast_003_tL \
+                                                 => ensemble_forecast_003_tM \
+                                                 => ensemble_forecast_003_tN \
+                                                 => ensemble_forecast_003_tO \
+                                                 => ensemble_forecast_003_tP \
+                                                 => housekeep
+                ensemble_forecast_003_tC      => ensemble_forecast_subjob_003_tC \
+                                                 => ensemble_forecast_subjob_003_sdfk & ensemble_forecast_subjob_003_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_003 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_003_tI      => ensemble_forecast_subjob_003_tI \
+                                                 => ensemble_forecast_subjob_003_sdfk & ensemble_forecast_subjob_003_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_003 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_003_tJ      => ensemble_forecast_subjob_003_tJ \
+                                                 => ensemble_forecast_subjob_003_sdfk & ensemble_forecast_subjob_003_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_003 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_003_tK      => ensemble_forecast_subjob_003_tK \
+                                                 => ensemble_forecast_subjob_003_sdfk & ensemble_forecast_subjob_003_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_003 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_003_tL      => ensemble_forecast_subjob_003_tL \
+                                                 => ensemble_forecast_subjob_003_sdfk & ensemble_forecast_subjob_003_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_003 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_003_tM      => ensemble_forecast_subjob_003_tM \
+                                                 => ensemble_forecast_subjob_003_sdfk & ensemble_forecast_subjob_003_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_003 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_003_tN      => ensemble_forecast_subjob_003_tN \
+                                                 => ensemble_forecast_subjob_003_sdfk & ensemble_forecast_subjob_003_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_003 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_003_tO      => ensemble_forecast_subjob_003_tO \
+                                                 => ensemble_forecast_subjob_003_sdfk & ensemble_forecast_subjob_003_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_003 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_003_tP      => ensemble_forecast_subjob_003_tP \
+                                                 => ensemble_forecast_subjob_003_sdfk & ensemble_forecast_subjob_003_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_003 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_long_003        => ensemble_forecast_subjob_003_sdfk \
+                                                 => ensemble_local & ensemble_downscale & ensemble_subjob_hook
+                ensemble_forecast_003_tK           => ensemble_forecast_all_tK
+                ensemble_forecast_003_tC            => ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_long_004
+                  ensemble_forecast_long_004      => ensemble_verificationmodel_database
+                  ensemble_forecast_long_004      => ensemble_res_delete
+                ensemble_forecast_long_004        => ensemble_forecast_end
+                ensemble_forecast_long_004:start \
+                                                 => ensemble_forecast_004_tC \
+                                                 => ensemble_forecast_004_tI \
+                                                 => ensemble_forecast_004_tJ \
+                                                 => ensemble_forecast_004_tK \
+                                                 => ensemble_forecast_004_tL \
+                                                 => ensemble_forecast_004_tM \
+                                                 => ensemble_forecast_004_tN \
+                                                 => ensemble_forecast_004_tO \
+                                                 => ensemble_forecast_004_tP \
+                                                 => housekeep
+                ensemble_forecast_004_tC      => ensemble_forecast_subjob_004_tC \
+                                                 => ensemble_forecast_subjob_004_sdfk & ensemble_forecast_subjob_004_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_004 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_004_tI      => ensemble_forecast_subjob_004_tI \
+                                                 => ensemble_forecast_subjob_004_sdfk & ensemble_forecast_subjob_004_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_004 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_004_tJ      => ensemble_forecast_subjob_004_tJ \
+                                                 => ensemble_forecast_subjob_004_sdfk & ensemble_forecast_subjob_004_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_004 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_004_tK      => ensemble_forecast_subjob_004_tK \
+                                                 => ensemble_forecast_subjob_004_sdfk & ensemble_forecast_subjob_004_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_004 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_004_tL      => ensemble_forecast_subjob_004_tL \
+                                                 => ensemble_forecast_subjob_004_sdfk & ensemble_forecast_subjob_004_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_004 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_004_tM      => ensemble_forecast_subjob_004_tM \
+                                                 => ensemble_forecast_subjob_004_sdfk & ensemble_forecast_subjob_004_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_004 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_004_tN      => ensemble_forecast_subjob_004_tN \
+                                                 => ensemble_forecast_subjob_004_sdfk & ensemble_forecast_subjob_004_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_004 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_004_tO      => ensemble_forecast_subjob_004_tO \
+                                                 => ensemble_forecast_subjob_004_sdfk & ensemble_forecast_subjob_004_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_004 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_004_tP      => ensemble_forecast_subjob_004_tP \
+                                                 => ensemble_forecast_subjob_004_sdfk & ensemble_forecast_subjob_004_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_004 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_long_004        => ensemble_forecast_subjob_004_sdfk \
+                                                 => ensemble_local & ensemble_downscale & ensemble_subjob_hook
+                ensemble_forecast_004_tK           => ensemble_forecast_all_tK
+                ensemble_forecast_004_tC            => ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_long_005
+                  ensemble_forecast_long_005      => ensemble_verificationmodel_database
+                  ensemble_forecast_long_005      => ensemble_res_delete
+                ensemble_forecast_long_005        => ensemble_forecast_end
+                ensemble_forecast_long_005:start \
+                                                 => ensemble_forecast_005_tC \
+                                                 => ensemble_forecast_005_tI \
+                                                 => ensemble_forecast_005_tJ \
+                                                 => ensemble_forecast_005_tK \
+                                                 => ensemble_forecast_005_tL \
+                                                 => ensemble_forecast_005_tM \
+                                                 => ensemble_forecast_005_tN \
+                                                 => ensemble_forecast_005_tO \
+                                                 => ensemble_forecast_005_tP \
+                                                 => housekeep
+                ensemble_forecast_005_tC      => ensemble_forecast_subjob_005_tC \
+                                                 => ensemble_forecast_subjob_005_sdfk & ensemble_forecast_subjob_005_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_005 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_005_tI      => ensemble_forecast_subjob_005_tI \
+                                                 => ensemble_forecast_subjob_005_sdfk & ensemble_forecast_subjob_005_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_005 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_005_tJ      => ensemble_forecast_subjob_005_tJ \
+                                                 => ensemble_forecast_subjob_005_sdfk & ensemble_forecast_subjob_005_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_005 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_005_tK      => ensemble_forecast_subjob_005_tK \
+                                                 => ensemble_forecast_subjob_005_sdfk & ensemble_forecast_subjob_005_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_005 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_005_tL      => ensemble_forecast_subjob_005_tL \
+                                                 => ensemble_forecast_subjob_005_sdfk & ensemble_forecast_subjob_005_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_005 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_005_tM      => ensemble_forecast_subjob_005_tM \
+                                                 => ensemble_forecast_subjob_005_sdfk & ensemble_forecast_subjob_005_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_005 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_005_tN      => ensemble_forecast_subjob_005_tN \
+                                                 => ensemble_forecast_subjob_005_sdfk & ensemble_forecast_subjob_005_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_005 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_005_tO      => ensemble_forecast_subjob_005_tO \
+                                                 => ensemble_forecast_subjob_005_sdfk & ensemble_forecast_subjob_005_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_005 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_005_tP      => ensemble_forecast_subjob_005_tP \
+                                                 => ensemble_forecast_subjob_005_sdfk & ensemble_forecast_subjob_005_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_005 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_long_005        => ensemble_forecast_subjob_005_sdfk \
+                                                 => ensemble_local & ensemble_downscale & ensemble_subjob_hook
+                ensemble_forecast_005_tK           => ensemble_forecast_all_tK
+                ensemble_forecast_005_tC            => ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_long_006
+                  ensemble_forecast_long_006      => ensemble_verificationmodel_database
+                  ensemble_forecast_long_006      => ensemble_res_delete
+                ensemble_forecast_long_006        => ensemble_forecast_end
+                ensemble_forecast_long_006:start \
+                                                 => ensemble_forecast_006_tC \
+                                                 => ensemble_forecast_006_tI \
+                                                 => ensemble_forecast_006_tJ \
+                                                 => ensemble_forecast_006_tK \
+                                                 => ensemble_forecast_006_tL \
+                                                 => ensemble_forecast_006_tM \
+                                                 => ensemble_forecast_006_tN \
+                                                 => ensemble_forecast_006_tO \
+                                                 => ensemble_forecast_006_tP \
+                                                 => housekeep
+                ensemble_forecast_006_tC      => ensemble_forecast_subjob_006_tC \
+                                                 => ensemble_forecast_subjob_006_sdfk & ensemble_forecast_subjob_006_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_006 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_006_tI      => ensemble_forecast_subjob_006_tI \
+                                                 => ensemble_forecast_subjob_006_sdfk & ensemble_forecast_subjob_006_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_006 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_006_tJ      => ensemble_forecast_subjob_006_tJ \
+                                                 => ensemble_forecast_subjob_006_sdfk & ensemble_forecast_subjob_006_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_006 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_006_tK      => ensemble_forecast_subjob_006_tK \
+                                                 => ensemble_forecast_subjob_006_sdfk & ensemble_forecast_subjob_006_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_006 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_006_tL      => ensemble_forecast_subjob_006_tL \
+                                                 => ensemble_forecast_subjob_006_sdfk & ensemble_forecast_subjob_006_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_006 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_006_tM      => ensemble_forecast_subjob_006_tM \
+                                                 => ensemble_forecast_subjob_006_sdfk & ensemble_forecast_subjob_006_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_006 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_006_tN      => ensemble_forecast_subjob_006_tN \
+                                                 => ensemble_forecast_subjob_006_sdfk & ensemble_forecast_subjob_006_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_006 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_006_tO      => ensemble_forecast_subjob_006_tO \
+                                                 => ensemble_forecast_subjob_006_sdfk & ensemble_forecast_subjob_006_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_006 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_006_tP      => ensemble_forecast_subjob_006_tP \
+                                                 => ensemble_forecast_subjob_006_sdfk & ensemble_forecast_subjob_006_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_006 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_long_006        => ensemble_forecast_subjob_006_sdfk \
+                                                 => ensemble_local & ensemble_downscale & ensemble_subjob_hook
+                ensemble_forecast_006_tK           => ensemble_forecast_all_tK
+                ensemble_forecast_006_tC            => ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_long_007
+                  ensemble_forecast_long_007      => ensemble_verificationmodel_database
+                  ensemble_forecast_long_007      => ensemble_res_delete
+                ensemble_forecast_long_007        => ensemble_forecast_end
+                ensemble_forecast_long_007:start \
+                                                 => ensemble_forecast_007_tC \
+                                                 => ensemble_forecast_007_tI \
+                                                 => ensemble_forecast_007_tJ \
+                                                 => ensemble_forecast_007_tK \
+                                                 => ensemble_forecast_007_tL \
+                                                 => ensemble_forecast_007_tM \
+                                                 => ensemble_forecast_007_tN \
+                                                 => ensemble_forecast_007_tO \
+                                                 => ensemble_forecast_007_tP \
+                                                 => housekeep
+                ensemble_forecast_007_tC      => ensemble_forecast_subjob_007_tC \
+                                                 => ensemble_forecast_subjob_007_sdfk & ensemble_forecast_subjob_007_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_007 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_007_tI      => ensemble_forecast_subjob_007_tI \
+                                                 => ensemble_forecast_subjob_007_sdfk & ensemble_forecast_subjob_007_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_007 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_007_tJ      => ensemble_forecast_subjob_007_tJ \
+                                                 => ensemble_forecast_subjob_007_sdfk & ensemble_forecast_subjob_007_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_007 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_007_tK      => ensemble_forecast_subjob_007_tK \
+                                                 => ensemble_forecast_subjob_007_sdfk & ensemble_forecast_subjob_007_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_007 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_007_tL      => ensemble_forecast_subjob_007_tL \
+                                                 => ensemble_forecast_subjob_007_sdfk & ensemble_forecast_subjob_007_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_007 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_007_tM      => ensemble_forecast_subjob_007_tM \
+                                                 => ensemble_forecast_subjob_007_sdfk & ensemble_forecast_subjob_007_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_007 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_007_tN      => ensemble_forecast_subjob_007_tN \
+                                                 => ensemble_forecast_subjob_007_sdfk & ensemble_forecast_subjob_007_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_007 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_007_tO      => ensemble_forecast_subjob_007_tO \
+                                                 => ensemble_forecast_subjob_007_sdfk & ensemble_forecast_subjob_007_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_007 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_007_tP      => ensemble_forecast_subjob_007_tP \
+                                                 => ensemble_forecast_subjob_007_sdfk & ensemble_forecast_subjob_007_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_007 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_long_007        => ensemble_forecast_subjob_007_sdfk \
+                                                 => ensemble_local & ensemble_downscale & ensemble_subjob_hook
+                ensemble_forecast_007_tK           => ensemble_forecast_all_tK
+                ensemble_forecast_007_tC            => ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_long_008
+                  ensemble_forecast_long_008      => ensemble_verificationmodel_database
+                  ensemble_forecast_long_008      => ensemble_res_delete
+                ensemble_forecast_long_008        => ensemble_forecast_end
+                ensemble_forecast_long_008:start \
+                                                 => ensemble_forecast_008_tC \
+                                                 => ensemble_forecast_008_tI \
+                                                 => ensemble_forecast_008_tJ \
+                                                 => ensemble_forecast_008_tK \
+                                                 => ensemble_forecast_008_tL \
+                                                 => ensemble_forecast_008_tM \
+                                                 => ensemble_forecast_008_tN \
+                                                 => ensemble_forecast_008_tO \
+                                                 => ensemble_forecast_008_tP \
+                                                 => housekeep
+                ensemble_forecast_008_tC      => ensemble_forecast_subjob_008_tC \
+                                                 => ensemble_forecast_subjob_008_sdfk & ensemble_forecast_subjob_008_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_008 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_008_tI      => ensemble_forecast_subjob_008_tI \
+                                                 => ensemble_forecast_subjob_008_sdfk & ensemble_forecast_subjob_008_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_008 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_008_tJ      => ensemble_forecast_subjob_008_tJ \
+                                                 => ensemble_forecast_subjob_008_sdfk & ensemble_forecast_subjob_008_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_008 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_008_tK      => ensemble_forecast_subjob_008_tK \
+                                                 => ensemble_forecast_subjob_008_sdfk & ensemble_forecast_subjob_008_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_008 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_008_tL      => ensemble_forecast_subjob_008_tL \
+                                                 => ensemble_forecast_subjob_008_sdfk & ensemble_forecast_subjob_008_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_008 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_008_tM      => ensemble_forecast_subjob_008_tM \
+                                                 => ensemble_forecast_subjob_008_sdfk & ensemble_forecast_subjob_008_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_008 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_008_tN      => ensemble_forecast_subjob_008_tN \
+                                                 => ensemble_forecast_subjob_008_sdfk & ensemble_forecast_subjob_008_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_008 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_008_tO      => ensemble_forecast_subjob_008_tO \
+                                                 => ensemble_forecast_subjob_008_sdfk & ensemble_forecast_subjob_008_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_008 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_008_tP      => ensemble_forecast_subjob_008_tP \
+                                                 => ensemble_forecast_subjob_008_sdfk & ensemble_forecast_subjob_008_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_008 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_long_008        => ensemble_forecast_subjob_008_sdfk \
+                                                 => ensemble_local & ensemble_downscale & ensemble_subjob_hook
+                ensemble_forecast_008_tK           => ensemble_forecast_all_tK
+                ensemble_forecast_008_tC            => ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_long_009
+                  ensemble_forecast_long_009      => ensemble_verificationmodel_database
+                  ensemble_forecast_long_009      => ensemble_res_delete
+                ensemble_forecast_long_009        => ensemble_forecast_end
+                ensemble_forecast_long_009:start \
+                                                 => ensemble_forecast_009_tC \
+                                                 => ensemble_forecast_009_tI \
+                                                 => ensemble_forecast_009_tJ \
+                                                 => ensemble_forecast_009_tK \
+                                                 => ensemble_forecast_009_tL \
+                                                 => ensemble_forecast_009_tM \
+                                                 => ensemble_forecast_009_tN \
+                                                 => ensemble_forecast_009_tO \
+                                                 => ensemble_forecast_009_tP \
+                                                 => housekeep
+                ensemble_forecast_009_tC      => ensemble_forecast_subjob_009_tC \
+                                                 => ensemble_forecast_subjob_009_sdfk & ensemble_forecast_subjob_009_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_009 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_009_tI      => ensemble_forecast_subjob_009_tI \
+                                                 => ensemble_forecast_subjob_009_sdfk & ensemble_forecast_subjob_009_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_009 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_009_tJ      => ensemble_forecast_subjob_009_tJ \
+                                                 => ensemble_forecast_subjob_009_sdfk & ensemble_forecast_subjob_009_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_009 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_009_tK      => ensemble_forecast_subjob_009_tK \
+                                                 => ensemble_forecast_subjob_009_sdfk & ensemble_forecast_subjob_009_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_009 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_009_tL      => ensemble_forecast_subjob_009_tL \
+                                                 => ensemble_forecast_subjob_009_sdfk & ensemble_forecast_subjob_009_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_009 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_009_tM      => ensemble_forecast_subjob_009_tM \
+                                                 => ensemble_forecast_subjob_009_sdfk & ensemble_forecast_subjob_009_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_009 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_009_tN      => ensemble_forecast_subjob_009_tN \
+                                                 => ensemble_forecast_subjob_009_sdfk & ensemble_forecast_subjob_009_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_009 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_009_tO      => ensemble_forecast_subjob_009_tO \
+                                                 => ensemble_forecast_subjob_009_sdfk & ensemble_forecast_subjob_009_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_009 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_009_tP      => ensemble_forecast_subjob_009_tP \
+                                                 => ensemble_forecast_subjob_009_sdfk & ensemble_forecast_subjob_009_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_009 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_long_009        => ensemble_forecast_subjob_009_sdfk \
+                                                 => ensemble_local & ensemble_downscale & ensemble_subjob_hook
+                ensemble_forecast_009_tK           => ensemble_forecast_all_tK
+                ensemble_forecast_009_tC            => ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_long_010
+                  ensemble_forecast_long_010      => ensemble_verificationmodel_database
+                  ensemble_forecast_long_010      => ensemble_res_delete
+                ensemble_forecast_long_010        => ensemble_forecast_end
+                ensemble_forecast_long_010:start \
+                                                 => ensemble_forecast_010_tC \
+                                                 => ensemble_forecast_010_tI \
+                                                 => ensemble_forecast_010_tJ \
+                                                 => ensemble_forecast_010_tK \
+                                                 => ensemble_forecast_010_tL \
+                                                 => ensemble_forecast_010_tM \
+                                                 => ensemble_forecast_010_tN \
+                                                 => ensemble_forecast_010_tO \
+                                                 => ensemble_forecast_010_tP \
+                                                 => housekeep
+                ensemble_forecast_010_tC      => ensemble_forecast_subjob_010_tC \
+                                                 => ensemble_forecast_subjob_010_sdfk & ensemble_forecast_subjob_010_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_010 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_010_tI      => ensemble_forecast_subjob_010_tI \
+                                                 => ensemble_forecast_subjob_010_sdfk & ensemble_forecast_subjob_010_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_010 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_010_tJ      => ensemble_forecast_subjob_010_tJ \
+                                                 => ensemble_forecast_subjob_010_sdfk & ensemble_forecast_subjob_010_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_010 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_010_tK      => ensemble_forecast_subjob_010_tK \
+                                                 => ensemble_forecast_subjob_010_sdfk & ensemble_forecast_subjob_010_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_010 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_010_tL      => ensemble_forecast_subjob_010_tL \
+                                                 => ensemble_forecast_subjob_010_sdfk & ensemble_forecast_subjob_010_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_010 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_010_tM      => ensemble_forecast_subjob_010_tM \
+                                                 => ensemble_forecast_subjob_010_sdfk & ensemble_forecast_subjob_010_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_010 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_010_tN      => ensemble_forecast_subjob_010_tN \
+                                                 => ensemble_forecast_subjob_010_sdfk & ensemble_forecast_subjob_010_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_010 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_010_tO      => ensemble_forecast_subjob_010_tO \
+                                                 => ensemble_forecast_subjob_010_sdfk & ensemble_forecast_subjob_010_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_010 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_010_tP      => ensemble_forecast_subjob_010_tP \
+                                                 => ensemble_forecast_subjob_010_sdfk & ensemble_forecast_subjob_010_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_010 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_long_010        => ensemble_forecast_subjob_010_sdfk \
+                                                 => ensemble_local & ensemble_downscale & ensemble_subjob_hook
+                ensemble_forecast_010_tK           => ensemble_forecast_all_tK
+                ensemble_forecast_010_tC            => ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_long_011
+                  ensemble_forecast_long_011      => ensemble_verificationmodel_database
+                  ensemble_forecast_long_011      => ensemble_res_delete
+                ensemble_forecast_long_011        => ensemble_forecast_end
+                ensemble_forecast_long_011:start \
+                                                 => ensemble_forecast_011_tC \
+                                                 => ensemble_forecast_011_tI \
+                                                 => ensemble_forecast_011_tJ \
+                                                 => ensemble_forecast_011_tK \
+                                                 => ensemble_forecast_011_tL \
+                                                 => ensemble_forecast_011_tM \
+                                                 => ensemble_forecast_011_tN \
+                                                 => ensemble_forecast_011_tO \
+                                                 => ensemble_forecast_011_tP \
+                                                 => housekeep
+                ensemble_forecast_011_tC      => ensemble_forecast_subjob_011_tC \
+                                                 => ensemble_forecast_subjob_011_sdfk & ensemble_forecast_subjob_011_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_011 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_011_tI      => ensemble_forecast_subjob_011_tI \
+                                                 => ensemble_forecast_subjob_011_sdfk & ensemble_forecast_subjob_011_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_011 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_011_tJ      => ensemble_forecast_subjob_011_tJ \
+                                                 => ensemble_forecast_subjob_011_sdfk & ensemble_forecast_subjob_011_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_011 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_011_tK      => ensemble_forecast_subjob_011_tK \
+                                                 => ensemble_forecast_subjob_011_sdfk & ensemble_forecast_subjob_011_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_011 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_011_tL      => ensemble_forecast_subjob_011_tL \
+                                                 => ensemble_forecast_subjob_011_sdfk & ensemble_forecast_subjob_011_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_011 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_011_tM      => ensemble_forecast_subjob_011_tM \
+                                                 => ensemble_forecast_subjob_011_sdfk & ensemble_forecast_subjob_011_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_011 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_011_tN      => ensemble_forecast_subjob_011_tN \
+                                                 => ensemble_forecast_subjob_011_sdfk & ensemble_forecast_subjob_011_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_011 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_011_tO      => ensemble_forecast_subjob_011_tO \
+                                                 => ensemble_forecast_subjob_011_sdfk & ensemble_forecast_subjob_011_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_011 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_011_tP      => ensemble_forecast_subjob_011_tP \
+                                                 => ensemble_forecast_subjob_011_sdfk & ensemble_forecast_subjob_011_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_011 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_long_011        => ensemble_forecast_subjob_011_sdfk \
+                                                 => ensemble_local & ensemble_downscale & ensemble_subjob_hook
+                ensemble_forecast_011_tK           => ensemble_forecast_all_tK
+                ensemble_forecast_011_tC            => ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_012
+                  ensemble_forecast_shrt_012      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_012      => ensembles_res_delete            \
+                                                  & ensemble_sync_main          \
+                                                  & ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_013
+                  ensemble_forecast_shrt_013      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_013      => ensembles_res_delete            \
+                                                  & ensemble_sync_main          \
+                                                  & ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_014
+                  ensemble_forecast_shrt_014      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_014      => ensembles_res_delete            \
+                                                  & ensemble_sync_main          \
+                                                  & ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_015
+                  ensemble_forecast_shrt_015      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_015      => ensembles_res_delete            \
+                                                  & ensemble_sync_main          \
+                                                  & ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_016
+                  ensemble_forecast_shrt_016      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_016      => ensembles_res_delete            \
+                                                  & ensemble_sync_main          \
+                                                  & ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_017
+                  ensemble_forecast_shrt_017      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_017      => ensembles_res_delete            \
+                                                  & ensemble_sync_main          \
+                                                  & ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_018
+                  ensemble_forecast_shrt_018      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_018      => ensembles_res_delete            \
+                                                  & ensemble_sync_main          \
+                                                  & ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_019
+                  ensemble_forecast_shrt_019      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_019      => ensembles_res_delete            \
+                                                  & ensemble_sync_main          \
+                                                  & ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_020
+                  ensemble_forecast_shrt_020      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_020      => ensembles_res_delete            \
+                                                  & ensemble_sync_main          \
+                                                  & ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_021
+                  ensemble_forecast_shrt_021      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_021      => ensembles_res_delete            \
+                                                  & ensemble_sync_main          \
+                                                  & ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_022
+                  ensemble_forecast_shrt_022      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_022      => ensembles_res_delete            \
+                                                  & ensemble_sync_main          \
+                                                  & ensemble_sync_forecast_tC
+                ensemble_forecast_end                 => ensemble_res_delete
+                ensemble_forecast_end                 => ensemble_user_hook
+           """
+        [[[ T06, T18 ]]]
+            graph = """
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_001
+                  ensemble_forecast_shrt_001      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_001      => ensembles_res_delete            \
+                                                  & ensemble_sync_main          \
+                                                  & ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_002
+                  ensemble_forecast_shrt_002      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_002      => ensembles_res_delete            \
+                                                  & ensemble_sync_main          \
+                                                  & ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_003
+                  ensemble_forecast_shrt_003      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_003      => ensembles_res_delete            \
+                                                  & ensemble_sync_main          \
+                                                  & ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_004
+                  ensemble_forecast_shrt_004      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_004      => ensembles_res_delete            \
+                                                  & ensemble_sync_main          \
+                                                  & ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_005
+                  ensemble_forecast_shrt_005      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_005      => ensembles_res_delete            \
+                                                  & ensemble_sync_main          \
+                                                  & ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_006
+                  ensemble_forecast_shrt_006      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_006      => ensembles_res_delete            \
+                                                  & ensemble_sync_main          \
+                                                  & ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_007
+                  ensemble_forecast_shrt_007      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_007      => ensembles_res_delete            \
+                                                  & ensemble_sync_main          \
+                                                  & ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_008
+                  ensemble_forecast_shrt_008      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_008      => ensembles_res_delete            \
+                                                  & ensemble_sync_main          \
+                                                  & ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_009
+                  ensemble_forecast_shrt_009      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_009      => ensembles_res_delete            \
+                                                  & ensemble_sync_main          \
+                                                  & ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_010
+                  ensemble_forecast_shrt_010      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_010      => ensembles_res_delete            \
+                                                  & ensemble_sync_main          \
+                                                  & ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_011
+                  ensemble_forecast_shrt_011      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_011      => ensembles_res_delete            \
+                                                  & ensemble_sync_main          \
+                                                  & ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_long_012
+                  ensemble_forecast_long_012      => ensemble_verificationmodel_database
+                  ensemble_forecast_long_012      => ensemble_res_delete
+                  ensemble_forecast_long_012      => ensemble_forecast_end
+                  ensemble_forecast_long_012:start \
+                                                 => ensemble_forecast_012_tC \
+                                                 => ensemble_forecast_012_tI \
+                                                 => ensemble_forecast_012_tJ \
+                                                 => ensemble_forecast_012_tK \
+                                                 => ensemble_forecast_012_tL \
+                                                 => ensemble_forecast_012_tM \
+                                                 => ensemble_forecast_012_tN \
+                                                 => ensemble_forecast_012_tO \
+                                                 => ensemble_forecast_012_tP \
+                                                 => housekeep
+                  ensemble_forecast_012_tC    => ensemble_forecast_subjob_012_tC \
+                                                 => ensemble_forecast_subjob_012_sdfk & ensemble_forecast_subjob_012_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_012 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_012_tI    => ensemble_forecast_subjob_012_tI \
+                                                 => ensemble_forecast_subjob_012_sdfk & ensemble_forecast_subjob_012_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_012 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_012_tJ    => ensemble_forecast_subjob_012_tJ \
+                                                 => ensemble_forecast_subjob_012_sdfk & ensemble_forecast_subjob_012_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_012 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_012_tK    => ensemble_forecast_subjob_012_tK \
+                                                 => ensemble_forecast_subjob_012_sdfk & ensemble_forecast_subjob_012_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_012 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_012_tL    => ensemble_forecast_subjob_012_tL \
+                                                 => ensemble_forecast_subjob_012_sdfk & ensemble_forecast_subjob_012_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_012 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_012_tM    => ensemble_forecast_subjob_012_tM \
+                                                 => ensemble_forecast_subjob_012_sdfk & ensemble_forecast_subjob_012_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_012 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_012_tN    => ensemble_forecast_subjob_012_tN \
+                                                 => ensemble_forecast_subjob_012_sdfk & ensemble_forecast_subjob_012_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_012 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_012_tO    => ensemble_forecast_subjob_012_tO \
+                                                 => ensemble_forecast_subjob_012_sdfk & ensemble_forecast_subjob_012_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_012 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_012_tP    => ensemble_forecast_subjob_012_tP \
+                                                 => ensemble_forecast_subjob_012_sdfk & ensemble_forecast_subjob_012_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_012 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_long_012      => ensemble_forecast_subjob_012_sdfk   \
+                                                 => ensemble_local & ensemble_downscale & ensemble_subjob_hook
+                  ensemble_forecast_012_tK         => ensemble_forecast_all_tK
+                  ensemble_forecast_012_tC          => ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_long_013
+                  ensemble_forecast_long_013      => ensemble_verificationmodel_database
+                  ensemble_forecast_long_013      => ensemble_res_delete
+                  ensemble_forecast_long_013      => ensemble_forecast_end
+                  ensemble_forecast_long_013:start \
+                                                 => ensemble_forecast_013_tC \
+                                                 => ensemble_forecast_013_tI \
+                                                 => ensemble_forecast_013_tJ \
+                                                 => ensemble_forecast_013_tK \
+                                                 => ensemble_forecast_013_tL \
+                                                 => ensemble_forecast_013_tM \
+                                                 => ensemble_forecast_013_tN \
+                                                 => ensemble_forecast_013_tO \
+                                                 => ensemble_forecast_013_tP \
+                                                 => housekeep
+                  ensemble_forecast_013_tC    => ensemble_forecast_subjob_013_tC \
+                                                 => ensemble_forecast_subjob_013_sdfk & ensemble_forecast_subjob_013_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_013 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_013_tI    => ensemble_forecast_subjob_013_tI \
+                                                 => ensemble_forecast_subjob_013_sdfk & ensemble_forecast_subjob_013_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_013 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_013_tJ    => ensemble_forecast_subjob_013_tJ \
+                                                 => ensemble_forecast_subjob_013_sdfk & ensemble_forecast_subjob_013_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_013 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_013_tK    => ensemble_forecast_subjob_013_tK \
+                                                 => ensemble_forecast_subjob_013_sdfk & ensemble_forecast_subjob_013_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_013 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_013_tL    => ensemble_forecast_subjob_013_tL \
+                                                 => ensemble_forecast_subjob_013_sdfk & ensemble_forecast_subjob_013_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_013 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_013_tM    => ensemble_forecast_subjob_013_tM \
+                                                 => ensemble_forecast_subjob_013_sdfk & ensemble_forecast_subjob_013_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_013 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_013_tN    => ensemble_forecast_subjob_013_tN \
+                                                 => ensemble_forecast_subjob_013_sdfk & ensemble_forecast_subjob_013_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_013 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_013_tO    => ensemble_forecast_subjob_013_tO \
+                                                 => ensemble_forecast_subjob_013_sdfk & ensemble_forecast_subjob_013_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_013 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_013_tP    => ensemble_forecast_subjob_013_tP \
+                                                 => ensemble_forecast_subjob_013_sdfk & ensemble_forecast_subjob_013_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_013 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_long_013      => ensemble_forecast_subjob_013_sdfk   \
+                                                 => ensemble_local & ensemble_downscale & ensemble_subjob_hook
+                  ensemble_forecast_013_tK         => ensemble_forecast_all_tK
+                  ensemble_forecast_013_tC          => ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_long_014
+                  ensemble_forecast_long_014      => ensemble_verificationmodel_database
+                  ensemble_forecast_long_014      => ensemble_res_delete
+                  ensemble_forecast_long_014      => ensemble_forecast_end
+                  ensemble_forecast_long_014:start \
+                                                 => ensemble_forecast_014_tC \
+                                                 => ensemble_forecast_014_tI \
+                                                 => ensemble_forecast_014_tJ \
+                                                 => ensemble_forecast_014_tK \
+                                                 => ensemble_forecast_014_tL \
+                                                 => ensemble_forecast_014_tM \
+                                                 => ensemble_forecast_014_tN \
+                                                 => ensemble_forecast_014_tO \
+                                                 => ensemble_forecast_014_tP \
+                                                 => housekeep
+                  ensemble_forecast_014_tC    => ensemble_forecast_subjob_014_tC \
+                                                 => ensemble_forecast_subjob_014_sdfk & ensemble_forecast_subjob_014_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_014 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_014_tI    => ensemble_forecast_subjob_014_tI \
+                                                 => ensemble_forecast_subjob_014_sdfk & ensemble_forecast_subjob_014_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_014 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_014_tJ    => ensemble_forecast_subjob_014_tJ \
+                                                 => ensemble_forecast_subjob_014_sdfk & ensemble_forecast_subjob_014_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_014 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_014_tK    => ensemble_forecast_subjob_014_tK \
+                                                 => ensemble_forecast_subjob_014_sdfk & ensemble_forecast_subjob_014_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_014 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_014_tL    => ensemble_forecast_subjob_014_tL \
+                                                 => ensemble_forecast_subjob_014_sdfk & ensemble_forecast_subjob_014_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_014 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_014_tM    => ensemble_forecast_subjob_014_tM \
+                                                 => ensemble_forecast_subjob_014_sdfk & ensemble_forecast_subjob_014_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_014 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_014_tN    => ensemble_forecast_subjob_014_tN \
+                                                 => ensemble_forecast_subjob_014_sdfk & ensemble_forecast_subjob_014_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_014 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_014_tO    => ensemble_forecast_subjob_014_tO \
+                                                 => ensemble_forecast_subjob_014_sdfk & ensemble_forecast_subjob_014_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_014 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_014_tP    => ensemble_forecast_subjob_014_tP \
+                                                 => ensemble_forecast_subjob_014_sdfk & ensemble_forecast_subjob_014_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_014 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_long_014      => ensemble_forecast_subjob_014_sdfk   \
+                                                 => ensemble_local & ensemble_downscale & ensemble_subjob_hook
+                  ensemble_forecast_014_tK         => ensemble_forecast_all_tK
+                  ensemble_forecast_014_tC          => ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_long_015
+                  ensemble_forecast_long_015      => ensemble_verificationmodel_database
+                  ensemble_forecast_long_015      => ensemble_res_delete
+                  ensemble_forecast_long_015      => ensemble_forecast_end
+                  ensemble_forecast_long_015:start \
+                                                 => ensemble_forecast_015_tC \
+                                                 => ensemble_forecast_015_tI \
+                                                 => ensemble_forecast_015_tJ \
+                                                 => ensemble_forecast_015_tK \
+                                                 => ensemble_forecast_015_tL \
+                                                 => ensemble_forecast_015_tM \
+                                                 => ensemble_forecast_015_tN \
+                                                 => ensemble_forecast_015_tO \
+                                                 => ensemble_forecast_015_tP \
+                                                 => housekeep
+                  ensemble_forecast_015_tC    => ensemble_forecast_subjob_015_tC \
+                                                 => ensemble_forecast_subjob_015_sdfk & ensemble_forecast_subjob_015_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_015 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_015_tI    => ensemble_forecast_subjob_015_tI \
+                                                 => ensemble_forecast_subjob_015_sdfk & ensemble_forecast_subjob_015_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_015 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_015_tJ    => ensemble_forecast_subjob_015_tJ \
+                                                 => ensemble_forecast_subjob_015_sdfk & ensemble_forecast_subjob_015_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_015 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_015_tK    => ensemble_forecast_subjob_015_tK \
+                                                 => ensemble_forecast_subjob_015_sdfk & ensemble_forecast_subjob_015_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_015 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_015_tL    => ensemble_forecast_subjob_015_tL \
+                                                 => ensemble_forecast_subjob_015_sdfk & ensemble_forecast_subjob_015_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_015 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_015_tM    => ensemble_forecast_subjob_015_tM \
+                                                 => ensemble_forecast_subjob_015_sdfk & ensemble_forecast_subjob_015_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_015 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_015_tN    => ensemble_forecast_subjob_015_tN \
+                                                 => ensemble_forecast_subjob_015_sdfk & ensemble_forecast_subjob_015_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_015 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_015_tO    => ensemble_forecast_subjob_015_tO \
+                                                 => ensemble_forecast_subjob_015_sdfk & ensemble_forecast_subjob_015_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_015 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_015_tP    => ensemble_forecast_subjob_015_tP \
+                                                 => ensemble_forecast_subjob_015_sdfk & ensemble_forecast_subjob_015_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_015 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_long_015      => ensemble_forecast_subjob_015_sdfk   \
+                                                 => ensemble_local & ensemble_downscale & ensemble_subjob_hook
+                  ensemble_forecast_015_tK         => ensemble_forecast_all_tK
+                  ensemble_forecast_015_tC          => ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_long_016
+                  ensemble_forecast_long_016      => ensemble_verificationmodel_database
+                  ensemble_forecast_long_016      => ensemble_res_delete
+                  ensemble_forecast_long_016      => ensemble_forecast_end
+                  ensemble_forecast_long_016:start \
+                                                 => ensemble_forecast_016_tC \
+                                                 => ensemble_forecast_016_tI \
+                                                 => ensemble_forecast_016_tJ \
+                                                 => ensemble_forecast_016_tK \
+                                                 => ensemble_forecast_016_tL \
+                                                 => ensemble_forecast_016_tM \
+                                                 => ensemble_forecast_016_tN \
+                                                 => ensemble_forecast_016_tO \
+                                                 => ensemble_forecast_016_tP \
+                                                 => housekeep
+                  ensemble_forecast_016_tC    => ensemble_forecast_subjob_016_tC \
+                                                 => ensemble_forecast_subjob_016_sdfk & ensemble_forecast_subjob_016_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_016 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_016_tI    => ensemble_forecast_subjob_016_tI \
+                                                 => ensemble_forecast_subjob_016_sdfk & ensemble_forecast_subjob_016_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_016 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_016_tJ    => ensemble_forecast_subjob_016_tJ \
+                                                 => ensemble_forecast_subjob_016_sdfk & ensemble_forecast_subjob_016_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_016 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_016_tK    => ensemble_forecast_subjob_016_tK \
+                                                 => ensemble_forecast_subjob_016_sdfk & ensemble_forecast_subjob_016_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_016 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_016_tL    => ensemble_forecast_subjob_016_tL \
+                                                 => ensemble_forecast_subjob_016_sdfk & ensemble_forecast_subjob_016_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_016 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_016_tM    => ensemble_forecast_subjob_016_tM \
+                                                 => ensemble_forecast_subjob_016_sdfk & ensemble_forecast_subjob_016_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_016 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_016_tN    => ensemble_forecast_subjob_016_tN \
+                                                 => ensemble_forecast_subjob_016_sdfk & ensemble_forecast_subjob_016_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_016 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_016_tO    => ensemble_forecast_subjob_016_tO \
+                                                 => ensemble_forecast_subjob_016_sdfk & ensemble_forecast_subjob_016_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_016 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_016_tP    => ensemble_forecast_subjob_016_tP \
+                                                 => ensemble_forecast_subjob_016_sdfk & ensemble_forecast_subjob_016_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_016 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_long_016      => ensemble_forecast_subjob_016_sdfk   \
+                                                 => ensemble_local & ensemble_downscale & ensemble_subjob_hook
+                  ensemble_forecast_016_tK         => ensemble_forecast_all_tK
+                  ensemble_forecast_016_tC          => ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_long_017
+                  ensemble_forecast_long_017      => ensemble_verificationmodel_database
+                  ensemble_forecast_long_017      => ensemble_res_delete
+                  ensemble_forecast_long_017      => ensemble_forecast_end
+                  ensemble_forecast_long_017:start \
+                                                 => ensemble_forecast_017_tC \
+                                                 => ensemble_forecast_017_tI \
+                                                 => ensemble_forecast_017_tJ \
+                                                 => ensemble_forecast_017_tK \
+                                                 => ensemble_forecast_017_tL \
+                                                 => ensemble_forecast_017_tM \
+                                                 => ensemble_forecast_017_tN \
+                                                 => ensemble_forecast_017_tO \
+                                                 => ensemble_forecast_017_tP \
+                                                 => housekeep
+                  ensemble_forecast_017_tC    => ensemble_forecast_subjob_017_tC \
+                                                 => ensemble_forecast_subjob_017_sdfk & ensemble_forecast_subjob_017_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_017 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_017_tI    => ensemble_forecast_subjob_017_tI \
+                                                 => ensemble_forecast_subjob_017_sdfk & ensemble_forecast_subjob_017_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_017 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_017_tJ    => ensemble_forecast_subjob_017_tJ \
+                                                 => ensemble_forecast_subjob_017_sdfk & ensemble_forecast_subjob_017_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_017 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_017_tK    => ensemble_forecast_subjob_017_tK \
+                                                 => ensemble_forecast_subjob_017_sdfk & ensemble_forecast_subjob_017_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_017 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_017_tL    => ensemble_forecast_subjob_017_tL \
+                                                 => ensemble_forecast_subjob_017_sdfk & ensemble_forecast_subjob_017_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_017 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_017_tM    => ensemble_forecast_subjob_017_tM \
+                                                 => ensemble_forecast_subjob_017_sdfk & ensemble_forecast_subjob_017_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_017 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_017_tN    => ensemble_forecast_subjob_017_tN \
+                                                 => ensemble_forecast_subjob_017_sdfk & ensemble_forecast_subjob_017_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_017 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_017_tO    => ensemble_forecast_subjob_017_tO \
+                                                 => ensemble_forecast_subjob_017_sdfk & ensemble_forecast_subjob_017_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_017 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_017_tP    => ensemble_forecast_subjob_017_tP \
+                                                 => ensemble_forecast_subjob_017_sdfk & ensemble_forecast_subjob_017_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_017 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_long_017      => ensemble_forecast_subjob_017_sdfk   \
+                                                 => ensemble_local & ensemble_downscale & ensemble_subjob_hook
+                  ensemble_forecast_017_tK         => ensemble_forecast_all_tK
+                  ensemble_forecast_017_tC          => ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_long_018
+                  ensemble_forecast_long_018      => ensemble_verificationmodel_database
+                  ensemble_forecast_long_018      => ensemble_res_delete
+                  ensemble_forecast_long_018      => ensemble_forecast_end
+                  ensemble_forecast_long_018:start \
+                                                 => ensemble_forecast_018_tC \
+                                                 => ensemble_forecast_018_tI \
+                                                 => ensemble_forecast_018_tJ \
+                                                 => ensemble_forecast_018_tK \
+                                                 => ensemble_forecast_018_tL \
+                                                 => ensemble_forecast_018_tM \
+                                                 => ensemble_forecast_018_tN \
+                                                 => ensemble_forecast_018_tO \
+                                                 => ensemble_forecast_018_tP \
+                                                 => housekeep
+                  ensemble_forecast_018_tC    => ensemble_forecast_subjob_018_tC \
+                                                 => ensemble_forecast_subjob_018_sdfk & ensemble_forecast_subjob_018_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_018 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_018_tI    => ensemble_forecast_subjob_018_tI \
+                                                 => ensemble_forecast_subjob_018_sdfk & ensemble_forecast_subjob_018_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_018 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_018_tJ    => ensemble_forecast_subjob_018_tJ \
+                                                 => ensemble_forecast_subjob_018_sdfk & ensemble_forecast_subjob_018_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_018 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_018_tK    => ensemble_forecast_subjob_018_tK \
+                                                 => ensemble_forecast_subjob_018_sdfk & ensemble_forecast_subjob_018_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_018 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_018_tL    => ensemble_forecast_subjob_018_tL \
+                                                 => ensemble_forecast_subjob_018_sdfk & ensemble_forecast_subjob_018_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_018 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_018_tM    => ensemble_forecast_subjob_018_tM \
+                                                 => ensemble_forecast_subjob_018_sdfk & ensemble_forecast_subjob_018_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_018 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_018_tN    => ensemble_forecast_subjob_018_tN \
+                                                 => ensemble_forecast_subjob_018_sdfk & ensemble_forecast_subjob_018_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_018 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_018_tO    => ensemble_forecast_subjob_018_tO \
+                                                 => ensemble_forecast_subjob_018_sdfk & ensemble_forecast_subjob_018_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_018 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_018_tP    => ensemble_forecast_subjob_018_tP \
+                                                 => ensemble_forecast_subjob_018_sdfk & ensemble_forecast_subjob_018_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_018 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_long_018      => ensemble_forecast_subjob_018_sdfk   \
+                                                 => ensemble_local & ensemble_downscale & ensemble_subjob_hook
+                  ensemble_forecast_018_tK         => ensemble_forecast_all_tK
+                  ensemble_forecast_018_tC          => ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_long_019
+                  ensemble_forecast_long_019      => ensemble_verificationmodel_database
+                  ensemble_forecast_long_019      => ensemble_res_delete
+                  ensemble_forecast_long_019      => ensemble_forecast_end
+                  ensemble_forecast_long_019:start \
+                                                 => ensemble_forecast_019_tC \
+                                                 => ensemble_forecast_019_tI \
+                                                 => ensemble_forecast_019_tJ \
+                                                 => ensemble_forecast_019_tK \
+                                                 => ensemble_forecast_019_tL \
+                                                 => ensemble_forecast_019_tM \
+                                                 => ensemble_forecast_019_tN \
+                                                 => ensemble_forecast_019_tO \
+                                                 => ensemble_forecast_019_tP \
+                                                 => housekeep
+                  ensemble_forecast_019_tC    => ensemble_forecast_subjob_019_tC \
+                                                 => ensemble_forecast_subjob_019_sdfk & ensemble_forecast_subjob_019_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_019 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_019_tI    => ensemble_forecast_subjob_019_tI \
+                                                 => ensemble_forecast_subjob_019_sdfk & ensemble_forecast_subjob_019_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_019 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_019_tJ    => ensemble_forecast_subjob_019_tJ \
+                                                 => ensemble_forecast_subjob_019_sdfk & ensemble_forecast_subjob_019_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_019 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_019_tK    => ensemble_forecast_subjob_019_tK \
+                                                 => ensemble_forecast_subjob_019_sdfk & ensemble_forecast_subjob_019_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_019 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_019_tL    => ensemble_forecast_subjob_019_tL \
+                                                 => ensemble_forecast_subjob_019_sdfk & ensemble_forecast_subjob_019_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_019 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_019_tM    => ensemble_forecast_subjob_019_tM \
+                                                 => ensemble_forecast_subjob_019_sdfk & ensemble_forecast_subjob_019_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_019 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_019_tN    => ensemble_forecast_subjob_019_tN \
+                                                 => ensemble_forecast_subjob_019_sdfk & ensemble_forecast_subjob_019_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_019 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_019_tO    => ensemble_forecast_subjob_019_tO \
+                                                 => ensemble_forecast_subjob_019_sdfk & ensemble_forecast_subjob_019_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_019 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_019_tP    => ensemble_forecast_subjob_019_tP \
+                                                 => ensemble_forecast_subjob_019_sdfk & ensemble_forecast_subjob_019_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_019 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_long_019      => ensemble_forecast_subjob_019_sdfk   \
+                                                 => ensemble_local & ensemble_downscale & ensemble_subjob_hook
+                  ensemble_forecast_019_tK         => ensemble_forecast_all_tK
+                  ensemble_forecast_019_tC          => ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_long_020
+                  ensemble_forecast_long_020      => ensemble_verificationmodel_database
+                  ensemble_forecast_long_020      => ensemble_res_delete
+                  ensemble_forecast_long_020      => ensemble_forecast_end
+                  ensemble_forecast_long_020:start \
+                                                 => ensemble_forecast_020_tC \
+                                                 => ensemble_forecast_020_tI \
+                                                 => ensemble_forecast_020_tJ \
+                                                 => ensemble_forecast_020_tK \
+                                                 => ensemble_forecast_020_tL \
+                                                 => ensemble_forecast_020_tM \
+                                                 => ensemble_forecast_020_tN \
+                                                 => ensemble_forecast_020_tO \
+                                                 => ensemble_forecast_020_tP \
+                                                 => housekeep
+                  ensemble_forecast_020_tC    => ensemble_forecast_subjob_020_tC \
+                                                 => ensemble_forecast_subjob_020_sdfk & ensemble_forecast_subjob_020_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_020 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_020_tI    => ensemble_forecast_subjob_020_tI \
+                                                 => ensemble_forecast_subjob_020_sdfk & ensemble_forecast_subjob_020_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_020 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_020_tJ    => ensemble_forecast_subjob_020_tJ \
+                                                 => ensemble_forecast_subjob_020_sdfk & ensemble_forecast_subjob_020_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_020 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_020_tK    => ensemble_forecast_subjob_020_tK \
+                                                 => ensemble_forecast_subjob_020_sdfk & ensemble_forecast_subjob_020_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_020 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_020_tL    => ensemble_forecast_subjob_020_tL \
+                                                 => ensemble_forecast_subjob_020_sdfk & ensemble_forecast_subjob_020_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_020 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_020_tM    => ensemble_forecast_subjob_020_tM \
+                                                 => ensemble_forecast_subjob_020_sdfk & ensemble_forecast_subjob_020_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_020 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_020_tN    => ensemble_forecast_subjob_020_tN \
+                                                 => ensemble_forecast_subjob_020_sdfk & ensemble_forecast_subjob_020_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_020 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_020_tO    => ensemble_forecast_subjob_020_tO \
+                                                 => ensemble_forecast_subjob_020_sdfk & ensemble_forecast_subjob_020_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_020 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_020_tP    => ensemble_forecast_subjob_020_tP \
+                                                 => ensemble_forecast_subjob_020_sdfk & ensemble_forecast_subjob_020_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_020 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_long_020      => ensemble_forecast_subjob_020_sdfk   \
+                                                 => ensemble_local & ensemble_downscale & ensemble_subjob_hook
+                  ensemble_forecast_020_tK         => ensemble_forecast_all_tK
+                  ensemble_forecast_020_tC          => ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_long_021
+                  ensemble_forecast_long_021      => ensemble_verificationmodel_database
+                  ensemble_forecast_long_021      => ensemble_res_delete
+                  ensemble_forecast_long_021      => ensemble_forecast_end
+                  ensemble_forecast_long_021:start \
+                                                 => ensemble_forecast_021_tC \
+                                                 => ensemble_forecast_021_tI \
+                                                 => ensemble_forecast_021_tJ \
+                                                 => ensemble_forecast_021_tK \
+                                                 => ensemble_forecast_021_tL \
+                                                 => ensemble_forecast_021_tM \
+                                                 => ensemble_forecast_021_tN \
+                                                 => ensemble_forecast_021_tO \
+                                                 => ensemble_forecast_021_tP \
+                                                 => housekeep
+                  ensemble_forecast_021_tC    => ensemble_forecast_subjob_021_tC \
+                                                 => ensemble_forecast_subjob_021_sdfk & ensemble_forecast_subjob_021_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_021 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_021_tI    => ensemble_forecast_subjob_021_tI \
+                                                 => ensemble_forecast_subjob_021_sdfk & ensemble_forecast_subjob_021_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_021 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_021_tJ    => ensemble_forecast_subjob_021_tJ \
+                                                 => ensemble_forecast_subjob_021_sdfk & ensemble_forecast_subjob_021_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_021 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_021_tK    => ensemble_forecast_subjob_021_tK \
+                                                 => ensemble_forecast_subjob_021_sdfk & ensemble_forecast_subjob_021_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_021 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_021_tL    => ensemble_forecast_subjob_021_tL \
+                                                 => ensemble_forecast_subjob_021_sdfk & ensemble_forecast_subjob_021_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_021 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_021_tM    => ensemble_forecast_subjob_021_tM \
+                                                 => ensemble_forecast_subjob_021_sdfk & ensemble_forecast_subjob_021_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_021 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_021_tN    => ensemble_forecast_subjob_021_tN \
+                                                 => ensemble_forecast_subjob_021_sdfk & ensemble_forecast_subjob_021_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_021 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_021_tO    => ensemble_forecast_subjob_021_tO \
+                                                 => ensemble_forecast_subjob_021_sdfk & ensemble_forecast_subjob_021_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_021 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_021_tP    => ensemble_forecast_subjob_021_tP \
+                                                 => ensemble_forecast_subjob_021_sdfk & ensemble_forecast_subjob_021_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_021 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_long_021      => ensemble_forecast_subjob_021_sdfk   \
+                                                 => ensemble_local & ensemble_downscale & ensemble_subjob_hook
+                  ensemble_forecast_021_tK         => ensemble_forecast_all_tK
+                  ensemble_forecast_021_tC          => ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_long_022
+                  ensemble_forecast_long_022      => ensemble_verificationmodel_database
+                  ensemble_forecast_long_022      => ensemble_res_delete
+                  ensemble_forecast_long_022      => ensemble_forecast_end
+                  ensemble_forecast_long_022:start \
+                                                 => ensemble_forecast_022_tC \
+                                                 => ensemble_forecast_022_tI \
+                                                 => ensemble_forecast_022_tJ \
+                                                 => ensemble_forecast_022_tK \
+                                                 => ensemble_forecast_022_tL \
+                                                 => ensemble_forecast_022_tM \
+                                                 => ensemble_forecast_022_tN \
+                                                 => ensemble_forecast_022_tO \
+                                                 => ensemble_forecast_022_tP \
+                                                 => housekeep
+                  ensemble_forecast_022_tC    => ensemble_forecast_subjob_022_tC \
+                                                 => ensemble_forecast_subjob_022_sdfk & ensemble_forecast_subjob_022_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_022 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_022_tI    => ensemble_forecast_subjob_022_tI \
+                                                 => ensemble_forecast_subjob_022_sdfk & ensemble_forecast_subjob_022_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_022 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_022_tJ    => ensemble_forecast_subjob_022_tJ \
+                                                 => ensemble_forecast_subjob_022_sdfk & ensemble_forecast_subjob_022_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_022 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_022_tK    => ensemble_forecast_subjob_022_tK \
+                                                 => ensemble_forecast_subjob_022_sdfk & ensemble_forecast_subjob_022_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_022 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_022_tL    => ensemble_forecast_subjob_022_tL \
+                                                 => ensemble_forecast_subjob_022_sdfk & ensemble_forecast_subjob_022_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_022 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_022_tM    => ensemble_forecast_subjob_022_tM \
+                                                 => ensemble_forecast_subjob_022_sdfk & ensemble_forecast_subjob_022_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_022 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_022_tN    => ensemble_forecast_subjob_022_tN \
+                                                 => ensemble_forecast_subjob_022_sdfk & ensemble_forecast_subjob_022_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_022 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_022_tO    => ensemble_forecast_subjob_022_tO \
+                                                 => ensemble_forecast_subjob_022_sdfk & ensemble_forecast_subjob_022_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_022 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_022_tP    => ensemble_forecast_subjob_022_tP \
+                                                 => ensemble_forecast_subjob_022_sdfk & ensemble_forecast_subjob_022_sduv \
+                                                 &  ensemble_thunderbirds_are_go_forecast_022 \
+                                                 => ensemble_sync_happy
+                  ensemble_forecast_long_022      => ensemble_forecast_subjob_022_sdfk   \
+                                                 => ensemble_local & ensemble_downscale & ensemble_subjob_hook
+                  ensemble_forecast_022_tK         => ensemble_forecast_all_tK
+                  ensemble_forecast_022_tC          => ensemble_sync_forecast_tC
+                ensemble_forecast_end                 => ensemble_res_delete
+                ensemble_forecast_end                 => ensemble_user_hook
+            """
+        [[[ T00, T06, T12, T18 ]]]
+            graph = """
+                long_forecast_tA                   => ensemble_start
+                ensemble_start[-PT6H] => ensemble_start
+                ensemble_forecast_redo_long_look_at[-PT6H]    => ensemble_start                               \
+                                              => ensemble_ens_tidy_observations & ensemble_forecast_redo_long_look_at
+                LONG_OBS_PROCESS_BACKGROUND:succeed-all => ensemble_ens_tidy_observations
+                ensemble_ens_tidy_observations              => ENSEMBLE_OBS
+                ENSEMBLE_OBS:succeed-all          => ensemble_ens_filter
+                ensemble_verificationmodel_database[-PT6H]:start => ENSEMBLE_OBS
+                ensemble_ens_filter & ensemble_forecast_redo_long_look_at => ENSEMBLE_ENS_ADDSURFACES:succeed-all => ensemble_ens_wiggle
+                ensemble_forecast_redo_long_look_at         => ensemble_forecast_long_000
+                ensemble_forecast_long_000         => ensemble_verificationmodel_database
+                ensemble_forecast_long_000         => ensemble_res_delete
+                ensemble_forecast_long_000         => ensemble_forecast_end
+                ensemble_forecast_long_000:start \
+                                                 => ensemble_forecast_000_tC \
+                                                 => ensemble_forecast_000_tI \
+                                                 => ensemble_forecast_000_tJ \
+                                                 => ensemble_forecast_000_tK \
+                                                 => ensemble_forecast_000_tL \
+                                                 => ensemble_forecast_000_tM \
+                                                 => ensemble_forecast_000_tN \
+                                                 => ensemble_forecast_000_tO \
+                                                 => ensemble_forecast_000_tP \
+                                                 => housekeep
+                ensemble_forecast_000_tC        => ensemble_forecast_subjob_000_tC \
+                                                 => ensemble_forecast_subjob_000_sdfk & ensemble_forecast_subjob_000_sduv \
+                                                 &  ensemble_thunderbirds_are_go_updown_or_000 & ensemble_thunderbirds_are_go_forecast_000 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_000_tI        => ensemble_forecast_subjob_000_tI \
+                                                 => ensemble_forecast_subjob_000_sdfk & ensemble_forecast_subjob_000_sduv \
+                                                 &  ensemble_thunderbirds_are_go_updown_or_000 & ensemble_thunderbirds_are_go_forecast_000 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_000_tJ        => ensemble_forecast_subjob_000_tJ \
+                                                 => ensemble_forecast_subjob_000_sdfk & ensemble_forecast_subjob_000_sduv \
+                                                 &  ensemble_thunderbirds_are_go_updown_or_000 & ensemble_thunderbirds_are_go_forecast_000 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_000_tK        => ensemble_forecast_subjob_000_tK \
+                                                 => ensemble_forecast_subjob_000_sdfk & ensemble_forecast_subjob_000_sduv \
+                                                 &  ensemble_thunderbirds_are_go_updown_or_000 & ensemble_thunderbirds_are_go_forecast_000 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_000_tL        => ensemble_forecast_subjob_000_tL \
+                                                 => ensemble_forecast_subjob_000_sdfk & ensemble_forecast_subjob_000_sduv \
+                                                 &  ensemble_thunderbirds_are_go_updown_or_000 & ensemble_thunderbirds_are_go_forecast_000 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_000_tM        => ensemble_forecast_subjob_000_tM \
+                                                 => ensemble_forecast_subjob_000_sdfk & ensemble_forecast_subjob_000_sduv \
+                                                 &  ensemble_thunderbirds_are_go_updown_or_000 & ensemble_thunderbirds_are_go_forecast_000 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_000_tN        => ensemble_forecast_subjob_000_tN \
+                                                 => ensemble_forecast_subjob_000_sdfk & ensemble_forecast_subjob_000_sduv \
+                                                 &  ensemble_thunderbirds_are_go_updown_or_000 & ensemble_thunderbirds_are_go_forecast_000 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_000_tO        => ensemble_forecast_subjob_000_tO \
+                                                 => ensemble_forecast_subjob_000_sdfk & ensemble_forecast_subjob_000_sduv \
+                                                 &  ensemble_thunderbirds_are_go_updown_or_000 & ensemble_thunderbirds_are_go_forecast_000 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_000_tP        => ensemble_forecast_subjob_000_tP \
+                                                 => ensemble_forecast_subjob_000_sdfk & ensemble_forecast_subjob_000_sduv \
+                                                 &  ensemble_thunderbirds_are_go_updown_or_000 & ensemble_thunderbirds_are_go_forecast_000 \
+                                                 => ensemble_sync_happy
+                ensemble_forecast_long_000            => ensemble_forecast_subjob_000_sdfk  \
+                                                 => ensemble_local & ensemble_downscale & ensemble_subjob_hook
+                ensemble_forecast_000_tK             => ensemble_forecast_all_tK
+                ensemble_forecast_000_tC              => ensemble_sync_forecast_tC
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_023
+                  ensemble_forecast_shrt_023      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_023      => ensembles_res_delete             \
+                                                  & ensemble_sync_main
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_024
+                  ensemble_forecast_shrt_024      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_024      => ensembles_res_delete             \
+                                                  & ensemble_sync_main
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_025
+                  ensemble_forecast_shrt_025      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_025      => ensembles_res_delete             \
+                                                  & ensemble_sync_main
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_026
+                  ensemble_forecast_shrt_026      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_026      => ensembles_res_delete             \
+                                                  & ensemble_sync_main
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_027
+                  ensemble_forecast_shrt_027      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_027      => ensembles_res_delete             \
+                                                  & ensemble_sync_main
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_028
+                  ensemble_forecast_shrt_028      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_028      => ensembles_res_delete             \
+                                                  & ensemble_sync_main
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_029
+                  ensemble_forecast_shrt_029      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_029      => ensembles_res_delete             \
+                                                  & ensemble_sync_main
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_030
+                  ensemble_forecast_shrt_030      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_030      => ensembles_res_delete             \
+                                                  & ensemble_sync_main
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_031
+                  ensemble_forecast_shrt_031      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_031      => ensembles_res_delete             \
+                                                  & ensemble_sync_main
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_032
+                  ensemble_forecast_shrt_032      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_032      => ensembles_res_delete             \
+                                                  & ensemble_sync_main
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_033
+                  ensemble_forecast_shrt_033      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_033      => ensembles_res_delete             \
+                                                  & ensemble_sync_main
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_034
+                  ensemble_forecast_shrt_034      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_034      => ensembles_res_delete             \
+                                                  & ensemble_sync_main
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_035
+                  ensemble_forecast_shrt_035      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_035      => ensembles_res_delete             \
+                                                  & ensemble_sync_main
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_036
+                  ensemble_forecast_shrt_036      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_036      => ensembles_res_delete             \
+                                                  & ensemble_sync_main
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_037
+                  ensemble_forecast_shrt_037      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_037      => ensembles_res_delete             \
+                                                  & ensemble_sync_main
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_038
+                  ensemble_forecast_shrt_038      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_038      => ensembles_res_delete             \
+                                                  & ensemble_sync_main
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_039
+                  ensemble_forecast_shrt_039      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_039      => ensembles_res_delete             \
+                                                  & ensemble_sync_main
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_040
+                  ensemble_forecast_shrt_040      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_040      => ensembles_res_delete             \
+                                                  & ensemble_sync_main
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_041
+                  ensemble_forecast_shrt_041      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_041      => ensembles_res_delete             \
+                                                  & ensemble_sync_main
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_042
+                  ensemble_forecast_shrt_042      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_042      => ensembles_res_delete             \
+                                                  & ensemble_sync_main
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_043
+                  ensemble_forecast_shrt_043      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_043      => ensembles_res_delete             \
+                                                  & ensemble_sync_main
+                  ensemble_ens_wiggle              => ensemble_forecast_shrt_044
+                  ensemble_forecast_shrt_044      => ensemble_verificationmodel_database
+                  ensemble_forecast_shrt_044      => ensembles_res_delete             \
+                                                  & ensemble_sync_main
+                ensemble_verificationmodel_database:start => ensemble_archive => housekeep
+                ensemble_verificationmodel_database       => housekeep
+                ensemble_forecast_end          => ensemble_sync_forecast    => housekeep
+                ensemble_forecast_end          => ensemble_sync_main    => housekeep
+                ensemble_verificationmodel_database        => ensemble_sync_verification     => housekeep
+                ensemble_sync_forecast_tC     => housekeep
+                ensemble_sync_happy          => housekeep
+                long_assimilation_look_at_little => !recover1 & !recover2 & !recover3
+                long_assimilation_look_at_little:fail => recover1
+                recover1 => recover2
+                recover2 => recover3
+                recover3 | brief_assimilation_look_at_larger => brief_forecast
+            """
+[runtime]
+    [[recover1, recover2, recover3]]
+        environment scripting = sleep 1
+[runtime]
+    [[ENSEMBLE]]
+    [[ENCOLD_START]]
+        inherit = ENSEMBLE
+    [[ENSEMBLE_SHARED]]
+        inherit = ENSEMBLE_HPC, CORETYPE_SHARED
+    [[ENSEMBLE_PARALLEL]]
+        inherit = ENSEMBLE_HPC, CORETYPE_PARALLEL
+    [[ENSEMBLE_ENS]]
+    [[ENSEMBLE_OBS]]
+        inherit = ENSEMBLE, HPC, INSTALL_DIAG
+    [[ENSEMBLE_ENS_ADDSURFACES]]
+        inherit = ENSEMBLE, HPC, ENSEMBLE_SHARED
+    [[ENSEMBLE_ENS_WIGGLES]]
+        inherit = ENSEMBLE, HPC, ENSEMBLE_SHARED
+    [[ENSEMBLE_FORECAST_REDO]]
+    [[ENSEMBLE_FORECAST]]
+    [[ENSEMBLE_FORECAST_CONTROL]]
+        inherit = ENSEMBLE, HPC, ENSEMBLE_PARALLEL, ENSEMBLE_FORECAST, ENSEMBLE_RES
+    [[ENSEMBLE_FORECAST_LONG]]
+        inherit = ENSEMBLE, HPC, ENSEMBLE_PARALLEL, ENSEMBLE_FORECAST, ENSEMBLE_RES
+    [[ENSEMBLE_FORECAST_SHRT]]
+        inherit = ENSEMBLE, HPC, ENSEMBLE_PARALLEL, ENSEMBLE_FORECAST, ENSEMBLES_RES
+    [[ENSEMBLE_VERIFICATIONMODEL]]
+        inherit = ENSEMBLE, HPC, ENSEMBLE_SHARED
+    [[ENSEMBLE_HPC]]
+    [[ENSEMBLE_RES]]
+    [[ENSEMBLES_RES]]
+    [[ensemble_install_startdata_cold]]
+        inherit = ENCOLD_START, HPC, CORETYPE_SHARED
+    [[ensemble_start]]
+        inherit = ENSEMBLE, LOCAL
+    [[ensemble_ens_tidy_observations]]
+        inherit = ENSEMBLE, HPC, ENSEMBLE_ENS, ENSEMBLE_RES
+    [[ensemble_ens_filter]]
+        inherit = ENSEMBLE, HPC, ENSEMBLE_ENS, ENSEMBLE_RES
+    [[ensemble_observations_process_000]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_001]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_002]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_003]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_004]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_005]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_006]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_007]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_008]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_009]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_010]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_011]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_012]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_013]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_014]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_015]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_016]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_017]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_018]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_019]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_020]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_021]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_022]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_023]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_024]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_025]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_026]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_027]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_028]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_029]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_030]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_031]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_032]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_033]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_034]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_035]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_036]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_037]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_038]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_039]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_040]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_041]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_042]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_043]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_observations_process_044]]
+        inherit = ENSEMBLE_OBS, ENSEMBLE_RES
+    [[ensemble_ens_add_temps_001]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_002]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_003]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_004]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_005]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_006]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_007]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_008]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_009]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_010]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_011]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_012]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_013]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_014]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_015]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_016]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_017]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_018]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_019]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_020]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_021]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_022]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_023]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_024]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_025]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_026]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_027]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_028]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_029]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_030]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_031]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_032]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_033]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_034]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_035]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_036]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_037]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_038]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_039]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_040]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_041]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_042]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_043]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_add_temps_044]]
+        inherit = ENSEMBLE_ENS_ADDSURFACES
+    [[ensemble_ens_wiggle]]
+        inherit = ENSEMBLE_ENS_WIGGLES
+    [[ensemble_forecast_redo_long_look_at]]
+        inherit = ENSEMBLE, HPC, ENSEMBLE_SHARED, ENSEMBLE_FORECAST_REDO
+    [[ensemble_forecast_long_000]]
+        inherit = ENSEMBLE_FORECAST_CONTROL, ENSEMBLE_FORECAST_LONG
+    [[ensemble_forecast_long_001]]
+        inherit = ENSEMBLE_FORECAST_LONG
+    [[ensemble_forecast_long_002]]
+        inherit = ENSEMBLE_FORECAST_LONG
+    [[ensemble_forecast_long_003]]
+        inherit = ENSEMBLE_FORECAST_LONG
+    [[ensemble_forecast_long_004]]
+        inherit = ENSEMBLE_FORECAST_LONG
+    [[ensemble_forecast_long_005]]
+        inherit = ENSEMBLE_FORECAST_LONG
+    [[ensemble_forecast_long_006]]
+        inherit = ENSEMBLE_FORECAST_LONG
+    [[ensemble_forecast_long_007]]
+        inherit = ENSEMBLE_FORECAST_LONG
+    [[ensemble_forecast_long_008]]
+        inherit = ENSEMBLE_FORECAST_LONG
+    [[ensemble_forecast_long_009]]
+        inherit = ENSEMBLE_FORECAST_LONG
+    [[ensemble_forecast_long_010]]
+        inherit = ENSEMBLE_FORECAST_LONG
+    [[ensemble_forecast_long_011]]
+        inherit = ENSEMBLE_FORECAST_LONG
+    [[ensemble_forecast_long_012]]
+        inherit = ENSEMBLE_FORECAST_LONG
+    [[ensemble_forecast_long_013]]
+        inherit = ENSEMBLE_FORECAST_LONG
+    [[ensemble_forecast_long_014]]
+        inherit = ENSEMBLE_FORECAST_LONG
+    [[ensemble_forecast_long_015]]
+        inherit = ENSEMBLE_FORECAST_LONG
+    [[ensemble_forecast_long_016]]
+        inherit = ENSEMBLE_FORECAST_LONG
+    [[ensemble_forecast_long_017]]
+        inherit = ENSEMBLE_FORECAST_LONG
+    [[ensemble_forecast_long_018]]
+        inherit = ENSEMBLE_FORECAST_LONG
+    [[ensemble_forecast_long_019]]
+        inherit = ENSEMBLE_FORECAST_LONG
+    [[ensemble_forecast_long_020]]
+        inherit = ENSEMBLE_FORECAST_LONG
+    [[ensemble_forecast_long_021]]
+        inherit = ENSEMBLE_FORECAST_LONG
+    [[ensemble_forecast_long_022]]
+        inherit = ENSEMBLE_FORECAST_LONG
+    [[ensemble_forecast_shrt_001]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_002]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_003]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_004]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_005]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_006]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_007]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_008]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_009]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_010]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_011]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_012]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_013]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_014]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_015]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_016]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_017]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_018]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_019]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_020]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_021]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_022]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_023]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_024]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_025]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_026]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_027]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_028]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_029]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_030]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_031]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_032]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_033]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_034]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_035]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_036]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_037]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_038]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_039]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_040]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_041]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_042]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_043]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_forecast_shrt_044]]
+        inherit = ENSEMBLE_FORECAST_SHRT
+    [[ensemble_verificationmodel_database]]
+        inherit = ENSEMBLE_VERIFICATIONMODEL
+    [[ensemble_archive]]
+        inherit = ENSEMBLE, HPC, ENSEMBLE_HPC, ARCHIVE
+[runtime]
+    [[ENSEMBLE_FORECAST_TRIGGER]]
+        inherit = ENSEMBLE, HPC, CORETYPE_SHARED
+    [[ENSEMBLE_SUBJOB]]
+        inherit = ENSEMBLE, HPC, ENSEMBLE_HPC, CORETYPE_SHARED
+    [[ENSEMBLE_THUNDERBIRDS_ARE_GO]]
+        inherit = ENSEMBLE, HPC, ENSEMBLE_HPC
+    [[ENSEMBLE_MIRROR]]
+        inherit = ENSEMBLE, HPC, ENSEMBLE_HPC, CORETYPE_SHARED
+    [[ensemble_start_00, ensemble_start_06, ensemble_start_12, ensemble_start_18]]
+        inherit = ENSEMBLE, OS_START
+    [[ensemble_forecast_end]]
+        inherit = ENSEMBLE, LOCAL
+    [[ensemble_user_hook]]
+        inherit = ENSEMBLE, HPC, ENSEMBLE_HPC, CORETYPE_SHARED
+    [[ensemble_res_create, ensembles_res_create]]
+        inherit = OS_RES_CREATE, ENSEMBLE_HPC
+    [[ensemble_res_delete, ensembles_res_delete]]
+        inherit = OS_RES_DELETE, ENSEMBLE_HPC
+    [[ensemble_sync_main, ensemble_sync_forecast, ensemble_sync_happy]]
+        inherit = ENSEMBLE_MIRROR
+    [[ensemble_sync_forecast_tC]]
+        inherit = ENSEMBLE_MIRROR
+    [[ensemble_sync_verification]]
+        inherit = ENSEMBLE_MIRROR
+    [[ensemble_forecast_000_tC]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_000_tI]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_000_tJ]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_000_tK]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_000_tL]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_000_tM]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_000_tN]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_000_tO]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_000_tP]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_001_tC]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_001_tI]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_001_tJ]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_001_tK]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_001_tL]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_001_tM]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_001_tN]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_001_tO]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_001_tP]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_002_tC]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_002_tI]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_002_tJ]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_002_tK]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_002_tL]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_002_tM]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_002_tN]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_002_tO]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_002_tP]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_003_tC]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_003_tI]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_003_tJ]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_003_tK]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_003_tL]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_003_tM]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_003_tN]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_003_tO]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_003_tP]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_004_tC]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_004_tI]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_004_tJ]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_004_tK]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_004_tL]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_004_tM]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_004_tN]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_004_tO]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_004_tP]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_005_tC]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_005_tI]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_005_tJ]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_005_tK]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_005_tL]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_005_tM]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_005_tN]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_005_tO]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_005_tP]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_006_tC]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_006_tI]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_006_tJ]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_006_tK]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_006_tL]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_006_tM]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_006_tN]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_006_tO]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_006_tP]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_007_tC]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_007_tI]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_007_tJ]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_007_tK]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_007_tL]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_007_tM]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_007_tN]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_007_tO]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_007_tP]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_008_tC]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_008_tI]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_008_tJ]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_008_tK]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_008_tL]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_008_tM]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_008_tN]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_008_tO]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_008_tP]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_009_tC]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_009_tI]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_009_tJ]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_009_tK]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_009_tL]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_009_tM]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_009_tN]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_009_tO]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_009_tP]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_010_tC]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_010_tI]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_010_tJ]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_010_tK]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_010_tL]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_010_tM]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_010_tN]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_010_tO]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_010_tP]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_011_tC]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_011_tI]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_011_tJ]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_011_tK]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_011_tL]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_011_tM]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_011_tN]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_011_tO]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_011_tP]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_012_tC]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_012_tI]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_012_tJ]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_012_tK]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_012_tL]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_012_tM]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_012_tN]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_012_tO]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_012_tP]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_013_tC]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_013_tI]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_013_tJ]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_013_tK]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_013_tL]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_013_tM]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_013_tN]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_013_tO]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_013_tP]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_014_tC]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_014_tI]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_014_tJ]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_014_tK]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_014_tL]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_014_tM]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_014_tN]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_014_tO]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_014_tP]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_015_tC]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_015_tI]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_015_tJ]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_015_tK]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_015_tL]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_015_tM]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_015_tN]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_015_tO]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_015_tP]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_016_tC]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_016_tI]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_016_tJ]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_016_tK]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_016_tL]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_016_tM]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_016_tN]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_016_tO]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_016_tP]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_017_tC]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_017_tI]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_017_tJ]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_017_tK]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_017_tL]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_017_tM]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_017_tN]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_017_tO]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_017_tP]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_018_tC]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_018_tI]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_018_tJ]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_018_tK]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_018_tL]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_018_tM]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_018_tN]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_018_tO]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_018_tP]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_019_tC]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_019_tI]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_019_tJ]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_019_tK]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_019_tL]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_019_tM]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_019_tN]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_019_tO]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_019_tP]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_020_tC]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_020_tI]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_020_tJ]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_020_tK]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_020_tL]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_020_tM]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_020_tN]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_020_tO]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_020_tP]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_021_tC]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_021_tI]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_021_tJ]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_021_tK]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_021_tL]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_021_tM]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_021_tN]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_021_tO]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_021_tP]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_022_tC]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_022_tI]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_022_tJ]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_022_tK]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_022_tL]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_022_tM]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_022_tN]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_022_tO]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_022_tP]]
+        inherit = ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_HPC
+    [[ensemble_forecast_all_tK]]
+        inherit = ENSEMBLE, LOCAL
+    [[ensemble_forecast_subjob_000_tC]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_000_tI]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_000_tJ]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_000_tK]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_000_tL]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_000_tM]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_000_tN]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_000_tO]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_000_tP]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_000_sdfk]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_000_sduv]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_thunderbirds_are_go_updown_or_000]]
+	    inherit = ENSEMBLE_THUNDERBIRDS_ARE_GO
+    [[ensemble_thunderbirds_are_go_forecast_000]]
+            inherit = ENSEMBLE_THUNDERBIRDS_ARE_GO
+    [[ensemble_forecast_subjob_001_tC]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_001_tI]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_001_tJ]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_001_tK]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_001_tL]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_001_tM]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_001_tN]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_001_tO]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_001_tP]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_001_sdfk]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_001_sduv]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_thunderbirds_are_go_forecast_001]]
+            inherit = ENSEMBLE_THUNDERBIRDS_ARE_GO
+    [[ensemble_forecast_subjob_002_tC]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_002_tI]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_002_tJ]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_002_tK]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_002_tL]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_002_tM]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_002_tN]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_002_tO]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_002_tP]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_002_sdfk]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_002_sduv]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_thunderbirds_are_go_forecast_002]]
+            inherit = ENSEMBLE_THUNDERBIRDS_ARE_GO
+    [[ensemble_forecast_subjob_003_tC]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_003_tI]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_003_tJ]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_003_tK]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_003_tL]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_003_tM]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_003_tN]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_003_tO]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_003_tP]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_003_sdfk]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_003_sduv]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_thunderbirds_are_go_forecast_003]]
+            inherit = ENSEMBLE_THUNDERBIRDS_ARE_GO
+    [[ensemble_forecast_subjob_004_tC]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_004_tI]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_004_tJ]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_004_tK]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_004_tL]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_004_tM]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_004_tN]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_004_tO]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_004_tP]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_004_sdfk]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_004_sduv]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_thunderbirds_are_go_forecast_004]]
+            inherit = ENSEMBLE_THUNDERBIRDS_ARE_GO
+    [[ensemble_forecast_subjob_005_tC]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_005_tI]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_005_tJ]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_005_tK]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_005_tL]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_005_tM]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_005_tN]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_005_tO]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_005_tP]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_005_sdfk]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_005_sduv]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_thunderbirds_are_go_forecast_005]]
+            inherit = ENSEMBLE_THUNDERBIRDS_ARE_GO
+    [[ensemble_forecast_subjob_006_tC]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_006_tI]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_006_tJ]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_006_tK]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_006_tL]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_006_tM]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_006_tN]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_006_tO]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_006_tP]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_006_sdfk]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_006_sduv]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_thunderbirds_are_go_forecast_006]]
+            inherit = ENSEMBLE_THUNDERBIRDS_ARE_GO
+    [[ensemble_forecast_subjob_007_tC]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_007_tI]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_007_tJ]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_007_tK]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_007_tL]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_007_tM]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_007_tN]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_007_tO]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_007_tP]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_007_sdfk]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_007_sduv]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_thunderbirds_are_go_forecast_007]]
+            inherit = ENSEMBLE_THUNDERBIRDS_ARE_GO
+    [[ensemble_forecast_subjob_008_tC]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_008_tI]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_008_tJ]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_008_tK]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_008_tL]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_008_tM]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_008_tN]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_008_tO]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_008_tP]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_008_sdfk]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_008_sduv]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_thunderbirds_are_go_forecast_008]]
+            inherit = ENSEMBLE_THUNDERBIRDS_ARE_GO
+    [[ensemble_forecast_subjob_009_tC]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_009_tI]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_009_tJ]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_009_tK]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_009_tL]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_009_tM]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_009_tN]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_009_tO]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_009_tP]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_009_sdfk]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_009_sduv]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_thunderbirds_are_go_forecast_009]]
+            inherit = ENSEMBLE_THUNDERBIRDS_ARE_GO
+    [[ensemble_forecast_subjob_010_tC]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_010_tI]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_010_tJ]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_010_tK]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_010_tL]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_010_tM]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_010_tN]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_010_tO]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_010_tP]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_010_sdfk]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_010_sduv]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_thunderbirds_are_go_forecast_010]]
+            inherit = ENSEMBLE_THUNDERBIRDS_ARE_GO
+    [[ensemble_forecast_subjob_011_tC]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_011_tI]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_011_tJ]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_011_tK]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_011_tL]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_011_tM]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_011_tN]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_011_tO]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_011_tP]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_011_sdfk]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_011_sduv]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_thunderbirds_are_go_forecast_011]]
+            inherit = ENSEMBLE_THUNDERBIRDS_ARE_GO
+    [[ensemble_forecast_subjob_012_tC]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_012_tI]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_012_tJ]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_012_tK]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_012_tL]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_012_tM]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_012_tN]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_012_tO]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_012_tP]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_012_sdfk]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_012_sduv]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_thunderbirds_are_go_forecast_012]]
+            inherit = ENSEMBLE_THUNDERBIRDS_ARE_GO
+    [[ensemble_forecast_subjob_013_tC]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_013_tI]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_013_tJ]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_013_tK]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_013_tL]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_013_tM]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_013_tN]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_013_tO]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_013_tP]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_013_sdfk]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_013_sduv]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_thunderbirds_are_go_forecast_013]]
+            inherit = ENSEMBLE_THUNDERBIRDS_ARE_GO
+    [[ensemble_forecast_subjob_014_tC]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_014_tI]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_014_tJ]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_014_tK]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_014_tL]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_014_tM]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_014_tN]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_014_tO]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_014_tP]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_014_sdfk]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_014_sduv]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_thunderbirds_are_go_forecast_014]]
+            inherit = ENSEMBLE_THUNDERBIRDS_ARE_GO
+    [[ensemble_forecast_subjob_015_tC]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_015_tI]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_015_tJ]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_015_tK]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_015_tL]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_015_tM]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_015_tN]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_015_tO]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_015_tP]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_015_sdfk]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_015_sduv]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_thunderbirds_are_go_forecast_015]]
+            inherit = ENSEMBLE_THUNDERBIRDS_ARE_GO
+    [[ensemble_forecast_subjob_016_tC]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_016_tI]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_016_tJ]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_016_tK]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_016_tL]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_016_tM]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_016_tN]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_016_tO]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_016_tP]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_016_sdfk]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_016_sduv]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_thunderbirds_are_go_forecast_016]]
+            inherit = ENSEMBLE_THUNDERBIRDS_ARE_GO
+    [[ensemble_forecast_subjob_017_tC]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_017_tI]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_017_tJ]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_017_tK]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_017_tL]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_017_tM]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_017_tN]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_017_tO]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_017_tP]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_017_sdfk]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_017_sduv]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_thunderbirds_are_go_forecast_017]]
+            inherit = ENSEMBLE_THUNDERBIRDS_ARE_GO
+    [[ensemble_forecast_subjob_018_tC]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_018_tI]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_018_tJ]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_018_tK]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_018_tL]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_018_tM]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_018_tN]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_018_tO]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_018_tP]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_018_sdfk]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_018_sduv]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_thunderbirds_are_go_forecast_018]]
+            inherit = ENSEMBLE_THUNDERBIRDS_ARE_GO
+    [[ensemble_forecast_subjob_019_tC]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_019_tI]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_019_tJ]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_019_tK]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_019_tL]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_019_tM]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_019_tN]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_019_tO]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_019_tP]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_019_sdfk]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_019_sduv]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_thunderbirds_are_go_forecast_019]]
+            inherit = ENSEMBLE_THUNDERBIRDS_ARE_GO
+    [[ensemble_forecast_subjob_020_tC]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_020_tI]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_020_tJ]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_020_tK]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_020_tL]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_020_tM]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_020_tN]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_020_tO]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_020_tP]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_020_sdfk]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_020_sduv]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_thunderbirds_are_go_forecast_020]]
+            inherit = ENSEMBLE_THUNDERBIRDS_ARE_GO
+    [[ensemble_forecast_subjob_021_tC]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_021_tI]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_021_tJ]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_021_tK]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_021_tL]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_021_tM]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_021_tN]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_021_tO]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_021_tP]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_021_sdfk]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_021_sduv]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_thunderbirds_are_go_forecast_021]]
+        inherit = ENSEMBLE_THUNDERBIRDS_ARE_GO
+    [[ensemble_forecast_subjob_022_tC]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_022_tI]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_022_tJ]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_022_tK]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_022_tL]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_022_tM]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_022_tN]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_022_tO]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_022_tP]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_022_sdfk]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_forecast_subjob_022_sduv]]
+        inherit = ENSEMBLE_SUBJOB
+    [[ensemble_thunderbirds_are_go_forecast_022]]
+        inherit = ENSEMBLE_THUNDERBIRDS_ARE_GO
+    [[ensemble_local]]
+        inherit = ENSEMBLE, HPC, ENSEMBLE_HPC, CORETYPE_SHARED
+        inherit = ENSEMBLE, HPC, ENSEMBLE_HPC
+    [[ensemble_downscale]]
+        inherit = ENSEMBLE, HPC, ENSEMBLE_HPC, CORETYPE_SHARED
+        inherit = ENSEMBLE, HPC, ENSEMBLE_HPC
+    [[ensemble_subjob_hook]]
+        inherit = ENSEMBLE, HPC, ENSEMBLE_HPC, CORETYPE_SHARED
+[scheduling]
+    [[dependencies]]
+        [[[ T00, T06, T12, T18 ]]]
+            graph = """
+                long_forecast_end => long_zoom_frozen_happyland => long_zoom_send_to_highway_happyland_yay
+                long_zoom_send_to_highway_happyland_yay => long_zoom_send_notification_to_highway_happyland_yay
+                long_zoom_send_notification_to_highway_happyland_yay => housekeep
+                long_forecast_end => long_zoom_frozen_happyland => long_zoom_send_to_highway_happyland_yay2
+                long_zoom_send_to_highway_happyland_yay2 => long_zoom_send_notification_to_highway_happyland_yay2
+                long_zoom_send_notification_to_highway_happyland_yay2 => housekeep
+            """
+[runtime]
+    [[LONG_ZOOM_SUBJOB]]
+        inherit = LONG, HPC, LONG_HPC
+    [[LONG_ZOOM_SEND_TO_HIGHWAY]]
+        inherit = LONG_ZOOM_SUBJOB
+     [[HAPPYLAND_ENV]]
+     [[LONG_ZOOM_SEND_HAPPYLAND]]
+       inherit = LONG_ZOOM_SEND_TO_HIGHWAY
+        [[LONG_ZOOM_SEND_HAPPYLAND_yay]]
+            inherit = LONG_ZOOM_SEND_HAPPYLAND
+        [[LONG_ZOOM_SEND_HAPPYLAND_yay2]]
+            inherit = LONG_ZOOM_SEND_HAPPYLAND
+    [[long_zoom_frozen_happyland]]
+        inherit = LONG_ZOOM_SUBJOB, HAPPYLAND_ENV
+        [[long_zoom_send_to_highway_happyland_yay]]
+            inherit = LONG_ZOOM_SEND_HAPPYLAND_yay, HAPPYLAND_ENV
+        [[long_zoom_send_notification_to_highway_happyland_yay]]
+            inherit = LONG_ZOOM_SEND_HAPPYLAND_yay, HAPPYLAND_ENV
+        [[long_zoom_send_to_highway_happyland_yay2]]
+            inherit = LONG_ZOOM_SEND_HAPPYLAND_yay2, HAPPYLAND_ENV
+        [[long_zoom_send_notification_to_highway_happyland_yay2]]
+            inherit = LONG_ZOOM_SEND_HAPPYLAND_yay2, HAPPYLAND_ENV
+[visualization]
+    default node attributes = style=filled, color=black, shape=box, fillcolor=khaki
+    collapsed families = \
+        LONG_FORECAST_TRIGGER, BRIEF_FORECAST_TRIGGER, LONG_SUBJOB, BRIEF_SUBJOB, LONG_DISPERSION,  \
+        LONG_DISPERSION_PROC, LONG_DISPERSION_ARCHIVING, LONG_DISPERSION_HOUSEKEEPING,  \
+        COLD_START, BRIEF_OBSERVATIONS_PROCESS_BACKGROUND, LONG_OBS_PROCESS_BACKGROUND,   \
+        BRIEF_OBS_PROCESS_LOOK_AT, LONG_OBS_PROCESS_LOOK_AT, LONG_OBS_DB_STUFF, BRIEF_OBS_DB_STUFF,   \
+        BRIEF_SURFACE_LANDSIM, \
+        ENSEMBLE_FORECAST_TRIGGER, ENSEMBLE_SUBJOB, \
+        ENSEMBLE_FORECAST_CONTROL, ENSEMBLE_FORECAST_LONG, ENSEMBLE_FORECAST_SHRT, \
+        ENSEMBLE_OBS, ENSEMBLE_ENS_ADDSURFACES, ENSEMBLE_ENS_WIGGLES, ENSEMBLE_VERIFICATIONMODEL, ENCOLD_START
+    [[node groups]]
+        archive_nodes = long_archive_short, long_archive_long, brief_archive
+    [[node attributes]]
+        long_start = fillcolor=violet
+        brief_start = fillcolor=violet
+        LONG_OBS = fillcolor=palegreen
+        BRIEF_OBS = fillcolor=palegreen
+        LONG_FORECAST_TRIGGER = fillcolor=powderblue
+        BRIEF_FORECAST_TRIGGER = fillcolor=powderblue
+        LONG_DISPERSION = fillcolor=powderblue
+        LONG_DISPERSION_PROC = fillcolor=powderblue
+        LONG_DISPERSION_ARCHIVING = fillcolor=powderblue
+        LONG_DISPERSION_HOUSEKEEPING = fillcolor=powderblue
+        LONG_SUBJOB = fillcolor=powderblue
+        BRIEF_SUBJOB = fillcolor=powderblue
+        BRIEF_SURFACE = fillcolor=burlywood
+        COLD_START = style=rounded
+        LONGBRIEF_FORECAST_REDO = fillcolor=gold
+        archive_nodes = fillcolor=tomato
+        ENCOLD_START = style=rounded
+        ensemble_start = fillcolor=violet
+        ENSEMBLE_OBS = fillcolor=orange
+        ENSEMBLE_ENS_ADDSURFACES = fillcolor=cyan
+        ENSEMBLE_ENS_WIGGLES = fillcolor=springgreen
+        ENSEMBLE_FORECAST = fillcolor=dodgerblue, fontsize=20
+        ENSEMBLE_VERIFICATIONMODEL = fillcolor=palegreen
+        ENSEMBLE_FORECAST_TRIGGER = fillcolor=powderblue
+        ENSEMBLE_SUBJOB = fillcolor=powderblue
+        ensemble_archive = fillcolor=tomato
+        OS_START = fillcolor=peru
+        OS_RES_CREATE = fillcolor=peru
+        OS_RES_DELETE = fillcolor=peru
+        housekeep = fillcolor=tomato
+        install_cold = style=rounded
+        install_cold_mirror = style=rounded

--- a/dev/suites/dave/suite.rc
+++ b/dev/suites/dave/suite.rc
@@ -7,20 +7,21 @@ background thread; (c) job submission in a background worker thread."""
 
 {% set N_LOCAL = 10 %}
 {% set N_REMOTE_PER_LOCAL = 2 %}
-[cylc]
-    [[job submission]]
-        delay between batches = 0
+#[cylc]
+#    [[job submission]]
+#        delay between batches = 0
 [scheduling]
-    initial cycle time = 20120101
-    final cycle time   = 20120110
-    runahead limit     = 100
-    [[special tasks]]
-        cold-start = cold_start
+    initial cycle point = 20120101
+    final cycle point   = 20120110
+    cycling mode        = integer
+    max active cycle points = 100
+#    [[special tasks]]
+#        cold-start = cold_start
     [[dependencies]]
-        [[[0]]]
+        [[[R1]]]
             graph = """
                 {% for X in range( 1, N_LOCAL + 1 ) %}
-                  local_{{ X }}[T-24] | cold_start => local_{{ X }}
+                  local_{{ X }}[-P24] | cold_start => local_{{ X }}
                   {% for Y in range( 1, N_REMOTE_PER_LOCAL + 1 ) %}
                     local_{{ X }} => remote_{{ X }}_{{ Y }}
                   {% endfor %}

--- a/dev/suites/diamond/suite.rc
+++ b/dev/suites/diamond/suite.rc
@@ -1,0 +1,39 @@
+#!jinja2
+
+# A suite designed to test cylc's handling of ensemble-type dependencies.
+
+# Implemented using jinja2 rather than parameterized tasks to allow for
+# profiling with older cylc versions.
+
+{% if not batch_system is defined %}
+    {% set batch_system = 'background' %}
+{% endif %}
+{% if not tasks is defined %}
+    {% set tasks = 100 %}
+{% endif %}
+
+[scheduling]
+    cycling mode = integer
+    initial cycle point = 1
+    {% if cycles is defined %}
+    final cycle point = {{cycles}}
+    {% endif %}
+    [[dependencies]]
+        [[[P1]]]
+            graph = """
+            end[-P1] => start
+            {% for task_no in range(tasks|int) -%}
+                start => task_{{task_no}} => end
+            {% endfor -%}
+            """
+[runtime]
+    [[root]]
+    {% if cylc_compat_mode is defined and cylc_compat_mode == '6' %}
+        command scripting = true
+        [[[job submission]]]
+            method = {{ batch_system }}
+    {% else %}
+        script = true
+        [[[job]]]
+            batch system = {{ batch_system }}
+    {% endif %}

--- a/dev/suites/family-triggers/suite.rc
+++ b/dev/suites/family-triggers/suite.rc
@@ -1,0 +1,39 @@
+#!jinja2
+
+# A suite to test the validation performance of cylc when dealing with family
+# triggers.
+
+# Implemented using jinja2 rather than parameterized tasks to allow for
+# profiling with older cylc versions.
+
+{% if not batch_system is defined %}
+    {% set batch_system = 'background' %}
+{% endif %}
+{% if not no_members is defined %}
+    {% set no_members = 50 %}
+{% endif %}
+
+[scheduling]
+    [[dependencies]]
+        graph = FAM1:succeed-all => FAM2
+[runtime]
+    [[root]]
+{% if cylc_compat_mode is defined and cylc_compat_mode == '6' %}
+        command scripting = true
+        [[[job submission]]]
+            method = {{ batch_system }}
+{% else %}
+        script = true
+        [[[job]]]
+            batch system = {{ batch_system }}
+{% endif %}
+    [[FAM1]]
+    [[FAM2]]
+{% for member in range(1,no_members|int) %}
+    [[fam1_member_{{member}}]]
+        inherit = FAM1
+{% endfor %}
+{% for member in range(1,no_members|int) %}
+    [[fam2_member_{{member}}]]
+        inherit = FAM2
+{% endfor %}

--- a/dev/suites/hello-world/suite.rc
+++ b/dev/suites/hello-world/suite.rc
@@ -1,0 +1,12 @@
+#!jinja2
+
+[scheduling]
+    [[dependencies]]
+        graph = hello_world
+[runtime]
+    [[hello_world]]
+    {% if cylc_compat_mode is defined and cylc_compat_mode == '6' %}
+        command scripting = echo "Hello World!"
+    {% else %}
+        script = echo "Hello World!"
+    {% endif %}

--- a/dev/suites/iso8601/one/suite.rc
+++ b/dev/suites/iso8601/one/suite.rc
@@ -11,17 +11,17 @@
 
         # TESTED:
         #[[[ PT6H ]]]
-        #    graph = "foo[T-PT6H] => foo => bar"
+        #    graph = "foo[-PT6H] => foo => bar"
 
         [[[ R1 ]]]
             graph = "cold_foo => foo"
 
         # TESTED:
         [[[ PT1H30M ]]]
-            graph = "foo[T-PT1H30M] => foo => bar"
+            graph = "foo[-PT1H30M] => foo => bar"
 
         [[[ PT5H ]]]
-            graph = "qux[T-PT5H] => qux"
+            graph = "qux[-PT5H] => qux"
 
         [[[ T06 ]]]
             graph = "foo => wibble"

--- a/lib/cylc/profiling/__init__.py
+++ b/lib/cylc/profiling/__init__.py
@@ -70,13 +70,17 @@ PROFILE_FILES = {
 
 
 # ------------- REGEXES ---------------
-# Cylc profiling REGEXES.
+# Matches the summary line from the cylc <cmd> --profile output.
 SUMMARY_LINE_REGEX = re.compile('([\d]+) function calls \(([\d]+) primitive'
                                 ' calls\) in ([\d.]+) CPU seconds')
+# Matches the memory checkpoints in the cylc <cmd> --profile output
 MEMORY_LINE_REGEX = re.compile('PROFILE: Memory: ([\d]+) KiB: ([\w.]+): (.*)')
+# Matches main-loop memory checkpoints in cylc <cmd> --profile output.
 LOOP_MEMORY_LINE_REGEX = re.compile('(?:loop #|end main loop \(total loops )'
                                     '([\d]+)(?:: |\): )(.*)')
+# Matches the sleep function line in cylc <cmd> --profile output.
 SLEEP_FUNCTION_REGEX = re.compile('([\d.]+)[\s]+[\d.]+[\s]+\{time.sleep\}')
+# The string prefixing the suite-startup timestamp (unix time).
 SUITE_STARTUP_STRING = 'SUITE STARTUP: '
 
 
@@ -85,7 +89,7 @@ METRIC_TITLE = 0  # For display purposes.
 METRIC_UNIT = 1  # For display purposes.
 METRIC_FILENAME = 2  # For output plots (no extension).
 METRIC_FIELDS = 3  # Fields metrics can be derived from in order of preference.
-METRICS = {
+METRICS = {  # Dict of all metrics measured by profile-battery.
     '001': ('Elapsed Time', 's', 'elapsed-time', [
             'real', 'Elapsed (wall clock) time (h:mm:ss or m:ss)',
             'cpu time'],),
@@ -109,11 +113,14 @@ METRICS = {
     '011': ('Elapsed Time - time.sleep()', 's', 'awake-time', [
             'awake cpu time'],)
 }
+# Metrics used if --full is not set.
+QUICK_ANALYSIS_METRICS = set(['001', '002', '005'])
+# Reverse lookup of METRICS, dict of fields stored with their metric codes.
 METRICS_BY_FIELD = {}
 for metric in METRICS:
     for field in METRICS[metric][METRIC_FIELDS]:
         METRICS_BY_FIELD[field] = metric
-QUICK_ANALYSIS_METRICS = set(['001', '002', '005'])
 
 
+# The profile mode(s) to use if un-specified.
 DEFAULT_PROFILE_MODES = ['time']

--- a/lib/cylc/profiling/__init__.py
+++ b/lib/cylc/profiling/__init__.py
@@ -72,7 +72,7 @@ PROFILE_FILES = {
 # ------------- REGEXES ---------------
 # Matches the summary line from the cylc <cmd> --profile output.
 SUMMARY_LINE_REGEX = re.compile('([\d]+) function calls \(([\d]+) primitive'
-                                ' calls\) in ([\d.]+) CPU seconds')
+                                ' calls\) in ([\d.]+)(?: CPU)? seconds')
 # Matches the memory checkpoints in the cylc <cmd> --profile output
 MEMORY_LINE_REGEX = re.compile('PROFILE: Memory: ([\d]+) KiB: ([\w.]+): (.*)')
 # Matches main-loop memory checkpoints in cylc <cmd> --profile output.

--- a/lib/cylc/profiling/__init__.py
+++ b/lib/cylc/profiling/__init__.py
@@ -49,7 +49,7 @@ EXPERIMENTS_PATH = os.path.join('dev', 'profile-experiments'
                                 )  # Path to built-in experiments.
 
 # Ancestor commit for cylc profile-battery
-PROFILE_COMMIT = 'abf238271d6cfe9cc5db5de812907195a5f8d5c7'  # TODO
+PROFILE_COMMIT = '0f5a7999ba9c93174d846a6679db4ce413388df7'
 
 # Ancestor commit for analysis-compatible cylc (run|validate) --profile
 CYLC_PROFILING_COMMIT = '016e6a97be16eaf1a33ea19398a1ade09f86719e'

--- a/lib/cylc/profiling/__init__.py
+++ b/lib/cylc/profiling/__init__.py
@@ -1,0 +1,119 @@
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Module used for profiling different cylc versions."""
+
+import os
+import re
+from subprocess import Popen, PIPE
+import sys
+
+from .git import is_git_repo
+
+
+def get_cylc_directory():
+    """Returns the location of cylc's working copy."""
+    ver_str, _ = Popen(['cylc', 'version', '--long'], stdout=PIPE
+                       ).communicate()
+    try:
+        return os.path.realpath(re.search('\((.*)\)', ver_str).groups()[0])
+    except IndexError:
+        sys.exit('Could not locate local git repository for cylc.')
+
+
+# Ensure that the cylc directory is a git repository.
+CYLC_DIR = get_cylc_directory()
+os.chdir(CYLC_DIR)
+if not is_git_repo():
+    print 'ERROR: profiling requires cylc to be a git repository.'
+    sys.exit(2)
+
+# Files and directories
+PROFILE_DIR_NAME = '.profiling'  # Path to profiling directory.
+PROFILE_FILE_NAME = 'results.json'  # Path to profiling results file
+PROFILE_PLOT_DIR_NAME = 'plots'  # Path to default plotting directory.
+USER_EXPERIMENT_DIR_NAME = 'experiments'  # Path to user defined experiments.
+EXPERIMENTS_PATH = os.path.join('dev', 'profile-experiments'
+                                )  # Path to built-in experiments.
+
+# Ancestor commit for cylc profile-battery
+PROFILE_COMMIT = 'abf238271d6cfe9cc5db5de812907195a5f8d5c7'  # TODO
+
+# Ancestor commit for analysis-compatible cylc (run|validate) --profile
+CYLC_PROFILING_COMMIT = '016e6a97be16eaf1a33ea19398a1ade09f86719e'
+
+# Profiling config.
+PROFILE_MODE_TIME = 'PROFILE_MODE_TIME'
+PROFILE_MODE_CYLC = 'PROFILE_MODE_CYLC'
+PROFILE_MODES = {'time': PROFILE_MODE_TIME,
+                 'cylc': PROFILE_MODE_CYLC}
+
+# Profile file suffixes.
+PROFILE_FILES = {
+    'cmd-out': '',
+    'cmd-err': '-cmd.err',
+    'time-err': '-time.err',
+    'startup': '-startup'
+}
+
+
+# ------------- REGEXES ---------------
+# Cylc profiling REGEXES.
+SUMMARY_LINE_REGEX = re.compile('([\d]+) function calls \(([\d]+) primitive'
+                                ' calls\) in ([\d.]+) CPU seconds')
+MEMORY_LINE_REGEX = re.compile('PROFILE: Memory: ([\d]+) KiB: ([\w.]+): (.*)')
+LOOP_MEMORY_LINE_REGEX = re.compile('(?:loop #|end main loop \(total loops )'
+                                    '([\d]+)(?:: |\): )(.*)')
+SLEEP_FUNCTION_REGEX = re.compile('([\d.]+)[\s]+[\d.]+[\s]+\{time.sleep\}')
+SUITE_STARTUP_STRING = 'SUITE STARTUP: '
+
+
+# -------------- METRICS ---------------
+METRIC_TITLE = 0  # For display purposes.
+METRIC_UNIT = 1  # For display purposes.
+METRIC_FILENAME = 2  # For output plots (no extension).
+METRIC_FIELDS = 3  # Fields metrics can be derived from in order of preference.
+METRICS = {
+    '001': ('Elapsed Time', 's', 'elapsed-time', [
+            'real', 'Elapsed (wall clock) time (h:mm:ss or m:ss)',
+            'cpu time'],),
+    '002': ('CPU Time - Total', 's', 'cpu-time', ['total cpu time'],),
+    '003': ('CPU Time - User', 's', 'user-time', [
+            'user', 'User time (seconds)'],),
+    '004': ('CPU Time - System', 's', 'system-time', [
+            'sys', 'System time (seconds)'],),
+    '005': ('Max Memory', 'kb', 'memory', [
+            'maximum resident set size', 'Maximum resident set size (kbytes)',
+            'mxmem'],),
+    '006': ('File System - Inputs', None, 'file-ins', [
+            'block input operations', 'File system inputs'],),
+    '007': ('File System - Outputs', None, 'file-outs', [
+            'block output operations', 'File system outputs'],),
+    '008': ('Startup Time', 's', 'startup-time', ['startup time'],),
+    '009': ('Number Of Main Loop Iterations', None, 'loop-count', [
+            'loop count'],),
+    '010': ('Average Main Loop Iteration Time', 's', 'loop-time', [
+            'avg loop time'],),
+    '011': ('Elapsed Time - time.sleep()', 's', 'awake-time', [
+            'awake cpu time'],)
+}
+METRICS_BY_FIELD = {}
+for metric in METRICS:
+    for field in METRICS[metric][METRIC_FIELDS]:
+        METRICS_BY_FIELD[field] = metric
+QUICK_ANALYSIS_METRICS = set(['001', '002', '005'])
+
+
+DEFAULT_PROFILE_MODES = ['time']

--- a/lib/cylc/profiling/analysis.py
+++ b/lib/cylc/profiling/analysis.py
@@ -1,0 +1,470 @@
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Module for performing analysis on profiling results."""
+
+from collections import OrderedDict
+import os
+import re
+import sys
+
+# Import modules required for plotting if avaliable.
+try:
+    import numpy
+    import warnings
+    warnings.simplefilter('ignore', numpy.RankWarning)
+    import matplotlib.cm as colour_map
+    import matplotlib.pyplot as plt
+    CAN_PLOT = True
+except ImportError:
+    CAN_PLOT = False
+
+from . import (PROFILE_MODE_TIME, PROFILE_MODE_CYLC, SUMMARY_LINE_REGEX,
+               MEMORY_LINE_REGEX, LOOP_MEMORY_LINE_REGEX, SLEEP_FUNCTION_REGEX,
+               SUITE_STARTUP_STRING, PROFILE_MODES, PROFILE_FILES, METRICS,
+               METRIC_TITLE, METRIC_UNIT, METRIC_FILENAME, METRIC_FIELDS,
+               QUICK_ANALYSIS_METRICS)
+from .git import (order_versions_by_date, describe)
+from cylc.wallclock import get_unix_time_from_time_string
+
+
+def mean(data):
+    """Return the mean average of a list of numbers."""
+    return sum(data) / float(len(data))
+
+
+def remove_profile_from_versions(versions):
+    """Handles any versions with "-profile" in the version_name.
+
+    Removes -profile* from the version name then sorts the versions by date
+    (using the new version names).
+    """
+    ret = list(versions)
+    flag = False
+    temp = {}
+    for version in ret:
+        try:
+            # Remove -profile from version_name if present.
+            ind = version['name'].index('-profile')
+            version['name'] = version['name'][:ind]
+            version_id = describe(version['name'])
+            # Temporally change the version_id to match the version_name.
+            if version_id:
+                temp[version['name']] = version['id']
+                version['id'] = version_id
+        except ValueError:
+            continue
+        else:
+            flag = True
+    if flag:
+        # Sort versions by date.
+        order_versions_by_date(ret)
+        # Revert version_ids.
+        for version in ret:
+            if version['name'] in temp:
+                version['id'] = temp[version['name']]
+        return ret
+    # No -profile versions, return the original list.
+    return versions
+
+
+def extract_results(result_file_dict, exp):
+    """Extract results from the result files output by each run."""
+    validate_mode = exp.get('validate_mode', False)
+    profile_modes = [PROFILE_MODES[mode] for mode in exp['profile modes']]
+
+    results = {}
+    data = {}
+    for run_name, result_files in result_file_dict.iteritems():
+        data[run_name] = []
+        for result_file in result_files:
+            profiling_results = {}
+            if PROFILE_MODE_TIME in profile_modes:
+                profiling_results.update(process_time_file(
+                    result_file + PROFILE_FILES['time-err']))
+            if PROFILE_MODE_CYLC in profile_modes:
+                suite_start_time = None
+                if not validate_mode:
+                    suite_start_time = get_startup_time(
+                        result_file + PROFILE_FILES['startup'])
+                profiling_results.update(process_out_file(
+                    result_file + PROFILE_FILES['cmd-out'], suite_start_time,
+                    validate_mode))
+            data[run_name].append(profiling_results)
+
+    results = process_results(data)
+    return results
+
+
+def get_startup_time(file_name):
+    """Return the value of the "SUITE STARTUP" entry as a string."""
+    with open(file_name, 'r') as startup_file:
+        return re.search('SUITE STARTUP: (.*)',
+                         startup_file.read()).groups()[0]
+
+
+def process_time_file(file_name):
+    """Extracts results from a result file generated using the /usr/bin/time
+    profiler."""
+    with open(file_name, 'r') as time_file:
+        ret = {}
+        lines = time_file.readlines()
+        for line in lines:
+            try:
+                field, value = line.strip().rsplit(': ', 1)
+            except ValueError:
+                print 'ERROR: Could not parse line "%s"' % line.strip()
+                continue
+            try:  # Try to cast as integer.
+                ret[field] = int(value)
+            except ValueError:
+                try:  # Try to cast as float.
+                    ret[field] = float(value)
+                except ValueError:
+                    if value.endswith('%'):  # Remove trailing % symbol
+                        try:  # Try to cast as integer.
+                            ret[field] = int(value[:-1])
+                        except ValueError:  # Try to cast as float.
+                            ret[field] = float(value[:-1])
+                    elif ':' in value:  # Is a time of form h:m:s or m:s
+                        seconds = 0.
+                        increment = 1.
+                        for time_field in reversed(value.split(':')):
+                            seconds += float(time_field) * increment
+                            increment *= 60
+                        ret[field] = seconds
+                    else:  # Cannot parse.
+                        if 'Command being timed' not in line:
+                            print 'ERROR: Could not parse value "%s"' % line
+                            ret[field] = value
+        if sys.platform == 'darwin':  # MacOS
+            ret['total cpu time'] = (ret['user'] + ret['sys'])
+        else:  # Assume Linux
+            ret['total cpu time'] = (ret['User time (seconds)'] +
+                                     ret['System time (seconds)'])
+        return ret
+
+
+def process_out_file(file_name, suite_start_time, validate=False):
+    """Extract data from the out log file."""
+    if not os.path.exists(file_name):
+        sys.exit('No file with path {0}'.format(file_name))
+    with open(file_name, 'r') as out_file:
+        ret = {}
+        lines = out_file.readlines()
+
+        # Get start time.
+        if lines[0].startswith(SUITE_STARTUP_STRING):
+            ret['suite start time'] = float(
+                lines[0][len(SUITE_STARTUP_STRING):])
+
+        # Scan through log entries.
+        ret['memory'] = OrderedDict()
+        loop_mem_entries = []
+        for line in lines:
+            # Profile summary.
+            match = SUMMARY_LINE_REGEX.search(line)
+            if match:
+                ret['function calls'] = int(match.groups()[0])
+                ret['primitive function calls'] = int(match.groups()[1])
+                ret['cpu time'] = float(match.groups()[2])
+                continue
+
+            # Memory info.
+            match = MEMORY_LINE_REGEX.search(line)
+            if match:
+                memory, module, checkpoint = tuple(match.groups())
+                ret['memory'][(module, checkpoint,)] = int(memory)
+
+                # Main loop memory info.
+                if not validate:
+                    match = LOOP_MEMORY_LINE_REGEX.search(checkpoint)
+                    if match:
+                        loop_no, time_str = match.groups()
+                        loop_mem_entries.append((
+                            int(loop_no),
+                            int(get_unix_time_from_time_string(time_str)),
+                        ))
+                continue
+
+            # Sleep time.
+            match = SLEEP_FUNCTION_REGEX.search(line)
+            if match:
+                ret['sleep time'] = float(match.groups()[0])
+                continue
+
+        # Number of loops.
+        if not validate:
+            ret['loop count'] = loop_mem_entries[-1][0]
+            ret['avg loop time'] = (float(loop_mem_entries[-1][1] -
+                                    loop_mem_entries[0][1]) /
+                                    loop_mem_entries[-1][0])
+
+        # Maximum memory usage.
+        ret['mxmem'] = max([ret['memory'][key] for key in ret['memory']])
+
+        # Startup time (time from running cmd to reaching the end of the first
+        # loop).
+        if not validate:
+            ret['startup time'] = (loop_mem_entries[0][1] -
+                                   round(float(suite_start_time), 1))
+
+        # Awake CPU time.
+        if not validate:
+            ret['awake cpu time'] = (ret['cpu time'] - ret['sleep time'])
+
+    return ret
+
+
+def process_results(results):
+    """Average over results for each run."""
+    processed_results = {}
+    all_metrics = set(METRICS.keys())
+    for run_name, run in results.iteritems():
+        processed_results[run_name] = {}
+        this_result = dict((metric, []) for metric in all_metrics)
+        for result in run:
+            for metric in all_metrics:
+                for field in METRICS[metric][METRIC_FIELDS]:
+                    if field in result:
+                        this_result[metric].append(result[field])
+            all_metrics = all_metrics & set(this_result.keys())
+        for metric in all_metrics:
+            if this_result[metric]:
+                processed_results[run_name][metric] = mean(this_result[metric])
+    for metric in set(METRICS.keys()) - all_metrics:
+        for run_name, run in processed_results.iteritems():
+            del run[metric]
+    return processed_results
+
+
+def get_metrics_for_experiment(experiment, results, quick_analysis=False):
+    """Return a set of metric keys present in the results for experiment
+
+    If a metric is missing from one result it is skipped.
+
+    """
+    metrics = set([])
+    for version_id in results:
+        if experiment['id'] in results[version_id]:
+            for run in results[version_id][experiment['id']].values():
+                if metrics:
+                    metrics = metrics & set(run.keys())
+                else:
+                    metrics = set(run.keys())
+    if quick_analysis:
+        return metrics & QUICK_ANALYSIS_METRICS
+    return metrics
+
+
+def get_metric_title(metric):
+    """Return a user-presentable title for a given metric key."""
+    metric_title = METRICS[metric][METRIC_TITLE]
+    metric_unit = METRICS[metric][METRIC_UNIT]
+    if metric_unit:
+        metric_title += ' (' + metric_unit + ')'
+    return metric_title
+
+
+def make_table(results, versions, experiment, quick_analysis=False):
+    """Produce a 2D array representing the results of the provided
+    experiment."""
+    metrics = get_metrics_for_experiment(experiment, results,
+                                         quick_analysis=quick_analysis)
+
+    # Make header rows.
+    table = [['Version', 'Run'] + [get_metric_title(metric) for metric in
+                                   sorted(metrics)]]
+
+    # Make content rows.
+    try:
+        for version in versions:
+            data = results[version['id']][experiment['id']]
+            run_names = data.keys()
+            try:
+                run_names.sort(key=lambda x: int(x))
+            except ValueError:
+                run_names.sort()
+            for run_name in run_names:
+                table.append([version['name'], run_name] +
+                             [data[run_name][metric] for metric in
+                              sorted(metrics)])
+    except ValueError:
+        print ('ERROR: Data is not complete. Try removing results and '
+               're-running any experiments')
+
+    return table
+
+
+def print_table(table, transpose=False):
+    """Print a 2D list as a table.
+
+    None values are printed as hyphens, use '' for blank cells.
+    """
+    if transpose:
+        table = map(list, zip(*table))
+    if not table:
+        return
+    for row_no in range(len(table)):
+        for col_no in range(len(table[0])):
+            cell = table[row_no][col_no]
+            if cell is None:
+                table[row_no][col_no] = []
+            else:
+                table[row_no][col_no] = str(cell)
+
+    col_widths = []
+    for col_no in range(len(table[0])):
+        col_widths.append(
+            max([len(table[row_no][col_no]) for row_no in range(len(table))]))
+
+    for row_no in range(len(table)):
+        for col_no in range(len(table[row_no])):
+            if col_no != 0:
+                sys.stdout.write('  ')
+            cell = table[row_no][col_no]
+            if type(cell) is list:
+                sys.stdout.write('-' * col_widths[col_no])
+            else:
+                sys.stdout.write(cell + ' ' * (col_widths[col_no] - len(cell)))
+        sys.stdout.write('\n')
+
+
+def plot_single(results, run_names, versions, metric, experiment,
+                axis, c_map):
+    """Create a bar chart comparing the results of all runs."""
+    n_groups = len(versions)
+    n_bars = len(run_names)
+    ind = numpy.arange(n_groups)
+    spacing = 0.1
+    width = (1. - spacing) / n_bars
+    colours = [c_map(x / (n_bars - 0.99)) for x in range(n_bars)]
+
+    for bar_no, run_name in enumerate(run_names):
+        data = [results[version['id']][experiment['id']][run_name][metric]
+                for version in versions]
+        axis.bar(ind + (bar_no * width), data, width, label=run_name,
+                 color=colours[bar_no])
+
+    axis.set_xticks(ind + ((width * n_bars) / 2.))
+    axis.set_xticklabels([version['name'] for
+                          version in versions])
+    axis.set_xlabel('Cylc Version')
+    axis.set_xlim([0, (1. * n_groups) - spacing])
+    if len(run_names) > 1:
+        axis.legend(loc='upper left', prop={'size': 9})
+
+
+def plot_scale(results, run_names, versions, metric, experiment,
+               axis, c_map, lobf_order=2):
+    """Create a scatter plot with line of best fit interpreting float(run_name)
+    as the x-axis value."""
+    x_data = [int(run_name) for run_name in run_names]
+    colours = [c_map(x / (len(versions) - 0.99)) for x in range(len(versions))]
+
+    for ver_no, version in enumerate(reversed(versions)):
+        y_data = []
+        for run_name in run_names:
+            y_data.append(
+                results[version['id']][experiment['id']][run_name][metric]
+            )
+
+        # Plot data point.
+        if lobf_order >= 1:
+            axis.plot(x_data, y_data, 'x', color=colours[ver_no])
+        else:
+            axis.plot(x_data, y_data, 'x', color=colours[ver_no],
+                      label=version['name'])
+
+        # Compute and plot line of best fit.
+        if lobf_order >= 1:
+            if lobf_order > 8:
+                print ('WARNING: Line of best fit order too high (' +
+                       lobf_order + '). Order has been set to 3.')
+                lobf_order = 3
+            lobf = numpy.polyfit(x_data, y_data, lobf_order)
+            line = numpy.linspace(x_data[0], x_data[-1], 100)
+            points = numpy.poly1d(lobf)(line)
+            axis.plot(line, points, '-', color=colours[ver_no],
+                      label=version['name'])
+
+        # Plot settings.
+        axis.set_xlabel(experiment['config']['x-axis'] if 'x-axis' in
+                        experiment['config'] else 'Tasks')
+        axis.legend(loc='upper left', prop={'size': 9})
+
+
+def plot_results(results, versions, experiment, plt_dir=None,
+                 quick_analysis=False, lobf_order=2):
+    """Plot the results for the provided experiment.
+
+    By default plots are
+    written out to plt_dir. If not plt_dir then the plots will be displayed
+    interactively.
+
+    Args:
+        results (dict): The data contained in the profiling results file.
+        versions (list): List of version dictionaries for versions to plot.
+        experiment (dict): Experiment dict for the experiment to plot.
+        plt_dir (str): Directory to render any plots into.
+        quick_analysis (bool - optional): If True only a small set of metrics
+            will be plotted.
+        lobf_order (int - optional): The polynomial order for the line of best
+            fit, will be used for ALL plots.
+
+    """
+    # Are we able to plot?
+    if not CAN_PLOT:
+        print ('\nWarning: Plotting requires numpy and maplotlib so cannot be '
+               'run.')
+        return
+
+    versions = remove_profile_from_versions(versions)
+
+    metrics = get_metrics_for_experiment(experiment, results,
+                                         quick_analysis=quick_analysis)
+    run_names = [run['name'] for run in experiment['config']['runs']]
+    plot_type = experiment['config']['analysis']
+
+    c_map = colour_map.Set1
+
+    # One plot per metric.
+    for metric in metrics:
+        # Set up plotting.
+        fig = plt.figure(111)
+        axis = fig.add_subplot(111)
+
+        if plot_type == 'single':
+            plot_single(results, run_names, versions, metric,
+                        experiment, axis, c_map)
+        elif plot_type == 'scale':
+            plot_scale(results, run_names, versions, metric,
+                       experiment, axis, c_map, lobf_order=lobf_order)
+
+        # Common config.
+        axis.grid(True)
+        axis.set_ylabel(get_metric_title(metric))
+
+        # Output graph.
+        if not plt_dir:
+            # Output directory not specified, use interractive mode.
+            plt.show()
+        else:
+            # Output directory specified, save figure as a pdf.
+            fig.savefig(os.path.join(plt_dir,
+                                     METRICS[metric][METRIC_FILENAME] +
+                                     '.pdf'))
+
+            fig.clear()

--- a/lib/cylc/profiling/analysis.py
+++ b/lib/cylc/profiling/analysis.py
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""Module for performing analysis on profiling results."""
+"""Module for performing analysis on profiling results and generating plots."""
 
 from collections import OrderedDict
 import os

--- a/lib/cylc/profiling/git.py
+++ b/lib/cylc/profiling/git.py
@@ -93,8 +93,5 @@ def has_changes_to_be_committed():
 
 def is_git_repo():
     """Returns true if we are currently within a git repository."""
-    proc = Popen('[ -d .git ] || git rev-parse --git-dir > /dev/null 2>&1',
-                 stdout=PIPE, stderr=PIPE, shell=True)
-    if proc.wait() != 0:
-        return False
-    return True
+    proc = Popen(['git', 'rev-parse', '--git-dir'], stdout=PIPE, stderr=PIPE,)
+    return proc.wait() == 0

--- a/lib/cylc/profiling/git.py
+++ b/lib/cylc/profiling/git.py
@@ -1,0 +1,100 @@
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Provides python wrappers to certain git commands."""
+
+import os
+from subprocess import (Popen, PIPE, CalledProcessError, check_call)
+
+
+class GitCheckoutError(Exception):
+    """Exception to be raised if a git checkout command fails."""
+    pass
+
+
+def describe(ref=None):
+    """Returns stdout of the `git describe <COMMIT>` command."""
+    try:
+        cmd = ['git', 'describe']
+        if ref:
+            cmd.append(ref)
+        return Popen(cmd, stdout=PIPE).communicate()[0].strip()
+    except CalledProcessError:
+        return None
+
+
+def is_ancestor_commit(commit1, commit2):
+    """Returns True if commit1 is an ancestor of commit2."""
+    try:
+        ancestor = Popen(['git', 'merge-base', commit1, commit2],
+                         stdout=PIPE).communicate()[0].strip()
+        return ancestor == commit1
+    except CalledProcessError:
+        return False
+
+
+def checkout(branch, delete_pyc=False):
+    """Checkouts the git branch with the provided name."""
+    try:
+        cmd = ['git', 'checkout', '-q', branch]
+        print '$ ' + ' '.join(cmd)
+        check_call(cmd)
+    except CalledProcessError:
+        raise GitCheckoutError()
+    try:
+        if delete_pyc:
+            cmd = ['find', 'lib', '-name', r'\*.pyc', '-delete']
+            print '$ ' + ' '.join(cmd)
+            check_call(cmd, stdout=open(os.devnull, 'wb'))
+    except CalledProcessError:
+        pass
+
+
+def get_commit_date(commit):
+    """Returns the commit date (in unix time) of the profided commit."""
+    return int(Popen(['git', 'show', '-s', '--format=%at', commit],
+                     stdout=PIPE).communicate()[0].split()[-1])
+
+
+def order_versions_by_date(versions):
+    """Orders a list of version objects by the date of the most recent
+    commit."""
+    versions.sort(key=lambda x: get_commit_date(x['id']))
+
+
+def order_identifiers_by_date(versions):
+    """Orders a list of git identifiers by the date of the most recent
+    commit."""
+    versions.sort(key=lambda x: get_commit_date(x))
+
+
+def has_changes_to_be_committed():
+    """Returns True if there are any un-committed changes to the working
+    copy."""
+    git_status = Popen(['git', 'status'], stdout=PIPE).communicate()[0]
+    if 'Changes to be committed' in git_status:
+        return True
+    if 'Changed but not updated' in git_status:
+        return True
+    return False
+
+
+def is_git_repo():
+    """Returns true if we are currently within a git repository."""
+    proc = Popen('[ -d .git ] || git rev-parse --git-dir > /dev/null 2>&1',
+                 stdout=PIPE, stderr=PIPE, shell=True)
+    if proc.wait() != 0:
+        return False
+    return True

--- a/lib/cylc/profiling/profile.py
+++ b/lib/cylc/profiling/profile.py
@@ -1,0 +1,330 @@
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Performs profiling of cylc.
+
+System calls to cylc are performed here.
+
+"""
+
+import os
+import shutil
+from subprocess import (Popen, PIPE, call as subprocess_call)
+import sys
+import tempfile
+import time
+import traceback
+
+from . import (PROFILE_MODE_TIME, PROFILE_MODE_CYLC, PROFILE_MODES,
+               PROFILE_FILES, CYLC_DIR, SUITE_STARTUP_STRING)
+from .analysis import extract_results
+from .git import (checkout, describe, GitCheckoutError,)
+
+
+# Environment for executing cylc commands in.
+CYLC_ENV = os.environ.copy()
+CYLC_ENV['CYLC_CONF_PATH'] = ''
+
+
+class SuiteFailedException(Exception):
+    """Exception to handle the failure of a suite-run / validate command."""
+
+    MESSAGE = '''ERROR: "{cmd}" returned a non-zero code.'
+    stdout: {stdout}
+    stderr: {stderr}'''
+
+    def __init__(self, cmd, stdout, stderr):
+        self.cmd = '$ ' + ' '.join(cmd)
+        self.stdout = stdout
+        self.stderr = stderr
+        Exception.__init__(self, str(self))
+
+    def __str__(self):
+        return self.MESSAGE.format(cmd=self.cmd, stdout=self.stdout,
+                                   stderr=self.stderr)
+
+
+class ProfilingKilledException(SuiteFailedException):
+    """Exception to handle the event that a user has canceled profiling whilst
+    a suite is runnnig."""
+    pass
+
+
+def cylc_major_version():
+    """Return the first character of the cylc version e.g. '7'."""
+    return Popen(['cylc', '--version'], env=CYLC_ENV, stdout=PIPE
+                 ).communicate()[0].strip()[0]
+
+
+def register_suite(reg, sdir):
+    """Registers the suite located in sdir with the registration name reg."""
+    cmd = ['cylc', 'register', reg, sdir]
+    print '$ ' + ' '.join(cmd)
+    if not subprocess_call(cmd, stdout=PIPE, env=CYLC_ENV):
+        return True
+    print '\tFailed'
+    return False
+
+
+def unregister_suite(reg):
+    """Unregisters the suite reg."""
+    cmd = ['cylc', 'unregister', reg]
+    print '$ ' + ' '.join(cmd)
+    subprocess_call(cmd, stdout=PIPE, env=CYLC_ENV)
+
+
+def purge_suite(reg):
+    """Deletes the run directory for this suite."""
+    print '$ rm -rf ' + os.path.expanduser(os.path.join('~', 'cylc-run', reg))
+    try:
+        shutil.rmtree(os.path.expanduser(os.path.join('~', 'cylc-run', reg)))
+    except Exception:
+        return False
+    else:
+        return True
+
+
+def run_suite(reg, options, out_file, profile_modes, mode='live'):
+    """Runs cylc run / cylc validate on the provided suite with the requested
+    profiling options.
+
+    Arguments:
+        reg (str): The registration of the suite to run.
+        options (list): List of jinja2 setting=value pairs.
+        out_file (str): The file to redirect stdout to.
+        profile_modes (list): List of profileing systems to employ
+            (i.e. cylc, time).
+        mode (str - optional): The mode to run the suite in, simulation, dummy,
+            live or validate.
+
+    Returns:
+        str - The path to the suite stderr if any is present.
+
+    """
+    cmds = []
+
+    # Cylc profiling, echo command start time.
+    if PROFILE_MODE_CYLC in profile_modes:
+        cmds += ['echo', SUITE_STARTUP_STRING, r'$(date +%s.%N)', '&&']
+
+    # /usr/bin/time profiling.
+    if PROFILE_MODE_TIME in profile_modes:
+        if sys.platform == 'darwin':  # MacOS
+            cmds += ['/usr/bin/time', '-lp']
+        else:  # Assume Linux
+            cmds += ['/usr/bin/time', '-v']
+
+        # Run using `sh -c` to enable the redirecton of output (darwins
+        # /usr/bin/time command does not have a -o option).
+        cmds += ['sh', '-c', "'"]
+
+    # Cylc run.
+    run_cmds = []
+    if mode == 'validate':
+        run_cmds = ['cylc', 'validate']
+    elif mode == 'profile-simulation':
+        # In simulation mode task scripts are manually replaced with sleep 1.
+        run_cmds = ['cylc', 'run', '--mode', 'live']
+    else:
+        run_cmds = ['cylc', 'run', '--mode', mode]
+    run_cmds += [reg]
+    cmds += run_cmds
+
+    # Jinja2 params.
+    jinja2_params = ['-s {0}'.format(option) for option in options]
+    if mode == 'profile-simulation':
+        # Add namespaces jinja2 param (list of task names).
+        tmp = ['-s namespaces=root']
+        namespaces = Popen(
+            ['cylc', 'list', reg] + jinja2_params + tmp, stdout=PIPE,
+            env=CYLC_ENV).communicate()[0].split() + ['root']
+        jinja2_params.append(
+            '-s namespaces={0}'.format(','.join(namespaces)))
+    cmds.extend(jinja2_params)
+
+    # Cylc profiling.
+    if PROFILE_MODE_CYLC in profile_modes:
+        if mode == 'validate':
+            sys.exit('ERROR: profile_mode "cylc" not possible in validate '
+                     'mode')
+        else:
+            cmds += ['--profile']
+
+    # No-detach mode.
+    if mode != 'validate':
+        cmds += ['--no-detach']
+
+    # Redirect output.
+    cmd_out = out_file + PROFILE_FILES['cmd-out']
+    cmd_err = out_file + PROFILE_FILES['cmd-err']
+    time_err = out_file + PROFILE_FILES['time-err']
+    startup_file = out_file + PROFILE_FILES['startup']
+    cmds += ['>', cmd_out, '2>', cmd_err]
+    if PROFILE_MODE_TIME in profile_modes:
+        cmds += ["'"]  # Close shell.
+
+    # Execute.
+    print '$ ' + ' '.join(cmds)
+    try:
+        proc = Popen(' '.join(cmds), shell=True, stderr=open(time_err, 'w+'),
+                     stdout=open(startup_file, 'w+'), env=CYLC_ENV)
+        if proc.wait():
+            raise SuiteFailedException(run_cmds, cmd_out, cmd_err)
+    except KeyboardInterrupt:
+        kill_cmd = ['cylc', 'stop', '--kill', reg]
+        print '$ ' + ' '.join(kill_cmd)
+        subprocess_call(kill_cmd, env=CYLC_ENV)
+        raise ProfilingKilledException(run_cmds, cmd_out, cmd_err)
+
+    # Return cylc stderr if present.
+    try:
+        if os.path.getsize(cmd_err) > 0:
+            return cmd_err
+    except OSError:
+        pass
+    return None
+
+
+def run_experiment(exp, version_id):
+    """Run the provided experiment on the currently checked-out version of
+    cylc. Return a dictionary of result files by run name."""
+    profile_modes = [PROFILE_MODES[mode] for mode in exp['profile modes']]
+    cylc_maj_version = cylc_major_version()
+    result_files = {}
+    to_purge = []
+    for run in exp['runs']:
+        results_for_run = []
+        sdir = os.path.expanduser(run['suite dir'])
+        reg = 'profile-' + str(time.time()).replace('.', '')
+        count = 0
+        while count < run['repeats'] + 1:
+            # Run suite.
+            out_file = tempfile.mkstemp()[1]
+            results_for_run.append(out_file)
+            register_suite(reg, sdir)
+            err_file = run_suite(
+                reg,
+                run['options'] + ['cylc_compat_mode=%s' % cylc_maj_version],
+                out_file,
+                profile_modes,
+                exp.get('mode', 'live'))
+            # Handle errors.
+            if err_file:
+                print >> sys.stderr, ('WARNING: non-empty suite error log: ' +
+                                      err_file)
+            # Tidy up.
+            if cylc_maj_version == '6':
+                unregister_suite(reg)
+            if not purge_suite(reg):
+                # Remove suite run dirs, if error then try again later.
+                to_purge.append(reg)
+            count += 1
+        result_files[run['name']] = results_for_run
+
+        if to_purge:
+            time.sleep(2)  # Wait a bit before trying again to remove run dirs.
+        for reg in to_purge:
+            if purge_suite(reg):
+                to_purge.remove(reg)
+
+        if to_purge:
+            print ('ERROR: The following suite(s) run directories could not be'
+                   ' deleted:')
+            print '\t', ' '.join(to_purge)
+
+    return result_files
+
+
+def delete_result_files(result_files):
+    """Deletes the temp files used to store experiment results."""
+    for files in result_files.values():
+        for file_ in files:
+            for suffix in PROFILE_FILES.values():
+                try:
+                    os.remove(file_ + suffix)
+                except OSError:
+                    pass
+
+
+def profile(schedule):
+    """Perform profiling for the provided schedule.
+
+    Args:
+        schedule (list): A list of tuples of the form
+            [(version_id, experiments)] where experiments is a list of
+            experiment objects.
+
+    Returns:
+        tuple - (results, checkout_count, success)
+          - results (dict) - A dictionary containing profiling results in the
+            form {version_id: experiment_id: metric: value}.
+          - checkout_count (int) - The number of times the git checkout command
+            has been executed.
+          - success (bool) - True if all experiments completed successfully,
+            else False.
+    """
+    checkout_count = 0
+    results = {}
+    success = True
+    for version_id, experiments in sorted(schedule.iteritems()):
+        # Checkout cylc version.
+        if version_id != describe():
+            try:
+                checkout(version_id, delete_pyc=True)
+                checkout_count += 1
+            except GitCheckoutError:
+                sys.exit('Error: git checkout failed, were changes made to the'
+                         ' working copy?')
+
+        # Run Experiment.
+        for experiment in experiments:
+            try:
+                result_files = run_experiment(experiment['config'], version_id)
+            except SuiteFailedException as exc:
+                # Experiment failed to run, move onto the next one.
+                print >> sys.stderr, ('Experiment "%s" failed at version "%s"'
+                                      '' % (experiment['name'], version_id))
+                print >> sys.stderr, exc
+                success = False
+                continue
+            except ProfilingKilledException as exc:
+                # Profiling has been terminated, return what results we have.
+                print exc
+                return results, checkout_count, False
+            else:
+                # Run analysis.
+                try:
+                    processed_results = extract_results(
+                        result_files, experiment['config'])
+                except:
+                    # Analysis failed, move onto the next experiment.
+                    traceback.print_exc()
+                    print ('Analysis failed on results from experiment "%s"'
+                           'running at version "%s"' % (experiment['name'],
+                                                        version_id))
+                    if any([PROFILE_MODES[mode] == PROFILE_MODE_CYLC for mode
+                            in experiment['config']['profile modes']]):
+                        print ('Are you trying to use profile mode "cylc" '
+                               'with an older version of cylc?')
+                    success = False
+                    continue
+                else:
+                    if version_id not in results:
+                        results[version_id] = {}
+                    results[version_id][experiment['id']] = (
+                        processed_results)
+                    delete_result_files(result_files)
+
+    return results, checkout_count, success

--- a/tests/profile-battery/00-compatability.t
+++ b/tests/profile-battery/00-compatability.t
@@ -1,0 +1,72 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Ensure that any changes to cylc haven't broken the profile-battery command
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 5
+#-------------------------------------------------------------------------------
+# Check the format of `cylc version --long`.
+run_ok "${TEST_NAME_BASE}-cylc-version" python -c "
+import os
+import sys
+os.chdir('${CYLC_DIR}/lib')
+from cylc.profiling import get_cylc_directory
+if get_cylc_directory() != '${CYLC_DIR}':
+    sys.exit(1)
+"
+#-------------------------------------------------------------------------------
+# Check for hello-world suite and that the cylc list command is still instated.
+TEST_NAME="${TEST_NAME_BASE}-cylc-list-hello-world-suite"
+run_ok "${TEST_NAME}" cylc list "${CYLC_DIR}/dev/suites/hello-world"
+cmp_ok "${TEST_NAME}.stdout" "${TEST_NAME}.stdout" "hello-world"
+#-------------------------------------------------------------------------------
+# Check that the suites located in $CYLC_DIR/dev/suites are still valid.
+TEST_NAME="${TEST_NAME_BASE}-dev-suites-validate"
+broken=
+for suite in $(find "${CYLC_DIR}/dev/suites" -name suite.rc)
+do
+    if ! cylc validate "${suite}" 2>&1 >/dev/null
+    then
+        broken="${suite}\n${broken}"
+    fi
+done
+if [[ -z "${broken}" ]]
+then
+    ok "${TEST_NAME}"
+else
+    echo -en "The following suites failed validation:\n${broken}" \
+        > "${TEST_NAME}.stderr"
+    cp "${TEST_NAME}.stderr" "${TEST_LOG_DIR}/${TEST_NAME}.stderr"
+    fail "${TEST_NAME}"
+fi
+#-------------------------------------------------------------------------------
+# Run the test experiment.
+TEST_NAME="${TEST_NAME_BASE}-run-test-experiment"
+cylc profile-battery -e test -v HEAD --test
+if [[ $? == 0 ]]
+then
+    ok "${TEST_NAME}"
+elif [[ $? == 2 ]]
+then
+    1>&2 echo "Test requires git repository."
+    skip 1
+else
+    1>&2 echo "Failed to run experiment" > "${TEST_NAME}.stderr"
+    cp "${TEST_NAME}.stderr" "${TEST_LOG_DIR}/${TEST_NAME}.stderr"
+    fail "${TEST_NAME}"
+fi

--- a/tests/profile-battery/test_header
+++ b/tests/profile-battery/test_header
@@ -1,0 +1,1 @@
+../lib/bash/test_header


### PR DESCRIPTION
Introduce `cylc profile-battery` command for comparing the overhead of running suites under different cylc versions. Close #1772 

`cylc profile-battery -e <experiment-ids> -v <version-ids>`

- Can only be run in a git repository.
  - Functional requirement for identifying cylc versions etc.
- Creates `cylc/.profile` directory (when run) for storing results etc.
- Experiments are json files which determine which suites to run, how to run them and how to profile them.
  - Currently these are json files, they could be upgraded to parsec if desired.
  - Built-in experiment files live in `cylc/dev/profile-experiments`, user experiment files live in `cylc/.profile/experiments`.
  - See `dev/profile-experiments/example` for info on experiment files.
  - Results are stored along with a checksum of the experiment file, once an experiment file is modified its results are orphaned (and can no-longer be plotted - this limitation could potentially be overcome) but can be reinstated using `cylc profile-battery promote <experiment-id>`.
  - Suites for profiling can be located anywhere accessible by the filesystem, built-in experiments should use suites in `dev/suites`.
- Version-ids can be any valid git identifier e.g. `6.11.2`, `HEAD`, `master`, `<some-commit>`.
- Profiling can be performed both on `run` and `validate`.
  - Profiling is performed using either `/usr/bin/time` and or `cylc <cmd> --profile`.
  - Only a few metrics are output to the user, to see more `cylc profile-battery -e <experiment_ids> -v <version_ids> --full`
- When run, profiling is performed then data is plotted (if matplotlib is installed) and output to `.profile/plots`.
- Results are saved to `.profile/results.json`, the experiment can then be run for other cylc versions and the results analysed.
  - Results file could be upgraded to results database if desired.
- To profile multiple cylc versions either check-out each one in turn then `cylc profile-battery -e <experiment> -v HEAD --no-plot` or specify all versions upfront and use the automatic `git checkout` feature `cylc profile-battery -e experiment -v HEAD 6.11.4 7.1.0`.

`cylc profile-battery --help` has some more details.

Other Changes:
- `dev/suites` are now compliant with cylc master (test added to ensure this).
- Profiling suites (including the "complex suite") added in `dev/suites`.