### PR TITLE
Fix log warning calls

### DIFF
--- a/lib/cylc/network/__init__.py
+++ b/lib/cylc/network/__init__.py
@@ -132,7 +132,7 @@ def check_access_priv(server_obj, required_privilege_level):
             priv_level, required_privilege_level,
             user, host, prog_name, uuid
         )
-        getLogger("log").warn(err)
+        getLogger("log").warning(err)
         # Raise an exception to be sent back to the client.
         raise Exception(err)
 

--- a/lib/cylc/network/https/client_reporter.py
+++ b/lib/cylc/network/https/client_reporter.py
@@ -110,14 +110,14 @@ class CommsClientReporter(object):
             (auth_user, prog_name, user, host, uuid,
              priv_level) = get_client_info()
         except Exception:
-            LOG.warn(
+            LOG.warning(
                 self.__class__.LOG_CONNECT_DENIED_TMPL % (
                     "unknown", "unknown", "unknown", "unknown")
             )
             return
         connection_denied = get_client_connection_denied()
         if connection_denied:
-            LOG.warn(
+            LOG.warning(
                 self.__class__.LOG_CONNECT_DENIED_TMPL % (
                     user, host, prog_name, uuid)
             )


### PR DESCRIPTION
Also for consistency, only use `.warning` (instead of `.warn`).

Fix #2228.