### PR TITLE
Optimise cycling objects

### DIFF
--- a/lib/cylc/cycling/__init__.py
+++ b/lib/cylc/cycling/__init__.py
@@ -428,7 +428,7 @@ class ExclusionBase(object):
         """creates an exclusions object that can contain integer points
         or integer sequences to be used as excluded points."""
         self.exclusion_sequences = []
-        self.exclusion_points = set()
+        self.exclusion_points = []
         self.exclusion_start_point = start_point
         self.exclusion_end_point = end_point
 

--- a/lib/cylc/cycling/__init__.py
+++ b/lib/cylc/cycling/__init__.py
@@ -102,6 +102,8 @@ class PointBase(object):
     _TYPE = None
     _TYPE_SORT_KEY = None
 
+    __slots__ = ('value')
+
     @abstractproperty
     def TYPE(self):
         return self._TYPE
@@ -200,6 +202,8 @@ class IntervalBase(object):
 
     _TYPE = None
     _TYPE_SORT_KEY = None
+
+    __slots__ = ('value')
 
     @abstractproperty
     def TYPE(self):
@@ -325,6 +329,8 @@ class SequenceBase(object):
     _TYPE = None
     _TYPE_SORT_KEY = None
 
+    __slots__ = ()
+
     @abstractproperty
     def TYPE(self):
         return self._TYPE
@@ -413,7 +419,10 @@ class SequenceBase(object):
 class ExclusionBase(object):
     """A collection of points or sequences that are treated in an
     exclusionary manner"""
+
     __metaclass__ = ABCMeta
+    __slots__ = ('exclusion_sequences', 'exclusion_points',
+                 'exclusion_start_point', 'exclusion_end_point')
 
     def __init__(self, start_point, end_point=None):
         """creates an exclusions object that can contain integer points

--- a/lib/cylc/cycling/integer.py
+++ b/lib/cylc/cycling/integer.py
@@ -250,8 +250,9 @@ class IntegerExclusions(ExclusionBase):
                 integer_point = get_point_from_expression(
                     point,
                     None,
-                    is_required=False)
-                self.exclusion_points.add(integer_point.standardise())
+                    is_required=False).standardise()
+                if integer_point not in self.exclusion_points:
+                    self.exclusion_points.append(integer_point)
             except PointParsingError:
                 # Try making an integer sequence
                 integer_exclusion_sequence = (IntegerSequence(

--- a/lib/cylc/cycling/integer.py
+++ b/lib/cylc/cycling/integer.py
@@ -121,6 +121,8 @@ class IntegerPoint(PointBase):
     TYPE = CYCLER_TYPE_INTEGER
     TYPE_SORT_KEY = CYCLER_TYPE_SORT_KEY_INTEGER
 
+    __slots__ = ('value')
+
     def __init__(self, value):
         if isinstance(value, int):
             value = str(value)
@@ -162,6 +164,8 @@ class IntegerInterval(IntervalBase):
 
     TYPE = CYCLER_TYPE_INTEGER
     TYPE_SORT_KEY = CYCLER_TYPE_SORT_KEY_INTEGER
+
+    __slots__ = ('value')
 
     @classmethod
     def from_integer(cls, integer):
@@ -230,6 +234,8 @@ class IntegerExclusions(ExclusionBase):
     """A collection of integer exclusion points, or sequences of
     integers that are treated in an exclusionary manner."""
 
+    __slots__ = ExclusionBase.__slots__
+
     def __init__(self, excl_points, start_point, end_point=None):
         """creates an exclusions object that can contain integer points
         or integer sequences to be used as excluded points."""
@@ -259,6 +265,9 @@ class IntegerSequence(SequenceBase):
 
     TYPE = CYCLER_TYPE_INTEGER
     TYPE_SORT_KEY = CYCLER_TYPE_SORT_KEY_INTEGER
+
+    __slots__ = ('p_context_start', 'p_context_stop', 'p_start', 'p_stop',
+                 'i_step', 'i_offset', 'exclusions')
 
     @classmethod
     def get_async_expr(cls, start_point=None):

--- a/lib/cylc/cycling/iso8601.py
+++ b/lib/cylc/cycling/iso8601.py
@@ -90,6 +90,8 @@ class ISO8601Point(PointBase):
     TYPE = CYCLER_TYPE_ISO8601
     TYPE_SORT_KEY = CYCLER_TYPE_SORT_KEY_ISO8601
 
+    __slots__ = ('value')
+
     @classmethod
     def from_nonstandard_string(cls, point_string):
         """Standardise a date-time string."""
@@ -173,6 +175,8 @@ class ISO8601Interval(IntervalBase):
     NULL_INTERVAL_STRING = "P0Y"
     TYPE = CYCLER_TYPE_ISO8601
     TYPE_SORT_KEY = CYCLER_TYPE_SORT_KEY_ISO8601
+
+    __slots__ = ('value')
 
     @classmethod
     def get_null(cls):
@@ -289,6 +293,9 @@ class ISO8601Exclusions(ExclusionBase):
     grouped exclusion sequences. The Python ``in`` and ``not in`` operators
     may be used on this object to determine if a point is in the collection
     of exclusion sequences."""
+
+    __slots__ = ExclusionBase.__slots__ + ('p_iso_exclusions',)
+
     def __init__(self, excl_points, start_point, end_point=None):
         super(ISO8601Exclusions, self).__init__(start_point, end_point)
         self.p_iso_exclusions = set()
@@ -318,6 +325,12 @@ class ISO8601Sequence(SequenceBase):
     TYPE = CYCLER_TYPE_ISO8601
     TYPE_SORT_KEY = CYCLER_TYPE_SORT_KEY_ISO8601
     _MAX_CACHED_POINTS = 100
+
+    __slots__ = ('dep_section', 'context_start_point', 'context_end_point',
+                 'offset', '_cached_first_point_values',
+                 '_cached_next_point_values', '_cached_valid_point_booleans',
+                 '_cached_recent_valid_points', 'spec', 'abbrev_util',
+                 'recurrence', 'exclusions', 'step', 'value')
 
     @classmethod
     def get_async_expr(cls, start_point=None):
@@ -364,16 +377,16 @@ class ISO8601Sequence(SequenceBase):
 
         # Determine the exclusion start point and end point
         try:
-            self.exclusion_start_point = ISO8601Point.from_nonstandard_string(
+            exclusion_start_point = ISO8601Point.from_nonstandard_string(
                 str(self.recurrence.start_point))
         except ValueError:
-            self.exclusion_start_point = self.context_start_point
+            exclusion_start_point = self.context_start_point
 
         try:
-            self.exclusion_end_point = ISO8601Point.from_nonstandard_string(
+            exclusion_end_point = ISO8601Point.from_nonstandard_string(
                 str(self.recurrence.end_point))
         except ValueError:
-            self.exclusion_end_point = self.context_end_point
+            exclusion_end_point = self.context_end_point
 
         self.exclusions = []
 
@@ -382,8 +395,8 @@ class ISO8601Sequence(SequenceBase):
             try:
                 self.exclusions = ISO8601Exclusions(
                     excl_points,
-                    self.exclusion_start_point,
-                    self.exclusion_end_point)
+                    exclusion_start_point,
+                    exclusion_end_point)
             except AttributeError:
                 pass
 

--- a/lib/cylc/cycling/iso8601.py
+++ b/lib/cylc/cycling/iso8601.py
@@ -298,7 +298,7 @@ class ISO8601Exclusions(ExclusionBase):
 
     def __init__(self, excl_points, start_point, end_point=None):
         super(ISO8601Exclusions, self).__init__(start_point, end_point)
-        self.p_iso_exclusions = set()
+        self.p_iso_exclusions = []
         self.build_exclusions(excl_points)
 
     def build_exclusions(self, excl_points):
@@ -307,8 +307,9 @@ class ISO8601Exclusions(ExclusionBase):
                 # Try making an ISO8601Point
                 exclusion_point = ISO8601Point.from_nonstandard_string(
                     str(point)) if point else None
-                self.exclusion_points.add(exclusion_point)
-                self.p_iso_exclusions.add(str(exclusion_point))
+                if exclusion_point not in self.exclusion_points:
+                    self.exclusion_points.append(exclusion_point)
+                    self.p_iso_exclusions.append(str(exclusion_point))
             except (AttributeError, TypeError, ValueError):
                 # Try making an ISO8601Sequence
                 exclusion = ISO8601Sequence(point, self.exclusion_start_point,

--- a/lib/cylc/cycling/iso8601.py
+++ b/lib/cylc/cycling/iso8601.py
@@ -392,7 +392,7 @@ class ISO8601Sequence(SequenceBase):
         self.exclusions = []
 
         # Creating an exclusions object instead
-        if excl_points is not None:
+        if excl_points:
             try:
                 self.exclusions = ISO8601Exclusions(
                     excl_points,

--- a/lib/cylc/cycling/iso8601.py
+++ b/lib/cylc/cycling/iso8601.py
@@ -489,9 +489,11 @@ class ISO8601Sequence(SequenceBase):
 
         for recurrence_iso_point in self.recurrence:
             # Is recurrence point greater than aribitrary point?
-            if (recurrence_iso_point > p_iso_point or
-                    (recurrence_iso_point in
-                     self.exclusions.p_iso_exclusions)):
+            if (
+                    recurrence_iso_point > p_iso_point or
+                    (self.exclusions and
+                     recurrence_iso_point in self.exclusions.p_iso_exclusions)
+            ):
                 break
             prev_iso_point = recurrence_iso_point
         if prev_iso_point is None:

--- a/lib/cylc/cycling/iso8601.py
+++ b/lib/cylc/cycling/iso8601.py
@@ -369,8 +369,8 @@ class ISO8601Sequence(SequenceBase):
 
         self.spec = dep_section
         self.abbrev_util = CylcTimeParser(self.context_start_point,
-                                         self.context_end_point,
-                                         SuiteSpecifics.iso8601_parsers)
+                                          self.context_end_point,
+                                          SuiteSpecifics.iso8601_parsers)
         # Parse_recurrence returns an isodatetime TimeRecurrence object
         # and a list of exclusion strings.
         self.recurrence, excl_points = self.abbrev_util.parse_recurrence(
@@ -711,7 +711,7 @@ def init(num_expanded_year_digits=0, custom_dump_format=None, time_zone=None,
     )
 
     SuiteSpecifics.iso8601_parsers = CylcTimeParser.initiate_parsers(
-        dump_format = SuiteSpecifics.DUMP_FORMAT,
+        dump_format=SuiteSpecifics.DUMP_FORMAT,
         num_expanded_year_digits=num_expanded_year_digits,
         assumed_time_zone=SuiteSpecifics.ASSUMED_TIME_ZONE
     )

--- a/lib/cylc/cycling/iso8601.py
+++ b/lib/cylc/cycling/iso8601.py
@@ -54,6 +54,7 @@ class SuiteSpecifics(object):
     abbrev_util = None
     interval_parser = None
     point_parser = None
+    iso8601_parsers = None
 
 
 def memoize(function):
@@ -353,12 +354,9 @@ class ISO8601Sequence(SequenceBase):
         self._cached_recent_valid_points = []
 
         self.spec = dep_section
-        self.abbrev_util = CylcTimeParser(
-            self.context_start_point, self.context_end_point,
-            num_expanded_year_digits=SuiteSpecifics.NUM_EXPANDED_YEAR_DIGITS,
-            dump_format=SuiteSpecifics.DUMP_FORMAT,
-            assumed_time_zone=SuiteSpecifics.ASSUMED_TIME_ZONE
-        )
+        self.abbrev_util = CylcTimeParser(self.context_start_point,
+                                         self.context_end_point,
+                                         SuiteSpecifics.iso8601_parsers)
         # Parse_recurrence returns an isodatetime TimeRecurrence object
         # and a list of exclusion strings.
         self.recurrence, excl_points = self.abbrev_util.parse_recurrence(
@@ -695,11 +693,15 @@ def init(num_expanded_year_digits=0, custom_dump_format=None, time_zone=None,
         dump_format=SuiteSpecifics.DUMP_FORMAT,
         assumed_time_zone=time_zone_hours_minutes
     )
-    SuiteSpecifics.abbrev_util = CylcTimeParser(
-        None, None,
-        num_expanded_year_digits=SuiteSpecifics.NUM_EXPANDED_YEAR_DIGITS,
-        dump_format=SuiteSpecifics.DUMP_FORMAT,
+
+    SuiteSpecifics.iso8601_parsers = CylcTimeParser.initiate_parsers(
+        dump_format = SuiteSpecifics.DUMP_FORMAT,
+        num_expanded_year_digits=num_expanded_year_digits,
         assumed_time_zone=SuiteSpecifics.ASSUMED_TIME_ZONE
+    )
+
+    SuiteSpecifics.abbrev_util = CylcTimeParser(
+        None, None, SuiteSpecifics.iso8601_parsers
     )
 
 

--- a/lib/cylc/time_parser.py
+++ b/lib/cylc/time_parser.py
@@ -112,6 +112,9 @@ class CylcTimeParser(object):
                                re.compile("W-\dT"),
                                re.compile("W-\d")]}
 
+    __slots__ = ('timepoint_parser', 'duration_parser', 'recurrence_parser',
+                 'context_start_point', 'context_end_point')
+
     def __init__(self, context_start_point, context_end_point, parsers):
         if context_start_point is not None:
             context_start_point = str(context_start_point)

--- a/lib/cylc/time_parser.py
+++ b/lib/cylc/time_parser.py
@@ -162,7 +162,7 @@ class CylcTimeParser(object):
         return (timepoint_parser,
                 isodatetime.parsers.DurationParser(),
                 isodatetime.parsers.TimeRecurrenceParser()
-               )
+                )
 
     def parse_interval(self, expr):
         """Parse an interval (duration) in full ISO date/time format."""

--- a/lib/cylc/time_parser.py
+++ b/lib/cylc/time_parser.py
@@ -74,31 +74,35 @@ class CylcTimeParser(object):
     """
 
     POINT_INVALID_FOR_CYLC_REGEXES = [
-        (r"^\d\d$", ("2 digit centuries not allowed. " +
-                     "Did you mean T-digit-digit e.g. 'T00'?"))
+        (re.compile(r"^\d\d$"),
+         ("2 digit centuries not allowed. Did you mean T-digit-digit e.g. "
+          "'T00'?"))
     ]
 
     RECURRENCE_FORMAT_REGEXES = [
-        (r"^(?P<start>[^PR/][^/]*)$", 3),
-        (r"^R(?P<reps>\d+)/(?P<start>[^PR/][^/]*)/(?P<end>[^PR/][^/]*)$", 1),
-        (r"^(?P<start>[^PR/][^/]*)/(?P<intv>P[^/]*)/?$", 3),
-        (r"^(?P<intv>P[^/]*)$", 3),
-        (r"^(?P<intv>P[^/]*)/(?P<end>[^PR/][^/]*)$", 4),
-        (r"^R(?P<reps>\d+)?/(?P<start>[^PR/][^/]*)/?$", 3),
-        (r"^R(?P<reps>\d+)?/(?P<start>[^PR/][^/]*)/(?P<intv>P[^/]*)$", 3),
-        (r"^R(?P<reps>\d+)?/(?P<start>)/(?P<intv>P[^/]*)$", 3),
-        (r"^R(?P<reps>\d+)?/(?P<intv>P[^/]*)/(?P<end>[^PR/][^/]*)$", 4),
-        (r"^R(?P<reps>\d+)?/(?P<intv>P[^/]*)/?$", 4),
-        (r"^R(?P<reps>\d+)?//(?P<end>[^PR/][^/]*)$", 4),
-        (r"^R(?P<reps>1)/?(?P<start>$)", 3),
-        (r"^R(?P<reps>1)//(?P<end>[^PR/][^/]*)$", 4)
+        (re.compile(r"^(?P<start>[^PR/][^/]*)$"), 3),
+        (re.compile(r"^R(?P<reps>\d+)/(?P<start>[^PR/][^/]*)/(?P<end>[^PR/]"
+                    "[^/]*)$"), 1),
+        (re.compile(r"^(?P<start>[^PR/][^/]*)/(?P<intv>P[^/]*)/?$"), 3),
+        (re.compile(r"^(?P<intv>P[^/]*)$"), 3),
+        (re.compile(r"^(?P<intv>P[^/]*)/(?P<end>[^PR/][^/]*)$"), 4),
+        (re.compile(r"^R(?P<reps>\d+)?/(?P<start>[^PR/][^/]*)/?$"), 3),
+        (re.compile(r"^R(?P<reps>\d+)?/(?P<start>[^PR/][^/]*)/(?P<intv>P[^/]"
+                    "*)$"), 3),
+        (re.compile(r"^R(?P<reps>\d+)?/(?P<start>)/(?P<intv>P[^/]*)$"), 3),
+        (re.compile(r"^R(?P<reps>\d+)?/(?P<intv>P[^/]*)/(?P<end>[^PR/][^/]*)"
+                    "$"), 4),
+        (re.compile(r"^R(?P<reps>\d+)?/(?P<intv>P[^/]*)/?$"), 4),
+        (re.compile(r"^R(?P<reps>\d+)?//(?P<end>[^PR/][^/]*)$"), 4),
+        (re.compile(r"^R(?P<reps>1)/?(?P<start>$)"), 3),
+        (re.compile(r"^R(?P<reps>1)//(?P<end>[^PR/][^/]*)$"), 4)
     ]
 
-    CHAIN_REGEX = '((?:[+-P]|[\dT])[\d\w]*)'
+    CHAIN_REGEX = re.compile('((?:[+-P]|[\dT])[\d\w]*)')
 
-    MIN_REGEX = 'min\(([^\)]+)\)'
+    MIN_REGEX = re.compile('min\(([^\)]+)\)')
 
-    OFFSET_REGEX = r"(?P<sign>[+-])(?P<intv>P.+)$"
+    OFFSET_REGEX = re.compile(r"(?P<sign>[+-])(?P<intv>P.+)$")
 
     TRUNCATED_REC_MAP = {"---": [re.compile("^\d\dT")],
                          "--": [re.compile("^\d\d\d\dT")],
@@ -116,14 +120,6 @@ class CylcTimeParser(object):
         self.timepoint_parser, self.duration_parser, self.recurrence_parser = (
             parsers)
 
-        self._recur_format_recs = []
-        for regex, format_num in self.RECURRENCE_FORMAT_REGEXES:
-            self._recur_format_recs.append((re.compile(regex), format_num))
-        self._offset_rec = re.compile(self.OFFSET_REGEX)
-        self._invalid_point_recs = [
-            (re.compile(regex), msg) for (regex, msg) in
-            self.POINT_INVALID_FOR_CYLC_REGEXES
-        ]
         if isinstance(context_start_point, basestring):
             context_start_point, _ = self._get_point_from_expression(
                 context_start_point, None)
@@ -205,7 +201,7 @@ class CylcTimeParser(object):
             context_start_point = self.context_start_point
         if context_end_point is None:
             context_end_point = self.context_end_point
-        for rec_object, format_num in self._recur_format_recs:
+        for rec_object, format_num in self.RECURRENCE_FORMAT_REGEXES:
             result = rec_object.search(expression)
             if not result:
                 continue
@@ -359,14 +355,14 @@ class CylcTimeParser(object):
         if expr.startswith("min("):
             expr = self._get_min_from_expression(expr, context)
 
-        if self._offset_rec.search(expr):
-            chain_expr = re.findall(self.CHAIN_REGEX, expr)
+        if self.OFFSET_REGEX.search(expr):
+            chain_expr = self.CHAIN_REGEX.findall(expr)
             expr = ""
             for item in chain_expr:
                 if "P" not in item:
                     expr += item
                     continue
-                split_expr = self._offset_rec.split(item)
+                split_expr = self.OFFSET_REGEX.split(item)
                 expr += split_expr.pop(0)
                 if split_expr[1] == "+":
                     split_expr.pop(1)
@@ -380,7 +376,7 @@ class CylcTimeParser(object):
                     expr_offset = expr_offset + expr_offset_item
         if not expr and allow_truncated:
             return context.copy(), expr_offset
-        for invalid_rec, msg in self._invalid_point_recs:
+        for invalid_rec, msg in self.POINT_INVALID_FOR_CYLC_REGEXES:
             if invalid_rec.search(expr):
                 raise CylcTimeSyntaxError("'%s': %s" % (expr, msg))
         expr_to_parse = expr

--- a/lib/cylc/time_parser.py
+++ b/lib/cylc/time_parser.py
@@ -108,28 +108,14 @@ class CylcTimeParser(object):
                                re.compile("W-\dT"),
                                re.compile("W-\d")]}
 
-    def __init__(self, context_start_point,
-                 context_end_point, num_expanded_year_digits=0,
-                 dump_format=None,
-                 assumed_time_zone=None):
+    def __init__(self, context_start_point, context_end_point, parsers):
         if context_start_point is not None:
             context_start_point = str(context_start_point)
         if context_end_point is not None:
             context_end_point = str(context_end_point)
-        self.num_expanded_year_digits = num_expanded_year_digits
-        if dump_format is None:
-            if num_expanded_year_digits:
-                dump_format = u"+XCCYYMMDDThhmmZ"
-            else:
-                dump_format = "CCYYMMDDThhmmZ"
+        self.timepoint_parser, self.duration_parser, self.recurrence_parser = (
+            parsers)
 
-        self.timepoint_parser = isodatetime.parsers.TimePointParser(
-            allow_only_basic=False,  # TODO - Ben: why was this set True
-            allow_truncated=True,
-            num_expanded_year_digits=num_expanded_year_digits,
-            dump_format=dump_format,
-            assumed_time_zone=assumed_time_zone
-        )
         self._recur_format_recs = []
         for regex, format_num in self.RECURRENCE_FORMAT_REGEXES:
             self._recur_format_recs.append((re.compile(regex), format_num))
@@ -139,16 +125,45 @@ class CylcTimeParser(object):
             self.POINT_INVALID_FOR_CYLC_REGEXES
         ]
         if isinstance(context_start_point, basestring):
-            context_start_point, offset = self._get_point_from_expression(
+            context_start_point, _ = self._get_point_from_expression(
                 context_start_point, None)
         self.context_start_point = context_start_point
         if isinstance(context_end_point, basestring):
-            context_end_point, offset = self._get_point_from_expression(
+            context_end_point, _ = self._get_point_from_expression(
                 context_end_point, None)
         self.context_end_point = context_end_point
-        self.duration_parser = isodatetime.parsers.DurationParser()
-        self.recurrence_parser = isodatetime.parsers.TimeRecurrenceParser(
-            timepoint_parser=self.timepoint_parser)
+
+    @staticmethod
+    def initiate_parsers(num_expanded_year_digits=0, dump_format=None,
+                         assumed_time_zone=None):
+        """Initiate datetime parsers required to initiate this class.
+
+        Returns:
+            tuple: (timepoint_parser, duration_parser, time_recurrence_parser)
+                - timepoint_parser - isodatetime.parsers.TimePointParser obj.
+                - duration_parser - isodatetime.parsers.DurationParser obj.
+                - time_recurrence_parser -
+                  isodatetime.parsers.TimeRecurrenceParser obj
+        """
+
+        if dump_format is None:
+            if num_expanded_year_digits:
+                dump_format = u"+XCCYYMMDDThhmmZ"
+            else:
+                dump_format = "CCYYMMDDThhmmZ"
+
+        timepoint_parser = isodatetime.parsers.TimePointParser(
+            allow_only_basic=False,
+            allow_truncated=True,
+            num_expanded_year_digits=num_expanded_year_digits,
+            dump_format=dump_format,
+            assumed_time_zone=assumed_time_zone
+        )
+
+        return (timepoint_parser,
+                isodatetime.parsers.DurationParser(),
+                isodatetime.parsers.TimeRecurrenceParser()
+               )
 
     def parse_interval(self, expr):
         """Parse an interval (duration) in full ISO date/time format."""
@@ -404,12 +419,16 @@ class TestRecurrenceSuite(unittest.TestCase):
         self._parsers = {
             0: CylcTimeParser(
                 self._start_point, self._end_point,
-                assumed_time_zone=UTC_UTC_OFFSET_HOURS_MINUTES
+                CylcTimeParser.initiate_parsers(
+                    assumed_time_zone=UTC_UTC_OFFSET_HOURS_MINUTES
+                )
             ),
             2: CylcTimeParser(
                 self._start_point, self._end_point,
-                num_expanded_year_digits=2,
-                assumed_time_zone=UTC_UTC_OFFSET_HOURS_MINUTES
+                CylcTimeParser.initiate_parsers(
+                    num_expanded_year_digits=2,
+                    assumed_time_zone=UTC_UTC_OFFSET_HOURS_MINUTES
+                )
             )
         }
 


### PR DESCRIPTION
Efficiency changes which reduce the memory and CPU impact of cycling objects:
 - Avoid creating multiple parser instances.
 - Move regex compilation out of the `__init__` method.
 - Slot classes.
 - Minor fiddling with exclusions objects (@dvalters could you check these changes).

In combination with slotting of the isodatetime library (https://github.com/metomi/isodatetime/pull/74) this reduces the resource requirements of suites with multiple sequences defined in the graphing.

The following results were obtained running `cylc validate` over the following suite varying the value of `sequences`:

```
[scheduling]
    initial cycle point = 2000
    spawn to max active cycle points = true
    max active cycle points = 5
    [[dependencies]]
{% for seq_no in range(sequences | default(10) | int) %}
    {% set minutes = seq_no % 60 %}
    {% set hours = ((seq_no / 60) | int) % 60 %}
        [[[R{{cycles | default(1)}}/+PT{{hours}}H{{minutes}}M]]]
            graph = task
{% endfor %}
```

![memory](https://user-images.githubusercontent.com/16705946/26974365-e2dfb56c-4d12-11e7-979f-2c0ac2f15d8c.jpeg)
![cpu-time](https://user-images.githubusercontent.com/16705946/26974364-e2dd39b8-4d12-11e7-97ef-99810a090541.jpeg)

I'll include this suite in the standard profile-battery tests in a future pull.
The impact on the runtime of the same suite:

![memory](https://user-images.githubusercontent.com/16705946/26974551-c4cea442-4d13-11e7-8376-b76fd42d4d4c.jpeg)
![cpu-time](https://user-images.githubusercontent.com/16705946/26974552-c4cf0748-4d13-11e7-92fe-b5571b03d585.jpeg)

The complex suite shows a small reduction in memory.