### PR TITLE
cylc gui: Fix traceback on no selected rows

### DIFF
--- a/lib/cylc/gui/updater_dot.py
+++ b/lib/cylc/gui/updater_dot.py
@@ -312,11 +312,13 @@ class DotUpdater(threading.Thread):
 
         """
         self.selected_rows = []
-        _, selected_paths = self.led_treeview.get_selection(
-        ).get_selected_rows()
-        model = self.led_treeview.get_model()
-        for path in selected_paths:
-            self.selected_rows.append(model.get_value(model.get_iter(path), 0))
+        selection = self.led_treeview.get_selection()
+        if selection:
+            _, selected_paths = selection.get_selected_rows()
+            model = self.led_treeview.get_model()
+            for path in selected_paths:
+                self.selected_rows.append(
+                    model.get_value(model.get_iter(path), 0))
 
     @staticmethod
     def _reselect_row(model, _, iter_, (selection, selected_rows,)):
@@ -338,9 +340,10 @@ class DotUpdater(threading.Thread):
 
         """
         selection = self.led_treeview.get_selection()
-        selection.unselect_all()
-        model = self.led_treeview.get_model()
-        model.foreach(self._reselect_row, (selection, self.selected_rows,))
+        if selection:
+            selection.unselect_all()
+            model = self.led_treeview.get_model()
+            model.foreach(self._reselect_row, (selection, self.selected_rows,))
 
     def ledview_widgets(self):
         self._get_expanded_rows()  # Make a note of expanded rows.

--- a/lib/cylc/gui/updater_dot.py
+++ b/lib/cylc/gui/updater_dot.py
@@ -314,7 +314,7 @@ class DotUpdater(threading.Thread):
         self.selected_rows = []
         selection = self.led_treeview.get_selection()
         if selection:
-            _, selected_paths = selection.get_selected_rows()
+            selected_paths = selection.get_selected_rows()[1]
             model = self.led_treeview.get_model()
             for path in selected_paths:
                 self.selected_rows.append(

--- a/lib/cylc/gui/view_tree.py
+++ b/lib/cylc/gui/view_tree.py
@@ -104,7 +104,8 @@ class ControlTree(object):
         # multiple selection
         ts = self.ttreeview.get_selection()
         self.ttreeview.set_rubber_banding(True)
-        ts.set_mode(gtk.SELECTION_MULTIPLE)
+        if ts:
+            ts.set_mode(gtk.SELECTION_MULTIPLE)
 
         self.ttreeview.connect(
             'button_press_event', self.on_treeview_button_pressed)
@@ -396,14 +397,17 @@ class TreeViewTaskExtractor(object):
     def get_selected_rows(self):
         """Returns a list of rows that are currently selected in the provided
         treeview. Rows are returned in the form (path, col1, col2)"""
-        model, rows = self.treeview.get_selection().get_selected_rows()
-        rows.sort()
         ret = []
-        for row in rows:
-            _iter = model.get_iter(row)
-            path = model.get_path(_iter)
-            ret.append((
-                path, model.get_value(_iter, 0), model.get_value(_iter, 1)))
+        selection = self.treeview.get_selection()
+        if selection:
+            model, rows = selection.get_selected_rows()
+            rows.sort()
+            for row in rows:
+                _iter = model.get_iter(row)
+                path = model.get_path(_iter)
+                ret.append((
+                    path, model.get_value(_iter, 0),
+                    model.get_value(_iter, 1)))
         return ret
 
     def _make_tree_from_rows(self, rows):


### PR DESCRIPTION
cylc gui can sometimes throw the following traceback when initially swapping view to the text view:
```
Traceback (most recent call last):
  File "/net/home/h03/fcm/cylc-7.3.0/lib/cylc/gui/updater_dot.py", line 482, in update_gui
    self.ledview_widgets()
  File "/net/home/h03/fcm/cylc-7.3.0/lib/cylc/gui/updater_dot.py", line 347, in ledview_widgets
    self._get_selected_rows()  # Make a note of selected rows.
  File "/net/home/h03/fcm/cylc-7.3.0/lib/cylc/gui/updater_dot.py", line 315, in _get_selected_rows
    _, selected_paths = self.led_treeview.get_selection(
AttributeError: 'NoneType' object has no attribute 'get_selected_rows'
```
i.e. when there are no selected rows.

This fixes `_get_selected_rows()` and `_set_selected_rows()` so they won't try and do anything if there are no rows to work with. 