### PR TITLE
Add user at host option to cylc monitor/gui.

### DIFF
--- a/bin/cylc-gui
+++ b/bin/cylc-gui
@@ -55,8 +55,11 @@ def main():
     sys.path.append(
         os.path.dirname(os.path.realpath(os.path.abspath(__file__))) + '/../')
 
-    parser = COP(__doc__, comms=True, noforce=True, jset=True,
-                 argdoc=[('[REG]', 'Suite name')])
+    parser = COP(
+        __doc__, comms=True, noforce=True, jset=True, argdoc=[
+            ('[REG]', 'Suite name'),
+            ('[USER_AT_HOST]', 'user@host:port, shorthand for --user, --host '
+             '& --port.')])
 
     parser.add_option(
         "-r", "--restricted",
@@ -90,10 +93,17 @@ def main():
     gtk.settings_get_default().set_long_property(
         "gtk-menu-images", True, "main")
 
-    if len(args) == 1:
+    suite = None
+    if len(args) > 0:
         suite = args[0]
-    else:
-        suite = None
+    if len(args) == 2:
+        try:
+            user_at_host, options.port = args[1].split(':')
+            options.owner, options.host = user_at_host.split('@')
+        except ValueError:
+            print >> sys.stderr, ('USER_AT_HOST must take the form '
+                                  '"user@host:port"')
+            sys.exit(1)
     app = ControlApp(
         suite, options.owner, options.host,
         options.port, options.comms_timeout,

--- a/bin/cylc-monitor
+++ b/bin/cylc-monitor
@@ -50,7 +50,9 @@ class SuiteMonitor(object):
             """cylc [info] monitor [OPTIONS] ARGS
 
 A terminal-based live suite monitor.  Exit with 'Ctrl-C'.""",
-            comms=True, noforce=True)
+            argdoc=[('REG', 'Suite name'),
+                    ('[USER_AT_HOST]', 'user@host:port, shorthand for --user, '
+                     '--host & --port.')], comms=True, noforce=True)
 
         self.parser.add_option(
             "-a", "--align",
@@ -94,6 +96,15 @@ A terminal-based live suite monitor.  Exit with 'Ctrl-C'.""",
     def run(self):
         (options, args) = self.parser.parse_args()
         suite = args[0]
+
+        if len(args) > 1:
+            try:
+                user_at_host, options.port = args[1].split(':')
+                options.owner, options.host = user_at_host.split('@')
+            except ValueError:
+                print >> sys.stderr, ('USER_AT_HOST must take the form '
+                                      '"user@host:port"')
+                sys.exit(1)
 
         client_name = os.path.basename(sys.argv[0])
         if options.restricted:

--- a/tests/cylc-scan/03-monitor.t
+++ b/tests/cylc-scan/03-monitor.t
@@ -1,0 +1,40 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test cylc monitor USER_AT_HOST interface.
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 4
+#-------------------------------------------------------------------------------
+init_suite "${TEST_NAME_BASE}" <<'__SUITE_RC__'
+[scheduling]
+    [[dependencies]]
+        graph = foo
+[runtime]
+    [[foo]]
+        script = sleep 60
+__SUITE_RC__
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+run_ok "${TEST_NAME_BASE}-run" cylc run "${SUITE_NAME}"
+
+TEST_NAME="${TEST_NAME_BASE}-monitor"
+run_ok "${TEST_NAME}" cylc monitor $(cylc scan | grep "${SUITE_NAME}") --once
+grep_ok "${SUITE_NAME} - 1 task" "${TEST_NAME}.stdout"
+#-------------------------------------------------------------------------------
+cylc stop --kill "${SUITE_NAME}"
+purge_suite "${SUITE_NAME}"


### PR DESCRIPTION
Closes #1752 

Adds an optional argument to `cylc monitor` and `gcylc` to enable output from cylc scan to be used for these commands.

i.e:
```bash
gcylc $(cylc scan | grep <suite_name>)
cylc monitor $(cylc scan | grep <suite_name>)
```