### PR TITLE
Strftime jinja2 filter: Add strptime option

### DIFF
--- a/doc/cug.tex
+++ b/doc/cug.tex
@@ -4977,6 +4977,16 @@ Examples:
     \item \lstinline={{START_CYCLE | strftime('%H:%M:%S %z')}}= - 08:00:00 +01
 \end{myitemize}
 
+It is also possible to parse non-standard date-time strings by passing a
+strptime string as the second argument.
+
+Examples:
+
+\begin{myitemize}
+    \item \lstinline={{'12,30,2000' | strftime('%m', '%m,%d,%Y')}}= - 12
+    \item \lstinline={{'1066/10/14 08:00:00' | strftime('%Y%m%dT%H', '%Y/%m/%d %H:%M:%S')}}= - 10661014T08
+\end{myitemize}
+
 \subsubsection{Associative Arrays In Jinja2}
 
 Associative arrays ({\em dicts} in Python) can be very useful.

--- a/lib/Jinja2Filters/strftime.py
+++ b/lib/Jinja2Filters/strftime.py
@@ -18,21 +18,25 @@
 from isodatetime.parsers import TimePointParser
 
 
-def strftime(iso8601_datetime, strftime):
+def strftime(iso8601_datetime, strftime, strptime=None):
     """Format an iso8601 datetime string using an strftime string.
 
     Args:
         iso8601_datetime (str): Any valid ISO8601 datetime as a string.
-        strftime (str): Any valid strftime string.
+        strftime (str): A valid strftime string to format the output datetime.
+        strptime (str - optional): A valid strptime string defining the format
+            of the provided iso8601_datetime.
 
     Return:
-        The result of applying the strftime to the iso8601_datetime
+        The result of applying the strftime to the iso8601_datetime as parsed
+        by the strptime string if provided.
 
     Raises:
         ISO8601SyntaxError: In the event of an invalid datetime string.
         StrftimeSyntaxError: In the event of an invalid strftime string.
 
     Examples:
+        >>> # Basic usage.
         >>> strftime('2000-01-01T00Z', '%H')
         '00'
         >>> strftime('2000', '%H')
@@ -43,15 +47,31 @@ def strftime(iso8601_datetime, strftime):
         '+0100'
         >>> strftime('10661014T08+01', '%j')  # Day of the year
         '287'
+
+        >>> # Strptime.
+        >>> strftime('12,30,2000', '%m', '%m,%d,%Y')
+        '12'
+        >>> strftime('1066/10/14 08:00:00', '%Y%m%dT%H', '%Y/%m/%d %H:%M:%S')
+        '10661014T08'
+
+        >>> # Exceptions.
         >>> try:
         ...     strftime('invalid', '%H')  # Invalid datetime.
         ... except Exception as exc:
         ...     print type(exc)
         <class 'isodatetime.parsers.ISO8601SyntaxError'>
         >>> try:
-        ...     strftime('2000', '%invalid')  # Invalid strftime
+        ...     strftime('2000', '%invalid')  # Invalid strftime.
+        ... except Exception as exc:
+        ...     print type(exc)
+        <class 'isodatetime.parser_spec.StrftimeSyntaxError'>
+        >>> try:
+        ...     strftime('2000', '%Y', '%invalid')  # Invalid strptime.
         ... except Exception as exc:
         ...     print type(exc)
         <class 'isodatetime.parser_spec.StrftimeSyntaxError'>
     """
-    return TimePointParser().parse(iso8601_datetime).strftime(strftime)
+    if not strptime:
+        return TimePointParser().parse(iso8601_datetime).strftime(strftime)
+    return TimePointParser().strptime(iso8601_datetime, strptime).strftime(
+        strftime)

--- a/lib/Jinja2Filters/strftime.py
+++ b/lib/Jinja2Filters/strftime.py
@@ -18,14 +18,15 @@
 from isodatetime.parsers import TimePointParser
 
 
-def strftime(iso8601_datetime, strftime, strptime=None):
+def strftime(iso8601_datetime, strftime_str, strptime_str=None):
     """Format an iso8601 datetime string using an strftime string.
 
     Args:
         iso8601_datetime (str): Any valid ISO8601 datetime as a string.
-        strftime (str): A valid strftime string to format the output datetime.
-        strptime (str - optional): A valid strptime string defining the format
-            of the provided iso8601_datetime.
+        strftime_str (str): A valid strftime string to format the output
+            datetime.
+        strptime_str (str - optional): A valid strptime string defining the
+            format of the provided iso8601_datetime.
 
     Return:
         The result of applying the strftime to the iso8601_datetime as parsed
@@ -71,7 +72,7 @@ def strftime(iso8601_datetime, strftime, strptime=None):
         ...     print type(exc)
         <class 'isodatetime.parser_spec.StrftimeSyntaxError'>
     """
-    if not strptime:
-        return TimePointParser().parse(iso8601_datetime).strftime(strftime)
-    return TimePointParser().strptime(iso8601_datetime, strptime).strftime(
-        strftime)
+    if not strptime_str:
+        return TimePointParser().parse(iso8601_datetime).strftime(strftime_str)
+    return TimePointParser().strptime(iso8601_datetime, strptime_str).strftime(
+        strftime_str)

--- a/tests/jinja2/09-custom-jinja2-filters.t
+++ b/tests/jinja2/09-custom-jinja2-filters.t
@@ -35,4 +35,6 @@ done
 # Run Jinja2 custom filters suite.
 TEST_NAME="${TEST_NAME_BASE}"-run-filters
 install_suite "${TEST_NAME_BASE}-install-filter-suite" "${TEST_NAME_BASE}"
-run_ok "${TEST_NAME}" cylc run "${SUITE_NAME}" --reference-test
+run_ok "${TEST_NAME}" cylc run "${SUITE_NAME}" --reference-test --debug
+#-------------------------------------------------------------------------------
+purge_suite "${SUITE_NAME}"

--- a/tests/jinja2/09-custom-jinja2-filters/suite.rc
+++ b/tests/jinja2/09-custom-jinja2-filters/suite.rc
@@ -1,28 +1,18 @@
 #!Jinja2
 
-{% set START_CYCLE = '01231212T1212' %}
-
 [scheduling]
-    initial cycle point = {{START_CYCLE}}
+    initial cycle point = 01231212T1212
     [[dependencies]]
         [[[R1]]]
             graph = strftime => pad => end
 [runtime]
     [[strftime]]
-        script = """
-if [[ "$HOURS:$MINUTES:$SECONDS" != '12:12:0' ]]; then
-    exit 1
-fi
-"""
+        pre-script = if [[ $TEST_1 != '00' ]]; then fail; fi
+        script = if [[ $TEST_2 != '30' ]]; then fail; fi
         [[[environment]]]
-            HOURS = {{ START_CYCLE | strftime('%H') }}
-            MINUTES = {{ START_CYCLE | strftime('%M') }}
-            SECONDS = {{ START_CYCLE | strftime('%S') }}
+            TEST_1 = {{ '2000' | strftime('%H') }}
+            TEST_2 = {{ '12-30-2000' | strftime('%d', '%m-%d-%Y') }}
     [[pad]]
-        script = """
-if [[ {{ 42 | pad(3, 0) }} != '042' ]]; then
-    exit 1
-fi 
-"""
+        script = if [[ {{ 42 | pad(3, 0) }} != '042' ]]; then fail; fi
     [[end]]
         script = true

--- a/tests/jinja2/09-custom-jinja2-filters/suite.rc
+++ b/tests/jinja2/09-custom-jinja2-filters/suite.rc
@@ -1,5 +1,8 @@
 #!Jinja2
 
+[cylc]
+    UTC mode = True
+
 [scheduling]
     initial cycle point = 01231212T1212
     [[dependencies]]

--- a/tests/jinja2/09-custom-jinja2-filters/suite.rc
+++ b/tests/jinja2/09-custom-jinja2-filters/suite.rc
@@ -7,12 +7,11 @@
             graph = strftime => pad => end
 [runtime]
     [[strftime]]
-        pre-script = if [[ $TEST_1 != '00' ]]; then fail; fi
-        script = if [[ $TEST_2 != '30' ]]; then fail; fi
+        script = test $TEST_1 == '00'; test $TEST_2 == '30'
         [[[environment]]]
             TEST_1 = {{ '2000' | strftime('%H') }}
             TEST_2 = {{ '12-30-2000' | strftime('%d', '%m-%d-%Y') }}
     [[pad]]
-        script = if [[ {{ 42 | pad(3, 0) }} != '042' ]]; then fail; fi
+        script = test {{ 42 | pad(3, 0) }} == '042'
     [[end]]
         script = true


### PR DESCRIPTION
Add a strptime option to the strftime filter to enable its usage with custom timepoint formats.