### PR TITLE
Fix poll timer after restart

### DIFF
--- a/lib/cylc/task_job_mgr.py
+++ b/lib/cylc/task_job_mgr.py
@@ -382,16 +382,20 @@ class TaskJobManager(object):
             if timeout is None or now <= timeout:
                 return False
             itask.timeout_timers[itask.state.status] = None
-            if itask.state.status == TASK_STATUS_RUNNING:
+            if (itask.state.status == TASK_STATUS_RUNNING and
+                    itask.summary['started_time'] is not None):
                 msg = 'job started %s ago, but has not finished' % (
                     get_seconds_as_interval_string(
                         timeout - itask.summary['started_time']))
                 event = 'execution timeout'
-            else:  # if itask.state.status == TASK_STATUS_SUBMITTED:
+            elif (itask.state.status == TASK_STATUS_SUBMITTED and
+                    itask.summary['submitted_time'] is not None):
                 msg = 'job submitted %s ago, but has not started' % (
                     get_seconds_as_interval_string(
                         timeout - itask.summary['submitted_time']))
                 event = 'submission timeout'
+            else:
+                return False
             LOG.warning(msg, itask=itask)
             self.task_events_mgr.setup_event_handlers(itask, event, msg)
             return True

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -355,7 +355,7 @@ class TaskPool(object):
         if row_idx == 0:
             OUT.info("LOADING task proxies")
         (cycle, name, spawned, status, hold_swap, submit_num, _,
-         user_at_host) = row
+         user_at_host, time_submit, time_run, timeout) = row
         try:
             itask = TaskProxy(
                 self.config.get_taskdef(name),
@@ -385,6 +385,12 @@ class TaskPool(object):
                 except ValueError:
                     itask.task_owner = None
                     itask.task_host = user_at_host
+                if time_submit:
+                    itask.set_event_time('submitted', time_submit)
+                if time_run:
+                    itask.set_event_time('started', time_run)
+                if timeout is not None:
+                    itask.timeout_timers[status] = timeout
 
             elif status in (TASK_STATUS_SUBMIT_FAILED, TASK_STATUS_FAILED):
                 itask.state.set_prerequisites_all_satisfied()

--- a/tests/database/00-simple/schema.out
+++ b/tests/database/00-simple/schema.out
@@ -12,3 +12,4 @@ CREATE TABLE task_jobs(cycle TEXT, name TEXT, submit_num INTEGER, is_manual_subm
 CREATE TABLE task_pool(cycle TEXT, name TEXT, spawned INTEGER, status TEXT, hold_swap TEXT, PRIMARY KEY(cycle, name));
 CREATE TABLE task_pool_checkpoints(id INTEGER, cycle TEXT, name TEXT, spawned INTEGER, status TEXT, hold_swap TEXT, PRIMARY KEY(id, cycle, name));
 CREATE TABLE task_states(name TEXT, cycle TEXT, time_created TEXT, time_updated TEXT, submit_num INTEGER, status TEXT, PRIMARY KEY(name, cycle));
+CREATE TABLE task_timeout_timers(cycle TEXT, name TEXT, timeout REAL, PRIMARY KEY(cycle, name));

--- a/tests/restart/28-execution-timeout.t
+++ b/tests/restart/28-execution-timeout.t
@@ -1,0 +1,33 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test restart with running task with execution timeout.
+. "$(dirname "$0")/test_header"
+set_test_number 4
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+suite_run_ok "${TEST_NAME_BASE}-run" cylc run "${SUITE_NAME}" --no-detach
+suite_run_ok "${TEST_NAME_BASE}-restart" \
+    cylc restart "${SUITE_NAME}" --no-detach --reference-test
+contains_ok "${SUITE_RUN_DIR}/log/job/1/foo/NN/job-activity.log" <<'__LOG__'
+[(('event-handler-00', 'execution timeout'), 1) cmd] echo foo.1 'execution timeout'
+[(('event-handler-00', 'execution timeout'), 1) ret_code] 0
+[(('event-handler-00', 'execution timeout'), 1) out] foo.1 execution timeout
+__LOG__
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/restart/28-execution-timeout/reference.log
+++ b/tests/restart/28-execution-timeout/reference.log
@@ -1,0 +1,3 @@
+2017-03-02T20:25:55Z INFO - Initial point: 1
+2017-03-02T20:25:55Z INFO - Final point: 1
+2017-03-02T20:25:55Z INFO - [bar.1] -triggered off ['foo.1']

--- a/tests/restart/28-execution-timeout/suite.rc
+++ b/tests/restart/28-execution-timeout/suite.rc
@@ -1,0 +1,20 @@
+[cylc]
+    UTC mode = True
+    cycle point format = %Y
+[scheduling]
+    [[dependencies]]
+        graph = foo => bar
+[runtime]
+    [[foo]]
+        script="""
+wait "${CYLC_TASK_MESSAGE_STARTED_PID}" 2'>/dev/null' || true
+sleep 1
+cylc stop --now --now "${CYLC_SUITE_NAME}"
+sleep 60
+"""
+        [[[events]]]
+            execution timeout = PT10S
+            handlers = echo %(id)s %(event)s
+            handler events = execution timeout
+    [[bar]]
+        script=true


### PR DESCRIPTION
Store timer timeout value (for submitted and running tasks) in suite
runtime database. Repopulate task attribute on restart.

Repopulate task submitted and started time attributes on restart.

Only report a submission timeout if submitted time is defined.
Only report an execution timeout if started time is defined.

Not yet ready for review.