### PR TITLE
gscan: fix suite still init traceback again

### DIFF
--- a/lib/cylc/gui/scanutil.py
+++ b/lib/cylc/gui/scanutil.py
@@ -313,8 +313,8 @@ def update_suites_info(
             continue
         try:
             result[KEY_PORT] = port
-            result[KEY_UPDATE_TIME] = int(float(result[KEY_UPDATE_TIME]))
             results[(host, result[KEY_OWNER], result[KEY_NAME])] = result
+            result[KEY_UPDATE_TIME] = int(float(result[KEY_UPDATE_TIME]))
         except (KeyError, TypeError, ValueError):
             pass
     expire_threshold = time() - DURATION_EXPIRE_STOPPED

--- a/lib/cylc/network/https/suite_identifier_server.py
+++ b/lib/cylc/network/https/suite_identifier_server.py
@@ -65,6 +65,10 @@ class SuiteIdServer(BaseCommsServer):
         if access_priv_ok(self, "state-totals"):
             summary_server = StateSummaryServer.get_inst()
             result[KEY_STATES] = summary_server.get_state_totals()
-            result[KEY_UPDATE_TIME] = summary_server.get_summary_update_time()
             result[KEY_TASKS_BY_STATE] = summary_server.get_tasks_by_state()
+            try:
+                result[KEY_UPDATE_TIME] = (
+                    summary_server.get_summary_update_time())
+            except SuiteStillInitialisingError:
+                pass
         return result


### PR DESCRIPTION
See also #2194. Looks like there is another `SuiteStillInitialisingError` we have missed on the server side.