### PR TITLE
Use preferred suite host self ID in SSL cert

### DIFF
--- a/lib/cylc/suite_srv_files_mgr.py
+++ b/lib/cylc/suite_srv_files_mgr.py
@@ -27,7 +27,8 @@ import sys
 import cylc.flags
 from cylc.mkdir_p import mkdir_p
 from cylc.owner import USER, is_remote_user
-from cylc.suite_host import get_hostname, is_remote_host, get_local_ip_address
+from cylc.suite_host import (
+    get_local_ip_address, get_suite_host, is_remote_host)
 
 
 class SuiteServiceFileError(Exception):
@@ -77,7 +78,7 @@ class SuiteSrvFilesManager(object):
         if owner is None:
             owner = USER
         if host is None:
-            host = get_hostname()
+            host = get_suite_host()
         path = self._get_cache_dir(reg, owner, host)
         self.cache[self.FILE_BASE_PASSPHRASE][(reg, owner, host)] = value
         # Dump to a file only for remote suites loaded via SSH.
@@ -237,7 +238,7 @@ To see if %(suite)s is running on '%(host)s:%(port)s':
             if my_owner is None:
                 my_owner = USER
             if my_host is None:
-                my_host = get_hostname()
+                my_host = get_suite_host()
             try:
                 return self.cache[item][(reg, my_owner, my_host)]
             except KeyError:
@@ -467,7 +468,7 @@ To see if %(suite)s is running on '%(host)s:%(port)s':
         if len(reg) > 64:
             common_name = reg[:61] + "..."
         # See https://github.com/kennethreitz/requests/issues/2621
-        host = get_hostname()
+        host = get_suite_host()
         ext = crypto.X509Extension(
             "subjectAltName",
             False,
@@ -566,7 +567,7 @@ To see if %(suite)s is running on '%(host)s:%(port)s':
                     if owner is None:
                         owner = USER
                     if host is None:
-                        host = get_hostname()
+                        host = get_suite_host()
                     host_value = data.get(self.KEY_HOST, "")
                     self.can_use_load_auths[(reg, owner, host)] = (
                         reg == data.get(self.KEY_NAME) and

--- a/tests/suite-host-self-id/00-address.t
+++ b/tests/suite-host-self-id/00-address.t
@@ -33,7 +33,7 @@ create_test_globalrc '' '
 [suite host self-identification]
     method = address'
 suite_run_ok "${TEST_NAME_BASE}-run" \
-    cylc run --reference-test --debug "${SUITE_NAME}" \
+    timeout 60 cylc run --reference-test --debug "${SUITE_NAME}" \
     "--set=MY_HOST_IP=${MY_HOST_IP}"
 #-------------------------------------------------------------------------------
 

--- a/tests/suite-host-self-id/00-address/suite.rc
+++ b/tests/suite-host-self-id/00-address/suite.rc
@@ -1,6 +1,10 @@
 #!Jinja2
 [cylc]
     UTC mode = True
+    [[events]]
+        abort on stalled = True
+        abort on inactivity = True
+        inactivity = PT1M
     [[reference test]]
         required run mode = live
         live mode suite timeout = PT1M
@@ -12,3 +16,5 @@
         script = """
 grep -F -q "CYLC_SUITE_HOST={{MY_HOST_IP}}" "${CYLC_SUITE_RUN_DIR}/.service/contact"
 """
+        [[[job]]]
+            execution time limit = PT30S


### PR DESCRIPTION
The modified test hangs on Ubuntu 16.04 metomi-vms - due to task unable to communicate back. We need to use `get_suite_host` in SSL certificate extension to ensure that the preferred suite host self ID is written to the certificate.

Reported by @dpmatthews.