### PR TITLE
job.sh: ensure cylc command is in PATH

### DIFF
--- a/lib/cylc/job.sh
+++ b/lib/cylc/job.sh
@@ -42,6 +42,11 @@ cylc__job__main() {
             break
         fi
     done
+    # Ensure that the "cylc" command is in PATH. It may not be set up correctly
+    # in Prelude above, and also not inherited from the job submit environment.
+    if ! which cylc 1>'/dev/null' 2>&1; then
+        PATH="${CYLC_DIR}/bin:${PATH}"
+    fi
     # Init-Script
     cylc__job__run_inst_func 'global_init_script'
     cylc__job__run_inst_func 'init_script'


### PR DESCRIPTION
PATH may not be set correctly by scripts in prelude, and also not inherited from the environment where the job was submitted.

See this conversation in [cylc Google Groups](https://groups.google.com/forum/?fromgroups#!topic/cylc/2_5AMM6qfwI).