### PR TITLE
Improve SSL certificate logic

### DIFF
--- a/lib/cylc/network/https/base_client.py
+++ b/lib/cylc/network/https/base_client.py
@@ -79,8 +79,6 @@ class BaseCommsClient(object):
         payload = fargs.pop("payload", None)
         method = fargs.pop("method", self.METHOD)
         host = self.host
-        if not self.host.split(".")[0].isdigit():
-            host = self.host.split(".")[0]
         if host == "localhost":
             host = get_hostname().split(".")[0]
         url = 'https://%s:%s/%s/%s' % (host, self.port, category, fname)


### PR DESCRIPTION
1. Client no longer removes domain suffix from host. Fix #2167.

2. Re-create SSL certificate on change to host. E.g. if a suite is registered on host A, but is later run on host B (with a shared file system with host A), the new logic will create a new SSL certificate. This ensures that the certificate is valid for the run host. (Change 2 is essential on our site after change 1, and may be related to the `SSLError` reported on [this Google Groups thread](https://groups.google.com/forum/?fromgroups#!topic/cylc/Eahss_mXgqM).)