### PR TITLE
Change Intercycle offsets from list to set.

### DIFF
--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -1527,10 +1527,10 @@ class SuiteConfig(object):
                 last_point = seq.get_stop_point()
                 if last_point is None:
                     # This dependency persists for the whole suite run.
-                    ltaskdef.intercycle_offsets.append(
+                    ltaskdef.intercycle_offsets.add(
                         (None, seq))
                 else:
-                    ltaskdef.intercycle_offsets.append(
+                    ltaskdef.intercycle_offsets.add(
                         (str(-(last_point - first_point)), seq))
                 cycle_point = first_point
             elif lnode.intercycle:
@@ -1538,7 +1538,7 @@ class SuiteConfig(object):
                     offset_tuple = (lnode.offset_string, seq)
                 else:
                     offset_tuple = (lnode.offset_string, None)
-                ltaskdef.intercycle_offsets.append(offset_tuple)
+                ltaskdef.intercycle_offsets.add(offset_tuple)
 
             trig = TaskTrigger(
                 lnode.name, lnode.output, lnode.offset_string, cycle_point,

--- a/lib/cylc/taskdef.py
+++ b/lib/cylc/taskdef.py
@@ -69,7 +69,7 @@ class TaskDef(object):
 
         # some defaults
         self.max_future_prereq_offset = None
-        self.intercycle_offsets = []
+        self.intercycle_offsets = set([])
         self.sequential = False
         self.suite_polling_cfg = {}
 


### PR DESCRIPTION
Whilst profiling cylc's memory usage for a suite I noticed that a taskdef was using 7.3Mb. This was largely due to 48'000 items (mostly duplicates) in the `taskdef.intercycle_offsets` list. This pull reduces this memory usage to 2.9Mb which amounts to roughly a 5% reduction in memory usage for the `Scheduler` object in this case.

The example in question is a somewhat extreme case, profiling results for the complex suite show a much smaller improvement:

| Version | Run | Elapsed Time (s) | CPU Time - Total (s) | Max Memory (kb) |
| ------- | --- | ---------------- | -------------------- | --------------- |
| intercycle-offsets-to-set | complex suite | 1064.4 | 316.7 | 84456.0 |
| master | complex suite | 1049.4 | 317.4 | 84552.0 |
