### PR TITLE
some gscan improvements

### DIFF
--- a/doc/src/cylc-user-guide/gcylcrc.tex
+++ b/doc/src/cylc-user-guide/gcylcrc.tex
@@ -180,7 +180,7 @@ to list your available themes.
 Sets the size (in pixels) of the cylc GUI at startup.
 
 \begin{myitemize}
-    \item {\em type:} integer list (x, y)
+    \item {\em type:} integer list: x, y
     \item {\em legal values:} positive integers
     \item {\em default:} 800, 500
     \item {\em example:} \lstinline@window size = 1000, 700@

--- a/doc/src/cylc-user-guide/gscanrc.tex
+++ b/doc/src/cylc-user-guide/gscanrc.tex
@@ -5,16 +5,24 @@
 \lstset{language=bash}
 
 This section defines all legal items and values for the gscan config
-file which should be located in
-\lstinline=$HOME/.cylc/gscan.rc=.
+file which should be located in \lstinline=$HOME/.cylc/gscan.rc=. Some items
+also affect the gpanel panel app.
+
+The main menubar and toolbar appear when the mouse pointer is moved toward the
+top of the gscan window.  The View menu allows you to change which columns are
+displayed, which hosts to scan for running suites, and the task state icon
+theme.
+
+At startup, the task state icon theme and icon size are taken from the gcylc
+config file \lstinline=$HOME/.cylc/gcylc.rc=.
+
 
 \subsection{Top Level Items}
 
-
 \subsubsection{activate on startup}
-Set whether
-\lstinline=cylc gpanel=
-will activate automatically when the gui is loaded or not.
+
+Set whether \lstinline=cylc gpanel= will activate automatically when the gui is
+loaded or not.
 
 \begin{myitemize}
     \item {\em type:} boolean (True or False)
@@ -23,21 +31,27 @@ will activate automatically when the gui is loaded or not.
 \item {\em example:} \lstinline@activate on startup = True@
 \end{myitemize}
 
-
 \subsubsection{columns}
-Set the data fields displayed initially when the
-\lstinline=cylc gscan=
-GUI starts. This
-can be changed later using the right click context menu.
-\newline
-Note that the order in
-which the fields are specified does not affect the order in which they are
-displayed.
+
+Set the columns to display when the \lstinline=cylc gscan= GUI starts. This can
+be changed later with the View menu.  The order in which the columns are
+specified here does not affect the display order.
 
 \begin{myitemize}
 \item {\em type:} string (a list of one or more view names)
-\item {\em legal values:} ``host'', ``owner'', ``status'', ``suite'',  ``title'',
-        ``updated''
+\item {\em legal values:} ``host'', ``owner'', ``status'', ``suite'',
+  ``title'', ``updated''
 \item {\em default:} ``status'', ``suite''
 \item {\em example:} \lstinline@columns = suite, title, status@
+\end{myitemize}
+
+\subsubsection{window size}
+
+Sets the size in pixels of the \lstinline=cylc gscan= GUI at startup.
+
+\begin{myitemize}
+    \item {\em type:} integer list: x, y
+    \item {\em legal values:} positive integers
+    \item {\em default:} 300, 200
+    \item {\em example:} \lstinline@window size = 1000, 700@
 \end{myitemize}

--- a/lib/cylc/cfgspec/gscan.py
+++ b/lib/cylc/cfgspec/gscan.py
@@ -29,7 +29,8 @@ USER_FILE = os.path.join(os.environ['HOME'], '.cylc', 'gscan.rc')
 
 SPEC = {
     'columns': vdr(vtype='string_list', default=['suite', 'status']),
-    'activate on startup': vdr(vtype='boolean', default=False)
+    'activate on startup': vdr(vtype='boolean', default=False),
+    'window size': vdr(vtype='integer_list', default=[300, 200]),
 }
 
 

--- a/lib/cylc/gui/gpanel.py
+++ b/lib/cylc/gui/gpanel.py
@@ -33,7 +33,8 @@ from cylc.cfgspec.gscan import gsfg
 import cylc.flags
 from cylc.gui.app_gcylc import run_get_stdout
 from cylc.gui.dot_maker import DotMaker
-from cylc.gui.scanutil import KEY_PORT, get_scan_menu, update_suites_info
+from cylc.gui.scanutil import (KEY_PORT, get_gpanel_scan_menu,
+                               update_suites_info)
 from cylc.gui.util import get_icon, setup_icons
 from cylc.network import KEY_STATES
 from cylc.network.suite_state_client import extract_group_state
@@ -203,17 +204,17 @@ class ScanPanelAppletUpdater(object):
 
         extra_items.append(gscan_item)
 
-        menu = get_scan_menu(suite_keys,
-                             self.theme_name, self._set_theme,
-                             self.has_stopped_suites(),
-                             self.clear_stopped_suites,
-                             self.hosts,
-                             self.set_hosts,
-                             self.update_now,
-                             self.start,
-                             program_name="cylc gpanel",
-                             extra_items=extra_items,
-                             is_stopped=self.quit)
+        menu = get_gpanel_scan_menu(suite_keys,
+                                    self.theme_name, self._set_theme,
+                                    self.has_stopped_suites(),
+                                    self.clear_stopped_suites,
+                                    self.hosts,
+                                    self.set_hosts,
+                                    self.update_now,
+                                    self.start,
+                                    program_name="cylc gpanel",
+                                    extra_items=extra_items,
+                                    is_stopped=self.quit)
         menu.popup(None, None, None, event.button, event.time)
         return False
 

--- a/lib/cylc/gui/gscan.py
+++ b/lib/cylc/gui/gscan.py
@@ -519,7 +519,7 @@ class ScanApp(object):
         gtk.main_quit()
         return False
 
-    def _toggle_hide_menu_bar(self, *args):
+    def _toggle_hide_menu_bar(self, *_):
         if self.menu_hbox.get_property("visible"):
             self.menu_hbox.hide_all()
         else:

--- a/lib/cylc/gui/gscan.py
+++ b/lib/cylc/gui/gscan.py
@@ -201,6 +201,13 @@ class ScanApp(object):
         self._set_dots()
 
         self.create_menubar()
+
+        accelgroup = gtk.AccelGroup()
+        self.window.add_accel_group(accelgroup)
+        key, modifier = gtk.accelerator_parse('<Alt>m')
+        accelgroup.connect_group(
+            key, modifier, gtk.ACCEL_VISIBLE, self._toggle_hide_menu_bar)
+
         self.create_tool_bar()
 
         self.menu_hbox = gtk.HBox()
@@ -502,7 +509,7 @@ class ScanApp(object):
                 launch_gcylc(suite_keys[0])
             return False
 
-        menu = get_scan_menu(suite_keys)
+        menu = get_scan_menu(suite_keys, self._toggle_hide_menu_bar)
         menu.popup(None, None, None, event.button, event.time)
         return False
 
@@ -512,15 +519,14 @@ class ScanApp(object):
         gtk.main_quit()
         return False
 
+    def _toggle_hide_menu_bar(self, *args):
+        if self.menu_hbox.get_property("visible"):
+            self.menu_hbox.hide_all()
+        else:
+            self.menu_hbox.show_all()
+
     def _on_query_tooltip(self, _, x, y, kbd_ctx, tooltip):
         """Handle a tooltip creation request."""
-        y_0 = self.treeview.convert_widget_to_tree_coords(0, 0)[1] * - 1
-        if y < y_0:
-            self.menu_hbox.show_all()
-            return False
-        else:
-            self.menu_hbox.hide_all()
-            return False
         tip_context = self.treeview.get_tooltip_context(x, y, kbd_ctx)
         if tip_context is None:
             self._prev_tooltip_location_id = None

--- a/lib/cylc/gui/gscan.py
+++ b/lib/cylc/gui/gscan.py
@@ -200,9 +200,14 @@ class ScanApp(object):
         self.dot_size = gcfg.get(['dot icon size'])
         self._set_dots()
 
-        self.create_main_menu()
+        self.create_menubar()
         self.create_tool_bar()
-        self.vbox.pack_start(self.menu_bar, False)
+
+        self.menu_hbox = gtk.HBox()
+        self.menu_hbox.pack_start(self.menu_bar, expand=True, fill=True)
+        self.menu_hbox.pack_start(self.tool_bar, expand=True, fill=True)
+        self.menu_hbox.show_all()
+        self.menu_hbox.hide_all()
 
         scrolled_window = gtk.ScrolledWindow()
         scrolled_window.set_policy(gtk.POLICY_AUTOMATIC,
@@ -210,7 +215,7 @@ class ScanApp(object):
         scrolled_window.add(self.suite_treeview)
         scrolled_window.show()
 
-        self.vbox.pack_start(self.tool_bar, False)
+        self.vbox.pack_start(self.menu_hbox, expand=False)
         self.vbox.pack_start(scrolled_window, expand=True, fill=True)
  
         self.window.add(self.vbox)
@@ -242,7 +247,7 @@ class ScanApp(object):
         """Handle a destroy of the theme legend window."""
         self.theme_legend_window = None
 
-    def create_main_menu(self):
+    def create_menubar(self):
         """Create the main menu."""
         self.menu_bar = gtk.MenuBar()
 
@@ -370,7 +375,6 @@ class ScanApp(object):
         help_menu = gtk.Menu()
         help_menu_root = gtk.MenuItem('_Help')
         help_menu_root.set_submenu(help_menu)
-        help_menu_root.set_right_justified(True)
 
         self.menu_bar.append(file_menu_root)
         self.menu_bar.append(view_menu_root)
@@ -550,6 +554,12 @@ class ScanApp(object):
 
     def _on_query_tooltip(self, _, x, y, kbd_ctx, tooltip):
         """Handle a tooltip creation request."""
+        if y < 27:  # You may need to fiddle with this parameter!
+            self.menu_hbox.show_all()
+            return False
+        else:
+            self.menu_hbox.hide_all()
+            return False
         tip_context = self.suite_treeview.get_tooltip_context(x, y, kbd_ctx)
         if tip_context is None:
             self._prev_tooltip_location_id = None

--- a/lib/cylc/gui/gscan.py
+++ b/lib/cylc/gui/gscan.py
@@ -502,8 +502,7 @@ class ScanApp(object):
                 launch_gcylc(suite_keys[0])
             return False
 
-        # TODO - only suite_keys needed?:
-        menu = get_scan_menu(suite_keys, self.hosts, self.updater.start)
+        menu = get_scan_menu(suite_keys)
         menu.popup(None, None, None, event.button, event.time)
         return False
 

--- a/lib/cylc/gui/gscan.py
+++ b/lib/cylc/gui/gscan.py
@@ -299,7 +299,6 @@ class ScanApp(object):
         img = gtk.image_new_from_stock(
             gtk.STOCK_SELECT_COLOR, gtk.ICON_SIZE_MENU)
         theme_item.set_image(img)
-        # theme_item.set_sensitive(not is_stopped)
         thememenu = gtk.Menu()
         theme_item.set_submenu(thememenu)
         theme_item.show()

--- a/lib/cylc/gui/gscan.py
+++ b/lib/cylc/gui/gscan.py
@@ -101,7 +101,7 @@ class ScanApp(object):
             str,  # states_text
             str)  # warning_text
         self._prev_tooltip_location_id = None
-        self.suite_treeview = gtk.TreeView(suite_treemodel)
+        self.treeview = gtk.TreeView(suite_treemodel)
 
         # Visibility of columns
         vis_cols = gsfg.get(["columns"])
@@ -131,7 +131,7 @@ class ScanApp(object):
             column.set_sort_column_id(col_id)
             column.set_visible(col_title.lower() in vis_cols)
             column.set_resizable(True)
-            self.suite_treeview.append_column(column)
+            self.treeview.append_column(column)
 
         # Construct the status column.
         status_column = gtk.TreeViewColumn(gsfg.COL_STATUS)
@@ -142,7 +142,7 @@ class ScanApp(object):
         status_column.pack_start(cell_text_cycle, expand=False)
         status_column.set_cell_data_func(
             cell_text_cycle, self._set_cell_text_cycle, self.CYCLE_COLUMN)
-        self.suite_treeview.append_column(status_column)
+        self.treeview.append_column(status_column)
 
         # Warning icon.
         warn_icon = gtk.CellRendererPixbuf()
@@ -167,17 +167,17 @@ class ScanApp(object):
             status_column.set_cell_data_func(
                 cell_pixbuf_state, self._set_cell_pixbuf_state, i)
 
-        self.suite_treeview.show()
-        if hasattr(self.suite_treeview, "set_has_tooltip"):
-            self.suite_treeview.set_has_tooltip(True)
+        self.treeview.show()
+        if hasattr(self.treeview, "set_has_tooltip"):
+            self.treeview.set_has_tooltip(True)
             try:
-                self.suite_treeview.connect('query-tooltip',
-                                            self._on_query_tooltip)
+                self.treeview.connect('query-tooltip',
+                                      self._on_query_tooltip)
             except TypeError:
                 # Lower PyGTK version.
                 pass
-        self.suite_treeview.connect("button-press-event",
-                                    self._on_button_press_event)
+        self.treeview.connect("button-press-event",
+                              self._on_button_press_event)
 
         patterns = {"name": None, "owner": None}
         for label, items in [
@@ -190,7 +190,7 @@ class ScanApp(object):
                     raise ValueError("Invalid %s pattern: %s" % (label, items))
 
         self.updater = ScanAppUpdater(
-            self.window, self.hosts, suite_treemodel, self.suite_treeview,
+            self.window, self.hosts, suite_treemodel, self.treeview,
             comms_timeout=comms_timeout, poll_interval=poll_interval,
             group_column_id=self.GROUP_COLUMN,
             name_pattern=patterns["name"], owner_pattern=patterns["owner"])
@@ -212,16 +212,16 @@ class ScanApp(object):
         scrolled_window = gtk.ScrolledWindow()
         scrolled_window.set_policy(gtk.POLICY_AUTOMATIC,
                                    gtk.POLICY_AUTOMATIC)
-        scrolled_window.add(self.suite_treeview)
+        scrolled_window.add(self.treeview)
         scrolled_window.show()
 
         self.vbox.pack_start(self.menu_hbox, expand=False)
         self.vbox.pack_start(scrolled_window, expand=True, fill=True)
- 
+
         self.window.add(self.vbox)
         self.window.connect("destroy", self._on_destroy_event)
         self.window.set_default_size(700, 300)
-        self.suite_treeview.grab_focus()
+        self.treeview.grab_focus()
         self.window.show()
 
         self.theme_legend_window = None
@@ -271,7 +271,7 @@ class ScanApp(object):
         col_item.set_image(img)
         col_item.show()
         col_menu = gtk.Menu()
-        for column_index, column in enumerate(self.suite_treeview.get_columns()):
+        for column_index, column in enumerate(self.treeview.get_columns()):
             name = column.get_title()
             is_visible = column.get_visible()
             column_item = gtk.CheckMenuItem(name.replace("_", "__"))
@@ -289,9 +289,10 @@ class ScanApp(object):
 
         # Construct theme chooser items (same as cylc.gui.app_main).
         theme_item = gtk.ImageMenuItem('Theme...')
-        img = gtk.image_new_from_stock(gtk.STOCK_SELECT_COLOR, gtk.ICON_SIZE_MENU)
+        img = gtk.image_new_from_stock(
+            gtk.STOCK_SELECT_COLOR, gtk.ICON_SIZE_MENU)
         theme_item.set_image(img)
-        #theme_item.set_sensitive(not is_stopped)
+        # theme_item.set_sensitive(not is_stopped)
         thememenu = gtk.Menu()
         theme_item.set_submenu(thememenu)
         theme_item.show()
@@ -351,7 +352,8 @@ class ScanApp(object):
                 'toggled', self.set_dot_size, dot_size)
 
         theme_legend_item = gtk.ImageMenuItem("Show task state key")
-        img = gtk.image_new_from_stock(gtk.STOCK_SELECT_COLOR, gtk.ICON_SIZE_MENU)
+        img = gtk.image_new_from_stock(
+            gtk.STOCK_SELECT_COLOR, gtk.ICON_SIZE_MENU)
         theme_legend_item.set_image(img)
         theme_legend_item.show()
         theme_legend_item.connect("activate", self.popup_theme_legend)
@@ -361,12 +363,14 @@ class ScanApp(object):
 
         # Construct a configure scanned hosts item.
         hosts_item = gtk.ImageMenuItem("Configure Hosts")
-        img = gtk.image_new_from_stock(gtk.STOCK_PREFERENCES, gtk.ICON_SIZE_MENU)
+        img = gtk.image_new_from_stock(
+            gtk.STOCK_PREFERENCES, gtk.ICON_SIZE_MENU)
         hosts_item.set_image(img)
         hosts_item.show()
         hosts_item.connect(
             "button-press-event",
-            lambda b, e: launch_hosts_dialog(self.hosts, self.updater.set_hosts))
+            lambda b, e: launch_hosts_dialog(
+                self.hosts, self.updater.set_hosts))
         view_menu.append(hosts_item)
 
         sep_item = gtk.SeparatorMenuItem()
@@ -427,7 +431,7 @@ class ScanApp(object):
         tooltip.enable()
         tooltip.set_tip(clear_stopped_button, "Clear stopped suites")
         clear_stopped_button.connect("clicked",
-                                  self.updater.clear_stopped_suites)
+                                     self.updater.clear_stopped_suites)
 
         expand_button = gtk.ToolButton(
             icon_widget=gtk.image_new_from_stock(
@@ -436,8 +440,8 @@ class ScanApp(object):
         tooltip = gtk.Tooltips()
         tooltip.enable()
         tooltip.set_tip(expand_button, "Expand all rows")
-        expand_button.connect("clicked",
-                lambda e: self.suite_treeview.expand_all())
+        expand_button.connect(
+            "clicked", lambda e: self.treeview.expand_all())
 
         collapse_button = gtk.ToolButton(
             icon_widget=gtk.image_new_from_stock(
@@ -446,8 +450,8 @@ class ScanApp(object):
         tooltip = gtk.Tooltips()
         tooltip.enable()
         tooltip.set_tip(collapse_button, "Collapse all rows")
-        collapse_button.connect("clicked",
-                lambda e: self.suite_treeview.collapse_all())
+        collapse_button.connect(
+            "clicked", lambda e: self.treeview.collapse_all())
 
         self.tool_bar.insert(update_now_button, 0)
         self.tool_bar.insert(clear_stopped_button, 0)
@@ -560,14 +564,14 @@ class ScanApp(object):
         else:
             self.menu_hbox.hide_all()
             return False
-        tip_context = self.suite_treeview.get_tooltip_context(x, y, kbd_ctx)
+        tip_context = self.treeview.get_tooltip_context(x, y, kbd_ctx)
         if tip_context is None:
             self._prev_tooltip_location_id = None
             return False
-        x, y = self.suite_treeview.convert_widget_to_bin_window_coords(x, y)
+        x, y = self.treeview.convert_widget_to_bin_window_coords(x, y)
         path, column, cell_x, _ = (
-            self.suite_treeview.get_path_at_pos(x, y))
-        model = self.suite_treeview.get_model()
+            self.treeview.get_path_at_pos(x, y))
+        model = self.treeview.get_model()
         iter_ = model.get_iter(path)
         parent_iter = model.iter_parent(iter_)
         if parent_iter is None or parent_iter and model.iter_has_child(iter_):
@@ -676,7 +680,7 @@ class ScanApp(object):
     def _on_toggle_column_visible(self, menu_item):
         """Toggle column visibility callback."""
         column_index = menu_item._connect_args
-        column = self.suite_treeview.get_columns()[column_index]
+        column = self.treeview.get_columns()[column_index]
         is_visible = column.get_visible()
         column.set_visible(not is_visible)
         self.updater.update()
@@ -812,7 +816,7 @@ class ScanAppUpdater(threading.Thread):
         self._should_force_update = False
         self.quit = False
         self.suite_treemodel = suite_treemodel
-        self.suite_treeview = suite_treeview
+        self.treeview = suite_treeview
         self.group_column_id = group_column_id
         self.tasks_by_state = {}
         self.warning_times = {}
@@ -834,16 +838,16 @@ class ScanAppUpdater(threading.Thread):
         """Expand a row if it matches rose_ids suite and host."""
         point_string_name_tuple = model.get(row_iter, 0, 1)
         if point_string_name_tuple in row_ids:
-            self.suite_treeview.expand_to_path(rpath)
+            self.treeview.expand_to_path(rpath)
         return False
 
     def _get_user_expanded_row_ids(self):
         """Return a list of user-expanded row point_strings and names."""
         names = []
-        model = self.suite_treeview.get_model()
+        model = self.treeview.get_model()
         if model is None or model.get_iter_first() is None:
             return names
-        self.suite_treeview.map_expanded_rows(self._add_expanded_row, names)
+        self.treeview.map_expanded_rows(self._add_expanded_row, names)
         return names
 
     def _get_warnings(self, key):
@@ -962,7 +966,7 @@ class ScanAppUpdater(threading.Thread):
 
             # Build up and assign group iters across the various suites
             if (group_iters.get(group) is None and
-                    self.suite_treeview.get_column(
+                    self.treeview.get_column(
                         self.group_column_id).get_visible()):
                 states_text = ""
                 for state, number in sorted(group_counts[group].items()):

--- a/lib/cylc/gui/scanutil.py
+++ b/lib/cylc/gui/scanutil.py
@@ -230,7 +230,7 @@ def get_gpanel_scan_menu(
     hosts_item.show()
     hosts_item.connect(
         "button-press-event",
-        lambda b, e: _launch_hosts_dialog(scanned_hosts, change_hosts_func))
+        lambda b, e: launch_hosts_dialog(scanned_hosts, change_hosts_func))
     menu.append(hosts_item)
 
     sep_item = gtk.SeparatorMenuItem()
@@ -244,7 +244,7 @@ def get_gpanel_scan_menu(
     info_item.show()
     info_item.connect(
         "button-press-event",
-        lambda b, e: _launch_about_dialog(program_name, scanned_hosts)
+        lambda b, e: launch_about_dialog(program_name, scanned_hosts)
     )
     menu.append(info_item)
     return menu

--- a/lib/cylc/gui/scanutil.py
+++ b/lib/cylc/gui/scanutil.py
@@ -40,38 +40,21 @@ DURATION_EXPIRE_STOPPED = 600.0
 KEY_PORT = "port"
 
 
-def get_scan_menu(suite_keys,
-                  theme_name, set_theme_func,
-                  has_stopped_suites, clear_stopped_suites_func,
-                  scanned_hosts, change_hosts_func,
-                  update_now_func, start_func,
-                  program_name, extra_items=None, owner=None,
+def get_scan_menu(suite_keys, start_func, owner=None,
                   is_stopped=False):
     """Return a right click menu for scan GUIs.
 
     suite_keys should be a list of (host, owner, suite) tuples (if any).
-    theme_name should be the name of the current theme.
-    set_theme_func should be a function accepting a new theme name.
-    has_stopped_suites should be a boolean denoting currently
-    stopped suites.
-    clear_stopped_suites should be a function with no arguments that
-    removes stopped suites from the current view.
-    scanned_hosts should be a list of currently scanned suite hosts.
-    change_hosts_func should be a function accepting a new list of
-    suite hosts to scan.
-    update_now_func should be a function with no arguments that
-    forces an update now or soon.
     start_func should be a function with no arguments that
     re-activates idle GUIs.
-    program_name should be a string describing the parent program.
-    extra_items (keyword) should be a list of extra menu items to add
-    to the right click menu.
     owner (keyword) should be the owner of the suites, if not the
     current user.
     is_stopped (keyword) denotes whether the GUI is in an inactive
     state.
 
     """
+
+    # TODO - what's start_func and is_stopped for?
     menu = gtk.Menu()
 
     if is_stopped:
@@ -82,6 +65,14 @@ def get_scan_menu(suite_keys,
         switch_on_item.connect("button-press-event",
                                lambda b, e: start_func())
         menu.append(switch_on_item)
+
+    if not suite_keys:
+        null_item = gtk.ImageMenuItem("Click on a suite or group")
+        img = gtk.image_new_from_stock(gtk.STOCK_DIALOG_WARNING, gtk.ICON_SIZE_MENU)
+        null_item.set_image(img)
+        null_item.show()
+        menu.append(null_item)
+        return menu
 
     # Construct gcylc launcher items for each relevant suite.
     for host, owner, suite in suite_keys:
@@ -95,31 +86,35 @@ def get_scan_menu(suite_keys,
             lambda b, e: launch_gcylc(b._connect_args))
         gcylc_item.show()
         menu.append(gcylc_item)
-    if suite_keys:
-        sep_item = gtk.SeparatorMenuItem()
-        sep_item.show()
-        menu.append(sep_item)
 
-    if extra_items is not None:
-        for item in extra_items:
-            menu.append(item)
-        sep_item = gtk.SeparatorMenuItem()
-        sep_item.show()
-        menu.append(sep_item)
+    sep_item = gtk.SeparatorMenuItem()
+    sep_item.show()
+    menu.append(sep_item)
 
     # Construct a cylc stop item to stop a suite
     if len(suite_keys) > 1:
-        stoptask_item = gtk.ImageMenuItem('Stop all')
+        stoptask_item = gtk.ImageMenuItem('Stop all...')
     else:
-        stoptask_item = gtk.ImageMenuItem('Stop')
+        stoptask_item = gtk.ImageMenuItem('Stop...')
 
+    stop_menu = gtk.Menu()
+    stoptask_item.set_submenu(stop_menu)
     img_stop = gtk.image_new_from_stock(gtk.STOCK_MEDIA_STOP,
                                         gtk.ICON_SIZE_MENU)
     stoptask_item.set_image(img_stop)
-    stoptask_item._connect_args = suite_keys, 'stop'
-    stoptask_item.connect("button-press-event",
+
+    for stop_type in ['', '--kill', '--now', '--now --now']:
+        item = gtk.ImageMenuItem('stop %s' % stop_type)
+        img_stop = gtk.image_new_from_stock(gtk.STOCK_MEDIA_STOP,
+                                            gtk.ICON_SIZE_MENU)
+        item.set_image(img_stop)
+        stop_menu.append(item)
+        item._connect_args = suite_keys, 'stop %s' % stop_type
+        item.connect("button-press-event",
                           lambda b, e: call_cylc_command(b._connect_args[0],
                                                          b._connect_args[1]))
+        item.show()
+
     stoptask_item.show()
     menu.append(stoptask_item)
 
@@ -155,102 +150,10 @@ def get_scan_menu(suite_keys,
     unstoptask_item.show()
     menu.append(unstoptask_item)
 
-    # Add another separator
-    sep_item = gtk.SeparatorMenuItem()
-    sep_item.show()
-    menu.append(sep_item)
-
-    # Construct theme chooser items (same as cylc.gui.app_main).
-    theme_item = gtk.ImageMenuItem('Theme')
-    img = gtk.image_new_from_stock(gtk.STOCK_SELECT_COLOR, gtk.ICON_SIZE_MENU)
-    theme_item.set_image(img)
-    theme_item.set_sensitive(not is_stopped)
-    thememenu = gtk.Menu()
-    theme_item.set_submenu(thememenu)
-    theme_item.show()
-
-    theme_items = {}
-    theme = "default"
-    theme_items[theme] = gtk.RadioMenuItem(label=theme)
-    thememenu.append(theme_items[theme])
-    theme_items[theme].theme_name = theme
-    for theme in gcfg.get(['themes']):
-        if theme == "default":
-            continue
-        theme_items[theme] = gtk.RadioMenuItem(
-            group=theme_items['default'], label=theme)
-        thememenu.append(theme_items[theme])
-        theme_items[theme].theme_name = theme
-
-    # set_active then connect, to avoid causing an unnecessary toggle now.
-    theme_items[theme_name].set_active(True)
-    for theme in gcfg.get(['themes']):
-        theme_items[theme].show()
-        theme_items[theme].connect(
-            'toggled',
-            lambda i: (i.get_active() and set_theme_func(i.theme_name)))
-
-    menu.append(theme_item)
-    theme_legend_item = gtk.MenuItem("Show task state key")
-    theme_legend_item.show()
-    theme_legend_item.set_sensitive(not is_stopped)
-    theme_legend_item.connect(
-        "button-press-event",
-        lambda b, e: ThemeLegendWindow(None, gcfg.get(['themes', theme_name]))
-    )
-    menu.append(theme_legend_item)
-    sep_item = gtk.SeparatorMenuItem()
-    sep_item.show()
-    menu.append(sep_item)
-
-    # Construct a trigger update item.
-    update_now_item = gtk.ImageMenuItem("Update Now")
-    img = gtk.image_new_from_stock(gtk.STOCK_REFRESH, gtk.ICON_SIZE_MENU)
-    update_now_item.set_image(img)
-    update_now_item.show()
-    update_now_item.set_sensitive(not is_stopped)
-    update_now_item.connect("button-press-event",
-                            lambda b, e: update_now_func())
-    menu.append(update_now_item)
-
-    # Construct a clean stopped suites item.
-    clear_item = gtk.ImageMenuItem("Clear Stopped Suites")
-    img = gtk.image_new_from_stock(gtk.STOCK_CLEAR, gtk.ICON_SIZE_MENU)
-    clear_item.set_image(img)
-    clear_item.show()
-    clear_item.set_sensitive(has_stopped_suites)
-    clear_item.connect("button-press-event",
-                       lambda b, e: clear_stopped_suites_func())
-    menu.append(clear_item)
-
-    # Construct a configure scanned hosts item.
-    hosts_item = gtk.ImageMenuItem("Configure Hosts")
-    img = gtk.image_new_from_stock(gtk.STOCK_PREFERENCES, gtk.ICON_SIZE_MENU)
-    hosts_item.set_image(img)
-    hosts_item.show()
-    hosts_item.connect(
-        "button-press-event",
-        lambda b, e: _launch_hosts_dialog(scanned_hosts, change_hosts_func))
-    menu.append(hosts_item)
-
-    sep_item = gtk.SeparatorMenuItem()
-    sep_item.show()
-    menu.append(sep_item)
-
-    # Construct an about dialog item.
-    info_item = gtk.ImageMenuItem("About")
-    img = gtk.image_new_from_stock(gtk.STOCK_ABOUT, gtk.ICON_SIZE_MENU)
-    info_item.set_image(img)
-    info_item.show()
-    info_item.connect(
-        "button-press-event",
-        lambda b, e: _launch_about_dialog(program_name, scanned_hosts)
-    )
-    menu.append(info_item)
     return menu
 
 
-def _launch_about_dialog(program_name, hosts):
+def launch_about_dialog(program_name, hosts):
     """Launch a modified version of the app_main.py About dialog."""
     hosts_text = "Hosts monitored: " + ", ".join(hosts)
     comments_text = hosts_text
@@ -269,7 +172,7 @@ def _launch_about_dialog(program_name, hosts):
     about.destroy()
 
 
-def _launch_hosts_dialog(existing_hosts, change_hosts_func):
+def launch_hosts_dialog(existing_hosts, change_hosts_func):
     """Launch a dialog for configuring the suite hosts to scan.
 
     Arguments:
@@ -378,7 +281,7 @@ def call_cylc_command(keys, command_id):
         if suite_version != CYLC_VERSION:
             env = dict(os.environ)
             env["CYLC_VERSION"] = suite_version
-        command = ["cylc", command_id] + args
+        command = ["cylc"] + command_id.split() + args
 
         if cylc.flags.debug:
             stdout = sys.stdout

--- a/lib/cylc/gui/scanutil.py
+++ b/lib/cylc/gui/scanutil.py
@@ -250,12 +250,25 @@ def get_gpanel_scan_menu(
     return menu
 
 
-def get_scan_menu(suite_keys):
+def get_scan_menu(suite_keys, toggle_hide_menu_bar):
     """Return a right click menu for the gscan GUI.
 
     suite_keys should be a list of (host, owner, suite) tuples (if any).
+    toggle_hide_menu_bar - function to show/hide main menu bar
 
     """
+    def _add_main_menu_item(menu):
+        sep_item = gtk.SeparatorMenuItem()
+        sep_item.show()
+        menu.append(sep_item)
+        main_menu_item = gtk.ImageMenuItem("toggle main menu (<Alt>m)")
+        img = gtk.image_new_from_stock(gtk.STOCK_INDEX, gtk.ICON_SIZE_MENU)
+        main_menu_item.set_image(img)
+        main_menu_item.connect("button-press-event",
+                               lambda b, e: toggle_hide_menu_bar())
+        main_menu_item.show()
+        menu.append(main_menu_item)
+
     menu = gtk.Menu()
 
     if not suite_keys:
@@ -265,6 +278,7 @@ def get_scan_menu(suite_keys):
         null_item.set_image(img)
         null_item.show()
         menu.append(null_item)
+        _add_main_menu_item(menu)
         return menu
 
     # Construct gcylc launcher items for each relevant suite.
@@ -343,6 +357,7 @@ def get_scan_menu(suite_keys):
                                                            b._connect_args[1]))
     unstoptask_item.show()
     menu.append(unstoptask_item)
+    _add_main_menu_item(menu)
 
     return menu
 

--- a/lib/cylc/gui/scanutil.py
+++ b/lib/cylc/gui/scanutil.py
@@ -40,21 +40,40 @@ DURATION_EXPIRE_STOPPED = 600.0
 KEY_PORT = "port"
 
 
-def get_scan_menu(suite_keys, start_func, owner=None,
+def get_gpanel_scan_menu(suite_keys,
+                  theme_name, set_theme_func,
+                  has_stopped_suites, clear_stopped_suites_func,
+                  scanned_hosts, change_hosts_func,
+                  update_now_func, start_func,
+                  program_name, extra_items=None, owner=None,
                   is_stopped=False):
-    """Return a right click menu for scan GUIs.
+    """Return a right click menu for the gpanel GUI.
+
+    TODO this used to be for gscan too; simplify now it's only for gpanel?
 
     suite_keys should be a list of (host, owner, suite) tuples (if any).
+    theme_name should be the name of the current theme.
+    set_theme_func should be a function accepting a new theme name.
+    has_stopped_suites should be a boolean denoting currently
+    stopped suites.
+    clear_stopped_suites should be a function with no arguments that
+    removes stopped suites from the current view.
+    scanned_hosts should be a list of currently scanned suite hosts.
+    change_hosts_func should be a function accepting a new list of
+    suite hosts to scan.
+    update_now_func should be a function with no arguments that
+    forces an update now or soon.
     start_func should be a function with no arguments that
     re-activates idle GUIs.
+    program_name should be a string describing the parent program.
+    extra_items (keyword) should be a list of extra menu items to add
+    to the right click menu.
     owner (keyword) should be the owner of the suites, if not the
     current user.
     is_stopped (keyword) denotes whether the GUI is in an inactive
     state.
 
     """
-
-    # TODO - what's start_func and is_stopped for?
     menu = gtk.Menu()
 
     if is_stopped:
@@ -65,6 +84,181 @@ def get_scan_menu(suite_keys, start_func, owner=None,
         switch_on_item.connect("button-press-event",
                                lambda b, e: start_func())
         menu.append(switch_on_item)
+
+    # Construct gcylc launcher items for each relevant suite.
+    for host, owner, suite in suite_keys:
+        gcylc_item = gtk.ImageMenuItem("Launch gcylc: %s - %s@%s" % (
+            suite.replace('_', '__'), owner, host))
+        img_gcylc = gtk.image_new_from_stock("gcylc", gtk.ICON_SIZE_MENU)
+        gcylc_item.set_image(img_gcylc)
+        gcylc_item._connect_args = (host, owner, suite)
+        gcylc_item.connect(
+            "button-press-event",
+            lambda b, e: launch_gcylc(b._connect_args))
+        gcylc_item.show()
+        menu.append(gcylc_item)
+    if suite_keys:
+        sep_item = gtk.SeparatorMenuItem()
+        sep_item.show()
+        menu.append(sep_item)
+
+    if extra_items is not None:
+        for item in extra_items:
+            menu.append(item)
+        sep_item = gtk.SeparatorMenuItem()
+        sep_item.show()
+        menu.append(sep_item)
+
+    # Construct a cylc stop item to stop a suite
+    if len(suite_keys) > 1:
+        stoptask_item = gtk.ImageMenuItem('Stop all')
+    else:
+        stoptask_item = gtk.ImageMenuItem('Stop')
+
+    img_stop = gtk.image_new_from_stock(gtk.STOCK_MEDIA_STOP,
+                                        gtk.ICON_SIZE_MENU)
+    stoptask_item.set_image(img_stop)
+    stoptask_item._connect_args = suite_keys, 'stop'
+    stoptask_item.connect("button-press-event",
+                          lambda b, e: call_cylc_command(b._connect_args[0],
+                                                         b._connect_args[1]))
+    stoptask_item.show()
+    menu.append(stoptask_item)
+
+    # Construct a cylc hold item to hold (pause) a suite
+    if len(suite_keys) > 1:
+        holdtask_item = gtk.ImageMenuItem('Hold all')
+    else:
+        holdtask_item = gtk.ImageMenuItem('Hold')
+
+    img_hold = gtk.image_new_from_stock(gtk.STOCK_MEDIA_PAUSE,
+                                        gtk.ICON_SIZE_MENU)
+    holdtask_item.set_image(img_hold)
+    holdtask_item._connect_args = suite_keys, 'hold'
+    holdtask_item.connect("button-press-event",
+                          lambda b, e: call_cylc_command(b._connect_args[0],
+                                                         b._connect_args[1]))
+    menu.append(holdtask_item)
+    holdtask_item.show()
+
+    # Construct a cylc release item to release a paused/stopped suite
+    if len(suite_keys) > 1:
+        unstoptask_item = gtk.ImageMenuItem('Release all')
+    else:
+        unstoptask_item = gtk.ImageMenuItem('Release')
+
+    img_release = gtk.image_new_from_stock(gtk.STOCK_MEDIA_PLAY,
+                                           gtk.ICON_SIZE_MENU)
+    unstoptask_item.set_image(img_release)
+    unstoptask_item._connect_args = suite_keys, 'release'
+    unstoptask_item.connect("button-press-event",
+                            lambda b, e: call_cylc_command(b._connect_args[0],
+                                                           b._connect_args[1]))
+    unstoptask_item.show()
+    menu.append(unstoptask_item)
+
+    # Add another separator
+    sep_item = gtk.SeparatorMenuItem()
+    sep_item.show()
+    menu.append(sep_item)
+
+    # Construct theme chooser items (same as cylc.gui.app_main).
+    theme_item = gtk.ImageMenuItem('Theme')
+    img = gtk.image_new_from_stock(gtk.STOCK_SELECT_COLOR, gtk.ICON_SIZE_MENU)
+    theme_item.set_image(img)
+    theme_item.set_sensitive(not is_stopped)
+    thememenu = gtk.Menu()
+    theme_item.set_submenu(thememenu)
+    theme_item.show()
+
+    theme_items = {}
+    theme = "default"
+    theme_items[theme] = gtk.RadioMenuItem(label=theme)
+    thememenu.append(theme_items[theme])
+    theme_items[theme].theme_name = theme
+    for theme in gcfg.get(['themes']):
+        if theme == "default":
+            continue
+        theme_items[theme] = gtk.RadioMenuItem(
+            group=theme_items['default'], label=theme)
+        thememenu.append(theme_items[theme])
+        theme_items[theme].theme_name = theme
+
+    # set_active then connect, to avoid causing an unnecessary toggle now.
+    theme_items[theme_name].set_active(True)
+    for theme in gcfg.get(['themes']):
+        theme_items[theme].show()
+        theme_items[theme].connect(
+            'toggled',
+            lambda i: (i.get_active() and set_theme_func(i.theme_name)))
+
+    menu.append(theme_item)
+    theme_legend_item = gtk.MenuItem("Show task state key")
+    theme_legend_item.show()
+    theme_legend_item.set_sensitive(not is_stopped)
+    theme_legend_item.connect(
+        "button-press-event",
+        lambda b, e: ThemeLegendWindow(None, gcfg.get(['themes', theme_name]))
+    )
+    menu.append(theme_legend_item)
+    sep_item = gtk.SeparatorMenuItem()
+    sep_item.show()
+    menu.append(sep_item)
+
+    # Construct a trigger update item.
+    update_now_item = gtk.ImageMenuItem("Update Now")
+    img = gtk.image_new_from_stock(gtk.STOCK_REFRESH, gtk.ICON_SIZE_MENU)
+    update_now_item.set_image(img)
+    update_now_item.show()
+    update_now_item.set_sensitive(not is_stopped)
+    update_now_item.connect("button-press-event",
+                            lambda b, e: update_now_func())
+    menu.append(update_now_item)
+
+    # Construct a clean stopped suites item.
+    clear_item = gtk.ImageMenuItem("Clear Stopped Suites")
+    img = gtk.image_new_from_stock(gtk.STOCK_CLEAR, gtk.ICON_SIZE_MENU)
+    clear_item.set_image(img)
+    clear_item.show()
+    clear_item.set_sensitive(has_stopped_suites)
+    clear_item.connect("button-press-event",
+                       lambda b, e: clear_stopped_suites_func())
+    menu.append(clear_item)
+
+    # Construct a configure scanned hosts item.
+    hosts_item = gtk.ImageMenuItem("Configure Hosts")
+    img = gtk.image_new_from_stock(gtk.STOCK_PREFERENCES, gtk.ICON_SIZE_MENU)
+    hosts_item.set_image(img)
+    hosts_item.show()
+    hosts_item.connect(
+        "button-press-event",
+        lambda b, e: _launch_hosts_dialog(scanned_hosts, change_hosts_func))
+    menu.append(hosts_item)
+
+    sep_item = gtk.SeparatorMenuItem()
+    sep_item.show()
+    menu.append(sep_item)
+
+    # Construct an about dialog item.
+    info_item = gtk.ImageMenuItem("About")
+    img = gtk.image_new_from_stock(gtk.STOCK_ABOUT, gtk.ICON_SIZE_MENU)
+    info_item.set_image(img)
+    info_item.show()
+    info_item.connect(
+        "button-press-event",
+        lambda b, e: _launch_about_dialog(program_name, scanned_hosts)
+    )
+    menu.append(info_item)
+    return menu
+
+
+def get_scan_menu(suite_keys):
+    """Return a right click menu for the gscan GUI.
+
+    suite_keys should be a list of (host, owner, suite) tuples (if any).
+
+    """
+    menu = gtk.Menu()
 
     if not suite_keys:
         null_item = gtk.ImageMenuItem("Click on a suite or group")

--- a/lib/cylc/gui/scanutil.py
+++ b/lib/cylc/gui/scanutil.py
@@ -40,13 +40,11 @@ DURATION_EXPIRE_STOPPED = 600.0
 KEY_PORT = "port"
 
 
-def get_gpanel_scan_menu(suite_keys,
-                  theme_name, set_theme_func,
-                  has_stopped_suites, clear_stopped_suites_func,
-                  scanned_hosts, change_hosts_func,
-                  update_now_func, start_func,
-                  program_name, extra_items=None, owner=None,
-                  is_stopped=False):
+def get_gpanel_scan_menu(
+        suite_keys, theme_name, set_theme_func, has_stopped_suites,
+        clear_stopped_suites_func, scanned_hosts, change_hosts_func,
+        update_now_func, start_func, program_name, extra_items=None,
+        owner=None, is_stopped=False):
     """Return a right click menu for the gpanel GUI.
 
     TODO this used to be for gscan too; simplify now it's only for gpanel?

--- a/lib/cylc/gui/scanutil.py
+++ b/lib/cylc/gui/scanutil.py
@@ -68,7 +68,8 @@ def get_scan_menu(suite_keys, start_func, owner=None,
 
     if not suite_keys:
         null_item = gtk.ImageMenuItem("Click on a suite or group")
-        img = gtk.image_new_from_stock(gtk.STOCK_DIALOG_WARNING, gtk.ICON_SIZE_MENU)
+        img = gtk.image_new_from_stock(
+            gtk.STOCK_DIALOG_WARNING, gtk.ICON_SIZE_MENU)
         null_item.set_image(img)
         null_item.show()
         menu.append(null_item)
@@ -110,9 +111,10 @@ def get_scan_menu(suite_keys, start_func, owner=None,
         item.set_image(img_stop)
         stop_menu.append(item)
         item._connect_args = suite_keys, 'stop %s' % stop_type
-        item.connect("button-press-event",
-                          lambda b, e: call_cylc_command(b._connect_args[0],
-                                                         b._connect_args[1]))
+        item.connect(
+            "button-press-event",
+            lambda b, e: call_cylc_command(b._connect_args[0],
+                                           b._connect_args[1]))
         item.show()
 
     stoptask_item.show()


### PR DESCRIPTION
(From late one night in a hotel room on recent trip).  Motivation: gscan looks so minimalist that new users tend to assume it is lacking in functionality; plus the right-click menu should really be for context (click-target) sensitive options, not for general view configuration options.

* right-click menu is now only for suite operations (open gcylc; stop, hold, release)
* extend "stop" functionality - via right-click sub-menu - to all suite stop methods
* new main menu and toolbar for general view configuration (columns, theme, etc.)
* new collapse/expand-all toolbar buttons
* new configurable state icon size (like gcylc)
* state key window now updates in-place if theme is changed
* right-click below suites now shows: "click on a suite or group"

~~Not for review yet - needs tidying - but any disagreement in principle  @cylc/core?~~

![foo](https://cloud.githubusercontent.com/assets/2362137/25578608/bf04a6b6-2eb3-11e7-8c37-228d656ad959.png)
