### PR TITLE
2229.fix fam collapse

### DIFF
--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -523,7 +523,7 @@ class SuiteConfig(object):
         self.collapsed_families_rc = (
             self.cfg['visualization']['collapsed families'])
         for fam in self.collapsed_families_rc:
-            if fam not in self.runtime['first-parent descendants'].keys():
+            if fam not in self.runtime['first-parent descendants']:
                 raise SuiteConfigError(
                     'ERROR [visualization]collapsed families: '
                     '%s is not a first parent' % fam)

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -522,6 +522,12 @@ class SuiteConfig(object):
 
         self.collapsed_families_rc = (
             self.cfg['visualization']['collapsed families'])
+        for fam in self.collapsed_families_rc:
+            if fam not in self.runtime['first-parent descendants'].keys():
+                raise SuiteConfigError(
+                    'ERROR [visualization]collapsed families: '
+                    '%s is not a first parent' % fam)
+
         if is_reload:
             # on suite reload retain an existing state of collapse
             # (used by the "cylc graph" viewer)

--- a/tests/validate/63-collapse-secondary-parent.t
+++ b/tests/validate/63-collapse-secondary-parent.t
@@ -1,0 +1,45 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Fail attempt to collapse a non first-parent family in the graph.
+# GitHub #2229.
+
+. "$(dirname "$0")/test_header"
+
+set_test_number 2
+
+cat >'suite.rc' <<__SUITE_RC__
+[scheduling]
+    [[dependencies]]
+        graph = BAR
+[runtime]
+    [[root]]
+        script = sleep 1
+    [[FOO]]
+    [[BAR]]
+    [[ukv_um_recon_ls]]
+        inherit = FOO, BAR
+[visualization]
+    collapsed families = BAR  # Troublesome setting.
+__SUITE_RC__
+
+run_fail "${TEST_NAME_BASE}" cylc validate 'suite.rc'
+
+ERR='ERROR \[visualization\]collapsed families: BAR is not a first parent'
+grep_ok "$ERR" "${TEST_NAME_BASE}.stderr"
+
+exit


### PR DESCRIPTION
Close #2229.

For the example in #2229:
```
$ cylc validate foo
'ERROR [visualization]collapsed families: BAR is not a first parent'
```