### PR TITLE
Remove spurious dependence on sqlite3 CLI.

### DIFF
--- a/bin/cylc-check-software
+++ b/bin/cylc-check-software
@@ -68,15 +68,8 @@ if ! which dot > /dev/null 2>&1; then
 else
     echo "ok"
 fi
-echo -n " + sqlite ... "
-if ! which sqlite3 > /dev/null 2>&1; then
-    echo "NOT FOUND"
-else
-    echo "ok"
-fi
 
 # Python packages
-# sqlite3 is part of the standard library since Python 2.5
 PKGS="pygraphviz:pygraphviz \
 pygtk:pygtk"
 

--- a/bin/cylc-test-battery
+++ b/bin/cylc-test-battery
@@ -70,8 +70,18 @@ By default all tests are executed.  To run just a subset of them:
   * skip all platform-specific tests with CYLC_TEST_RUN_PLATFORM=false
   List specific tests relative to $CYLC_DIR (i.e. starting with "test/").
 Some platform-specific tests are automatically skipped, depending on platform.
-DEVELOPERS: new platform-specific tests must set "CYLC_TEST_IS_GENERIC=false"
-before sourcing the test_header.
+
+FOR DEVELOPERS:
+  * Platform-specific tests must set "CYLC_TEST_IS_GENERIC=false" before
+    sourcing the test_header.
+  * Tests requiring the sqlite3 CLI must be skipped if sqlite3 is not installed
+    (it is not otherwise a Cylc software prerequisite):
+| if ! which sqlite3 > /dev/null; then
+|     # Skip the remaining 3 tests.
+|     skip 3 "sqlite3 not installed?"
+|     purge_suite \$SUITE_NAME
+|     exit 0
+| fi
 
 For more information see "Reference Tests" in the User Guide.
 

--- a/doc/cug.tex
+++ b/doc/cug.tex
@@ -387,12 +387,6 @@ previous section, emerges naturally at run time.
     \item {\bf OS: A Linux or Unix variant (including, reportedly, Apple OS X).}
     \item {\bf The Python Language, version 2.6 or later, but not 3.x yet}.
         \newline \url{https://python.org}
-    \item {\bf sqlite (a server-less, zero-configuration, SQL database
-        engine}). The Python API to sqlite is part of the Python standard
-        library. The command line interface is likely included in your Linux
-        distribution already. Cylc generates an sqlite database for each suite
-        as it runs, to record task events and status.
-        \newline \url{http://sqlite.org}
 \end{myitemize}
 
 The following packages are technically optional as you can construct
@@ -517,7 +511,6 @@ $ yum install ImageMagick
 # Python packages:
 $ easy_install pygraphviz
 
-# (sqlite 3.7.13 already installed on the system)
 \end{lstlisting}
 
 If you do not have root access on your intended cylc host machine and
@@ -529,10 +522,9 @@ installed properly:
 \lstset{language=transcript}
 \begin{lstlisting}
 $ cylc check-software
-Checking for Python >= 2.6 ... found 2.7.3 ... ok
+Checking for Python >= 2.6 ... found 2.7.6 ... ok
 Checking for non-Python packages:
  + Graphviz ... ok
- + sqlite ... ok
 Checking for Python packages:
  + pygraphviz ... ok
  + pygtk ... ok
@@ -639,7 +631,6 @@ $ cylc check-software
 Checking for Python >= 2.6 ... found 2.7.3 ... ok
 Checking for non-Python packages:
  + Graphviz ... ok
- + sqlite ... ok
 Checking for Python packages:
  + pygraphviz ... ok
  + pygtk ... ok
@@ -6898,24 +6889,9 @@ to expose the default scripting.
 \subsubsection{Restarting Suites With A Different Run Mode?}
 
 The run mode is recorded in the suite run database files. Cylc will not let
-you {\em restart} a non-live mode suite in live mode, or vice versa -
-any attempt to do the former would certainly be a mistake (because the
-simulation mode dummy tasks do not generate any of the real outputs
-depended on by downstream live tasks), and the latter, while feasible,
-would corrupt the task pool by turning it over to simulation mode.
-The easiest way to test a live suite in simulation mode, if you don't want to
-obliterate the current suite run database files by doing a cold or warm start
-(as opposed to a restart from the previous state) is to take a quick copy of
-the suite and run the copy in simulation mode. However, if you really want to
-run a live suite forward in simulation mode without copying it, do this:
-\begin{myenumerate}
-    \item Back up the live mode suite database files.
-    \item Using the \lstinline=sqlite3= command or otherwise,
-          update the value of \lstinline=run_mode= in the
-          \lstinline=suite_params= table in the
-          \lstinline=cylc-suite-private.db= file.
-    \item Later, restart the live suite from the restored back up.
-\end{myenumerate}
+you {\em restart} a non-live mode suite in live mode, or vice versa. To
+test a live suite in simulation mode just take a quick copy of it and run the
+the copy in simulation mode.
 
 \subsection{Automated Reference Test Suites}
 \label{AutoRefTests}

--- a/doc/cug.tex
+++ b/doc/cug.tex
@@ -6961,7 +6961,6 @@ you wish:
         abort on timeout = True
 \end{lstlisting}
 
-
 \subsection{Inter-suite Dependence: Triggering Off Task States In Other Suites}
 \label{SuiteStatePolling}
 
@@ -7042,39 +7041,34 @@ Note that the remote suite does not have to be running when polling commences
 because the command interrogates the suite run database, not the suite server
 process.
 
-\section{Other Topics In Brief}
+\subsection{Suite Run Databases}
+\label{Suite Run Databases}
 
-The following topics have yet to be documented in detail.
+Suites maintain \lstinline=sqlite= databases to record run history and restart
+checkpoints etc.:
 
-\begin{myitemize}
-    \item Intervening in suites, e.g.\ stopping, removing, inserting tasks:
-        see \lstinline=cylc control help=.
-
-    \item Interrogating suites and tasks:
-        see \lstinline=cylc info help=, \lstinline=cylc show help=,
-        and \lstinline=cylc discovery help=.
-
-    \item Understanding suite evolution, particularly in delayed/catchup
-        operation: the Tutorial helps here (\ref{Tutorial}),
-        along with running the example suites.
-
-    \item Task insertion (add a new task proxy instance to a running suite):
-        see \lstinline=cylc insert --help=.
-
-    \item Sub-suites: to run another suite inside a task, just invoke the
-        sub-suite, with appropriate start and end cycle points (probably a
-        single cycle point), via the host task's \lstinline=script= item:
-
-\lstset{language=suiterc}
+\lstset{language=transcript}
 \begin{lstlisting}
-[runtime]
-    [[foo]]
-        script = \
- "cylc run SUITE $CYLC_TASK_CYCLE_POINT --until=$CYLC_TASK_CYCLE_POINT"
+$HOME/cylc-run/<SUITE-NAME>/log/db
 \end{lstlisting}
 
-\end{myitemize}
-\lstset{language=transcript}
+You can use any standard sqlite interface to read these databases, such as the
+Python standard library \lstinline=sqlite3= module, and a command line tool of
+the same name:
+
+\begin{lstlisting}
+$ sqlite3 ~/cylc-run/foo/log/db << _END_
+> .headers on
+> select * from task_events where name is "foo";
+> _END_
+name|cycle|time|submit_num|event|message
+foo|1|2017-03-12T11:06:08Z|1|incrementing submit number|
+foo|1|2017-03-12T11:06:09Z|1|submission succeeded|
+foo|1|2017-03-12T11:06:09Z|1|output completed|started
+foo|1|2017-03-12T11:06:09Z|1|started|
+foo|1|2017-03-12T11:06:19Z|1|output completed|succeeded
+foo|1|2017-03-12T11:06:19Z|1|succeeded|
+\end{lstlisting}
 
 \section{Suite Storage, Discovery, Revision Control, and Deployment}
 \label{SuiteStorageEtc}

--- a/doc/suiterc.tex
+++ b/doc/suiterc.tex
@@ -185,10 +185,9 @@ on it will abort with exit status 1 if any task fails.
 \subsubsection[health check interval]{[cylc] \textrightarrow health check interval}
 \label{health-check-interval}
 
-Specify an time interval when a running cylc suite will attempt to check that
-its run directory and port file exist, and that the port file contains the
-expected information. If the suite run directory is not found or if the port
-file is removed or modified, the suite will shut itself down automatically.
+Specify the time interval on which a running cylc suite will check that its run
+directory exists and that its contact file contains the expected information.
+If not, the suite will shut itself down automatically.
 
 \begin{myitemize}
     \item {\em type:} ISO 8601 duration/interval representation (e.g.

--- a/tests/broadcast/00-simple.t
+++ b/tests/broadcast/00-simple.t
@@ -17,12 +17,18 @@
 #-------------------------------------------------------------------------------
 # Test broadcasts
 . "$(dirname "$0")/test_header"
+
 set_test_number 4
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
 suite_run_ok "${TEST_NAME_BASE}-run" \
     cylc run --debug --reference-test "${SUITE_NAME}"
+
+if ! which sqlite3 > /dev/null; then
+    skip 2 "sqlite3 not installed?"
+    exit 0
+fi
 
 DB_FILE="$(cylc get-global-config '--print-run-dir')/${SUITE_NAME}/log/db"
 NAME='select-broadcast-events.out'

--- a/tests/cylc-insert/03-insert-old.t
+++ b/tests/cylc-insert/03-insert-old.t
@@ -35,6 +35,11 @@ sed '/WARNING: deprecated items were automatically upgraded/d; /^ \* (/d' \
     "${RUN_DIR}/${SUITE_NAME}/log/suite/err" >"${TEST_NAME}"
 cmp_ok $TEST_NAME </dev/null
 #-------------------------------------------------------------------------------
+if ! which sqlite3 > /dev/null; then
+    skip 3 "sqlite3 not installed?"
+    purge_suite $SUITE_NAME
+    exit 0
+fi
 TEST_NAME=$TEST_NAME_BASE-db-end
 RUN_DIR=$(cylc get-global-config --print-run-dir)
 run_ok "$TEST_NAME" sqlite3 "${RUN_DIR}/${SUITE_NAME}/log/db" \

--- a/tests/cylc-poll/11-event-time.t
+++ b/tests/cylc-poll/11-event-time.t
@@ -25,6 +25,12 @@ run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
 suite_run_ok "${TEST_NAME_BASE}" \
     cylc run --reference-test --debug "${SUITE_NAME}"
 
+if ! which sqlite3 > /dev/null; then
+    skip 1 "sqlite3 not installed?"
+    purge_suite "${SUITE_NAME}"
+    exit 0
+fi
+
 RUND="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}"
 sed -n 's/CYLC_JOB_EXIT_TIME=//p' "${RUND}/log/job/1/w1/NN/job.status" >'st-time.txt'
 sqlite3 "${RUND}/log/db" '

--- a/tests/database/00-simple.t
+++ b/tests/database/00-simple.t
@@ -23,6 +23,12 @@ install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
 suite_run_ok "${TEST_NAME_BASE}-run" cylc run --debug "${SUITE_NAME}"
 
+if ! which sqlite3 > /dev/null; then
+    skip 6 "sqlite3 not installed?"
+    purge_suite "${SUITE_NAME}"
+    exit 0
+fi
+
 DB_FILE="$(cylc get-global-config '--print-run-dir')/${SUITE_NAME}/log/db"
 
 NAME='schema.out'

--- a/tests/database/01-broadcast.t
+++ b/tests/database/01-broadcast.t
@@ -26,6 +26,12 @@ suite_run_ok "${TEST_NAME_BASE}-run" \
 
 DB_FILE="$(cylc get-global-config '--print-run-dir')/${SUITE_NAME}/log/db"
 
+if ! which sqlite3 > /dev/null; then
+    skip 3 "sqlite3 not installed?"
+    purge_suite "${SUITE_NAME}"
+    exit 0
+fi
+
 NAME='select-broadcast-events.out'
 sqlite3 "${DB_FILE}" \
     'SELECT change, point, namespace, key, value FROM broadcast_events' >"${NAME}"

--- a/tests/database/02-retry.t
+++ b/tests/database/02-retry.t
@@ -24,6 +24,12 @@ run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
 suite_run_ok "${TEST_NAME_BASE}-run" \
     cylc run --debug --reference-test "${SUITE_NAME}"
 
+if ! which sqlite3 > /dev/null; then
+    skip 1 "sqlite3 not installed?"
+    purge_suite "${SUITE_NAME}"
+    exit 0
+fi
+
 DB_FILE="$(cylc get-global-config '--print-run-dir')/${SUITE_NAME}/log/db"
 
 NAME='select-task-jobs.out'

--- a/tests/database/03-remote.t
+++ b/tests/database/03-remote.t
@@ -30,6 +30,12 @@ run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
 suite_run_ok "${TEST_NAME_BASE}-run" \
     cylc run --debug --reference-test "${SUITE_NAME}"
 
+if ! which sqlite3 > /dev/null; then
+    skip 1 "sqlite3 not installed?"
+    purge_suite "${SUITE_NAME}"
+    exit 0
+fi
+
 DB_FILE="$(cylc get-global-config '--print-run-dir')/${SUITE_NAME}/log/db"
 
 NAME='select-task-jobs.out'

--- a/tests/database/04-lock-recover.t
+++ b/tests/database/04-lock-recover.t
@@ -42,6 +42,12 @@ grep_ok "stmt=DELETE FROM task_pool" \
 grep_ok "stmt_args\[0\]=\[\]" \
     "${TEST_NAME_BASE}-run.stderr.grep"
 
+if ! which sqlite3 > /dev/null; then
+    skip 1 "sqlite3 not installed?"
+    purge_suite "${SUITE_NAME}"
+    exit 0
+fi
+
 DB_FILE="$(cylc get-global-config '--print-run-dir')/${SUITE_NAME}/log/db"
 
 NAME='select-task-states.out'

--- a/tests/database/05-lock-recover-100.t
+++ b/tests/database/05-lock-recover-100.t
@@ -24,6 +24,12 @@ run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
 suite_run_ok "${TEST_NAME_BASE}-run" \
     cylc run --debug --reference-test "${SUITE_NAME}"
 
+if ! which sqlite3 > /dev/null; then
+    skip 1 "sqlite3 not installed?"
+    purge_suite "${SUITE_NAME}"
+    exit 0
+fi
+
 DB_FILE="$(cylc get-global-config '--print-run-dir')/${SUITE_NAME}/log/db"
 
 NAME='select-task-states.out'

--- a/tests/database/06-task-message.t
+++ b/tests/database/06-task-message.t
@@ -24,6 +24,12 @@ run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
 suite_run_ok "${TEST_NAME_BASE}-run" \
     cylc run --debug --reference-test "${SUITE_NAME}"
 
+if ! which sqlite3 > /dev/null; then
+    skip 1 "sqlite3 not installed?"
+    purge_suite "${SUITE_NAME}"
+    exit 0
+fi
+
 DB_FILE="$(cylc get-global-config '--print-run-dir')/${SUITE_NAME}/log/db"
 
 NAME='select-task-events.out'

--- a/tests/job-file-trap/00-sigusr1.t
+++ b/tests/job-file-trap/00-sigusr1.t
@@ -49,34 +49,39 @@ run_tests() {
         sleep 1
     done
     TIMEOUT=$(($(date +%s) + 10))
-    while ! sqlite3 "${SUITE_RUN_DIR}/log/db" \
-                'SELECT status FROM task_states WHERE name=="t1";' \
-                >"$TEST_NAME-db-t1" 2>/dev/null \
-            && (($TIMEOUT > $(date +%s)))
-    do
-        sleep 1
-    done
-    grep_ok "^\(submitted\|running\)$" "$TEST_NAME-db-t1"
-    # Start the job again and see what happens
-    mkdir -p $SUITE_RUN_DIR/work/1/t1/
-    touch $SUITE_RUN_DIR/work/1/t1/file # Allow t1 to complete
-    $SUITE_RUN_DIR/log/job/1/t1/01/job </dev/null >/dev/null 2>&1 &
-    # Wait for suite to complete
-    TIMEOUT=$(($(date +%s) + 120))
-    while [[ -f "${SUITE_RUN_DIR}/.service/contact" ]] && (($TIMEOUT > $(date +%s))); do
-        sleep 1
-    done
-    # Test t1 status in DB
-    sqlite3 "${SUITE_RUN_DIR}/log/db" \
-        'SELECT status FROM task_states WHERE name=="t1";' >"$TEST_NAME-db-t1"
-    cmp_ok "$TEST_NAME-db-t1" - <<<'succeeded'
-    # Test reference
-    TIMEOUT=$(($(date +%s) + 120))
-    while ! grep -q 'DONE' $SUITE_RUN_DIR/log/suite/out \
-            && (($TIMEOUT > $(date +%s)))
-    do
-        sleep 1
-    done
+
+    if ! which sqlite3 > /dev/null; then
+        skip 2 "sqlite3 not installed?"
+    else
+        while ! sqlite3 "${SUITE_RUN_DIR}/log/db" \
+                    'SELECT status FROM task_states WHERE name=="t1";' \
+                    >"$TEST_NAME-db-t1" 2>/dev/null \
+                && (($TIMEOUT > $(date +%s)))
+        do
+            sleep 1
+        done
+        grep_ok "^\(submitted\|running\)$" "$TEST_NAME-db-t1"
+        # Start the job again and see what happens
+        mkdir -p $SUITE_RUN_DIR/work/1/t1/
+        touch $SUITE_RUN_DIR/work/1/t1/file # Allow t1 to complete
+        $SUITE_RUN_DIR/log/job/1/t1/01/job </dev/null >/dev/null 2>&1 &
+        # Wait for suite to complete
+        TIMEOUT=$(($(date +%s) + 120))
+        while [[ -f "${SUITE_RUN_DIR}/.service/contact" ]] && (($TIMEOUT > $(date +%s))); do
+            sleep 1
+        done
+        # Test t1 status in DB
+        sqlite3 "${SUITE_RUN_DIR}/log/db" \
+            'SELECT status FROM task_states WHERE name=="t1";' >"$TEST_NAME-db-t1"
+        cmp_ok "$TEST_NAME-db-t1" - <<<'succeeded'
+        # Test reference
+        TIMEOUT=$(($(date +%s) + 120))
+        while ! grep -q 'DONE' $SUITE_RUN_DIR/log/suite/out \
+                && (($TIMEOUT > $(date +%s)))
+        do
+            sleep 1
+        done
+    fi
     grep_ok 'SUITE REFERENCE TEST PASSED' $SUITE_RUN_DIR/log/suite/out
     purge_suite $SUITE_NAME
     exit

--- a/tests/job-submission/11-garbage-host-command.t
+++ b/tests/job-submission/11-garbage-host-command.t
@@ -23,6 +23,13 @@ install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
 suite_run_ok "${TEST_NAME_BASE}-run" \
     cylc run --debug --reference-test "${SUITE_NAME}"
+
+if ! which sqlite3 > /dev/null; then
+    skip 1 "sqlite3 not installed?"
+    purge_suite "${SUITE_NAME}"
+    exit 0
+fi
+
 sqlite3 \
     "$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/log/db" \
     'SELECT submit_num,submit_status FROM task_jobs WHERE name=="t1"' \

--- a/tests/reload/10-runahead.t
+++ b/tests/reload/10-runahead.t
@@ -28,6 +28,11 @@ run_ok $TEST_NAME cylc validate $SUITE_NAME
 TEST_NAME=$TEST_NAME_BASE-run
 run_fail $TEST_NAME cylc run --debug $SUITE_NAME
 #-------------------------------------------------------------------------------
+if ! which sqlite3 > /dev/null; then
+    skip 1 "sqlite3 not installed?"
+    purge_suite "${SUITE_NAME}"
+    exit 0
+fi
 TEST_NAME=$TEST_NAME_BASE-check-fail
 DB_FILE="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/log/db"
 QUERY='SELECT COUNT(*) FROM task_states WHERE status == "failed"'

--- a/tests/reload/19-remote-kill.t
+++ b/tests/reload/19-remote-kill.t
@@ -32,6 +32,11 @@ suite_run_fail "${TEST_NAME_BASE}-run" \
     cylc run --debug --reference-test \
     --set="CYLC_TEST_HOST=${TEST_HOST}" \
      "${SUITE_NAME}"
+if ! which sqlite3 > /dev/null; then
+    skip 1 "sqlite3 not installed?"
+    purge_suite "${SUITE_NAME}"
+    exit 0
+fi
 sqlite3 "${SUITE_RUN_DIR}/.service/db" \
     'SELECT cycle,name,run_status FROM task_jobs' >'db.out'
 cmp_ok 'db.out' <<'__OUT__'

--- a/tests/remote/00-basic.t
+++ b/tests/remote/00-basic.t
@@ -28,6 +28,11 @@ run_ok $TEST_NAME cylc validate $SUITE_NAME
 TEST_NAME=$TEST_NAME_BASE-run
 suite_run_ok $TEST_NAME cylc run --reference-test --debug $SUITE_NAME
 #-------------------------------------------------------------------------------
+if ! which sqlite3 > /dev/null; then
+    skip 2 "sqlite3 not installed?"
+    purge_suite "${SUITE_NAME}"
+    exit 0
+fi
 TEST_NAME=$TEST_NAME_BASE-userathost
 sqlite3 "${SUITE_RUN_DIR}/log/db" \
     'select user_at_host from task_jobs where name=="foo"' >'foo-host.txt'

--- a/tests/restart/00-pre-initial.t
+++ b/tests/restart/00-pre-initial.t
@@ -24,6 +24,11 @@ run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
 suite_run_ok "${TEST_NAME_BASE}-run" cylc run --debug "${SUITE_NAME}"
 suite_run_ok "${TEST_NAME_BASE}-restart" cylc restart --debug "${SUITE_NAME}"
 
+if ! which sqlite3 > /dev/null; then
+    skip 1 "sqlite3 not installed?"
+    purge_suite "${SUITE_NAME}"
+    exit 0
+fi
 RUND="$(cylc get-global-config --print-run-dir)"
 sqlite3 "${RUND}/${SUITE_NAME}/log/db" \
     'SELECT name, cycle, status FROM task_states ORDER BY name, cycle' \

--- a/tests/restart/01-broadcast.t
+++ b/tests/restart/01-broadcast.t
@@ -36,6 +36,11 @@ suite_run_ok $TEST_NAME cylc run --no-detach $SUITE_NAME
 TEST_NAME=$TEST_NAME_BASE-restart-run
 suite_run_ok $TEST_NAME cylc restart --no-detach $SUITE_NAME
 #-------------------------------------------------------------------------------
+if ! which sqlite3 > /dev/null; then
+    skip 5 "sqlite3 not installed?"
+    purge_suite "${SUITE_NAME}"
+    exit 0
+fi
 grep_ok "broadcast_task|20130923T0000Z|0||waiting" \
     $TEST_DIR/pre-restart-db
 grep_ok "send_a_broadcast_task|20130923T0000Z|1|1|succeeded" \

--- a/tests/restart/02-failed.t
+++ b/tests/restart/02-failed.t
@@ -36,6 +36,11 @@ suite_run_ok $TEST_NAME cylc run --debug $SUITE_NAME
 TEST_NAME=$TEST_NAME_BASE-restart-run
 suite_run_ok $TEST_NAME cylc restart --debug $SUITE_NAME
 #-------------------------------------------------------------------------------
+if ! which sqlite3 > /dev/null; then
+    skip 3 "sqlite3 not installed?"
+    purge_suite "${SUITE_NAME}"
+    exit 0
+fi
 grep_ok "failed_task|20130923T0000Z|1|1|failed" \
     $TEST_DIR/pre-restart-db
 contains_ok $TEST_DIR/post-restart-db <<'__DB_DUMP__'

--- a/tests/restart/03-retrying.t
+++ b/tests/restart/03-retrying.t
@@ -36,6 +36,11 @@ suite_run_ok $TEST_NAME cylc run --debug $SUITE_NAME
 TEST_NAME=$TEST_NAME_BASE-restart-run
 suite_run_ok $TEST_NAME cylc restart --debug $SUITE_NAME
 #-------------------------------------------------------------------------------
+if ! which sqlite3 > /dev/null; then
+    skip 3 "sqlite3 not installed?"
+    purge_suite "${SUITE_NAME}"
+    exit 0
+fi
 grep_ok "retrying_task|20130923T0000Z|1|1|retrying" \
     $TEST_DIR/pre-restart-db
 contains_ok $TEST_DIR/post-restart-db <<'__DB_DUMP__'

--- a/tests/restart/04-running.t
+++ b/tests/restart/04-running.t
@@ -37,6 +37,11 @@ sleep 10
 TEST_NAME=$TEST_NAME_BASE-restart-run
 suite_run_ok $TEST_NAME cylc restart --debug $SUITE_NAME
 #-------------------------------------------------------------------------------
+if ! which sqlite3 > /dev/null; then
+    skip 3 "sqlite3 not installed?"
+    purge_suite "${SUITE_NAME}"
+    exit 0
+fi
 grep_ok "running_task|20130923T0000Z|1|1|running" \
     $TEST_DIR/pre-restart-db
 contains_ok $TEST_DIR/post-restart-db <<'__DB_DUMP__'

--- a/tests/restart/05-submit-failed.t
+++ b/tests/restart/05-submit-failed.t
@@ -36,6 +36,11 @@ suite_run_ok $TEST_NAME cylc run --debug $SUITE_NAME
 TEST_NAME=$TEST_NAME_BASE-run
 suite_run_ok $TEST_NAME cylc restart --debug $SUITE_NAME
 #-------------------------------------------------------------------------------
+if ! which sqlite3 > /dev/null; then
+    skip 3 "sqlite3 not installed?"
+    purge_suite "${SUITE_NAME}"
+    exit 0
+fi
 grep_ok "submit_failed_task|20130923T0000Z|1|1|submit-failed" \
     $TEST_DIR/pre-restart-db
 contains_ok $TEST_DIR/post-restart-db <<'__DB_DUMP__'

--- a/tests/restart/06-succeeded.t
+++ b/tests/restart/06-succeeded.t
@@ -36,6 +36,11 @@ suite_run_ok $TEST_NAME cylc run --debug $SUITE_NAME
 TEST_NAME=$TEST_NAME_BASE-restart-run
 suite_run_ok $TEST_NAME cylc restart --debug $SUITE_NAME
 #-------------------------------------------------------------------------------
+if ! which sqlite3 > /dev/null; then
+    skip 3 "sqlite3 not installed?"
+    purge_suite "${SUITE_NAME}"
+    exit 0
+fi
 grep_ok "succeeded_task|20130923T0000Z|1|1|succeeded" \
     $TEST_DIR/pre-restart-db
 contains_ok $TEST_DIR/post-restart-db <<'__DB_DUMP__'

--- a/tests/restart/07-waiting.t
+++ b/tests/restart/07-waiting.t
@@ -36,6 +36,11 @@ suite_run_ok $TEST_NAME cylc run --debug $SUITE_NAME
 TEST_NAME=$TEST_NAME_BASE-restart-run
 suite_run_ok $TEST_NAME cylc restart --debug $SUITE_NAME
 #-------------------------------------------------------------------------------
+if ! which sqlite3 > /dev/null; then
+    skip 2 "sqlite3 not installed?"
+    purge_suite "${SUITE_NAME}"
+    exit 0
+fi
 contains_ok $TEST_DIR/post-restart-db <<'__DB_DUMP__'
 finish|20130923T0000Z|0||waiting
 shutdown|20130923T0000Z|1|1|succeeded

--- a/tests/restart/13-bad-job-host.t
+++ b/tests/restart/13-bad-job-host.t
@@ -31,6 +31,11 @@ run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
 suite_run_ok "${TEST_NAME_BASE}-run" cylc run --debug "${SUITE_NAME}"
 # Modify DB with garbage host
 CYLC_SUITE_RUN_DIR="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}"
+if ! which sqlite3 > /dev/null; then
+    skip 2 "sqlite3 not installed?"
+    purge_suite "${SUITE_NAME}"
+    exit 0
+fi
 for DB_NAME in 'log/db' '.service/db'; do
     sqlite3 "${CYLC_SUITE_RUN_DIR}/${DB_NAME}" \
         'UPDATE task_jobs SET user_at_host="garbage" WHERE name=="t-remote";'

--- a/tests/restart/14-multicycle.t
+++ b/tests/restart/14-multicycle.t
@@ -29,6 +29,11 @@ TEST_NAME=$TEST_NAME_BASE-validate
 run_ok $TEST_NAME cylc validate $SUITE_NAME
 cmp_ok "$TEST_NAME.stderr" </dev/null
 #-------------------------------------------------------------------------------
+if ! which sqlite3 > /dev/null; then
+    skip 5 "sqlite3 not installed?"
+    purge_suite "${SUITE_NAME}"
+    exit 0
+fi
 TEST_NAME=$TEST_NAME_BASE-run
 suite_run_ok $TEST_NAME cylc run --debug $SUITE_NAME
 #-------------------------------------------------------------------------------

--- a/tests/restart/15-state-to-db.t
+++ b/tests/restart/15-state-to-db.t
@@ -18,8 +18,9 @@
 # Test upgrade of 6.10.X database + state on restart.
 . "$(dirname "$0")/test_header"
 
-set_test_number 18
+which sqlite3 > /dev/null || skip_all
 
+set_test_number 18
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 mkdir -p "${SUITE_RUN_DIR}/state"

--- a/tests/restart/20-event-retry.t
+++ b/tests/restart/20-event-retry.t
@@ -23,10 +23,14 @@ install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 SUITED="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}"
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
 suite_run_ok "${TEST_NAME_BASE}-run" cylc run "${SUITE_NAME}" --debug
-sqlite3 "${SUITED}/log/db" \
-    'SELECT COUNT(*) FROM task_action_timers WHERE ctx_key_pickle GLOB "*event-handler-00*"' \
-    >"${TEST_NAME_BASE}-db-n-entries"
-cmp_ok "${TEST_NAME_BASE}-db-n-entries" <<<'1'
+if ! which sqlite3 > /dev/null; then
+    skip 1 "sqlite3 not installed?"
+else
+    sqlite3 "${SUITED}/log/db" \
+        'SELECT COUNT(*) FROM task_action_timers WHERE ctx_key_pickle GLOB "*event-handler-00*"' \
+        >"${TEST_NAME_BASE}-db-n-entries"
+    cmp_ok "${TEST_NAME_BASE}-db-n-entries" <<<'1'
+fi
 suite_run_ok "${TEST_NAME_BASE}-restart" cylc restart "${SUITE_NAME}" --debug
 cmp_ok "${SUITED}/file" <<'__TEXT__'
 1

--- a/tests/restart/22-hold.t
+++ b/tests/restart/22-hold.t
@@ -22,19 +22,27 @@ install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
 suite_run_ok "${TEST_NAME_BASE}-run" cylc run "${SUITE_NAME}" --debug
-sqlite3 "${SUITE_RUN_DIR}/log/db" \
-    'SELECT status,hold_swap FROM task_pool WHERE cycle=="2016" AND name=="t2"' \
-    >'t2-status.out'
-cmp_ok 't2-status.out' <<<'held|waiting'
+if ! which sqlite3 > /dev/null; then
+    skip 1 "sqlite3 not installed?"
+else
+    sqlite3 "${SUITE_RUN_DIR}/log/db" \
+      'SELECT status,hold_swap FROM task_pool WHERE cycle=="2016" AND name=="t2"' \
+          >'t2-status.out'
+    cmp_ok 't2-status.out' <<<'held|waiting'
+fi
 suite_run_ok "${TEST_NAME_BASE}-restart" cylc restart "${SUITE_NAME}" --debug
 grep_ok 'INFO - + t2\.2016 held (waiting)' "${SUITE_RUN_DIR}/log/suite/out"
-sqlite3 "${SUITE_RUN_DIR}/log/db" 'SELECT * FROM task_pool ORDER BY cycle, name' \
-    >'task-pool.out'
-cmp_ok 'task-pool.out' <<__OUT__
+if ! which sqlite3 > /dev/null; then
+    skip 1 "sqlite3 not installed?"
+else
+    sqlite3 "${SUITE_RUN_DIR}/log/db" 'SELECT * FROM task_pool ORDER BY cycle, name' \
+        >'task-pool.out'
+    cmp_ok 'task-pool.out' <<__OUT__
 2017|t1|1|succeeded|
 2017|t2|1|succeeded|
 2018|t1|0|waiting|
 2018|t2|0|waiting|
 __OUT__
+fi
 purge_suite "${SUITE_NAME}"
 exit

--- a/tests/restart/23-hold-retry.t
+++ b/tests/restart/23-hold-retry.t
@@ -23,22 +23,30 @@ install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
 suite_run_ok "${TEST_NAME_BASE}-run" \
     cylc run "${SUITE_NAME}" --debug --until=2016
-sqlite3 "${SUITE_RUN_DIR}/log/db" 'SELECT * FROM task_pool ORDER BY cycle, name' \
-    >'task-pool.out'
-contains_ok 'task-pool.out' <<__OUT__
+if ! which sqlite3 > /dev/null; then
+    skip 1 "sqlite3 not installed?"
+else
+    sqlite3 "${SUITE_RUN_DIR}/log/db" 'SELECT * FROM task_pool ORDER BY cycle, name' \
+        >'task-pool.out'
+    contains_ok 'task-pool.out' <<__OUT__
 2016|t2|1|held|retrying
 2017|t1|0|waiting|
 2017|t2|0|waiting|
 __OUT__
+fi
 suite_run_ok "${TEST_NAME_BASE}-restart" \
     cylc restart "${SUITE_NAME}" --debug --until=2017
 grep_ok 'INFO - + t2\.2016 held (retrying)' "${SUITE_RUN_DIR}/log/suite/out"
-sqlite3 "${SUITE_RUN_DIR}/log/db" 'SELECT * FROM task_pool ORDER BY cycle, name' \
-    >'task-pool.out'
-contains_ok 'task-pool.out' <<__OUT__
+if ! which sqlite3 > /dev/null; then
+    skip 1 "sqlite3 not installed?"
+else
+    sqlite3 "${SUITE_RUN_DIR}/log/db" 'SELECT * FROM task_pool ORDER BY cycle, name' \
+        >'task-pool.out'
+    contains_ok 'task-pool.out' <<__OUT__
 2016|t2|1|succeeded|
 2018|t1|0|waiting|
 2018|t2|0|waiting|
 __OUT__
+fi
 purge_suite "${SUITE_NAME}"
 exit

--- a/tests/restart/24-upgrade-db-611.t
+++ b/tests/restart/24-upgrade-db-611.t
@@ -18,6 +18,7 @@
 # Test upgrade of 6.11.X database on restart.
 . "$(dirname "$0")/test_header"
 
+which sqlite3 > /dev/null || skip_all "sqlite3 not installed?"
 set_test_number 8
 
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"

--- a/tests/restart/25-hold-suite.t
+++ b/tests/restart/25-hold-suite.t
@@ -22,33 +22,48 @@ install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
 suite_run_ok "${TEST_NAME_BASE}-run" cylc run "${SUITE_NAME}" --debug
-sqlite3 "${SUITE_RUN_DIR}/log/db" \
-    'SELECT value FROM suite_params WHERE key=="is_held"' >'suite-is-held.out'
-cmp_ok 'suite-is-held.out' <<<'1'
+
+if ! which sqlite3 > /dev/null; then
+    skip 1 "sqlite3 not installed?"
+else
+    sqlite3 "${SUITE_RUN_DIR}/log/db" \
+        'SELECT value FROM suite_params WHERE key=="is_held"' >'suite-is-held.out'
+    cmp_ok 'suite-is-held.out' <<<'1'
+fi
 run_ok "${TEST_NAME_BASE}-restart" cylc restart "${SUITE_NAME}"
 # Ensure suite has started
 poll ! test -f "${SUITE_RUN_DIR}/.service/contact"
 cylc trigger "${SUITE_NAME}" 't2.2016'
 poll ! test -f "${SUITE_RUN_DIR}/log/job/2016/t2/01/job.status"
 poll ! grep -q 'CYLC_JOB_EXIT' "${SUITE_RUN_DIR}/log/job/2016/t2/01/job.status"
-sqlite3 "${SUITE_RUN_DIR}/log/db" \
-    'SELECT status,hold_swap FROM task_pool WHERE cycle=="2017" AND name=="t2"' \
-    >'task-pool.out'
-cmp_ok 'task-pool.out' <<<'held|waiting'
+
+if ! which sqlite3 > /dev/null; then
+    skip 1 "sqlite3 not installed?"
+else
+    sqlite3 "${SUITE_RUN_DIR}/log/db" \
+        'SELECT status,hold_swap FROM task_pool WHERE cycle=="2017" AND name=="t2"' \
+            >'task-pool.out'
+    cmp_ok 'task-pool.out' <<<'held|waiting'
+fi
 cylc release "${SUITE_NAME}"
 cylc poll "${SUITE_NAME}"
 # Ensure suite has completed
 poll test -f "${SUITE_RUN_DIR}/.service/contact"
-sqlite3 "${SUITE_RUN_DIR}/log/db" \
-    'SELECT value FROM suite_params WHERE key=="is_held"' >'suite-is-held.out'
-cmp_ok 'suite-is-held.out' <'/dev/null'
-sqlite3 "${SUITE_RUN_DIR}/log/db" \
-    'SELECT * FROM task_pool ORDER BY cycle, name' >'task-pool.out'
-cmp_ok 'task-pool.out' <<'__OUT__'
+
+if ! which sqlite3 > /dev/null; then
+    skip 2 "sqlite3 not installed?"
+else
+    sqlite3 "${SUITE_RUN_DIR}/log/db" \
+        'SELECT value FROM suite_params WHERE key=="is_held"' >'suite-is-held.out'
+    cmp_ok 'suite-is-held.out' <'/dev/null'
+    sqlite3 "${SUITE_RUN_DIR}/log/db" \
+        'SELECT * FROM task_pool ORDER BY cycle, name' >'task-pool.out'
+    cmp_ok 'task-pool.out' <<'__OUT__'
 2017|t1|1|succeeded|
 2017|t2|1|succeeded|
 2018|t1|0|waiting|
 2018|t2|0|waiting|
 __OUT__
+fi
 purge_suite "${SUITE_NAME}"
 exit

--- a/tests/restart/26-remote-kill.t
+++ b/tests/restart/26-remote-kill.t
@@ -28,20 +28,29 @@ install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
 suite_run_ok "${TEST_NAME_BASE}-run" cylc run "${SUITE_NAME}" --debug
-sqlite3 "${SUITE_RUN_DIR}/log/db" \
-    'SELECT status FROM task_pool WHERE cycle=="1" AND NAME=="t1"' \
-    >'t1-status.out'
-cmp_ok 't1-status.out' <<<'running'
+if ! which sqlite3 > /dev/null; then
+    skip 1 "sqlite3 not installed?"
+else
+    sqlite3 "${SUITE_RUN_DIR}/log/db" \
+        'SELECT status FROM task_pool WHERE cycle=="1" AND NAME=="t1"' \
+            >'t1-status.out'
+    cmp_ok 't1-status.out' <<<'running'
+fi
 run_ok "${TEST_NAME_BASE}-restart" cylc restart "${SUITE_NAME}"
 # Ensure suite has started
 poll ! test -f "${SUITE_RUN_DIR}/.service/contact"
 cylc kill "${SUITE_NAME}" 't1.1'
 # Ensure suite has completed
 poll test -f "${SUITE_RUN_DIR}/.service/contact"
-sqlite3 "${SUITE_RUN_DIR}/log/db" \
-    'SELECT status FROM task_pool WHERE cycle=="1" AND NAME=="t1"' \
-    >'t1-status.out'
-cmp_ok 't1-status.out' <<<'failed'
+
+if ! which sqlite3 > /dev/null; then
+    skip 1 "sqlite3 not installed?"
+else
+    sqlite3 "${SUITE_RUN_DIR}/log/db" \
+        'SELECT status FROM task_pool WHERE cycle=="1" AND NAME=="t1"' \
+            >'t1-status.out'
+    cmp_ok 't1-status.out' <<<'failed'
+fi
 purge_suite_remote "${CYLC_TEST_HOST}" "${SUITE_NAME}"
 purge_suite "${SUITE_NAME}"
 exit

--- a/tests/restart/27-broadcast-timeout.t
+++ b/tests/restart/27-broadcast-timeout.t
@@ -22,9 +22,13 @@ install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
 suite_run_ok "${TEST_NAME_BASE}-run" cylc run "${SUITE_NAME}" --debug
-sqlite3 "${SUITE_RUN_DIR}/log/db" \
-    'SELECT * FROM broadcast_states' >'sqlite3.out'
-cmp_ok 'sqlite3.out' <<<'*|root|[events]submission timeout|60.0'
+if ! which sqlite3 > /dev/null; then
+    skip 1 "sqlite3 not installed?"
+else
+  sqlite3 "${SUITE_RUN_DIR}/log/db" \
+      'SELECT * FROM broadcast_states' >'sqlite3.out'
+    cmp_ok 'sqlite3.out' <<<'*|root|[events]submission timeout|60.0'
+fi
 suite_run_ok "${TEST_NAME_BASE}-restart" \
     cylc restart "${SUITE_NAME}" --debug --reference-test
 purge_suite "${SUITE_NAME}"

--- a/tests/retries/00-execution-retry.t
+++ b/tests/retries/00-execution-retry.t
@@ -28,14 +28,18 @@ run_ok $TEST_NAME cylc validate $SUITE_NAME
 TEST_NAME=$TEST_NAME_BASE-run
 suite_run_ok $TEST_NAME cylc run --reference-test --debug $SUITE_NAME
 #-------------------------------------------------------------------------------
-sqlite3 \
-    "$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/log/db" \
-    'select try_num, submit_num from task_jobs' >'select.out'
-cmp_ok 'select.out' <<'__OUT__'
+if ! which sqlite3 > /dev/null; then
+    skip 1 "sqlite3 not installed?"
+else
+    sqlite3 \
+        "$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/log/db" \
+        'select try_num, submit_num from task_jobs' >'select.out'
+    cmp_ok 'select.out' <<'__OUT__'
 1|1
 2|2
 3|3
 4|4
 __OUT__
+fi
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/retries/01-submission-retry.t
+++ b/tests/retries/01-submission-retry.t
@@ -28,14 +28,18 @@ run_ok $TEST_NAME cylc validate $SUITE_NAME
 TEST_NAME=$TEST_NAME_BASE-run
 suite_run_ok $TEST_NAME cylc run --reference-test --debug $SUITE_NAME
 #-------------------------------------------------------------------------------
-sqlite3 \
-    "$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/log/db" \
-    'select try_num, submit_num from task_jobs' >'select.out'
-cmp_ok 'select.out' <<'__OUT__'
+if ! which sqlite3 > /dev/null; then
+    skip 1 "sqlite3 not installed?"
+else
+    sqlite3 \
+        "$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/log/db" \
+        'select try_num, submit_num from task_jobs' >'select.out'
+    cmp_ok 'select.out' <<'__OUT__'
 1|1
 1|2
 1|3
 1|4
 __OUT__
+fi
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/runahead/00-runahead.t
+++ b/tests/runahead/00-runahead.t
@@ -28,15 +28,19 @@ run_ok $TEST_NAME cylc validate $SUITE_NAME
 TEST_NAME=$TEST_NAME_BASE-run
 run_fail $TEST_NAME cylc run --debug $SUITE_NAME
 #-------------------------------------------------------------------------------
-TEST_NAME=$TEST_NAME_BASE-check-fail
-DB="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/log/db"
-TASKS=$(sqlite3 $DB 'select count(*) from task_states where status is "failed"')
-# manual comparison for the test
-if (($TASKS==4)); then
-    ok $TEST_NAME
-else 
-    fail $TEST_NAME
-fi 
+if ! which sqlite3 > /dev/null; then
+    skip 1 "sqlite3 not installed?"
+else
+    TEST_NAME=$TEST_NAME_BASE-check-fail
+    DB="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/log/db"
+    TASKS=$(sqlite3 $DB 'select count(*) from task_states where status is "failed"')
+    # manual comparison for the test
+    if (($TASKS==4)); then
+        ok $TEST_NAME
+    else 
+        fail $TEST_NAME
+    fi 
+fi
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-check-timeout
 LOG=$(cylc get-global-config --print-run-dir)/$SUITE_NAME/log/suite/log

--- a/tests/runahead/01-check-default-simple.t
+++ b/tests/runahead/01-check-default-simple.t
@@ -28,12 +28,16 @@ run_ok $TEST_NAME cylc validate -v $SUITE_NAME
 TEST_NAME=$TEST_NAME_BASE-run
 run_fail $TEST_NAME cylc run --debug $SUITE_NAME
 #-------------------------------------------------------------------------------
-TEST_NAME=$TEST_NAME_BASE-max-cycle
-DB="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/log/db"
-run_ok $TEST_NAME sqlite3 $DB "select max(cycle) from task_states"
-cmp_ok "$TEST_NAME.stdout" <<'__OUT__'
+if ! which sqlite3 > /dev/null; then
+    skip 2 "sqlite3 not installed?"
+else
+    TEST_NAME=$TEST_NAME_BASE-max-cycle
+    DB="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/log/db"
+    run_ok $TEST_NAME sqlite3 $DB "select max(cycle) from task_states"
+    cmp_ok "$TEST_NAME.stdout" <<'__OUT__'
 20100101T1800Z
 __OUT__
+fi
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-check-timeout
 LOG=$(cylc get-global-config --print-run-dir)/$SUITE_NAME/log/suite/log

--- a/tests/runahead/02-check-default-complex.t
+++ b/tests/runahead/02-check-default-complex.t
@@ -28,12 +28,16 @@ run_ok $TEST_NAME cylc validate -v $SUITE_NAME
 TEST_NAME=$TEST_NAME_BASE-run
 run_fail $TEST_NAME cylc run --debug $SUITE_NAME
 #-------------------------------------------------------------------------------
-TEST_NAME=$TEST_NAME_BASE-max-cycle
-DB="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/log/db"
-run_ok $TEST_NAME sqlite3 $DB "select max(cycle) from task_states"
-cmp_ok "$TEST_NAME.stdout" <<'__OUT__'
+if ! which sqlite3 > /dev/null; then
+    skip 2 "sqlite3 not installed?"
+else
+    TEST_NAME=$TEST_NAME_BASE-max-cycle
+    DB="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/log/db"
+    run_ok $TEST_NAME sqlite3 $DB "select max(cycle) from task_states"
+    cmp_ok "$TEST_NAME.stdout" <<'__OUT__'
 20100102T0500Z
 __OUT__
+fi
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-check-timeout
 LOG=$(cylc get-global-config --print-run-dir)/$SUITE_NAME/log/suite/log

--- a/tests/runahead/03-check-default-future.t
+++ b/tests/runahead/03-check-default-future.t
@@ -30,13 +30,17 @@ TEST_NAME=$TEST_NAME_BASE-run
 run_fail $TEST_NAME cylc run --debug --set=FUTURE_TRIGGER_START_POINT=T04 \
     $SUITE_NAME
 #-------------------------------------------------------------------------------
-TEST_NAME=$TEST_NAME_BASE-max-cycle
-DB="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/log/db"
-run_ok $TEST_NAME sqlite3 $DB "select max(cycle) from task_states where name \
-is 'foo' and status is 'failed'"
-cmp_ok "$TEST_NAME.stdout" <<'__OUT__'
+if ! which sqlite3 > /dev/null; then
+    skip 2 "sqlite3 not installed?"
+else
+    TEST_NAME=$TEST_NAME_BASE-max-cycle
+    DB="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/log/db"
+    run_ok $TEST_NAME sqlite3 $DB "select max(cycle) from task_states where name \
+    is 'foo' and status is 'failed'"
+    cmp_ok "$TEST_NAME.stdout" <<'__OUT__'
 20100101T0200Z
 __OUT__
+fi
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-check-timeout
 LOG=$(cylc get-global-config --print-run-dir)/$SUITE_NAME/log/suite/log

--- a/tests/runahead/04-no-final-cycle.t
+++ b/tests/runahead/04-no-final-cycle.t
@@ -28,6 +28,11 @@ run_ok $TEST_NAME cylc validate $SUITE_NAME
 TEST_NAME=$TEST_NAME_BASE-run
 run_ok $TEST_NAME cylc run --debug $SUITE_NAME
 #-------------------------------------------------------------------------------
+if ! which sqlite3 > /dev/null; then
+    skip 1 "sqlite3 not installed?"
+    purge_suite "${SUITE_NAME}"
+    exit 0
+fi
 TEST_NAME=$TEST_NAME_BASE-check-fail
 DB="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/log/db"
 TASKS=$(sqlite3 $DB 'select count(*) from task_states where status is "failed"')

--- a/tests/runahead/05-check-default-future-2.t
+++ b/tests/runahead/05-check-default-future-2.t
@@ -30,13 +30,17 @@ TEST_NAME=$TEST_NAME_BASE-run
 run_fail $TEST_NAME cylc run --debug --set=FUTURE_TRIGGER_START_POINT=T02 \
     $SUITE_NAME
 #-------------------------------------------------------------------------------
-TEST_NAME=$TEST_NAME_BASE-max-cycle
-DB="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/log/db"
-run_ok $TEST_NAME sqlite3 $DB "select max(cycle) from task_states where name \
-is 'foo' and status is 'failed'"
-cmp_ok "$TEST_NAME.stdout" <<'__OUT__'
+if ! which sqlite3 > /dev/null; then
+    skip 2 "sqlite3 not installed?"
+else
+    TEST_NAME=$TEST_NAME_BASE-max-cycle
+    DB="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/log/db"
+    run_ok $TEST_NAME sqlite3 $DB "select max(cycle) from task_states where name \
+    is 'foo' and status is 'failed'"
+    cmp_ok "$TEST_NAME.stdout" <<'__OUT__'
 20100101T0800Z
 __OUT__
+fi
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-check-timeout
 LOG=$(cylc get-global-config --print-run-dir)/$SUITE_NAME/log/suite/log

--- a/tests/special/00-sequential.t
+++ b/tests/special/00-sequential.t
@@ -25,6 +25,13 @@ install_suite $TEST_NAME_BASE sequential
 TEST_NAME=$TEST_NAME_BASE-validate
 run_ok $TEST_NAME cylc validate $SUITE_NAME
 #-------------------------------------------------------------------------------
+if ! which sqlite3 > /dev/null; then
+    skip 1 "sqlite3 not installed?"
+    purge_suite "${SUITE_NAME}"
+    exit 0
+fi
+
+# Suite uses sqlite3 CLI.
 TEST_NAME=$TEST_NAME_BASE-run
 suite_run_ok $TEST_NAME cylc run --reference-test --debug $SUITE_NAME
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
(ping @dpmatthews)

The sqlite3 CLI has long been listed as a Cylc software prerequisite, but in fact it is only used in the test battery.

This PR removes the dependency and associated documentation. Tested by running the test battery after uninstalling sqlite3 on my VM.

All use of `sqlite3` CLI in test scripts now has to be protected by appropriate `skip` calls, if sqlite3 is not installed on the test host.  Documented this for developers, in `cylc test-battery --help`.