### PR TITLE
Fix example/task-states.

### DIFF
--- a/examples/task-states/bin/change-my-job-sub-method.sh
+++ b/examples/task-states/bin/change-my-job-sub-method.sh
@@ -9,6 +9,5 @@ echo "${0}:resetting job submission method with cylc broadcast"
 
 NAME=${TASKID%.*}
 CYCLE=${TASKID#*.}
+cylc broadcast -n $NAME -p $CYCLE --set '[job]batch system=background' $SUITE
 
-echo cylc broadcast -n $NAME -t $CYCLE --set "[job]batch system=background" $SUITE
-cylc broadcast -n $NAME -t $CYCLE --set "[job]batch system=background" $SUITE

--- a/examples/task-states/suite.rc
+++ b/examples/task-states/suite.rc
@@ -3,6 +3,10 @@ title = "gcylc task state color theme demo"
 description = """Generate a lot of possible task states,
 to show what they look like live in gcylc."""
 
+[cylc]
+    UTC mode = True
+    cycle point format = %Y-%m-%dT%HZ
+
 [scheduling]
     initial cycle point = 20120808T00
     final cycle point = 20120812T00


### PR DESCRIPTION
Minor fix to one example suite (was using obsolete `cylc broadcast` syntax).  One review will do for this.