### PR TITLE
Fix gcylc treeview (broken after 7.4.0).

### DIFF
--- a/lib/cylc/gui/updater_tree.py
+++ b/lib/cylc/gui/updater_tree.py
@@ -228,7 +228,7 @@ class TreeUpdater(threading.Thread):
                 tkeys = ['submitted_time_string', 'started_time_string',
                          'finished_time_string']
 
-                if id in self.fam_state_summary:
+                if is_fam:
                     # Family timing currently left empty.
                     for dt in tkeys:
                         t_info[dt] = ""


### PR DESCRIPTION
On master: view a cycling suite in gcylc treeview, click filter options, click and unclick 'runahead':
```
Traceback (most recent call last):
  File "/home/vagrant/cylc.git/lib/cylc/gui/app_gcylc.py", line 3133, in check_task_filter_buttons
    self.refresh_views()
  File "/home/vagrant/cylc.git/lib/cylc/gui/app_gcylc.py", line 3177, in refresh_views
    view.refresh()
  File "/home/vagrant/cylc.git/lib/cylc/gui/view_tree.py", line 274, in refresh
    self.t.update_gui()
  File "/home/vagrant/cylc.git/lib/cylc/gui/updater_tree.py", line 245, in update_gui
    t_info[dt] = summary[id][dt]
KeyError: 'submitted_time_string'
```