### PR TITLE
Sdg updates

### DIFF
--- a/doc/src/suite-design-guide/general-principles.tex
+++ b/doc/src/suite-design-guide/general-principles.tex
@@ -512,11 +512,13 @@ effect delete the work directories of tasks other than its intended target.
 \begin{lstlisting}
 # Shared work directory: tasks can read and write in $PWD - use with caution!
 [scheduling]
+    initial cycle point = 2018
     [[dependencies]]
-        graph = write_data => read_data
+        [[[P1Y]]]
+            graph = write_data => read_data
 [runtime]
     [[WORKSPACE]]
-        work sub-directory = datadir
+        work sub-directory = $CYLC_TASK_CYCLE_POINT/datadir
     [[write_data]]
         inherit = WORKSPACE
         script = write-data.exe

--- a/doc/src/suite-design-guide/general-principles.tex
+++ b/doc/src/suite-design-guide/general-principles.tex
@@ -651,4 +651,32 @@ path from the workflow:
 %\end{minipage}
 %\end{figure}
 
+\subsection{Include Files}
+
+Include-files should not be overused, but they can sometimes be useful
+(e.g.\ see Portable Suites~\ref{Portable Suites}):
+
+\begin{lstlisting}
+#...
+{% include 'inc/foo.rc' %}
+\end{lstlisting}
+
+(Technically this inserts a Jinja2-rendered file template). Cylc also has a
+native include mechanism that pre-dates Jinja2 support and literally inlines
+the include-file:
+
+\begin{lstlisting}
+#...
+%include 'inc/foo.rc'
+\end{lstlisting}
+
+The two methods normally produce the same result, but use the Jinja2 version if
+you need to construct an include-file name from a variable (because Cylc
+include-files get inlined before Jinja2 processing is done):
+
+\begin{lstlisting}
+#...
+{% include 'inc/' ~ SITE ~ '.rc' %}
+\end{lstlisting}
+
 

--- a/doc/src/suite-design-guide/portable-suites.tex
+++ b/doc/src/suite-design-guide/portable-suites.tex
@@ -109,8 +109,8 @@ where the site include-file \lstinline=site/niwa.rc= contains:
 \subsection{Site-Specific Graphs}
 
 Repeated \lstinline=graph= strings under the same graph section headings are
-always additive (graph strings are the only exception to the normal overriding
-of repeated items). So, for instance, this graph:
+always additive (graph strings are the only exception to the normal repeat item
+override semantics). So, for instance, this graph:
 
 \begin{lstlisting}
 [scheduling]
@@ -180,6 +180,7 @@ mess) and it exposes all site configuration to all users:
 [runtime]
     [[model]]
         script = run-model.sh
+{# Site switch blocks not recommended:#}
 {% if SITE == 'niwa' %}
         [[[job]]]
             batch system = loadleveler
@@ -231,7 +232,6 @@ where IDL is available. The IDL-dependence switch can be set per site like this:
 \lstset{language=suiterc}
 \begin{lstlisting}
 #...
-{% set HAVE_IDL = False %}  {# Default. #}
 {% from SITE ~ '-vars.rc' import HAVE_IDL, OTHER_VAR %}
 graph = """
   pre => model => post
@@ -246,10 +246,11 @@ where for \lstinline@SITE = niwa@ the file \lstinline=niwa-vars.rc= contains:
 \begin{lstlisting}
 {# niwa-vars.rc #}
 {% set HAVE_IDL = True %}
+{% set OTHER_VAR = "the quick brown fox" %}
 \end{lstlisting}
 
-Note this really assumes a significantly smaller number of options (IDL or not,
-in this case) than sites, otherwise the IDL workflow should just go in the site
+Note we are assuming there are significantly fewer options (IDL or not, in this
+case) than sites, otherwise the IDL workflow should just go in the site
 include-files of the sites that need it.
 
 \subsection{Site-Specific Optional Suite Configs}

--- a/doc/src/suite-design-guide/preamble.tex
+++ b/doc/src/suite-design-guide/preamble.tex
@@ -30,7 +30,7 @@
 
 % Code listings: default style.
 \definecolor{keywords}{rgb}{0.8,0.4,0.0}
-\definecolor{comments}{rgb}{0.8,0.7,0.3}
+\definecolor{comments}{rgb}{1.0,0.3,0.5}
 \definecolor{identifiers}{rgb}{0.3,0.4,0.5}
 \definecolor{strings}{rgb}{0.2,0.5,0.3}
 \definecolor{basic}{rgb}{0.2,0.3,0.4}
@@ -55,7 +55,7 @@ upquote=true,
 \definecolor{level1}{rgb}{0.0,0.2,0.6}
 \definecolor{level2}{rgb}{0.0,0.3,0.7}
 \definecolor{level3}{rgb}{0.0,0.4,0.8}
-\definecolor{jinja2}{rgb}{0.1,0.7,0.4}
+\definecolor{jinja2}{rgb}{0.7,0.5,0.3}
 \lstdefinelanguage{suiterc}
 {
 string=[b]{"},

--- a/doc/src/suite-design-guide/style-guide.tex
+++ b/doc/src/suite-design-guide/style-guide.tex
@@ -12,8 +12,8 @@ of tabs and spaces in the same file can render to a mess.
 Use \lstinline=grep -InPr "\t" *= to find tabs recursively in files in
 a directory.
 
-In {\em vim} use \lstinline=%retab= to convert existing tabs to spaces, 
-and set \lstinline=expandtab= to automatically convert new tabs. 
+In {\em vim} use \lstinline=%retab= to convert existing tabs to spaces,
+and set \lstinline=expandtab= to automatically convert new tabs.
 
 In {\em emacs} use {\em whitespace-cleanup}.
 
@@ -38,7 +38,7 @@ $ sed --in-place 's/[[:space:]]\+$//' path/to/file
 Or do a similar search-and-replace operation in your editor. Editors like {\em
 vim} and {\em emacs} can also be configured to highlight or automatically
 remove trailing whitespace on the fly.
-    
+
 \subsection{Indentation}
 
 Consistent indentation makes a suite definition more readable, it shows section
@@ -85,14 +85,14 @@ to, and trailing comments should be preceded by two spaces, as shown above.
 
 \subsubsection{Script String Lines}
 
-Script strings are written verbatim to task job scripts and interpreted by the
-job shell. They are subject to shell, not suite.rc, syntax rules and do not
-have to be indented:
+Script strings are written verbatim to task job scripts so they should really
+be indented from the left margin:
 
 \lstset{language=suiterc}
 \begin{lstlisting}
 [runtime]
     [[foo]]
+        # Recommended.
         post-script = """
 if [[ $RESULT == "bad" ]]; then
     echo Goodbye World!
@@ -100,15 +100,15 @@ if [[ $RESULT == "bad" ]]; then
 fi"""
 \end{lstlisting}
 
-Indentation is ignored by the shell, however, so script lines can be indented
-as if part of the suite.rc syntax, or even out to the triple quotes, if you
-feel it aids readability (but watch line length with large indents;
-see~\ref{Line Length}):
+Indentation is {\em mostly} ignored by the bash interpreter, however, so if you
+feel it aids readability it is {\em mostly} harmless to indent internal script
+lines as if part of the Cylc syntax, or even out to the triple quotes:
 
 \lstset{language=suiterc}
 \begin{lstlisting}
 [runtime]
     [[foo]]
+        # OK, but...
         post-script = """
             if [[ $RESULT == "bad" ]]; then
                 echo Goodbye World!
@@ -116,7 +116,24 @@ see~\ref{Line Length}):
             fi"""
 \end{lstlisting}
 
-Both styles are acceptable; choose one and use it consistently.
+But if you do this, watch your line length (see~\ref{Line Length}) and {\em do not
+indent here documents}:
+
+\lstset{language=suiterc}
+\begin{lstlisting}
+[runtime]
+    [[foo]]
+        # ... this is an error!
+        script = """
+        cat >> log.txt <<_EOF_
+            The quick brown fox jumped
+            over the lazy dog.
+        _EOF_
+                 """
+\end{lstlisting}
+
+(The leading whitespace would end up in \lstinline=log.txt=, and indenting the
+\lstinline=_EOF_= marker is actually an error).
 
 \subsubsection{Graph String Lines}
 
@@ -130,7 +147,7 @@ Multiline \lstinline@graph@ strings can be entirely free-form:
      # Main workflow:
   FAMILY:succeed-all => bar & baz => qux
 
-     # Housekeeping: 
+     # Housekeeping:
   qux => rose_arch => rose_prune"""
 \end{lstlisting}
 
@@ -147,7 +164,7 @@ indents; see~\ref{Line Length}):
            # Main workflow:
            FAMILY:succeed-all => bar & baz => qux
 
-           # Housekeeping: 
+           # Housekeeping:
            qux => rose_arch => rose_prune"""
 \end{lstlisting}
 


### PR DESCRIPTION
Small updates to the Suite Design Guide after TISD feedback on the final draft. Mainly:

- changed advice on indenting script strings in light of the fact that *here docs should not be indented*
- documented include-file syntax

(Intending to "publish" this at last, after one more change at most: describing environment config options...)