### PR TITLE
Abort  job script with custom message.

### DIFF
--- a/bin/cylc-message
+++ b/bin/cylc-message
@@ -17,15 +17,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """cylc [task] message [OPTIONS] MESSAGE ...
 
-This command is part of the cylc task messaging interface, used by
-running tasks to communicate progress to their parent suite.
+This command is used by task jobs to automatically report success and failure.
 
-The message command can be used to report "message outputs" completed.
-Other messages received by the suite daemon will just be logged.
+It can also be used to send info-, warning-, or critical-priority messages
+back, and to report registered task "message outputs" completed.
 
-Suite and task identity are determined from the task execution
-environment supplied by the suite (or by the single task 'submit'
-command, in which case case the message is just printed to stdout)."""
+Note: to abort a job script with a custom error message, use cylc__job_abort:
+  cylc__job_abort 'message...'
+(for technical reasons this is a shell function, not a cylc sub-command)."""
 
 
 import os

--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -94,6 +94,7 @@ class TaskEventsManager(object):
     EVENT_SUCCEEDED = TASK_OUTPUT_SUCCEEDED
     HANDLER_CUSTOM = "event-handler"
     HANDLER_MAIL = "event-mail"
+    JOB_FAILED = "job failed"
     HANDLER_JOB_LOGS_RETRIEVE = "job-logs-retrieve"
     INCOMING_FLAG = ">"
     LEVELS = {
@@ -333,8 +334,9 @@ class TaskEventsManager(object):
                 itask.state.status in [
                     TASK_STATUS_READY, TASK_STATUS_SUBMITTED,
                     TASK_STATUS_SUBMIT_FAILED, TASK_STATUS_RUNNING]):
+            # Generic fail message, via polling.
             # (submit- states in case of very fast submission and execution).
-            self._process_message_failed(itask, event_time)
+            self._process_message_failed(itask, event_time, self.JOB_FAILED)
         elif message == self.EVENT_SUBMIT_FAILED:
             self._process_message_submit_failed(itask, event_time)
         elif message == TASK_OUTPUT_SUBMITTED:
@@ -345,6 +347,12 @@ class TaskEventsManager(object):
             signal = message.replace(TaskMessage.FAIL_MESSAGE_PREFIX, "")
             self.suite_db_mgr.put_update_task_jobs(itask, {
                 "run_signal": signal})
+            self._process_message_failed(itask, event_time, self.JOB_FAILED)
+        elif message.startswith(TaskMessage.ABORT_MESSAGE_PREFIX):
+            # Abort with message.
+            self._process_message_failed(
+                itask, event_time,
+                message.replace(TaskMessage.ABORT_MESSAGE_PREFIX, ''))
         elif message.startswith(TaskMessage.VACATION_MESSAGE_PREFIX):
             cylc.flags.pflag = True
             itask.state.reset_state(TASK_STATUS_SUBMITTED)
@@ -578,7 +586,7 @@ class TaskEventsManager(object):
                 if cylc.flags.debug:
                     ERR.debug(traceback.format_exc())
 
-    def _process_message_failed(self, itask, event_time):
+    def _process_message_failed(self, itask, event_time, message):
         """Helper for process_message, handle a failed message."""
         if event_time is None:
             event_time = get_current_time_string()
@@ -590,10 +598,11 @@ class TaskEventsManager(object):
         if (TASK_STATUS_RETRYING not in itask.try_timers or
                 itask.try_timers[TASK_STATUS_RETRYING].next() is None):
             # No retry lined up: definitive failure.
-            # Note the TASK_STATUS_FAILED output is only added if needed.
             cylc.flags.pflag = True
             itask.state.reset_state(TASK_STATUS_FAILED)
-            self.setup_event_handlers(itask, "failed", 'job failed')
+            self.setup_event_handlers(itask, "failed", message)
+            LOG.critical("job(%02d) %s" % (
+                itask.submit_num, "failed"), itask=itask)
         else:
             # There is a retry lined up
             timeout_str = (
@@ -604,7 +613,7 @@ class TaskEventsManager(object):
             LOG.info("job(%02d) %s" % (itask.submit_num, msg), itask=itask)
             itask.summary['latest_message'] = msg
             self.setup_event_handlers(
-                itask, "retry", "job failed, %s" % delay_msg)
+                itask, "retry", "%s, %s" % (self.JOB_FAILED, delay_msg))
             itask.state.reset_state(TASK_STATUS_RETRYING)
 
     def _process_message_started(self, itask, event_time):

--- a/lib/cylc/task_message.py
+++ b/lib/cylc/task_message.py
@@ -40,6 +40,7 @@ class TaskMessage(object):
     CYLC_JOB_EXIT_TIME = "CYLC_JOB_EXIT_TIME"
     CYLC_MESSAGE = "CYLC_MESSAGE"
 
+    ABORT_MESSAGE_PREFIX = "Task job script aborted with "
     FAIL_MESSAGE_PREFIX = "Task job script received signal "
     VACATION_MESSAGE_PREFIX = "Task job script vacated by signal "
 
@@ -235,6 +236,10 @@ class TaskMessage(object):
                     job_status_file.write("%s=%s\n" % (
                         self.CYLC_JOB_EXIT,
                         message.replace(self.FAIL_MESSAGE_PREFIX, "")))
+                elif message.startswith(self.ABORT_MESSAGE_PREFIX):
+                    job_status_file.write("%s=%s\n" % (
+                        self.CYLC_JOB_EXIT,
+                        message.replace(self.ABORT_MESSAGE_PREFIX, "")))
                 elif message.startswith(self.VACATION_MESSAGE_PREFIX):
                     # Job vacated, remove entries related to current job
                     job_status_file_name = job_status_file.name

--- a/tests/events/34-task-abort.t
+++ b/tests/events/34-task-abort.t
@@ -1,0 +1,42 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test job abort-with-message and interaction with failed handler.
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 3
+#-------------------------------------------------------------------------------
+install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-validate
+run_ok $TEST_NAME cylc validate $SUITE_NAME
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-run
+suite_run_ok $TEST_NAME cylc run --no-detach --debug $SUITE_NAME
+#-------------------------------------------------------------------------------
+LOG="${SUITE_RUN_DIR}/log/job/1/foo/NN/job-activity.log"
+cat "${LOG}" | grep "event-handler" > 'edited-job-activity.log'
+cmp_ok 'edited-job-activity.log' <<__LOG__
+[(('event-handler-00', 'failed'), 2) cmd] echo "!!!FAILED!!!" failed foo.1 2 '"ERROR: rust never sleeps"'
+[(('event-handler-00', 'failed'), 2) ret_code] 0
+[(('event-handler-00', 'failed'), 2) out] !!!FAILED!!! failed foo.1 2 "ERROR: rust never sleeps"
+__LOG__
+#-------------------------------------------------------------------------------
+purge_suite "${SUITE_NAME}"
+exit
+#-------------------------------------------------------------------------------
+purge_suite $SUITE_NAME

--- a/tests/events/34-task-abort.t
+++ b/tests/events/34-task-abort.t
@@ -18,7 +18,7 @@
 # Test job abort-with-message and interaction with failed handler.
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
-set_test_number 3
+set_test_number 5
 #-------------------------------------------------------------------------------
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
@@ -28,15 +28,22 @@ run_ok $TEST_NAME cylc validate $SUITE_NAME
 TEST_NAME=$TEST_NAME_BASE-run
 suite_run_ok $TEST_NAME cylc run --no-detach --debug $SUITE_NAME
 #-------------------------------------------------------------------------------
+# Check failed handler only call on last try.
 LOG="${SUITE_RUN_DIR}/log/job/1/foo/NN/job-activity.log"
-cat "${LOG}" | grep "event-handler" > 'edited-job-activity.log'
+grep "event-handler" "${LOG}" > 'edited-job-activity.log'
 cmp_ok 'edited-job-activity.log' <<__LOG__
 [(('event-handler-00', 'failed'), 2) cmd] echo "!!!FAILED!!!" failed foo.1 2 '"ERROR: rust never sleeps"'
 [(('event-handler-00', 'failed'), 2) ret_code] 0
 [(('event-handler-00', 'failed'), 2) out] !!!FAILED!!! failed foo.1 2 "ERROR: rust never sleeps"
 __LOG__
 #-------------------------------------------------------------------------------
-purge_suite "${SUITE_NAME}"
-exit
+# Check job stdout stops at the abort call.
+LOG="${SUITE_RUN_DIR}/log/job/1/foo/NN/job.out"
+# ...before abort
+TEST_NAME=${TEST_NAME_BASE}-stdout1
+run_ok $TEST_NAME grep ONE "${LOG}"
+# ...after abort
+TEST_NAME=${TEST_NAME_BASE}-stdout2
+run_fail $TEST_NAME grep TWO "${LOG}"
 #-------------------------------------------------------------------------------
-purge_suite $SUITE_NAME
+purge_suite "${SUITE_NAME}"

--- a/tests/events/34-task-abort/suite.rc
+++ b/tests/events/34-task-abort/suite.rc
@@ -1,0 +1,18 @@
+title = "Test job abort with retries and failed handler"
+[cylc]
+    [[events]]
+        inactivity = PT20S
+        abort on inactivity = True
+[scheduling]
+    [[dependencies]]
+        graph = "foo:fail => !foo"
+[runtime]
+    [[foo]]
+        script = """
+echo ONE
+cylc__job_abort "ERROR: rust never sleeps"
+echo TWO"""
+        [[[job]]]
+            execution retry delays = PT5S
+        [[[events]]]
+            failed handler = echo "!!!FAILED!!!" %(event)s %(id)s %(submit_num)s %(message)s


### PR DESCRIPTION
Close #2274 

 * ~~general CRITICAL event handler (c.f. our current WARNING handler)~~ [now in #2304]
 * custom abort-with-message function with message passed to the 'failed' event handler.

Test case to show the abort function works properly with execution retries (abort message is logged each try, but only passed to the failed handler at last try) and compare with trapped exit:
```
[scheduling]
    [[dependencies]]
        graph = t-abort & t-fail
[runtime]
    [[root]]
        [[[job]]]
            execution retry delays = PT5S
        [[[events]]]
            failed handler = echo "!!!FAILED!!! "
    [[t-abort]]
        script = """
echo ONE; sleep 5
cylc__job_abort "ERROR: rust never sleeps"
sleep 5; echo TWO"""
    [[t-fail]]
        script = """
echo ONE; sleep 5
/bin/false
sleep 5; echo TWO"""
```

@matthewrmshin - see if you agree with the approach before I and document and add tests.  It's more or less in line with our discussion on #2274.

Note slightly unorthodox implementation by means of a shell function that the user has to call in task scripting.  Probably should hook this into `cylc message` or a new command `cylc abort`?  (It would be nice to avoid yet another command, but `cylc message` doesn't seem very appropriate in this case... `cylc message --abort` maybe ...)