### PR TITLE
Improve logic for recording a good job log retrieval

### DIFF
--- a/tests/events/32-task-event-job-logs-retrieve-2.t
+++ b/tests/events/32-task-event-job-logs-retrieve-2.t
@@ -1,0 +1,46 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test remote job logs retrieval OK with only "job.out" on a succeeded task.
+CYLC_TEST_IS_GENERIC=false
+. "$(dirname "$0")/test_header"
+HOST=$(cylc get-global-config -i '[test battery]remote host' 2>'/dev/null')
+if [[ -z "${HOST}" ]]; then
+    skip_all '"[test battery]remote host": not defined'
+fi
+set_test_number 5
+create_test_globalrc
+
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+run_ok "${TEST_NAME_BASE}-validate" \
+    cylc validate -s "HOST=${HOST}" "${SUITE_NAME}"
+suite_run_ok "${TEST_NAME_BASE}-run" \
+    cylc run --reference-test --debug -s "HOST=${HOST}" "${SUITE_NAME}"
+
+sed "/'job-logs-retrieve'/!d" \
+    "${SUITE_RUN_DIR}/log/job/1/t1/01/job-activity.log" \
+    >'edited-activities.log'
+cmp_ok 'edited-activities.log' <<'__LOG__'
+[('job-logs-retrieve', 1) ret_code] 0
+__LOG__
+exists_ok "${SUITE_RUN_DIR}/log/job/1/t1/01/job.out"
+exists_fail "${SUITE_RUN_DIR}/log/job/1/t1/01/job.err"
+
+purge_suite_remote "${HOST}" "${SUITE_NAME}"
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/events/32-task-event-job-logs-retrieve-2/reference.log
+++ b/tests/events/32-task-event-job-logs-retrieve-2/reference.log
@@ -1,0 +1,3 @@
+2015-06-19T14:47:30+01 INFO - Initial point: 1
+2015-06-19T14:47:30+01 INFO - Final point: 1
+2015-06-19T14:47:30+01 INFO - [t1.1] -triggered off []

--- a/tests/events/32-task-event-job-logs-retrieve-2/suite.rc
+++ b/tests/events/32-task-event-job-logs-retrieve-2/suite.rc
@@ -1,0 +1,18 @@
+#!jinja2
+
+title=Task Event Job Log Retrieve 1
+
+[cylc]
+    [[reference test]]
+        live mode suite timeout=PT1M
+
+[scheduling]
+    [[dependencies]]
+        graph=t1
+
+[runtime]
+    [[t1]]
+        script=rm -f "${CYLC_TASK_LOG_ROOT}.err"
+        [[[remote]]]
+            host = {{HOST}}
+            retrieve job logs = True

--- a/tests/events/33-task-event-job-logs-retrieve-3.t
+++ b/tests/events/33-task-event-job-logs-retrieve-3.t
@@ -1,0 +1,49 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test remote job logs retrieval OK with only "job.out" on a succeeded task.
+CYLC_TEST_IS_GENERIC=false
+. "$(dirname "$0")/test_header"
+HOST=$(cylc get-global-config -i '[test battery]remote host' 2>'/dev/null')
+if [[ -z "${HOST}" ]]; then
+    skip_all '"[test battery]remote host": not defined'
+fi
+set_test_number 5
+create_test_globalrc
+
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+run_ok "${TEST_NAME_BASE}-validate" \
+    cylc validate -s "HOST=${HOST}" "${SUITE_NAME}"
+suite_run_fail "${TEST_NAME_BASE}-run" \
+    cylc run --reference-test --debug -s "HOST=${HOST}" "${SUITE_NAME}"
+
+sed "/'job-logs-retrieve'/!d" \
+    "${SUITE_RUN_DIR}/log/job/1/t1/01/job-activity.log" \
+    >'edited-activities.log'
+cmp_ok 'edited-activities.log' <<'__LOG__'
+[('job-logs-retrieve', 1) ret_code] 1
+[('job-logs-retrieve', 1) err] File(s) not retrieved: job.err
+[('job-logs-retrieve', 1) ret_code] 1
+[('job-logs-retrieve', 1) err] File(s) not retrieved: job.err
+__LOG__
+exists_ok "${SUITE_RUN_DIR}/log/job/1/t1/01/job.out"
+exists_fail "${SUITE_RUN_DIR}/log/job/1/t1/01/job.err"
+
+purge_suite_remote "${HOST}" "${SUITE_NAME}"
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/events/33-task-event-job-logs-retrieve-3/reference.log
+++ b/tests/events/33-task-event-job-logs-retrieve-3/reference.log
@@ -1,0 +1,3 @@
+2015-06-19T14:47:30+01 INFO - Initial point: 1
+2015-06-19T14:47:30+01 INFO - Final point: 1
+2015-06-19T14:47:30+01 INFO - [t1.1] -triggered off []

--- a/tests/events/33-task-event-job-logs-retrieve-3/suite.rc
+++ b/tests/events/33-task-event-job-logs-retrieve-3/suite.rc
@@ -1,0 +1,24 @@
+#!jinja2
+
+title=Task Event Job Log Retrieve 1
+
+[cylc]
+    [[events]]
+        abort on timeout = True
+        timeout = PT1M
+    [[reference test]]
+        live mode suite timeout=PT1M
+        expected task failures = t1.1
+
+[scheduling]
+    [[dependencies]]
+        graph=t1
+
+[runtime]
+    [[t1]]
+        script=false
+        err-script=rm -f "${CYLC_TASK_LOG_ROOT}.err"
+        [[[remote]]]
+            host = {{HOST}}
+            retrieve job logs = True
+            retrieve job logs retry delays = 2*PT5S


### PR DESCRIPTION
Expect `job.out` for all completed jobs.
Expect `job.err` for task not in succeeded state.

Previously:
* It expects either `job.out` and `job.err`.
* Failed retrieval not reported to `job-activity.log`.