### PR TITLE
Support imported suite modules.

### DIFF
--- a/bin/cylc-broadcast
+++ b/bin/cylc-broadcast
@@ -135,7 +135,7 @@ def get_rdict(left, right=None):
             cur_dict[tail.strip()] = right
             tail = None
     upg({'runtime': {'__MANY__': rdict}}, 'test')
-    validate(rdict, SPEC['runtime']['__MANY__'])
+    validate('broadcast', rdict, SPEC['runtime']['__MANY__'])
     return rdict
 
 

--- a/dev/suites/module/lib/cylc/ncmovie.rc
+++ b/dev/suites/module/lib/cylc/ncmovie.rc
@@ -1,0 +1,30 @@
+#!Jinja2
+
+# INPUTS:
+#   {{FILE_IN}} - input UM file
+#   {{FIELDS}} - list of STASH codes to use
+#   {{NF_JOBS}} - no. of jobs to generate PNG frames concurrently
+#   {{FILE_OUT}} - output .webm movie file
+
+[cylc]
+    [[parameters]]
+         n = 1..{{NF_JOBS}}
+    [[parameter templates]]
+         n = -R%(n)s
+[scheduling]
+    [[dependencies]]
+        graph = select => frames<n> => movie
+[runtime]
+    [[root]]
+        [[[environment]]]
+            FOO = foo
+    [[MODULE]]  # (Modules don't know their 'import as' name.)
+        [[[environment]]]
+            FRAMESDIR = $CYLC_SUITE_SHARE_DIR/frames
+    [[select]]
+        inherit = MODULE  # optional
+        script = "echo select.sh {{FILE_IN}} \"{{FIELDS}}\" fields.nc"
+    [[frames<n>]]
+        script = "echo frames.sh fields.nc frames-dir"
+    [[movie]]
+        script = "echo MOVIE frames-dir {{FILE_OUT}}"

--- a/dev/suites/module/suite.rc
+++ b/dev/suites/module/suite.rc
@@ -1,0 +1,26 @@
+%import ncmovie as NCM
+[cylc]
+    cycle point format = %Y
+[scheduling]
+    initial cycle point = 2010
+    [[dependencies]]
+        [[[R1]]]
+            graph = start => model
+        [[[R/+P1Y/P1Y]]]
+            # (Or use  module family: NCM:succeed-all.)
+            graph = """model[-P1Y] => model => NCM__select
+                       NCM__movie => upload"""
+[runtime]
+    [[model]]
+    [[upload]]
+    [[NCM]]
+        script = echo tea
+[module interface]
+    [[NCM]]
+        FIELDS = "1 2 3"
+        FILE_IN = $CYLC_SUITE_SHARE_PATH/forecast.um
+        FILE_OUT = $CYLC_SUITE_SHARE_PATH/forecast.webm
+        NF_JOBS = 3
+[visualization]
+    [[node attributes]]
+        NCM = "color=red"

--- a/lib/cylc/cfgspec/suite.py
+++ b/lib/cylc/cfgspec/suite.py
@@ -398,6 +398,11 @@ SPEC = {
             },
         },
     },
+    'module interface': {
+        '__MANY__': {
+            '__MANY__': vdr(vtype='string'),
+        },
+    },
     'visualization': {
         'initial cycle point': vdr(vtype='cycletime'),
         'final cycle point': vdr(vtype='final_cycletime'),
@@ -418,6 +423,85 @@ SPEC = {
         },
         'node attributes': {
             '__MANY__': vdr(vtype='string_list', default=[]),
+        },
+    },
+}
+
+# Module spec is a subset of the full suite spec.
+MODULE_SPEC = {
+    'cylc': {
+        'parameters': {
+            '__MANY__': vdr(vtype='parameter_list'),
+        },
+        'parameter templates': {
+            '__MANY__': vdr(vtype='string'),
+        },
+    },
+    'scheduling': {
+        'dependencies': {
+            'graph': vdr(vtype='string'),
+        },
+    },
+    'runtime': {
+        '__MANY__': {
+            'inherit': vdr(vtype='string_list', default=[]),
+            'title': vdr(vtype='string', default=""),
+            'description': vdr(vtype='string', default=""),
+            'URL': vdr(vtype='string', default=""),
+            'init-script': vdr(vtype='string', default=""),
+            'env-script': vdr(vtype='string', default=""),
+            'err-script': vdr(vtype='string', default=""),
+            'pre-script': vdr(vtype='string', default=""),
+            'script': vdr(vtype='string', default=""),
+            'post-script': vdr(vtype='string', default=""),
+            'extra log files': vdr(vtype='string_list', default=[]),
+            'enable resurrection': vdr(vtype='boolean', default=False),
+            'work sub-directory': vdr(vtype='string'),
+            'simulation': {
+                'default run length': vdr(vtype='interval', default='PT10S'),
+                'speedup factor': vdr(vtype='float', default=None),
+                'time limit buffer': vdr(vtype='interval', default='PT10S'),
+                'fail cycle points': vdr(vtype='string_list', default=[]),
+                'fail try 1 only': vdr(vtype='boolean', default=True),
+                'disable task event handlers': vdr(
+                    vtype='boolean', default=True),
+            },
+            'environment filter': {
+                'include': vdr(vtype='string_list'),
+                'exclude': vdr(vtype='string_list'),
+            },
+            'job': {
+                'batch system': vdr(vtype='string', default='background'),
+                'batch submit command template': vdr(vtype='string'),
+                'execution polling intervals': vdr(
+                    vtype='interval_list'),
+                'execution retry delays': vdr(
+                    vtype='interval_list', default=[]),
+                'execution time limit': vdr(vtype='interval'),
+                'shell': vdr(vtype='string', default='/bin/bash'),
+                'submission polling intervals': vdr(
+                    vtype='interval_list'),
+                'submission retry delays': vdr(
+                    vtype='interval_list', default=[]),
+            },
+            'remote': {
+                'host': vdr(vtype='string'),
+                'owner': vdr(vtype='string'),
+                'suite definition directory': vdr(vtype='string'),
+                'retrieve job logs': vdr(vtype='boolean', default=None),
+                'retrieve job logs max size': vdr(vtype='string'),
+                'retrieve job logs retry delays': vdr(
+                    vtype='interval_list'),
+            },
+            'environment': {
+                '__MANY__': vdr(vtype='string'),
+            },
+            'directives': {
+                '__MANY__': vdr(vtype='string'),
+            },
+            'outputs': {
+                '__MANY__': vdr(vtype='string'),
+            },
         },
     },
 }
@@ -508,4 +592,20 @@ class RawSuiteConfig(config):
             cls._INSTANCES[fpath] = cls(
                 SPEC, upg, tvars=tvars, output_fname=output_fname)
             cls._INSTANCES[fpath].loadcfg(fpath, "suite definition")
+        return cls._INSTANCES[fpath]
+
+
+class RawSuiteModuleConfig(config):
+    """Raw module configuration."""
+    _INSTANCES = {}
+
+    @classmethod
+    def get_inst(cls, fpath, is_reload=False, tvars=None, output_fname=None):
+        """Return the default instance."""
+        if fpath not in cls._INSTANCES or is_reload:
+            if tvars is None:
+                tvars = []
+            cls._INSTANCES[fpath] = cls(
+                MODULE_SPEC, upg, tvars=tvars, output_fname=output_fname)
+            cls._INSTANCES[fpath].loadcfg(fpath, "suite module definition")
         return cls._INSTANCES[fpath]

--- a/lib/parsec/ToDo.txt
+++ b/lib/parsec/ToDo.txt
@@ -17,4 +17,3 @@ EXTENSION:
     - move inheritance from cylc suite config into parsec?
     - test repeated section and item add-or-override)
     - test site/user style add-or-override
-    - abort if compulsory items not found (currently prints a warning)

--- a/lib/parsec/config.py
+++ b/lib/parsec/config.py
@@ -20,7 +20,7 @@ import re
 from parsec import ParsecError
 from parsec.fileparse import parse
 from parsec.util import printcfg
-from parsec.validate import validate, check_compulsory, expand, validator
+from parsec.validate import validate, expand, validator
 from parsec.OrderedDict import OrderedDictWithDefaults
 from parsec.util import replicate, itemstr
 from parsec.upgrade import UpgradeError
@@ -67,23 +67,19 @@ class config(object):
         validate it against the spec, and if this is not the first load,
         combine/override with the existing loaded config."""
 
-        sparse = parse(rcfile, self.output_fname, self.tvars)
+        sparse, modules = parse(rcfile, self.output_fname, self.tvars)
+        self.modules = modules
 
         if self.upgrader is not None:
             self.upgrader(sparse, title)
 
-        self.validate(sparse)
+        validate(rcfile, sparse, self.spec)
 
         if not self.sparse:
             self.sparse = sparse
         else:
             # Already loaded, override with new items.
             replicate(self.sparse, sparse)
-
-    def validate(self, sparse):
-        "Validate sparse config against the file spec."
-        validate(sparse, self.spec)
-        check_compulsory(sparse, self.spec)
 
     def expand(self):
         "Flesh out undefined items with defaults, if any, from the spec."

--- a/lib/parsec/example/cfgspec.py
+++ b/lib/parsec/example/cfgspec.py
@@ -39,7 +39,6 @@ SPEC = {
             'string lists' :
             {
                 '__MANY__'   : vdr( vtype="string_list"  ),
-                'compulsory' : vdr( vtype="string_list", default=["jumped","over","the"], compulsory=True )
                 },
             'integer lists' : { '__MANY__' : vdr( vtype="integer_list", allow_zeroes=False ) },
             'float lists'   : { '__MANY__' : vdr( vtype="float_list", allow_zeroes=False   ) },

--- a/lib/parsec/example/site.rc
+++ b/lib/parsec/example/site.rc
@@ -59,7 +59,6 @@ brown fox # or lazy dog"""
         fou = "the, quick", "brown, fox",  # double quotes, internal commas
         fiv = 'the #quick', 'brown #fox' # single quotes, internal comments
         fiv = "the #quick", "brown #fox" # double quotes, internal comments
-        compulsory = "one", "two"
     [[integer lists]]
         foo = 1,2,3,3,3,4,4
         bar = 1,2,3*3,2*4, # multipliers and trailing comma

--- a/lib/parsec/example/user.rc
+++ b/lib/parsec/example/user.rc
@@ -59,7 +59,6 @@ brown fox # or lazy dog"""
         fou = "the, quick", "brown , fox",  # double quotes, internal commas
         fiv = 'the #quick', 'brown #fox' # single quotes, internal comments
         fiv = "the #quick", "brown #fox" # double quotes, internal comments
-        compulsory = "one", "two"
     [[integer lists]]
         foo = 1,2,3,3,3,4,4
         bar = 1,2,3*3,2*4, # multipliers and trailing comma


### PR DESCRIPTION
Close #1829 

## Method

(see temporary example in `dev/suites/module/`on this branch)

Parse suite.rc into a sparse dict as usual, but record any use of   `%import foo as BAR`.

Then, for each import statement:
  * find `foo.rc` in module search path `<suite-dir>/lib/cylc:$CYLC_MODULE_PATH`
  * parse it into a sparse dict via a cut-down suite config spec: parameters, graph with no cycling, runtime defs
    - with Jinja2 inputs set via a new main suite config section `[module interface][[BAR]]`

Then, before graph parsing, parameter expansion, and inheritance processing, incorporate each module sparse dict into the main suite sparse dict:
  * take module parameter definitions to main suite
  * take module runtime to main suite:
    - all module task names prefixed with `BAR__` and wrapped in a first-parent family `BAR`
    - explicit module `root` or `MODULE` family merged to family `BAR` inherited by all module tasks (module root should not affect main suite root; and note the module doesn't know the name it will be imported as) 
  * add the module graph - i.e. its internal dependencies - to any main suite graph that refers to the module family or tasks

## Notes

Suite and modules are parsed entirely separately (prior to graph parsing, parameter expansion, and inheritance of the combined result) so suite Jinja2 variables are not available in modules, or vice versa, except via the explicit module interface.

Module root does not affect suite root (it is converted to family `BAR`)

Suites can pass information into modules by:
  * Explicit Jinja2 "module interface" variables - if these are not supplied by the suite, module parsing will fail with undefined variable errors.  This allows the module to expose anything, including structure switches and parameter ranges or values, to the importing suite.
  * Settings defined under family `BAR` in the main suite, will be inherited by all module tasks.

Modules do not have:
  * any cycling-related config - they define pieces of workflow to be used in main suite cycling sections
  * internal queues, clock-triggers etc., event hooks - these should be configured in the main suite via the module family name (or module task names if necessary)

### Outstanding issues and/or limitations (that I'm aware of)?
  * one graph per module ... might we need module workflow variants, e.g. for cold-start vs cycling?
  * need to copy in module `bin/` (and any other files in the module source directory) at import time (module tasks may have their own task scripts...)
  * I haven't thought through how this will work with `rose suite-run` and module versioning - hopefully pretty straightforward.

@cylc/core - IMO this was easy to implement than I expected, and the result is better than I expected (e.g. in terms of a clean interface that avoids unwanted cross-pollination between module and suite settings), but it would be good to get your thoughts on this before I continue (not that there is is much more to do, if you agree with the implementation).
