### PR TITLE
profile-battery can now handle dirty revs better

### DIFF
--- a/lib/cylc/profiling/git.py
+++ b/lib/cylc/profiling/git.py
@@ -64,8 +64,12 @@ def checkout(branch, delete_pyc=False):
 
 def get_commit_date(commit):
     """Returns the commit date (in unix time) of the profided commit."""
-    return int(Popen(['git', 'show', '-s', '--format=%at', commit],
-                     stdout=PIPE).communicate()[0].split()[-1])
+    try:
+        return int(Popen(['git', 'show', '-s', '--format=%at', commit],
+                         stdout=PIPE, stderr=PIPE
+                         ).communicate()[0].split()[-1])
+    except IndexError:
+        get_commit_date(commit.split('-')[0])
 
 
 def order_versions_by_date(versions):


### PR DESCRIPTION
For handling revisions with tags like `7.1.0-32-gf973e18`.