### PR TITLE
Distinguish False and None properly in global config.

### DIFF
--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -621,7 +621,10 @@ class GlobalConfig(config):
             if host == 'localhost':
                 continue
             for item, value in cfg['hosts'][host].items():
-                newvalue = value or cfg['hosts']['localhost'][item]
+                if value is None:
+                    newvalue = cfg['hosts']['localhost'][item]
+                else:
+                    newvalue = value
                 if newvalue and 'directory' in item:
                     # replace local home dir with $HOME for evaluation on other
                     # host


### PR DESCRIPTION

Fix bug that affects boolean derived host items set to False when the same localhost item is set to True.

Found by trying to set `use login shell = False` in job hosts, with `use login shell = True` in localhost.

> git blame: 0ac4ac8a lib/cylc/cfgspec/site.py      (Hilary James Oliver 2014-02-09 15:44:42 +1300 625)  

(Ouch somewhat surprising this hadn't shown up before).

This code fixes the bug - I'll add a test later tonight - hopefully we can get this in cylc-7.4 tomorrow. 