### PR TITLE
job.sh: fix ERR trap

### DIFF
--- a/lib/cylc/job.sh
+++ b/lib/cylc/job.sh
@@ -53,8 +53,7 @@ cylc__job__main() {
     for signal_name in ${CYLC_VACATION_SIGNALS:-}; do
         trap "cylc__job__trap_vacation ${signal_name}" "${signal_name}"
     done
-    set -u
-    set -o pipefail
+    set -euo pipefail
     # Export CYLC_ suite and task environment variables
     cylc__job__inst__cylc_env
     # Write task job self-identify

--- a/tests/api-suite-info/03-get-graph-raw-4/suite.rc
+++ b/tests/api-suite-info/03-get-graph-raw-4/suite.rc
@@ -1,4 +1,5 @@
 [cylc]
+   UTC mode = True
    [[reference test]]
        required run mode = live
        live mode suite timeout = PT30S

--- a/tests/jobscript/12-err-script.t
+++ b/tests/jobscript/12-err-script.t
@@ -22,7 +22,7 @@ set_test_number 4
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
 run_ok "${TEST_NAME_BASE}-run" cylc run "${SUITE_NAME}" --reference-test --debug
-grep_ok 'ERR foo bar baz qux' "${SUITE_RUN_DIR}/log/job/1/foo/01/job.err"
+grep_ok 'EXIT foo bar baz qux' "${SUITE_RUN_DIR}/log/job/1/foo/01/job.err"
 run_fail "${TEST_NAME_BASE}-grep-02" \
     grep -q -F 'ERR foo bar baz qux' "${SUITE_RUN_DIR}/log/job/1/foo/02/job.err"
 

--- a/tests/jobscript/15-semicolon.t
+++ b/tests/jobscript/15-semicolon.t
@@ -1,7 +1,7 @@
 #!/bin/bash
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
 # Copyright (C) 2008-2017 NIWA
-#
+# 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
@@ -15,22 +15,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test pipefail cylc/cylc#1783
-. "$(dirname "$0")/test_header"
+# Test error trapping in cmd1; cmd2 syntax. If cmd1 fails, the error trap
+# should trigger.
+. "$(dirname "${0}")/test_header"
+set_test_number 2
 
-set_test_number 3
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
-TEST_NAME=$TEST_NAME_BASE-validate
-run_ok "${TEST_NAME}-validate" cylc validate "${SUITE_NAME}"
-TEST_NAME=$TEST_NAME_BASE-run
-suite_run_fail "${TEST_NAME_BASE}-run" \
-    cylc run --no-detach --reference-test "${SUITE_NAME}"
-
-# Make sure t1.1.1's status file is in place
-T1_STATUS_FILE="${SUITE_RUN_DIR}/log/job/1/t1/01/job.status"
-contains_ok "${T1_STATUS_FILE}" <<'__STATUS__'
-CYLC_JOB_EXIT=EXIT
-__STATUS__
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+run_ok "${TEST_NAME_BASE}-run" cylc run "${SUITE_NAME}" --reference-test --debug
 
 purge_suite "${SUITE_NAME}"
 exit

--- a/tests/jobscript/15-semicolon/reference.log
+++ b/tests/jobscript/15-semicolon/reference.log
@@ -1,0 +1,4 @@
+2017-02-09T16:45:37Z INFO - Initial point: 1
+2017-02-09T16:45:37Z INFO - Final point: 1
+2017-02-09T16:45:37Z INFO - [foo.1] -triggered off []
+2017-02-09T16:45:37Z INFO - [foo.1] -triggered off []

--- a/tests/jobscript/15-semicolon/suite.rc
+++ b/tests/jobscript/15-semicolon/suite.rc
@@ -1,0 +1,17 @@
+[cylc]
+    [[reference test]]
+        expected task failures = foo.1
+    [[events]]
+        abort on stalled = True
+[scheduling]
+    [[dependencies]]
+        graph = foo
+[runtime]
+    [[foo]]
+        script = """
+if ((${CYLC_TASK_SUBMIT_NUMBER} == 1)); then
+    false; true
+fi
+"""
+        [[[job]]]
+            execution retry delays = PT0S


### PR DESCRIPTION
Turn on `set -e` so that if `cmd1` fails in a `cmd1; cmd2` syntax, the
failure is trapped.