### PR TITLE
Fix SGE directives with space in key.

### DIFF
--- a/lib/cylc/batch_sys_handlers/sge.py
+++ b/lib/cylc/batch_sys_handlers/sge.py
@@ -50,9 +50,14 @@ class SGEHandler(object):
             directives[key] = value
         lines = []
         for key, value in directives.items():
-            if value:
+            if value and " " in key:
+                # E.g. -l h_rt=3:00:00
+                lines.append("%s%s=%s" % (self.DIRECTIVE_PREFIX, key, value))
+            elif value:
+                # E.g. -q queue_name
                 lines.append("%s%s %s" % (self.DIRECTIVE_PREFIX, key, value))
             else:
+                # E.g. -V
                 lines.append("%s%s" % (self.DIRECTIVE_PREFIX, key))
         return lines
 

--- a/tests/jobscript/14-sge-format.t
+++ b/tests/jobscript/14-sge-format.t
@@ -1,0 +1,35 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test that SGE directives are formatted correctly. GitHub #2215
+. "$(dirname "${0}")/test_header"
+#-------------------------------------------------------------------------------
+set_test_number 6
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+#-------------------------------------------------------------------------------
+TEST_NAME="${TEST_NAME_BASE}-validate"
+run_ok "${TEST_NAME}" cylc validate "${SUITE_NAME}"
+#-------------------------------------------------------------------------------
+TEST_NAME="${TEST_NAME_BASE}-script"
+run_ok "${TEST_NAME}" cylc jobscript "${SUITE_NAME}" foo.1
+grep_ok "^#\$ -l h_rt=0:10:00$" "${TEST_NAME}.stdout"
+grep_ok "^#\$ -l s_vmem=1G,s_cpu=60$" "${TEST_NAME}.stdout"
+grep_ok "^#\$ -V$" "${TEST_NAME}.stdout"
+grep_ok "^#\$ -q queuename$" "${TEST_NAME}.stdout"
+#-------------------------------------------------------------------------------
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/jobscript/14-sge-format/suite.rc
+++ b/tests/jobscript/14-sge-format/suite.rc
@@ -1,0 +1,13 @@
+title = "Job script: directives test for SGE"
+[scheduling]
+    [[dependencies]]
+        graph = foo
+[runtime]
+    [[foo]]
+        [[[job]]]
+            batch system = sge
+            execution time limit = PT10M
+        [[[directives]]]
+            -V =
+            -q = queuename
+            -l = s_vmem=1G,s_cpu=60


### PR DESCRIPTION
Reported at BoM: under SGE the new(ish) `execution time limit` setting gets formatted as:

```
#$ -l h_rt 0:20:00
```
instead of
```
#$ -l h_rt=0:20:00
```

This patch fixes the problem.