### PR TITLE
#2164 - fix Jinja2 processing of site config

### DIFF
--- a/lib/parsec/jinja2support.py
+++ b/lib/parsec/jinja2support.py
@@ -74,6 +74,10 @@ def jinja2process(flines, dir_, template_vars=None):
         for item in sorted(template_vars.items()):
             print '    + %s=%s' % item
 
+    # Jinja2 render method requires a dictionary as argument (not None):
+    if not template_vars:
+        template_vars={}
+
     # CALLERS SHOULD HANDLE JINJA2 TEMPLATESYNTAXERROR AND TEMPLATEERROR
     # AND TYPEERROR (e.g. for not using "|int" filter on number inputs.
     # Convert unicode to plain str, ToDo - still needed for parsec?)

--- a/lib/parsec/jinja2support.py
+++ b/lib/parsec/jinja2support.py
@@ -76,7 +76,7 @@ def jinja2process(flines, dir_, template_vars=None):
 
     # Jinja2 render method requires a dictionary as argument (not None):
     if not template_vars:
-        template_vars={}
+        template_vars = {}
 
     # CALLERS SHOULD HANDLE JINJA2 TEMPLATESYNTAXERROR AND TEMPLATEERROR
     # AND TYPEERROR (e.g. for not using "|int" filter on number inputs.


### PR DESCRIPTION
`jinja2support.py` uses `None` to indicate that no Jinja2 template variables are defined. This causes an error when passed to the Jinja2 render method, which expects a dictionary. The suggested solution involves converting None into an empty dictionary.

Close #2164.