### PR TITLE
Change [queues][default] to [queues][root]

### DIFF
--- a/doc/src/cylc-user-guide/cug.tex
+++ b/doc/src/cylc-user-guide/cug.tex
@@ -6384,27 +6384,27 @@ assigned by task or family name.
 Queue configuration is done under the [scheduling] section of the suite.rc file
 (like dependencies, internal queues constrain {\em when} a task runs).
 
-By default every task is assigned to the {\em default} queue, which by default
+By default every task is assigned to the {\em root} queue, which by default
 has a zero limit (interpreted by cylc as no limit). To use a single queue for
-the whole suite just set the default queue limit:
+the whole suite just set the root queue limit:
 \lstset{language=suiterc}
 \begin{lstlisting}
 [scheduling]
-    [[ queues]]
+    [[queues]]
         # limit the entire suite to 5 active tasks at once
-        [[[default]]]
+        [[[root]]]
             limit = 5
 \end{lstlisting}
 To use additional queues just name each one, set their limits, and assign
 members:
 \begin{lstlisting}
 [scheduling]
-    [[ queues]]
+    [[queues]]
         [[[q_foo]]]
             limit = 5
             members = foo, bar, baz
 \end{lstlisting}
-Any tasks not assigned to a particular queue will remain in the default
+Any tasks not assigned to a particular queue will remain in the root
 queue. The {\em queues} example suite illustrates how queues work by
 running two task trees side by side (as seen in the graph GUI) each
 limited to 2 and 3 tasks respectively:

--- a/doc/src/cylc-user-guide/suiterc.tex
+++ b/doc/src/cylc-user-guide/suiterc.tex
@@ -829,9 +829,9 @@ predecessor had been submitted.
 
 Configuration of internal queues, by which the number of simultaneously
 active tasks (submitted or running) can be limited, per queue. By
-default a single queue called {\em default} is defined, with all tasks
+default a single queue called {\em root} is defined, with all tasks
 assigned to it and no limit. To use a single queue for the whole suite
-just set the limit on the {\em default} queue as required.
+just set the limit on the {\em root} queue as required.
 See also~\ref{InternalQueues}.
 
 \paragraph[{[[[}\_\_QUEUE\_\_{]]]}]{[scheduling] \textrightarrow [[queues]] \textrightarrow [[[\_\_QUEUE\_\_]]]}
@@ -841,7 +841,7 @@ Section heading for configuration of a single queue. Replace
 
 \begin{myitemize}
 \item {\em type:} string
-\item {\em default:} ``default''
+\item {\em default:} ``root''
 \end{myitemize}
 
 \paragraph[limit]{[scheduling] \textrightarrow [[queues]] \textrightarrow [[[\_\_QUEUE\_\_]]] \textrightarrow limit}
@@ -858,7 +858,7 @@ A list of member tasks, or task family names, to assign to this queue
 (assigned tasks will automatically be removed from the default queue).
 \begin{myitemize}
 \item {\em type:} Comma-separated list of strings (task or family names).
-\item {\em default:} none for user-defined queues; all tasks for the ``default'' queue
+\item {\em default:} none for user-defined queues; all tasks for the ``root'' queue
 \end{myitemize}
 
 \subsubsection[{[[}special tasks{]]}]{[scheduling] \textrightarrow [[special tasks]]}

--- a/examples/queues/suite.rc
+++ b/examples/queues/suite.rc
@@ -1,12 +1,12 @@
 title = demonstrates internal queueing
 description = """
-Two trees of tasks: the first uses the default queue set to a limit of
+Two trees of tasks: the first uses the root queue set to a limit of
 two active tasks at once; the second uses another queue limited to three
 active tasks at once. Run via the graph control GUI for a clear view.
               """
 [scheduling]
     [[queues]]
-        [[[default]]]
+        [[[root]]]
             limit = 2
         [[[foo]]]
             limit = 3

--- a/lib/cylc/cfgspec/suite.py
+++ b/lib/cylc/cfgspec/suite.py
@@ -276,7 +276,7 @@ SPEC = {
         'spawn to max active cycle points': vdr(
             vtype='boolean', default=False),
         'queues': {
-            'default': {
+            'root': {
                 'limit': vdr(vtype='integer', default=0),
                 'members': vdr(vtype='string_list', default=[]),
             },
@@ -494,6 +494,10 @@ def upg(cfg, descr):
     u.obsolete('7.2.2', ['cylc', 'simulation mode'])
     u.obsolete('7.2.2', ['runtime', '__MANY__', 'dummy mode'])
     u.obsolete('7.2.2', ['runtime', '__MANY__', 'simulation mode'])
+    u.deprecate(
+        '7.3.0',
+        ['scheduling', 'queues', 'default'],
+        ['scheduling', 'queues', 'root'])
     u.upgrade()
 
 

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -1086,7 +1086,7 @@ class SuiteConfig(object):
 
         # First add all tasks to the default queue.
         all_task_names = self.get_task_name_list()
-        queues['default']['members'] = all_task_names
+        queues['root']['members'] = all_task_names
 
         # Then reassign to other queues as requested.
         warnings = []
@@ -1106,7 +1106,7 @@ class SuiteConfig(object):
                         # This includes sub-families.
                         if qmember not in qmembers:
                             try:
-                                queues['default']['members'].remove(fmem)
+                                queues['root']['members'].remove(fmem)
                             except ValueError:
                                 if fmem in requeued:
                                     msg = "%s: ignoring %s from %s (%s)" % (
@@ -1123,7 +1123,7 @@ class SuiteConfig(object):
                     # Is a task.
                     if qmember not in qmembers:
                         try:
-                            queues['default']['members'].remove(qmember)
+                            queues['root']['members'].remove(qmember)
                         except ValueError:
                             if qmember in requeued:
                                 msg = "%s: ignoring '%s' (%s)" % (

--- a/tests/cylc-diff/00-basic.t
+++ b/tests/cylc-diff/00-basic.t
@@ -63,7 +63,7 @@ Suite definitions ${SUITE_NAME1} and ${SUITE_NAME2} differ
 
 3 common items differ ${SUITE_NAME1}(<) ${SUITE_NAME2}(>)
 
-   [scheduling] [[queues]] [[[default]]]
+   [scheduling] [[queues]] [[[root]]]
  <   members = ['foo', 'bar']
  >   members = ['food', 'barley']
 

--- a/tests/cylc-diff/03-icp.t
+++ b/tests/cylc-diff/03-icp.t
@@ -70,7 +70,7 @@ Suite definitions ${SUITE_NAME1} and ${SUITE_NAME2} differ
 
 3 common items differ ${SUITE_NAME1}(<) ${SUITE_NAME2}(>)
 
-   [scheduling] [[queues]] [[[default]]]
+   [scheduling] [[queues]] [[[root]]]
  <   members = ['foo', 'bar']
  >   members = ['food', 'barley']
 

--- a/tests/cylc-diff/04-icp-2.t
+++ b/tests/cylc-diff/04-icp-2.t
@@ -71,7 +71,7 @@ Suite definitions ${SUITE_NAME1} and ${SUITE_NAME2} differ
 
 3 common items differ ${SUITE_NAME1}(<) ${SUITE_NAME2}(>)
 
-   [scheduling] [[queues]] [[[default]]]
+   [scheduling] [[queues]] [[[root]]]
  <   members = ['foo', 'bar']
  >   members = ['food', 'barley']
 

--- a/tests/cylc-get-config/00-simple/section1.stdout
+++ b/tests/cylc-get-config/00-simple/section1.stdout
@@ -11,7 +11,7 @@ final cycle point = 1
     [[[R1]]]
         graph = OPS:finish-all => VAR
 [[queues]]
-    [[[default]]]
+    [[[root]]]
         limit = 0
         members = ops_s1, ops_s2, ops_p1, ops_p2, var_p1, var_p2, var_s1, var_s2
 [[special tasks]]

--- a/tests/task-proc-loop/00-count/suite.rc
+++ b/tests/task-proc-loop/00-count/suite.rc
@@ -4,7 +4,7 @@
         abort on timeout = True
 [scheduling]
     [[queues]]
-        [[[default]]]
+        [[[root]]]
             limit = 1
     [[dependencies]]
         graph = m1 & m2


### PR DESCRIPTION
On discussion earlier we thought it would make more sense for the "default" queue to be renamed to "root" as, like the "root" runtime section it applies to all tasks in the suite by default, except where its overridden - just like the runtime settings from root.

Feel free to discuss.