### PR TITLE
Fix bug in gui after http-connection change

### DIFF
--- a/lib/cylc/network/https/base_client.py
+++ b/lib/cylc/network/https/base_client.py
@@ -88,6 +88,8 @@ class BaseCommsClient(object):
             function = func_dicts[0]
             func_dict = {"function": function}
             func_dict.update(fargs)
+        else:
+            func_dict = None
 
         if self.host is None and self.port is not None:
             self.host = get_hostname()


### PR DESCRIPTION
Fixes GUI bug introduced by #2271.

(For reference from earlier email chain):

> No, I think it's something to do with 
> https://github.com/cylc/cylc/pull/2271/
> 
> cylc gui --debug SUITE says:
> 
> UPDATE 2017-05-11T20:03:30+10
> (connected)
>   CONNECTION LOST local variable 'func_dict' referenced before assignment  # <---- !!
>   ConnectSchd start
>   reconnection... succeeded
>   ConnectSchd stop
> ....
> 