### PR TITLE
Add new cylc command to show task timings.

### DIFF
--- a/bin/cylc
+++ b/bin/cylc
@@ -237,6 +237,7 @@ utility_commands['cycle-point'] = [
 utility_commands['scp-transfer'] = ['scp-transfer']
 utility_commands['suite-state'] = ['suite-state']
 utility_commands['ls-checkpoints'] = ['ls-checkpoints']
+utility_commands['show-times'] = ['show-times']
 
 hook_commands = OrderedDict()
 hook_commands['email-suite'] = ['email-suite']
@@ -437,6 +438,7 @@ comsum['jobscript'] = 'Generate a task job script and print it to stdout'
 comsum['scp-transfer'] = 'Scp-based file transfer for cylc suites'
 comsum['suite-state'] = 'Query the task states in a suite'
 comsum['ls-checkpoints'] = 'Display task pool etc at given events'
+comsum['show-times'] = 'Display table of task timing information'
 
 # hook
 comsum['email-task'] = 'A task event hook script that sends email alerts'

--- a/bin/cylc
+++ b/bin/cylc
@@ -237,7 +237,7 @@ utility_commands['cycle-point'] = [
 utility_commands['scp-transfer'] = ['scp-transfer']
 utility_commands['suite-state'] = ['suite-state']
 utility_commands['ls-checkpoints'] = ['ls-checkpoints']
-utility_commands['show-times'] = ['show-times']
+utility_commands['report-timings'] = ['report-timings']
 
 hook_commands = OrderedDict()
 hook_commands['email-suite'] = ['email-suite']
@@ -438,7 +438,7 @@ comsum['jobscript'] = 'Generate a task job script and print it to stdout'
 comsum['scp-transfer'] = 'Scp-based file transfer for cylc suites'
 comsum['suite-state'] = 'Query the task states in a suite'
 comsum['ls-checkpoints'] = 'Display task pool etc at given events'
-comsum['show-times'] = 'Display table of task timing information'
+comsum['report-timings'] = 'Display table of task timing information'
 
 # hook
 comsum['email-task'] = 'A task event hook script that sends email alerts'

--- a/bin/cylc-report-timings
+++ b/bin/cylc-report-timings
@@ -119,7 +119,7 @@ def main():
 
     suite = args.pop(0)
     run_db = _get_dao(suite)
-    row_buf = format_rows(*run_db.select_task_events_for_timing())
+    row_buf = format_rows(*run_db.select_task_times())
 
     with smart_open(options.output_filename) as output:
         if options.show_raw:

--- a/bin/cylc-report-timings
+++ b/bin/cylc-report-timings
@@ -16,14 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""cylc [util] show-times [OPTIONS] REG
+"""cylc [util] report-timings [OPTIONS] REG
 
-Retrieve timing information for the given cylc suite that can be
-used for fine-grain diagnostics for wait time and run time performance
-analysis.  Two main categories of output are available: summary output
-(in text or web format) and raw output.  If an output filename is
-supplied, output is redirected there otherwise both summary and raw
-outputs are printed to standard output.
+Retrieve suite timing information for wait and run time performance analysis.
+Raw output and summary output (in text or HTML format) are available.  Output
+is sent to standard output, unless an output filename is supplied.
 
 Summary Output (the default):
 Data stratified by host and batch system that provides a statistical
@@ -31,12 +28,9 @@ summary of
     1. Queue wait time (duration between task submission and start times)
     2. Task run time (duration between start and succeed times)
     3. Total run time (duration between task submission and succeed times)
-Text output will show summary tables in text only.  Web output generates
-HTML that contains boxplots as well as summary tables suitable for viewing
-in a browser.  Both summary options require the use of the Pandas library,
-and the web summary output requires the Matplotlib plotting library.  If
-these libraries are not available, an error message will be printed and the
-summary will not be generated.
+Summary tables can be output in plain text format, or HTML with embedded SVG
+boxplots.  Both summary options require the Pandas library, and the HTML
+summary option requires the Matplotlib library.
 
 Raw Output:
 A flat list of tabular data that provides (for each task and cycle) the
@@ -76,7 +70,6 @@ def smart_open(filename=None):
 
     See https://stackoverflow.com/a/17603000
 
-
     """
     if filename and filename != '-':
         fh = open(filename, 'w')
@@ -96,7 +89,7 @@ def main():
     )
     parser.add_option(
         "-r", "--raw",
-        help="Show raw timing output for downstream processing.",
+        help="Show raw timing output suitable for custom diagnostics.",
         action="store_true", default=False, dest="show_raw"
     )
     parser.add_option(
@@ -120,7 +113,7 @@ def main():
     ]
     if output_options.count(True) > 1:
         parser.error('Cannot combine output formats (choose one)')
-    if output_options.count(True) == 0:
+    if not any(output_options):
         # No output specified - choose summary by default
         options.show_summary = True
 
@@ -201,7 +194,7 @@ class TimingSummary(object):
         self.df = pd.DataFrame({
             'queue_time': (
                 df['start_time'] - df['submit_time']).apply(self._dt_to_s),
-            'run_time':  (
+            'run_time': (
                 df['succeed_time'] - df['start_time']).apply(self._dt_to_s),
             'total_time': (
                 df['succeed_time'] - df['submit_time']).apply(self._dt_to_s),
@@ -245,9 +238,7 @@ class TimingSummary(object):
         try:
             import pandas as pd
         except ImportError:
-            msg = 'Cannot import pandas - summary unavailable.'
-            sys.stderr.write(msg)
-            raise Exception(msg)
+            raise Exception('Cannot import pandas - summary unavailable.')
 
     @staticmethod
     def _dt_to_s(dt):
@@ -273,7 +264,7 @@ class TextTimingSummary(TimingSummary):
 
     def write_category(self, buf, category, df_reshape, df_describe):
         buf.write(category.center(self.line_width) + '\n')
-        buf.write(('-'*len(category)).center(self.line_width) + '\n')
+        buf.write(('-' * len(category)).center(self.line_width) + '\n')
         buf.write(df_describe[category].to_string())
         buf.write('\n\n')
 
@@ -357,9 +348,9 @@ class HTMLTimingSummary(TimingSummary):
             import matplotlib
             matplotlib.use('Agg')
         except ImportError:
-            msg = 'Cannot import pandas - summary unavailable.'
-            sys.stderr.write(msg)
-            raise Exception(msg)
+            raise Exception(
+                'Cannot import matplotlib - HTML summary unavailable.'
+            )
         super(HTMLTimingSummary, self)._check_imports()
 
 

--- a/bin/cylc-report-timings
+++ b/bin/cylc-report-timings
@@ -259,7 +259,7 @@ class TextTimingSummary(TimingSummary):
     def write_group_header(self, buf, group):
         title = 'Host: %s\tBatch System: %s' % group
         buf.write('=' * self.line_width + '\n')
-        buf.write(title.center(self.line_width-1) + '\n')
+        buf.write(title.center(self.line_width - 1) + '\n')
         buf.write('=' * self.line_width + '\n')
 
     def write_category(self, buf, category, df_reshape, df_describe):

--- a/bin/cylc-show-times
+++ b/bin/cylc-show-times
@@ -20,17 +20,27 @@
 
 Retrieve timing information for the given cylc suite that can be
 used for fine-grain diagnostics for wait time and run time performance
-analysis:
+analysis.  Two main categories of output are available:
+
+Summary Output (the default):
+Tabular data stratified by host and batch system that provides a statistical
+summary of
+    1. Queue wait time (duration between task submission and start times)
+    2. Task run time (duration between start and succeed times)
+    3. Total run time (duration between task submission and succeed times)
+This statistical summary requires the Pandas library for data analysis and
+will print an error message if summary output is invoked without this library
+being available.
+
+Raw Output:
+A flat list of tabular data that provides (for each task and cycle) the
     1. Time of successful submission
     2. Time of task start
     3. Time of task successful completion
+as well as information about the batch system and remote host to permit
+stratification/grouping if desired by downstream processors.
 
-Timings are shown only for succeeded tasks, and includes information
-about the batch system and remote host to permit stratification/grouping
-if desired (e.g. a typical metric for batch systems like PBS is how
-long the job waited in the queue, which can be obtained by subtracting
-the submit time from the start time - however, this metric is less
-meaningful for background jobs where no batch system is involved).
+Timings are shown only for succeeded tasks.
 
 For long-running and/or large suites (i.e. for suites with many task events),
 the database query to obtain the timing information may take some time.
@@ -42,6 +52,7 @@ from cylc.remote import remrun
 if remrun().execute():
     sys.exit(0)
 
+import cStringIO as StringIO
 import os
 
 import cylc.flags
@@ -55,19 +66,42 @@ def main():
         __doc__,
         argdoc=[('REG', 'Suite name')]
     )
+    parser.add_option(
+        "-r", "--raw",
+        help="Show raw timing output for downstream processing.",
+        action="store_true", default=False, dest="show_raw"
+    )
+    parser.add_option(
+        "-s", "--summary",
+        help="Show summary timing output for tasks.",
+        action="store_true", default=False, dest="show_summary"
+    )
     options, args = parser.parse_args()
+
+    if options.show_raw and options.show_summary:
+        parser.error('Cannot combine summary and raw output (choose one)')
+    elif not (options.show_raw or options.show_summary):
+        # Neither one specified - choose summary by default
+        options.show_summary = True
+
     suite = args.pop(0)
     run_db = _get_dao(suite)
-    pretty_print_rows(*run_db.select_task_events_for_timing())
+    buf = format_rows(*run_db.select_task_events_for_timing())
+
+    if options.show_raw:
+        _raw_output(buf)
+    elif options.show_summary:
+        _summary_output(buf)
 
 
-def pretty_print_rows(header, rows):
-    """Pretty-print the row data to sys.stdout
+def format_rows(header, rows):
+    """Write the rows in tabular format to a string buffer.
 
     Ensure that each column is wide enough to contain the widest data
     value and the widest header value.
 
     """
+    sio = StringIO.StringIO()
     max_lengths = [
         max(data_len, head_len)
         for data_len, head_len in zip(
@@ -76,9 +110,11 @@ def pretty_print_rows(header, rows):
         )
     ]
     formatter = ' '.join(['%%-%ds' % l for l in max_lengths]) + '\n'
-    sys.stdout.write(formatter % header)
+    sio.write(formatter % header)
     for r in rows:
-        sys.stdout.write(formatter % r)
+        sio.write(formatter % r)
+    sio.seek(0)
+    return sio
 
 
 def _get_dao(suite):
@@ -91,6 +127,67 @@ def _get_dao(suite):
         CylcSuiteDAO.DB_FILE_BASE_NAME
     )
     return CylcSuiteDAO(pub_db_path, is_public=True)
+
+
+def _raw_output(buf):
+    """Print raw tabular output to the screen."""
+    sys.stdout.write(buf.getvalue())
+
+
+def _summary_output(buf):
+    """
+    Print summary tabular output (stratified by host and batch system)
+    to the screen.
+
+    """
+    try:
+        import pandas as pd
+    except ImportError:
+        sys.stderr.write(
+            "Error importing pandas - summary output not available.\n"
+        )
+        sys.exit(1)
+    df = pd.read_csv(
+        buf, delim_whitespace=True, index_col=[0,1,2,3], parse_dates=[4,5,6]
+    )
+    df_dt = pd.DataFrame({
+        'queue_time': (df['start_time']-df['submit_time']).apply(_dt_to_s),
+        'run_time': (df['succeed_time']-df['start_time']).apply(_dt_to_s),
+        'total_time': (df['succeed_time']-df['submit_time']).apply(_dt_to_s),
+    })
+    for group, df_g in df_dt.groupby(level=['host', 'batch_system']):
+        _print_h1_title('Host: %s\tBatch System: %s' % group)
+        df_summary = df_g.groupby(level='name').describe()
+        if df_summary.index.nlevels > 1:
+            df_summary = df_summary.unstack()   # for pandas < 0.20.0
+        for category in sorted(set(df_summary.columns.get_level_values(0))):
+            _print_h2_title(category)
+            print df_summary[category].to_string()
+            print ''
+
+
+def _dt_to_s(dt):
+    """Convert timedelta duration to seconds."""
+    try:
+        return dt.total_seconds()
+    except AttributeError:
+        # Older versions of pandas have the timedelta as a Numpy timedelta64
+        # type, which didn't support total_seconds
+        import pandas as pd
+        return pd.Timedelta(dt).total_seconds()
+
+
+def _print_h1_title(title, linewidth=80):
+    """Display a level-1 header."""
+    print '='*linewidth
+    print title.center(linewidth)
+    print '='*linewidth
+
+
+def _print_h2_title(title, linewidth=80):
+    """Display a level-2 header."""
+    print title.center(linewidth)
+    print ('-'*len(title)).center(linewidth)
 
 
 if __name__ == "__main__":

--- a/bin/cylc-show-times
+++ b/bin/cylc-show-times
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""cylc [util] show-times [OPTIONS] REG
+
+Retrieve timing information for the given cylc suite that can be
+used for fine-grain diagnostics for wait time and run time performance
+analysis:
+    1. Time of successful submission
+    2. Time of task start
+    3. Time of task successful completion
+
+Timings are shown only for succeeded tasks, and includes information
+about the batch system and remote host to permit stratification/grouping
+if desired (e.g. a typical metric for batch systems like PBS is how
+long the job waited in the queue, which can be obtained by subtracting
+the submit time from the start time - however, this metric is less
+meaningful for background jobs where no batch system is involved).
+
+For long-running and/or large suites (i.e. for suites with many task events),
+the database query to obtain the timing information may take some time.
+
+"""
+
+import sys
+from cylc.remote import remrun
+if remrun().execute():
+    sys.exit(0)
+
+import os
+
+import cylc.flags
+from cylc.cfgspec.globalcfg import GLOBAL_CFG
+from cylc.option_parsers import CylcOptionParser as COP
+from cylc.rundb import CylcSuiteDAO
+
+
+def main():
+    parser = COP(
+        __doc__,
+        argdoc=[('REG', 'Suite name')]
+    )
+    options, args  = parser.parse_args()
+    suite = args.pop(0)
+    run_db = _get_dao(suite)
+    pretty_print_rows(*run_db.select_task_events_for_timing())
+
+
+def pretty_print_rows(header, rows):
+    """Pretty-print the row data to sys.stdout
+
+    Ensure that each column is wide enough to contain the widest data
+    value and the widest header value.
+
+    """
+    max_lengths = [
+        max(data_len, head_len)
+        for data_len, head_len in zip(
+            [max([len(r[i]) for r in rows]) for i in range(len(header))],
+            [len(h) for h in header]
+        )
+    ]
+    formatter = ' '.join(['%%-%ds' % l for l in max_lengths]) + '\n'
+    sys.stdout.write(formatter % header)
+    for r in rows:
+        sys.stdout.write(formatter % r)
+
+
+def _get_dao(suite):
+    """Return the DAO (public) for suite."""
+    suite_log_dir = GLOBAL_CFG.get_derived_host_item(
+        suite, 'suite log directory'
+    )
+    pub_db_path = os.path.join(
+        os.path.dirname(suite_log_dir),
+        CylcSuiteDAO.DB_FILE_BASE_NAME
+    )
+    return CylcSuiteDAO(pub_db_path, is_public=True)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:
+        if cylc.flags.debug:
+            raise
+        sys.exit(str(exc))

--- a/bin/cylc-show-times
+++ b/bin/cylc-show-times
@@ -20,17 +20,23 @@
 
 Retrieve timing information for the given cylc suite that can be
 used for fine-grain diagnostics for wait time and run time performance
-analysis.  Two main categories of output are available:
+analysis.  Two main categories of output are available: summary output
+(in text or web format) and raw output.  If an output filename is
+supplied, output is redirected there otherwise both summary and raw
+outputs are printed to standard output.
 
 Summary Output (the default):
-Tabular data stratified by host and batch system that provides a statistical
+Data stratified by host and batch system that provides a statistical
 summary of
     1. Queue wait time (duration between task submission and start times)
     2. Task run time (duration between start and succeed times)
     3. Total run time (duration between task submission and succeed times)
-This statistical summary requires the Pandas library for data analysis and
-will print an error message if summary output is invoked without this library
-being available.
+Text output will show summary tables in text only.  Web output generates
+HTML that contains boxplots as well as summary tables suitable for viewing
+in a browser.  Both summary options require the use of the Pandas library,
+and the web summary output requires the Matplotlib plotting library.  If
+these libraries are not available, an error message will be printed and the
+summary will not be generated.
 
 Raw Output:
 A flat list of tabular data that provides (for each task and cycle) the
@@ -53,12 +59,34 @@ if remrun().execute():
     sys.exit(0)
 
 import cStringIO as StringIO
+import contextlib
 import os
 
 import cylc.flags
 from cylc.cfgspec.globalcfg import GLOBAL_CFG
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.rundb import CylcSuiteDAO
+
+
+@contextlib.contextmanager
+def smart_open(filename=None):
+    """
+    Allow context management for output to either a file or
+    to standard output transparently.
+
+    See https://stackoverflow.com/a/17603000
+
+
+    """
+    if filename and filename != '-':
+        fh = open(filename, 'w')
+    else:
+        fh = sys.stdout
+    try:
+        yield fh
+    finally:
+        if fh is not sys.stdout:
+            fh.close()
 
 
 def main():
@@ -73,25 +101,42 @@ def main():
     )
     parser.add_option(
         "-s", "--summary",
-        help="Show summary timing output for tasks.",
+        help="Show textual summary timing output for tasks.",
         action="store_true", default=False, dest="show_summary"
     )
+    parser.add_option(
+        "-w", "--web-summary",
+        help="Show HTML summary timing output for tasks.",
+        action="store_true", default=False, dest="html_summary"
+    )
+    parser.add_option(
+        "-O", "--output-file",
+        help="Output to a specific file",
+        action="store", default=None, dest="output_filename")
     options, args = parser.parse_args()
 
-    if options.show_raw and options.show_summary:
-        parser.error('Cannot combine summary and raw output (choose one)')
-    elif not (options.show_raw or options.show_summary):
-        # Neither one specified - choose summary by default
+    output_options = [
+        options.show_raw, options.show_summary, options.html_summary
+    ]
+    if output_options.count(True) > 1:
+        parser.error('Cannot combine output formats (choose one)')
+    if output_options.count(True) == 0:
+        # No output specified - choose summary by default
         options.show_summary = True
 
     suite = args.pop(0)
     run_db = _get_dao(suite)
-    buf = format_rows(*run_db.select_task_events_for_timing())
+    row_buf = format_rows(*run_db.select_task_events_for_timing())
 
-    if options.show_raw:
-        _raw_output(buf)
-    elif options.show_summary:
-        _summary_output(buf)
+    with smart_open(options.output_filename) as output:
+        if options.show_raw:
+            output.write(row_buf.getvalue())
+        else:
+            if options.show_summary:
+                summary = TextTimingSummary(row_buf)
+            elif options.html_summary:
+                summary = HTMLTimingSummary(row_buf)
+            summary.write_summary(output)
 
 
 def format_rows(header, rows):
@@ -129,66 +174,193 @@ def _get_dao(suite):
     return CylcSuiteDAO(pub_db_path, is_public=True)
 
 
-def _raw_output(buf):
-    """Print raw tabular output to the screen."""
-    sys.stdout.write(buf.getvalue())
+class TimingSummary(object):
+    """Base class for summarizing timing output from cylc run database."""
 
+    def __init__(self, filepath_or_buffer=None):
+        """Set up internal dataframe storage for time durations."""
 
-def _summary_output(buf):
-    """
-    Print summary tabular output (stratified by host and batch system)
-    to the screen.
+        self._check_imports()
+        if filepath_or_buffer is not None:
+            self.read_timings(filepath_or_buffer)
+        else:
+            self.df = None
+            self.by_host_and_batch = None
 
-    """
-    try:
+    def read_timings(self, filepath_or_buffer):
+        """
+        Set up time duration dataframe storage based on start/stop/succeed
+        times from flat database output.
+
+        """
         import pandas as pd
-    except ImportError:
-        sys.stderr.write(
-            "Error importing pandas - summary output not available.\n"
+        df = pd.read_csv(
+            filepath_or_buffer, delim_whitespace=True, index_col=[0, 1, 2, 3],
+            parse_dates=[4, 5, 6]
         )
-        sys.exit(1)
-    df = pd.read_csv(
-        buf, delim_whitespace=True, index_col=[0, 1, 2, 3],
-        parse_dates=[4, 5, 6]
-    )
-    df_dt = pd.DataFrame({
-        'queue_time': (df['start_time'] - df['submit_time']).apply(_dt_to_s),
-        'run_time': (df['succeed_time'] - df['start_time']).apply(_dt_to_s),
-        'total_time': (df['succeed_time'] - df['submit_time']).apply(_dt_to_s),
-    })
-    for group, df_g in df_dt.groupby(level=['host', 'batch_system']):
-        _print_h1_title('Host: %s\tBatch System: %s' % group)
-        df_summary = df_g.groupby(level='name').describe()
-        if df_summary.index.nlevels > 1:
-            df_summary = df_summary.unstack()   # for pandas < 0.20.0
-        for category in sorted(set(df_summary.columns.get_level_values(0))):
-            _print_h2_title(category)
-            print df_summary[category].to_string()
-            print ''
+        self.df = pd.DataFrame({
+            'queue_time': (
+                df['start_time'] - df['submit_time']).apply(self._dt_to_s),
+            'run_time':  (
+                df['succeed_time'] - df['start_time']).apply(self._dt_to_s),
+            'total_time': (
+                df['succeed_time'] - df['submit_time']).apply(self._dt_to_s),
+        })
+        self.by_host_and_batch = self.df.groupby(
+            level=['host', 'batch_system']
+        )
 
+    def write_summary(self, buf=None):
+        """Using the stored timings dataframe, output the data summary."""
 
-def _dt_to_s(dt):
-    """Convert timedelta duration to seconds."""
-    try:
-        return dt.total_seconds()
-    except AttributeError:
-        # Older versions of pandas have the timedelta as a Numpy timedelta64
-        # type, which didn't support total_seconds
+        if buf is None:
+            buf = sys.stdout
+        self.write_summary_header(buf)
+        for group, df in self.by_host_and_batch:
+            self.write_group_header(buf, group)
+            df_reshape = df.unstack('name').stack(level=0)
+            df_describe = df.groupby(level='name').describe()
+            if df_describe.index.nlevels > 1:
+                df_describe = df_describe.unstack()  # for pandas < 0.20.0
+            df_describe.index.rename(None, inplace=True)
+            for timing_category in self.df.columns:
+                self.write_category(
+                    buf, timing_category, df_reshape, df_describe
+                )
+        self.write_summary_footer(buf)
+
+    def write_summary_header(self, buf):
+        pass
+
+    def write_summary_footer(self, buf):
+        pass
+
+    def write_group_header(self, buf, group):
+        pass
+
+    def write_category(self, buf, category, df_reshape, df_describe):
+        pass
+
+    def _check_imports(self):
+        try:
+            import pandas as pd
+        except ImportError:
+            msg = 'Cannot import pandas - summary unavailable.'
+            sys.stderr.write(msg)
+            raise Exception(msg)
+
+    @staticmethod
+    def _dt_to_s(dt):
         import pandas as pd
-        return pd.Timedelta(dt).total_seconds()
+        try:
+            return dt.total_seconds()
+        except AttributeError:
+            # Older versions of pandas have the timedelta as a numpy
+            # timedelta64 type, which didn't support total_seconds
+            return pd.Timedelta(dt).total_seconds()
 
 
-def _print_h1_title(title, linewidth=80):
-    """Display a level-1 header."""
-    print '=' * linewidth
-    print title.center(linewidth)
-    print '=' * linewidth
+class TextTimingSummary(TimingSummary):
+    """Timing summary in text form."""
+
+    line_width = 80
+
+    def write_group_header(self, buf, group):
+        title = 'Host: %s\tBatch System: %s' % group
+        buf.write('=' * self.line_width + '\n')
+        buf.write(title.center(self.line_width-1) + '\n')
+        buf.write('=' * self.line_width + '\n')
+
+    def write_category(self, buf, category, df_reshape, df_describe):
+        buf.write(category.center(self.line_width) + '\n')
+        buf.write(('-'*len(category)).center(self.line_width) + '\n')
+        buf.write(df_describe[category].to_string())
+        buf.write('\n\n')
 
 
-def _print_h2_title(title, linewidth=80):
-    """Display a level-2 header."""
-    print title.center(linewidth)
-    print ('-' * len(title)).center(linewidth)
+class HTMLTimingSummary(TimingSummary):
+    """Timing summary in HTML form."""
+
+    def write_summary_header(self, buf):
+        css = """
+            body {
+                font-family: Sans-Serif;
+                text-align: center;
+            }
+            h1 {
+                background-color: grey;
+            }
+            h2 {
+                width: 85%;
+                background-color: #f0f0f0;
+                margin: auto;
+            }
+            table {
+                width: 75%;
+                margin: auto;
+                border-collapse: collapse;
+            }
+            tr:nth-child(even) {
+                background-color: #f2f2f2;
+            }
+            td {
+                text-align: right;
+            }
+            th, td {
+                border-bottom: 1px solid grey;
+            }
+            svg {
+                width: 65%;
+                height: auto;
+                margin: auto;
+                display: block;
+            }
+            .timing {
+                padding-bottom: 40px;
+            }
+        """
+
+        buf.write('<html><head><style>%s</style></head><body>' % css)
+
+    def write_summary_footer(self, buf):
+        buf.write('</body></html>')
+
+    def write_group_header(self, buf, group):
+        buf.write('<h1>Timings for host %s using batch system %s</h1>' % group)
+
+    def write_category(self, buf, category, df_reshape, df_describe):
+        import matplotlib.pyplot as plt
+        buf.write('<div class="timing" id=%s>' % category)
+        buf.write('<h2>%s</h2>\n' % (category.replace('_', ' ').title()))
+        ax = df_reshape.xs(category, level=3).plot(kind='box', vert=False)
+        ax.invert_yaxis()
+        ax.set_xlabel('Seconds')
+        plt.tight_layout()
+        plt.gcf().savefig(buf, format='svg')
+        try:
+            table = df_describe[category].to_html(
+                classes="summary", index_names=False, border=0
+            )
+        except TypeError:
+            # older pandas don't support the "border" argument
+            # so explicitly remove it
+            table = df_describe[category].to_html(
+                classes="summary", index_names=False
+            )
+            table = table.replace('border="1"', '')
+        buf.write(table)
+        buf.write('</div>')
+        pass
+
+    def _check_imports(self):
+        try:
+            import matplotlib
+            matplotlib.use('Agg')
+        except ImportError:
+            msg = 'Cannot import pandas - summary unavailable.'
+            sys.stderr.write(msg)
+            raise Exception(msg)
+        super(HTMLTimingSummary, self)._check_imports()
 
 
 if __name__ == "__main__":

--- a/bin/cylc-show-times
+++ b/bin/cylc-show-times
@@ -55,7 +55,7 @@ def main():
         __doc__,
         argdoc=[('REG', 'Suite name')]
     )
-    options, args  = parser.parse_args()
+    options, args = parser.parse_args()
     suite = args.pop(0)
     run_db = _get_dao(suite)
     pretty_print_rows(*run_db.select_task_events_for_timing())

--- a/bin/cylc-show-times
+++ b/bin/cylc-show-times
@@ -148,12 +148,13 @@ def _summary_output(buf):
         )
         sys.exit(1)
     df = pd.read_csv(
-        buf, delim_whitespace=True, index_col=[0,1,2,3], parse_dates=[4,5,6]
+        buf, delim_whitespace=True, index_col=[0, 1, 2, 3],
+        parse_dates=[4, 5, 6]
     )
     df_dt = pd.DataFrame({
-        'queue_time': (df['start_time']-df['submit_time']).apply(_dt_to_s),
-        'run_time': (df['succeed_time']-df['start_time']).apply(_dt_to_s),
-        'total_time': (df['succeed_time']-df['submit_time']).apply(_dt_to_s),
+        'queue_time': (df['start_time'] - df['submit_time']).apply(_dt_to_s),
+        'run_time': (df['succeed_time'] - df['start_time']).apply(_dt_to_s),
+        'total_time': (df['succeed_time'] - df['submit_time']).apply(_dt_to_s),
     })
     for group, df_g in df_dt.groupby(level=['host', 'batch_system']):
         _print_h1_title('Host: %s\tBatch System: %s' % group)
@@ -179,15 +180,15 @@ def _dt_to_s(dt):
 
 def _print_h1_title(title, linewidth=80):
     """Display a level-1 header."""
-    print '='*linewidth
+    print '=' * linewidth
     print title.center(linewidth)
-    print '='*linewidth
+    print '=' * linewidth
 
 
 def _print_h2_title(title, linewidth=80):
     """Display a level-2 header."""
     print title.center(linewidth)
-    print ('-'*len(title)).center(linewidth)
+    print ('-' * len(title)).center(linewidth)
 
 
 if __name__ == "__main__":

--- a/lib/cylc/rundb.py
+++ b/lib/cylc/rundb.py
@@ -686,7 +686,7 @@ class CylcSuiteDAO(object):
         for row_idx, row in enumerate(self.connect().execute(stmt, stmt_args)):
             callback(row_idx, list(row))
 
-    def select_task_events_for_timing(self):
+    def select_task_times(self):
         """Select submit/start/stop times to compute job timings.
 
         To make data interpretation easier, choose the most recent succeeded
@@ -694,27 +694,20 @@ class CylcSuiteDAO(object):
         """
         q = """
             SELECT
-                %(task_jobs)s.name,
-                %(task_jobs)s.cycle,
-                %(task_jobs)s.user_at_host,
-                %(task_jobs)s.batch_sys_name,
-                %(task_jobs)s.time_submit,
-                %(task_jobs)s.time_run,
-                %(task_jobs)s.time_run_exit
+                name,
+                cycle,
+                user_at_host,
+                batch_sys_name,
+                time_submit,
+                time_run,
+                time_run_exit
             FROM
-                %(task_jobs)s INNER JOIN %(task_states)s
-            ON
-                %(task_jobs)s.name = %(task_states)s.name
-                AND
-                %(task_jobs)s.cycle = %(task_states)s.cycle
-                AND
-                %(task_jobs)s.submit_num = %(task_states)s.submit_num
+                %(task_jobs)s
             WHERE
-                %(task_states)s.status = '%(succeeded)s'
+                run_status = %(succeeded)d
         """ % {
             'task_jobs': self.TABLE_TASK_JOBS,
-            'task_states': self.TABLE_TASK_STATES,
-            'succeeded': 'succeeded',
+            'succeeded': 0,
         }
         columns = (
             'name', 'cycle', 'host', 'batch_system',

--- a/lib/cylc/rundb.py
+++ b/lib/cylc/rundb.py
@@ -732,12 +732,15 @@ class CylcSuiteDAO(object):
                 e.name, e.cycle, e.submit_num
         """ % {
             'task_events': self.TABLE_TASK_EVENTS,
-            'task_jobs':   self.TABLE_TASK_JOBS,
-            'submitted':   'submitted',
-            'started':     'started',
-            'succeeded':   'succeeded',
+            'task_jobs': self.TABLE_TASK_JOBS,
+            'submitted': 'submitted',
+            'started': 'started',
+            'succeeded': 'succeeded',
         }
-        columns = ('name', 'cycle', 'host', 'batch_system', 'submit_time', 'start_time', 'succeed_time')
+        columns = (
+            'name', 'cycle', 'host', 'batch_system',
+            'submit_time', 'start_time', 'succeed_time'
+        )
         return columns, [r for r in self.connect().execute(q)]
 
     def take_checkpoints(self, event, other_daos=None):

--- a/lib/cylc/rundb.py
+++ b/lib/cylc/rundb.py
@@ -702,29 +702,18 @@ class CylcSuiteDAO(object):
                 %(task_jobs)s.time_run,
                 %(task_jobs)s.time_run_exit
             FROM
-                %(task_jobs)s
-                INNER JOIN
-                (
-                    SELECT
-                        name,
-                        cycle,
-                        MAX(submit_num) AS max_retry
-                    FROM
-                        %(task_events)s
-                    WHERE
-                        event = '%(succeeded)s'
-                    GROUP BY
-                        name, cycle
-                ) AS succeeded_tasks
-                ON
-                    %(task_jobs)s.name = succeeded_tasks.name
-                    AND
-                    %(task_jobs)s.cycle = succeeded_tasks.cycle
-                    AND
-                    %(task_jobs)s.submit_num = succeeded_tasks.max_retry
+                %(task_jobs)s INNER JOIN %(task_states)s
+            ON
+                %(task_jobs)s.name = %(task_states)s.name
+                AND
+                %(task_jobs)s.cycle = %(task_states)s.cycle
+                AND
+                %(task_jobs)s.submit_num = %(task_states)s.submit_num
+            WHERE
+                %(task_states)s.status = '%(succeeded)s'
         """ % {
-            'task_events': self.TABLE_TASK_EVENTS,
             'task_jobs': self.TABLE_TASK_JOBS,
+            'task_states': self.TABLE_TASK_STATES,
             'succeeded': 'succeeded',
         }
         columns = (


### PR DESCRIPTION

Add a new query to the run database and a top-level driver
script that will allow interrogation of task times to facilitate
generation of statistics about wallclock time required for tasks,
including information necessary to generate batch queue wait times,
task run time (which was already available through the GUI), and
total wallclock time for the task.