### PR TITLE
Fix gui graph view filter runahead

### DIFF
--- a/lib/cylc/network/https/suite_info_server.py
+++ b/lib/cylc/network/https/suite_info_server.py
@@ -111,6 +111,11 @@ class SuiteInfoServer(BaseCommsServer):
             group_all = ast.literal_eval(group_all)
         if isinstance(ungroup_all, basestring):
             ungroup_all = ast.literal_eval(ungroup_all)
+        if isinstance(stop_point_string, basestring):
+            try:
+                stop_point_string = ast.literal_eval(stop_point_string)
+            except ValueError:
+                pass
         return self._put(
             "get_graph_raw", (start_point_string, stop_point_string),
             {"group_nodes": group_nodes,

--- a/tests/api-suite-info/01-get-graph-raw-2.t
+++ b/tests/api-suite-info/01-get-graph-raw-2.t
@@ -1,0 +1,56 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test suite info API, get_graph_raw, simple usage
+. "$(dirname "$0")/test_header"
+set_test_number 3
+
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+suite_run_ok "${TEST_NAME_BASE}-run" \
+    cylc run --reference-test --debug "${SUITE_NAME}"
+cmp_ok "${SUITE_RUN_DIR}/ctb-get-graph-raw.out" <<'__OUT__'
+[
+    [
+        [
+            "t1.2020", 
+            null, 
+            null, 
+            false, 
+            false
+        ], 
+        [
+            "t1.2020", 
+            "t1.2021", 
+            null, 
+            false, 
+            false
+        ]
+    ], 
+    {}, 
+    [
+        "t1"
+    ], 
+    [
+        "t1"
+    ]
+]
+__OUT__
+
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/api-suite-info/01-get-graph-raw-2/bin/ctb-get-graph-raw
+++ b/tests/api-suite-info/01-get-graph-raw-2/bin/ctb-get-graph-raw
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Suite Info API test, get_graph_raw."""
+
+import json
+import os
+import sys
+
+from cylc.network.suite_info_client import SuiteInfoClient
+
+
+def main():
+    kwargs = {
+        'start_point_string': None,
+        'stop_point_string': None,
+        'group_nodes': None,
+        'ungroup_nodes': None,
+        'ungroup_recursive': False,
+        'group_all': False,
+        'ungroup_all': False}
+    for item in sys.argv[1:]:
+        key, value = item.split('=', 1)
+        kwargs[key] = value
+    client = SuiteInfoClient(os.environ['CYLC_SUITE_NAME'])
+    print json.dumps(client.get_info('get_graph_raw', **kwargs), indent=4)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/api-suite-info/01-get-graph-raw-2/reference.log
+++ b/tests/api-suite-info/01-get-graph-raw-2/reference.log
@@ -1,0 +1,4 @@
+2013/09/30 16:48:11 INFO - Initial point: 2020
+2013/09/30 16:48:11 INFO - Final point: 2021
+2013/09/30 16:48:11 INFO - [t1.2020] -triggered off []
+2013/09/30 16:48:11 INFO - [t1.2021] -triggered off ['t1.2020']

--- a/tests/api-suite-info/01-get-graph-raw-2/suite.rc
+++ b/tests/api-suite-info/01-get-graph-raw-2/suite.rc
@@ -1,0 +1,20 @@
+[cylc]
+   cycle point format = %Y
+   [[reference test]]
+       required run mode = live
+       live mode suite timeout = PT30S
+[scheduling]
+    initial cycle point = 2020
+    final cycle point = 2021
+    [[dependencies]]
+        [[[P1Y]]]
+            graph = t1[-P1Y] => t1
+[runtime]
+    [[t1]]
+        script = """
+if [[ "${CYLC_TASK_CYCLE_POINT}" == '2020' ]]; then
+    ctb-get-graph-raw \
+        'start_point_string=2020' 'stop_point_string=None' 'group_nodes=T' \
+        >"${CYLC_SUITE_RUN_DIR}/ctb-get-graph-raw.out"
+fi
+"""


### PR DESCRIPTION
Suite info server, `get_graph_raw` was not handling `stop_point_str=None` correctly.

Fix #2176.