### PR TITLE
Cat-log - open job logs in editor

### DIFF
--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -298,8 +298,9 @@ def main():
             sys.exit(1)
 
         viewfile = NamedTemporaryFile(
-                suffix='.' + os.path.basename(filename),
-                prefix=suite + '.', dir=cylc_tmpdir)
+            suffix='.' + os.path.basename(filename),
+            prefix=suite + '.', dir=cylc_tmpdiir
+       )
 
         for line in lines:
             viewfile.write(line + '\n')

--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -300,7 +300,7 @@ def main():
         viewfile = NamedTemporaryFile(
             suffix='.' + os.path.basename(filename),
             prefix=suite + '.', dir=cylc_tmpdiir
-       )
+        )
 
         for line in lines:
             viewfile.write(line + '\n')

--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -299,7 +299,7 @@ def main():
 
         viewfile = NamedTemporaryFile(
             suffix='.' + os.path.basename(filename),
-            prefix=suite + '.', dir=cylc_tmpdir
+            prefix=suite.replace('/', '_') + '.', dir=cylc_tmpdir
         )
 
         for line in lines:

--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -34,7 +34,6 @@ from pipes import quote
 import shlex
 from subprocess import Popen, PIPE
 import traceback
-import pdb
 
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.owner import is_remote_user
@@ -244,7 +243,6 @@ def get_task_job_attrs(options, suite, point, task, submit_num):
 
 def main():
     """Implement cylc cat-log CLI."""
-    pdb.set_trace()
     parser = get_option_parser()
     options, args = parser.parse_args()
     suite = args[0]

--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -299,12 +299,12 @@ def main():
 
         viewfile = NamedTemporaryFile(
             suffix='.' + os.path.basename(filename),
-            prefix=suite + '.', dir=cylc_tmpdiir
+            prefix=suite + '.', dir=cylc_tmpdir
         )
 
         for line in lines:
             viewfile.write(line + '\n')
-            viewfile.seek(0, 0)
+        viewfile.seek(0, 0)
 
         os.chmod(viewfile.name, 0400)
 
@@ -369,15 +369,14 @@ def main():
 
             if modtime2 > modtime1:
                 print >> sys.stderr, (
-                    'WARNING: YOU HAVE EDITED A TEMPORARY READ_ONLY COPY OF: ')
-                print >> sys.stderr, filename
-            else:
-                print >> sys.stderr, 'NO CHANGES MADE TO: %s' % viewfile.name
+                    'WARNING: YOU HAVE EDITED A TEMPORARY READ_ONLY COPY : ')
+                print >> sys.stderr, viewfile.name
 
             viewfile.close()
 
         if ret_code == 0:
             break
+
     if ret_code and err:
         sys.stderr.write(err)
     sys.exit(ret_code)

--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -294,15 +294,12 @@ def main():
         if os.path.exists(filename):
             lines = read_and_proc(filename)
         else:
-            print
-            print >> sys.stderr, (
-               'No such file or directory: ')
-            print >> sys.stderr, filename
-            print
+            print >> sys.stderr, 'No such file or directory: %s' % filename
             sys.exit(1)
 
         viewfile = NamedTemporaryFile(
-                suffix='.' + os.path.basename(filename), prefix=suite + '.', dir=cylc_tmpdir)
+                suffix='.' + os.path.basename(filename),
+                prefix=suite + '.', dir=cylc_tmpdir)
 
         for line in lines:
             viewfile.write(line + '\n')
@@ -338,11 +335,11 @@ def main():
                 "local tail command template"))
             commands.append(shlex.split(cmd_tmpl % {"filename": filename}))
     elif options.geditor or options.editor:
-        command_list = re.split(' ', editor)
+        command_list = editor.split()
         command_list.append(viewfile.name)
         commands.append(command_list)
     else:
-        commands.append(['cat', filename])
+        commands.append(["cat", filename])
 
     # Deal with remote [user@]host
     if user_at_host:
@@ -370,17 +367,11 @@ def main():
             modtime2 = os.stat(viewfile.name).st_mtime
 
             if modtime2 > modtime1:
-                print
                 print >> sys.stderr, (
-                    'WARNING: YOU HAVE EDITED A TEMPORARY READ_ONLY LOG/JOB COPY:')
+                    'WARNING: YOU HAVE EDITED A TEMPORARY READ_ONLY COPY OF: ')
                 print >> sys.stderr, filename
-                print
             else:
-                print
-                print >> sys.stderr, (
-                    'NO CHANGES MADE TO:')
-                print >> sys.stderr, viewfile.name
-                print
+                print >> sys.stderr, 'NO CHANGES MADE TO: %s' % viewfile.name
 
             viewfile.close()
 

--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -29,6 +29,7 @@ if remrun().execute():
     sys.exit(0)
 
 import os
+import re
 from tempfile import NamedTemporaryFile
 from pipes import quote
 import shlex
@@ -129,6 +130,12 @@ def get_option_parser():
 	"-g", "--geditor",
 	help="force use of the configured GUI editor.",
 	action="store_true", default=False, dest="geditor")
+
+    parser.add_option(
+	"-b", "--teditor",
+	help="force use of the configured Non-GUI editor.",
+	action="store_true", default=False, dest="editor")
+
 
     return parser
 
@@ -281,26 +288,21 @@ def main():
     cylc_tmpdir = GLOBAL_CFG.get_tmpdir()
     if options.geditor:
             editor = GLOBAL_CFG.get(['editors', 'gui'])
-    else:
+    elif options.editor:
             editor = GLOBAL_CFG.get(['editors', 'terminal'])
        
-    lines = read_and_proc(filename)
+    if os.path.exists(filename):
+         lines = read_and_proc(filename)
+    else:
+        print
+        print >> sys.stderr, (
+            'No such file or directory: ')
+        print >> sys.stderr, filename
+        print
+        sys.exit(1)
 
-    if options.filename == "out" :
-	viewfile = NamedTemporaryFile(
-			suffix=".job.out", prefix=suite + '.', dir=cylc_tmpdir)
-    elif options.filename == "job-activity.log" :
-	viewfile = NamedTemporaryFile(
-			suffix=".job-activity.log", prefix=suite + '.', dir=cylc_tmpdir)
-    elif options.filename == "err" :
-       	viewfile = NamedTemporaryFile(
-			suffix=".job.err", prefix=suite + '.', dir=cylc_tmpdir)
-    elif options.filename == "job-edit.diff" :
-       	viewfile = NamedTemporaryFile(
-			suffix=".job-edit.diff", prefix=suite + '.', dir=cylc_tmpdir)
-    elif options.filename == "job.status" :
-       	viewfile = NamedTemporaryFile(
-			suffix=".job.status", prefix=suite + '.', dir=cylc_tmpdir)
+    viewfile = NamedTemporaryFile(
+	 	suffix='.' + os.path.basename(filename), prefix=suite + '.', dir=cylc_tmpdir)
 
     for line in lines:
 	viewfile.write(line + '\n')
@@ -336,8 +338,12 @@ def main():
             cmd_tmpl = str(GLOBAL_CFG.get_host_item(
                 "local tail command template"))
             commands.append(shlex.split(cmd_tmpl % {"filename": filename}))
+    elif options.geditor or options.editor:
+        command_list = re.split(' ', editor)
+        command_list.append(viewfile.name)
+        commands.append(command_list)
     else:
-        commands.append([editor, viewfile.name])
+        commands.append([ 'cat', filename])
 
     # Deal with remote [user@]host
     if user_at_host:
@@ -356,6 +362,27 @@ def main():
         proc = Popen(command, stderr=stderr)
         err = proc.communicate()[1]
         ret_code = proc.wait()
+	if ret_code != 0:
+            print >>sys.stderr, command, 'failed:', ret_code
+            sys.exit(1)
+
+        modtime2 = os.stat(viewfile.name).st_mtime
+   
+        if modtime2 > modtime1:
+            print
+            print >> sys.stderr, (
+                'WARNING: YOU HAVE EDITED A TEMPORARY READ_ONLY LOG/JOB COPY:')
+            print >> sys.stderr, viewfile.name
+            print
+        else:
+            print
+            print >> sys.stderr, (
+                'NO CHANGES MADE TO:')
+            print >> sys.stderr, viewfile.name
+            print
+
+        viewfile.close()
+
         if ret_code == 0:
             break
     if ret_code and err:

--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -127,15 +127,14 @@ def get_option_parser():
         action="store_const", const=LIST_MODE_REMOTE, dest="list_mode")
 
     parser.add_option(
-	"-g", "--geditor",
-	help="force use of the configured GUI editor.",
-	action="store_true", default=False, dest="geditor")
+        "-g", "--geditor",
+        help="force use of the configured GUI editor.",
+        action="store_true", default=False, dest="geditor")
 
     parser.add_option(
-	"-b", "--teditor",
-	help="force use of the configured Non-GUI editor.",
-	action="store_true", default=False, dest="editor")
-
+        "-b", "--teditor",
+        help="force use of the configured Non-GUI editor.",
+        action="store_true", default=False, dest="editor")
 
     return parser
 
@@ -290,28 +289,28 @@ def main():
             editor = GLOBAL_CFG.get(['editors', 'gui'])
     elif options.editor:
             editor = GLOBAL_CFG.get(['editors', 'terminal'])
-       
-    if os.path.exists(filename):
-         lines = read_and_proc(filename)
-    else:
-        print
-        print >> sys.stderr, (
-            'No such file or directory: ')
-        print >> sys.stderr, filename
-        print
-        sys.exit(1)
 
-    viewfile = NamedTemporaryFile(
-	 	suffix='.' + os.path.basename(filename), prefix=suite + '.', dir=cylc_tmpdir)
+    if options.editor or options.geditor:
+        if os.path.exists(filename):
+            lines = read_and_proc(filename)
+        else:
+            print
+            print >> sys.stderr, (
+               'No such file or directory: ')
+            print >> sys.stderr, filename
+            print
+            sys.exit(1)
 
-    for line in lines:
-	viewfile.write(line + '\n')
-    viewfile.seek(0, 0)
+        viewfile = NamedTemporaryFile(
+                suffix='.' + os.path.basename(filename), prefix=suite + '.', dir=cylc_tmpdir)
 
-    os.chmod(viewfile.name, 0400)
+        for line in lines:
+            viewfile.write(line + '\n')
+            viewfile.seek(0, 0)
 
-    modtime1 = os.stat(viewfile.name).st_mtime
+        os.chmod(viewfile.name, 0400)
 
+        modtime1 = os.stat(viewfile.name).st_mtime
 
     # Construct the shell command
     commands = []
@@ -343,7 +342,7 @@ def main():
         command_list.append(viewfile.name)
         commands.append(command_list)
     else:
-        commands.append([ 'cat', filename])
+        commands.append(['cat', filename])
 
     # Deal with remote [user@]host
     if user_at_host:
@@ -362,26 +361,28 @@ def main():
         proc = Popen(command, stderr=stderr)
         err = proc.communicate()[1]
         ret_code = proc.wait()
-	if ret_code != 0:
-            print >>sys.stderr, command, 'failed:', ret_code
-            sys.exit(1)
 
-        modtime2 = os.stat(viewfile.name).st_mtime
-   
-        if modtime2 > modtime1:
-            print
-            print >> sys.stderr, (
-                'WARNING: YOU HAVE EDITED A TEMPORARY READ_ONLY LOG/JOB COPY:')
-            print >> sys.stderr, viewfile.name
-            print
-        else:
-            print
-            print >> sys.stderr, (
-                'NO CHANGES MADE TO:')
-            print >> sys.stderr, viewfile.name
-            print
+        if options.editor or options.geditor:
+            if ret_code != 0:
+                print >>sys.stderr, command, 'failed:', ret_code
+                sys.exit(1)
 
-        viewfile.close()
+            modtime2 = os.stat(viewfile.name).st_mtime
+
+            if modtime2 > modtime1:
+                print
+                print >> sys.stderr, (
+                    'WARNING: YOU HAVE EDITED A TEMPORARY READ_ONLY LOG/JOB COPY:')
+                print >> sys.stderr, filename
+                print
+            else:
+                print
+                print >> sys.stderr, (
+                    'NO CHANGES MADE TO:')
+                print >> sys.stderr, viewfile.name
+                print
+
+            viewfile.close()
 
         if ret_code == 0:
             break

--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -29,10 +29,12 @@ if remrun().execute():
     sys.exit(0)
 
 import os
+from tempfile import NamedTemporaryFile
 from pipes import quote
 import shlex
 from subprocess import Popen, PIPE
 import traceback
+import pdb
 
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.owner import is_remote_user
@@ -41,6 +43,7 @@ from cylc.suite_host import is_remote_host
 from cylc.suite_logging import get_logs
 from cylc.cfgspec.globalcfg import GLOBAL_CFG
 from cylc.task_id import TaskID
+from parsec.fileparse import read_and_proc
 
 
 NAME_DEFAULT = "log"
@@ -122,6 +125,11 @@ def get_option_parser():
         "-y", "--list-remote",
         help="Task job log only: List log directory on the job host",
         action="store_const", const=LIST_MODE_REMOTE, dest="list_mode")
+
+    parser.add_option(
+	"-g", "--geditor",
+	help="force use of the configured GUI editor.",
+	action="store_true", default=False, dest="geditor")
 
     return parser
 
@@ -236,6 +244,7 @@ def get_task_job_attrs(options, suite, point, task, submit_num):
 
 def main():
     """Implement cylc cat-log CLI."""
+    pdb.set_trace()
     parser = get_option_parser()
     options, args = parser.parse_args()
     suite = args[0]
@@ -271,6 +280,39 @@ def main():
         else:
             owner, host = (None, user_at_host)
 
+    cylc_tmpdir = GLOBAL_CFG.get_tmpdir()
+    if options.geditor:
+            editor = GLOBAL_CFG.get(['editors', 'gui'])
+    else:
+            editor = GLOBAL_CFG.get(['editors', 'terminal'])
+       
+    lines = read_and_proc(filename)
+
+    if options.filename == "out" :
+	viewfile = NamedTemporaryFile(
+			suffix=".job.out", prefix=suite + '.', dir=cylc_tmpdir)
+    elif options.filename == "job-activity.log" :
+	viewfile = NamedTemporaryFile(
+			suffix=".job-activity.log", prefix=suite + '.', dir=cylc_tmpdir)
+    elif options.filename == "err" :
+       	viewfile = NamedTemporaryFile(
+			suffix=".job.err", prefix=suite + '.', dir=cylc_tmpdir)
+    elif options.filename == "job-edit.diff" :
+       	viewfile = NamedTemporaryFile(
+			suffix=".job-edit.diff", prefix=suite + '.', dir=cylc_tmpdir)
+    elif options.filename == "job.status" :
+       	viewfile = NamedTemporaryFile(
+			suffix=".job.status", prefix=suite + '.', dir=cylc_tmpdir)
+
+    for line in lines:
+	viewfile.write(line + '\n')
+    viewfile.seek(0, 0)
+
+    os.chmod(viewfile.name, 0400)
+
+    modtime1 = os.stat(viewfile.name).st_mtime
+
+
     # Construct the shell command
     commands = []
     if options.location_mode:
@@ -297,7 +339,7 @@ def main():
                 "local tail command template"))
             commands.append(shlex.split(cmd_tmpl % {"filename": filename}))
     else:
-        commands.append(["cat", filename])
+        commands.append([editor, viewfile.name])
 
     # Deal with remote [user@]host
     if user_at_host:
@@ -308,6 +350,7 @@ def main():
     err = None
     for command in commands:
         stderr = PIPE
+
         if options.debug:
             sys.stderr.write(
                 " ".join([quote(item) for item in command]) + "\n")

--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -336,7 +336,7 @@ def main():
                 "local tail command template"))
             commands.append(shlex.split(cmd_tmpl % {"filename": filename}))
     elif options.geditor or options.editor:
-        command_list = editor.split()
+        command_list = shlex.split(editor)
         command_list.append(viewfile.name)
         commands.append(command_list)
     else:

--- a/bin/cylc-view
+++ b/bin/cylc-view
@@ -135,7 +135,9 @@ def main():
 
     # write to a temporary file
     viewfile = NamedTemporaryFile(
-        suffix=".suite.rc", prefix=suite + '.', dir=cylc_tmpdir)
+        suffix=".suite.rc", prefix=suite.replace('/', '_') + '.',
+        dir=cylc_tmpdir
+    )
     for line in lines:
         viewfile.write(line + '\n')
     viewfile.seek(0, 0)

--- a/lib/cylc/cycling/iso8601.py
+++ b/lib/cylc/cycling/iso8601.py
@@ -783,7 +783,7 @@ class TestISO8601Sequence(unittest.TestCase):
                                   '20000101T0500Z'])
 
     def test_multiple_exclusions_simple(self):
-        """Tests the generation of points for sequences with multiple exclusions
+        """Tests generation of points for sequences with multiple exclusions
         """
         init(time_zone='Z')
         sequence = ISO8601Sequence('PT1H!(20000101T02Z,20000101T03Z)',

--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -1237,27 +1237,27 @@ been defined for this suite""").inform()
         try:
             task_state_summary = self.updater.full_state_summary[task_id]
         except KeyError:
-            warning_dialog(task_id + ' is not live', self.window).warn()
+            warning_dialog('%s is not live' % task_id, self.window).warn()
             return False
         if (not task_state_summary['logfiles'] and
                 not task_state_summary.get('job_hosts')):
             warning_dialog('%s has no log files' % task_id, self.window).warn()
         else:
             if choice == 'job-activity.log':
-                command = ("cylc cat-log --activity --geditor" + " " +
-                          self.cfg.suite + " " + task_id)
+                command_opt = "--activity"
             elif choice == 'job.status':
-                command = ("cylc cat-log --status --geditor" + " " +
-                          self.cfg.suite + " " + task_id)
+                command_opt = "--status"
             elif choice == 'job.out':
-                command = ("cylc cat-log --stdout --geditor" + " " +
-                          self.cfg.suite + " " + task_id)
+                command_opt = "--stdout"
             elif choice == 'job.err':
-                command = ("cylc cat-log --stderr --geditor" + " " +
-                          self.cfg.suite + " " + task_id)
+                command_opt = "--stderr"
             elif choice == 'job':
-                command = ("cylc cat-log --geditor" + " " +
-                          self.cfg.suite + " " + task_id)
+                command_opt = ""
+
+            command = (
+                "cylc cat-log %s --geditor %s %s" % (
+                    command_opt, self.cfg.suite, task_id)
+            )
 
             foo = gcapture_tmpfile(command, self.cfg.cylc_tmpdir, 400, 400)
             self.gcapture_windows.append(foo)

--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -1246,15 +1246,18 @@ been defined for this suite""").inform()
 	    if choice == 'job-activity.log':
             	command = ("cylc cat-log --activity --geditor" + " " +
 			  self.cfg.suite + " " + task_id)
-	    elif choice == 'job.status'
-            	command = ("cylc cat-log --status --geditor%" + " " +
+	    elif choice == 'job.status':
+            	command = ("cylc cat-log --status --geditor" + " " +
 			  self.cfg.suite + " " + task_id)
-	    elif choice == 'job.out'
+	    elif choice == 'job.out':
             	command = ("cylc cat-log --stdout --geditor" + " " +
 			  self.cfg.suite + " " + task_id)
-	    elif choice == 'job.err'
+	    elif choice == 'job.err':
             	command = ("cylc cat-log --stderr --geditor" + " " +
 			  self.cfg.suite + " " + task_id)
+            elif choice == 'job':
+           	command = ("cylc cat-log --geditor" + " " +
+			  self.cfg.suite + " " + task_id)	
 	
 	    foo = gcapture_tmpfile(command, self.cfg.cylc_tmpdir, 400, 400)
 	    self.gcapture_windows.append(foo)
@@ -1395,10 +1398,7 @@ been defined for this suite""").inform()
                 # help_menu.append(cug_pdf_item)
                 # cug_pdf_item.connect('activate', self.browse, '--pdf')
 
-        # Separator.
-        menu.append(gtk.SeparatorMenuItem())
-
-        # View In Editor.
+                # View In Editor.
                 view_editor_menu = gtk.Menu()
                 view_editor_item = gtk.ImageMenuItem("View In Editor")
                 img = gtk.image_new_from_stock(gtk.STOCK_DIALOG_INFO,
@@ -1413,6 +1413,7 @@ been defined for this suite""").inform()
                 # item.connect
 
                 for key, filename in [
+                        ('job script', 'job'),
                         ('job activity log', 'job-activity.log'),
                         ('job status file', 'job.status')]:
                     item = gtk.ImageMenuItem(key)

--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -1243,25 +1243,25 @@ been defined for this suite""").inform()
                 not task_state_summary.get('job_hosts')):
             warning_dialog('%s has no log files' % task_id, self.window).warn()
         else:
-	    if choice == 'job-activity.log':
-            	command = ("cylc cat-log --activity --geditor" + " " +
-			  self.cfg.suite + " " + task_id)
-	    elif choice == 'job.status':
-            	command = ("cylc cat-log --status --geditor" + " " +
-			  self.cfg.suite + " " + task_id)
-	    elif choice == 'job.out':
-            	command = ("cylc cat-log --stdout --geditor" + " " +
-			  self.cfg.suite + " " + task_id)
-	    elif choice == 'job.err':
-            	command = ("cylc cat-log --stderr --geditor" + " " +
-			  self.cfg.suite + " " + task_id)
+            if choice == 'job-activity.log':
+                command = ("cylc cat-log --activity --geditor" + " " +
+                          self.cfg.suite + " " + task_id)
+            elif choice == 'job.status':
+                command = ("cylc cat-log --status --geditor" + " " +
+                          self.cfg.suite + " " + task_id)
+            elif choice == 'job.out':
+                command = ("cylc cat-log --stdout --geditor" + " " +
+                          self.cfg.suite + " " + task_id)
+            elif choice == 'job.err':
+                command = ("cylc cat-log --stderr --geditor" + " " +
+                          self.cfg.suite + " " + task_id)
             elif choice == 'job':
-           	command = ("cylc cat-log --geditor" + " " +
-			  self.cfg.suite + " " + task_id)	
-	
-	    foo = gcapture_tmpfile(command, self.cfg.cylc_tmpdir, 400, 400)
-	    self.gcapture_windows.append(foo)
-	    foo.run()
+                command = ("cylc cat-log --geditor" + " " +
+                          self.cfg.suite + " " + task_id)
+
+            foo = gcapture_tmpfile(command, self.cfg.cylc_tmpdir, 400, 400)
+            self.gcapture_windows.append(foo)
+            foo.run()
 
     def view_task_info(self, w, e, task_id, choice):
         try:
@@ -1439,8 +1439,8 @@ been defined for this suite""").inform()
                     item.set_sensitive(
                         t_states[0] in TASK_STATUSES_WITH_JOB_LOGS)
 
-	# Separator
-	menu.append(gtk.SeparatorMenuItem())
+        # Separator
+        menu.append(gtk.SeparatorMenuItem())
 
         # Trigger (run now).
         trigger_now_item = gtk.ImageMenuItem('Trigger (run now)')


### PR DESCRIPTION
`cylc cat-log` - allow opening job logs in users' editor ( temporary read only copy ); same via gcylc.

~~[not ready for review yet - coming soon]~~