### PR TITLE
Reduce number of HTTP connections to address CPU usage

### DIFF
--- a/lib/cylc/gui/updater.py
+++ b/lib/cylc/gui/updater.py
@@ -302,16 +302,15 @@ class Updater(threading.Thread):
 
     def retrieve_state_summaries(self):
         """Retrieve suite summary."""
-        ret = self.state_summary_client.get_suite_state_summary()
         glbl, states, fam_states = (
             self.state_summary_client.get_suite_state_summary())
-        self.ancestors = self.suite_info_client.get_info(
-            'get_first_parent_ancestors')
-        self.ancestors_pruned = self.suite_info_client.get_info(
-            'get_first_parent_ancestors', pruned=True)
-        self.descendants = self.suite_info_client.get_info(
-            'get_first_parent_descendants')
-        self.all_families = self.suite_info_client.get_info('get_all_families')
+
+        (self.ancestors, self.ancestors_pruned, self.descendants,
+            self.all_families) = self.suite_info_client.get_info(
+                {'function': 'get_first_parent_ancestors'},
+                {'function': 'get_first_parent_ancestors', 'pruned': True},
+                {'function': 'get_first_parent_descendants'},
+                {'function': 'get_all_families'})
 
         self.mode = glbl['run_mode']
 
@@ -400,7 +399,7 @@ class Updater(threading.Thread):
         try:
             err_log_changed = self.retrieve_err_log()
             summaries_changed = self.retrieve_summary_update_time()
-            if self.summary_update_time is not None:
+            if self.summary_update_time is not None and summaries_changed:
                 self.retrieve_state_summaries()
         except Exception as exc:
             if self.status == SUITE_STATUS_STOPPING:

--- a/lib/cylc/network/https/base_client.py
+++ b/lib/cylc/network/https/base_client.py
@@ -21,7 +21,6 @@ import os
 import sys
 from uuid import uuid4
 import warnings
-import unittest
 
 import cylc.flags
 from cylc.network import (
@@ -371,54 +370,56 @@ class BaseCommsClientAnon(BaseCommsClient):
         return False
 
 
-class TestBaseCommsClient(unittest.TestCase):
-    """Unit testing class to test the methods in BaseCommsClient
-    """
-    def test_url_compiler(self):
-        """Tests that the url parser works for a single url and command"""
-        category = 'info'  # Could be any from cylc/network/__init__.py
-        host = "localhost"
-        func_dict = {"function": "test_command",
-                     "apples": "False",
-                     "oranges": "True",
-                     "method": "GET",
-                     "payload": "None"}
-
-        myCommsClient = BaseCommsClient("test-suite", port=80)
-        request = myCommsClient._compile_url(category, func_dict, host)
-        test_url = ('https://localhost:80/info/test_command'
-                    '?apples=False&oranges=True')
-
-        self.assertEqual(request['url'], test_url)
-        self.assertEqual(request['payload'], "None")
-        self.assertEqual(request['method'], "GET")
-
-    def test_get_data_from_url_single(self):
-        """Test the get data from _get_data_from_url() function"""
-        myCommsClient = BaseCommsClient("dummy-suite")
-        url = "http://httpbin.org/get"
-        payload = None
-        method = "GET"
-        request = [{"url": url, "payload": payload, "method": method}]
-        ret = myCommsClient._get_data_from_url(request)
-        self.assertEqual(ret['url'], "http://httpbin.org/get")
-
-    def test_get_data_from_url_multiple(self):
-        myCommsClient = BaseCommsClient("dummy-suite")
-        payload = None
-        method = "GET"
-        request1 = {"url": "http://httpbin.org/get#1",
-                    "payload": payload, "method": method}
-        request2 = {"url": "http://httpbin.org/get#2",
-                    "payload": payload, "method": method}
-        request3 = {"url": "http://httpbin.org/get#3",
-                    "payload": payload, "method": method}
-
-        rets = myCommsClient._get_data_from_url([request1, request2, request3])
-
-        for i in range(2):
-            self.assertEqual(rets[i]['url'], "http://httpbin.org/get")
-
-
 if __name__ == '__main__':
+    import unittest
+
+    class TestBaseCommsClient(unittest.TestCase):
+        """Unit testing class to test the methods in BaseCommsClient
+        """
+        def test_url_compiler(self):
+            """Tests that the url parser works for a single url and command"""
+            category = 'info'  # Could be any from cylc/network/__init__.py
+            host = "localhost"
+            func_dict = {"function": "test_command",
+                         "apples": "False",
+                         "oranges": "True",
+                         "method": "GET",
+                         "payload": "None"}
+
+            myCommsClient = BaseCommsClient("test-suite", port=80)
+            request = myCommsClient._compile_url(category, func_dict, host)
+            test_url = ('https://localhost:80/info/test_command'
+                        '?apples=False&oranges=True')
+
+            self.assertEqual(request['url'], test_url)
+            self.assertEqual(request['payload'], "None")
+            self.assertEqual(request['method'], "GET")
+
+        def test_get_data_from_url_single(self):
+            """Test the get data from _get_data_from_url() function"""
+            myCommsClient = BaseCommsClient("dummy-suite")
+            url = "http://httpbin.org/get"
+            payload = None
+            method = "GET"
+            request = [{"url": url, "payload": payload, "method": method}]
+            ret = myCommsClient._get_data_from_url(request)
+            self.assertEqual(ret['url'], "http://httpbin.org/get")
+
+        def test_get_data_from_url_multiple(self):
+            myCommsClient = BaseCommsClient("dummy-suite")
+            payload = None
+            method = "GET"
+            request1 = {"url": "http://httpbin.org/get#1",
+                        "payload": payload, "method": method}
+            request2 = {"url": "http://httpbin.org/get#2",
+                        "payload": payload, "method": method}
+            request3 = {"url": "http://httpbin.org/get#3",
+                        "payload": payload, "method": method}
+
+            rets = myCommsClient._get_data_from_url([request1,
+                                                     request2, request3])
+
+            for i in range(2):
+                self.assertEqual(rets[i]['url'], "http://httpbin.org/get")
+
     unittest.main()

--- a/lib/cylc/network/https/base_client.py
+++ b/lib/cylc/network/https/base_client.py
@@ -90,13 +90,6 @@ class BaseCommsClient(object):
             func_dict = {"function": function}
             func_dict.update(fargs)
 
-        # I.e. if we haven't passed multiple dictionaries
-        # if len(func_dicts) == 1 and fargs is not None:
-        #     func_dicts.update(fargs)
-        # if len(func_dicts) == 1:
-        #     func_dicts = list(func_dicts)
-        # Error check here? Multiple dicts and fargs not allowed?
-
         if self.host is None and self.port is not None:
             self.host = get_hostname()
         try:
@@ -104,10 +97,6 @@ class BaseCommsClient(object):
         except (IOError, ValueError, SuiteServiceFileError):
             raise ConnectionInfoError(self.suite)
         handle_proxies()
-        # each func could have a different method and payload
-        # payload = fargs.pop("payload", None)
-        # method = fargs.pop("method", self.METHOD)
-        #
         host = self.host
         if host == "localhost":
             host = get_hostname().split(".")[0]
@@ -117,14 +106,13 @@ class BaseCommsClient(object):
             # dictionary containing: url, payload, method
             request = self._compile_url(category, func_dict, host)
             http_requests.append(request)
-        except:
+        except (IndexError, ValueError, AttributeError):
             for f_dict in func_dicts:
                 request = self._compile_url(category, f_dict, host)
                 http_requests.append(request)
         # returns a list of http returns from the requests
         return self._get_data_from_url(http_requests)
 
-    # def _get_data_from_url(self, url, json_data, method=None):
     def _get_data_from_url(self, http_requests):
         requests_ok = True
         try:

--- a/lib/cylc/network/https/suite_info_client.py
+++ b/lib/cylc/network/https/suite_info_client.py
@@ -26,8 +26,8 @@ class SuiteInfoClient(BaseCommsClient):
 
     METHOD = BaseCommsClient.METHOD_GET
 
-    def get_info(self, command, **arg_dict):
-        return self.call_server_func(COMMS_INFO_OBJ_NAME, command, **arg_dict)
+    def get_info(self, *command, **arg_dict):
+        return self.call_server_func(COMMS_INFO_OBJ_NAME, *command, **arg_dict)
 
 
 class SuiteInfoClientAnon(BaseCommsClientAnon):
@@ -35,5 +35,5 @@ class SuiteInfoClientAnon(BaseCommsClientAnon):
 
     METHOD = BaseCommsClient.METHOD_GET
 
-    def get_info(self, command, **arg_dict):
-        return self.call_server_func(COMMS_INFO_OBJ_NAME, command, **arg_dict)
+    def get_info(self, *command, **arg_dict):
+        return self.call_server_func(COMMS_INFO_OBJ_NAME, *command, **arg_dict)

--- a/tests/api-suite-info/04-api-suite-info-unit-tests.t
+++ b/tests/api-suite-info/04-api-suite-info-unit-tests.t
@@ -1,0 +1,24 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Run suite info API unit tests.
+. $(dirname $0)/test_header
+
+set_test_number 1
+
+TEST_NAME=$TEST_NAME_BASE-unit-tests
+run_ok $TEST_NAME python $CYLC_DIR/lib/cylc/network/https/base_client.py


### PR DESCRIPTION
Removes redundant calls to getting suite state info and bundles some http requests into one http connection. Addresses issue in #2256 as per suggestions from @matthewrmshin. 