### PR TITLE
job.sh: avoid overriding environment/shell builtin

### DIFF
--- a/tests/jobscript/13-hostname.t
+++ b/tests/jobscript/13-hostname.t
@@ -1,0 +1,27 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test HOSTNAME does not get modified by job script.
+. "$(dirname "${0}")/test_header"
+set_test_number 2
+
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+run_ok "${TEST_NAME_BASE}-run" cylc run "${SUITE_NAME}" --reference-test --debug
+
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/jobscript/13-hostname/reference.log
+++ b/tests/jobscript/13-hostname/reference.log
@@ -1,0 +1,3 @@
+2017-02-09T16:45:37Z INFO - Initial point: 1
+2017-02-09T16:45:37Z INFO - Final point: 1
+2017-02-09T16:45:37Z INFO - [foo.1] -triggered off []

--- a/tests/jobscript/13-hostname/suite.rc
+++ b/tests/jobscript/13-hostname/suite.rc
@@ -1,0 +1,12 @@
+[cylc]
+    [[events]]
+        abort on stalled = True
+[scheduling]
+    [[dependencies]]
+        graph = foo
+[runtime]
+    [[foo]]
+        init-script = """
+CYLC_TEST_HOSTNAME="${HOSTNAME:-}"
+"""
+        script = test "${CYLC_TEST_HOSTNAME}" = "${HOSTNAME:-}"


### PR DESCRIPTION
`HOSTNAME` was the main problem reported here. It is apparently a bash
built-in. To avoid local shell function variables from overriding the
environment or shell built-in, this change modifies all local shell
function variables to lower case. All other global shell and environment
variables should be protected by the `CYLC_` prefix or by setting them
to their most usual values only if they are not set (e.g. using syntax
such as `USER="${USER:-$(whoami)}"`).

Reported by @steoxley.