### PR TITLE
Cycling abstract base classes refactor

### DIFF
--- a/lib/cylc/cycling/__init__.py
+++ b/lib/cylc/cycling/__init__.py
@@ -415,12 +415,10 @@ class TestBaseClasses(unittest.TestCase):
     def test_simple_abstract_class_test(self):
         """Cannot instantiate abstract classes, they must be defined in
         the subclasses"""
-        with self.assertRaises(TypeError):
-            SequenceBase("sequence-string", "context_string")
-        with self.assertRaises(TypeError):
-            IntervalBase("value")
-        with self.assertRaises(TypeError):
-            PointBase("value")
+        self.assertRaises(TypeError, SequenceBase, "sequence-string",
+                          "context_string")
+        self.assertRaises(TypeError, IntervalBase, "value")
+        self.assertRaises(TypeError, PointBase, "value")
 
 
 if __name__ == '__main__':

--- a/lib/cylc/cycling/__init__.py
+++ b/lib/cylc/cycling/__init__.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from pprint import _type
 
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
 # Copyright (C) 2008-2017 NIWA
@@ -17,6 +18,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """This module provides base classes for cycling data objects."""
+
+from abc import ABCMeta, abstractmethod, abstractproperty
 
 
 def parse_exclusion(expr):
@@ -79,7 +82,7 @@ class SequenceDegenerateError(Exception):
 
 class PointBase(object):
 
-    """The base class for single points in a cycler sequence.
+    """The abstract base class for single points in a cycler sequence.
 
     Points should be based around a string value.
 
@@ -92,27 +95,39 @@ class PointBase(object):
     method to reprocess their value into a standard form.
 
     """
+    __metaclass__ = ABCMeta
 
-    TYPE = None
-    TYPE_SORT_KEY = None
+    _TYPE = None
+    _TYPE_SORT_KEY = None
+
+    @abstractproperty
+    def TYPE(self):
+        return self._TYPE
+
+    @abstractproperty
+    def TYPE_SORT_KEY(self):
+        return self._TYPE_SORT_KEY
 
     def __init__(self, value):
         if not isinstance(value, basestring):
             raise TypeError(type(value))
         self.value = value
 
+    @abstractmethod
     def add(self, other):
         """Add other (interval) to self, returning a point."""
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     def cmp_(self, other):
         """Compare self to other point, returning a 'cmp'-like result."""
-        raise NotImplementedError()
+        pass
 
     def standardise(self):
         """Format self.value into a standard representation and check it."""
         return self
 
+    @abstractmethod
     def sub(self, other):
         """Subtract other (interval or point), returning a point or interval.
 
@@ -123,7 +138,7 @@ class PointBase(object):
          IntervalBase-derived object)
 
         """
-        raise NotImplementedError()
+        pass
 
     def __str__(self):
         # Stringify.
@@ -180,36 +195,51 @@ class IntervalBase(object):
     method to reprocess their value into a standard form.
 
     """
+    __metaclass__ = ABCMeta
 
-    TYPE = None
-    TYPE_SORT_KEY = None
+    _TYPE = None
+    _TYPE_SORT_KEY = None
+
+    @abstractproperty
+    def TYPE(self):
+        return self._TYPE
+
+    @abstractproperty
+    def TYPE_SORT_KEY(self):
+        return self._TYPE_SORT_KEY
 
     @classmethod
+    @abstractmethod
     def get_null(cls):
         """Return a null interval."""
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     def get_inferred_child(self, string):
         """For a given string, infer the offset given my instance units."""
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     def __abs__(self):
         # Return an interval with absolute values for all properties.
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     def __mul__(self, factor):
         # Return an interval with all properties multiplied by factor.
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     def __nonzero__(self):
         # Return True if the interval has any non-zero properties.
-        raise NotImplementedError()
+        pass
 
     def __init__(self, value):
         if not isinstance(value, basestring):
             raise TypeError(type(value))
         self.value = value
 
+    @abstractmethod
     def add(self, other):
         """Add other to self, returning a Point or Interval.
 
@@ -220,19 +250,21 @@ class IntervalBase(object):
          IntervalBase-derived object)
 
         """
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     def cmp_(self, other):
         """Compare self to other (interval), returning a 'cmp'-like result."""
-        raise NotImplementedError()
+        pass
 
     def standardise(self):
         """Format self.value into a standard representation."""
         return self
 
+    @abstractmethod
     def sub(self, other):
         """Subtract other (interval) from self; return an interval."""
-        raise NotImplementedError()
+        pass
 
     def is_null(self):
         return (self == self.get_null())
@@ -268,7 +300,7 @@ class IntervalBase(object):
 
 class SequenceBase(object):
 
-    """The base class for cycler sequences.
+    """The abstract base class for cycler sequences.
 
     Subclasses should accept a sequence-specific string, a
     start context string, and a stop context string as
@@ -287,68 +319,92 @@ class SequenceBase(object):
     is equal to another (represents the same set of points).
 
     """
+    __metaclass__ = ABCMeta
 
-    TYPE = None
-    TYPE_SORT_KEY = None
+    _TYPE = None
+    _TYPE_SORT_KEY = None
+
+    @abstractproperty
+    def TYPE(self):
+        return self._TYPE
+
+    @abstractproperty
+    def TYPE_SORT_KEY(self):
+        return self._TYPE_SORT_KEY
 
     @classmethod
+    @abstractmethod  # Note: stacked decorator not strictly enforced in Py2.x
     def get_async_expr(cls, start_point=0):
         """Express a one-off sequence at the initial cycle point."""
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     def __init__(self, sequence_string, context_start, context_stop=None):
         """Parse sequence string according to context point strings."""
         pass
 
+    @abstractmethod
     def get_interval(self):
         """Return the cycling interval of this sequence."""
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     def get_offset(self):
         """Deprecated: return the offset used for this sequence."""
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     def set_offset(self, i_offset):
         """Deprecated: alter state to offset the entire sequence."""
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     def is_on_sequence(self, point):
         """Is point on-sequence, disregarding bounds?"""
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     def _get_point_in_bounds(self, point):
         """Return point, or None if out of bounds."""
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     def is_valid(self, point):
         """Is point on-sequence and in-bounds?"""
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     def get_prev_point(self, point):
         """Return the previous point < point, or None if out of bounds."""
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     def get_nearest_prev_point(self, point):
         """Return the largest point < some arbitrary point."""
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     def get_next_point(self, point):
         """Return the next point > point, or None if out of bounds."""
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     def get_next_point_on_sequence(self, point):
         """Return the next point > point assuming that point is on-sequence,
         or None if out of bounds."""
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     def get_first_point(self, point):
         """Return the first point >= to point, or None if out of bounds."""
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     def get_stop_point(self):
         """Return the last point in this sequence, or None if unbounded."""
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     def __eq__(self, other):
         # Return True if other (sequence) is equal to self.
-        raise NotImplementedError()
+        pass

--- a/lib/cylc/cycling/__init__.py
+++ b/lib/cylc/cycling/__init__.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from pprint import _type
 
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
 # Copyright (C) 2008-2017 NIWA
@@ -18,6 +17,8 @@ from pprint import _type
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """This module provides base classes for cycling data objects."""
+
+import unittest
 
 from abc import ABCMeta, abstractmethod, abstractproperty
 
@@ -118,7 +119,6 @@ class PointBase(object):
         """Add other (interval) to self, returning a point."""
         pass
 
-    @abstractmethod
     def cmp_(self, other):
         """Compare self to other point, returning a 'cmp'-like result."""
         pass
@@ -363,10 +363,9 @@ class SequenceBase(object):
         """Is point on-sequence, disregarding bounds?"""
         pass
 
-    @abstractmethod
     def _get_point_in_bounds(self, point):
         """Return point, or None if out of bounds."""
-        pass
+        raise NotImplementedError("Not implemented yet")
 
     @abstractmethod
     def is_valid(self, point):
@@ -408,3 +407,21 @@ class SequenceBase(object):
     def __eq__(self, other):
         # Return True if other (sequence) is equal to self.
         pass
+
+
+class TestBaseClasses(unittest.TestCase):
+    """Test the abstract base classes cannot be instantiated on their own
+    """
+    def test_simple_abstract_class_test(self):
+        """Cannot instantiate abstract classes, they must be defined in
+        the subclasses"""
+        with self.assertRaises(TypeError):
+            SequenceBase("sequence-string", "context_string")
+        with self.assertRaises(TypeError):
+            IntervalBase("value")
+        with self.assertRaises(TypeError):
+            PointBase("value")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/graph_parser/00-unittests.t
+++ b/tests/graph_parser/00-unittests.t
@@ -18,7 +18,8 @@
 # Run graph parser unit tests.
 . $(dirname $0)/test_header
 
-set_test_number 1
+set_test_number 2
 
 TEST_NAME=$TEST_NAME_BASE-unit-tests
 run_ok $TEST_NAME python $CYLC_DIR/lib/cylc/graph_parser.py
+run_ok $TEST_NAME python $CYLC_DIR/lib/cylc/cycling/__init__.py


### PR DESCRIPTION
`cylc/cycling/__init__.py` contains base classes that are used to inherit from to create the `ISO8601Sequence`, `IS8601Interval`, `ISO8601Point` classes. This PR really just tidies up the base classes implementation so they are more pythonic abstract base classes. (Rather than just a bunch of "`raise NotImplementedErrors`".) It also prevents the base classes being instantiated on their own, and ensures that the base class methods are defined in any subclasses created. 

(~~It's a prequel to solving the rest of issue #1960~~<sup>1</sup>, but I thought I would check this doesn't break anything first, or it's a terrible idea etc..)

<sup>1</sup>Not absolutely essential to this issue now.