### PR TITLE
graph parser: fix suite state polling regex

### DIFF
--- a/lib/cylc/graph_parser.py
+++ b/lib/cylc/graph_parser.py
@@ -19,6 +19,7 @@
 import re
 import unittest
 from cylc.param_expand import GraphExpander
+from cylc.task_id import TaskID
 
 """Module for parsing cylc graph strings."""
 
@@ -95,36 +96,42 @@ class GraphParser(object):
     LEN_FAM_TRIG_EXT_ALL = len(FAM_TRIG_EXT_ALL)
     LEN_FAM_TRIG_EXT_ANY = len(FAM_TRIG_EXT_ANY)
 
+    _RE_NODE = r'(?:!)?' + TaskID.NAME_RE
+    _RE_PARAMS = r'<[\w,=\-+]+>'
+    _RE_OFFSET = r'\[[\w\-\+\^:]+\]'
+    _RE_TRIG = r':[\w\-]+'
+
     # Match fully qualified parameterized single nodes.
     REC_NODE_FULL = re.compile(r'''
         (
-        (?:(?:!)?\w[\w\-+%@]*)  # node name
-        (?:<[\w,=\-+]+>)?       # optional parameter list
-        (?:\[[\w\-\+\^:]+\])?   # optional cycle point offset
-        (?::[\w\-]+)?           # optional trigger type
+        (?:''' + _RE_NODE + r''')    # node name
+        (?:''' + _RE_PARAMS + r''')? # optional parameter list
+        (?:''' + _RE_OFFSET + r''')? # optional cycle point offset
+        (?:''' + _RE_TRIG + r''')?   # optional trigger type
         )
     ''', re.X)           # end of string
 
     # Extract node info from a left-side expression, after parameter expansion.
     REC_NODES = re.compile(r'''
-        ((?:!)?\w[\w\-+%@]*)  # node name
-        (\[[\w\-\+\^:]+\])?   # optional cycle point offset
-        (:[\w\-]+)?           # optional trigger type
+        (''' + _RE_NODE + r''')      # node name
+        (''' + _RE_OFFSET + r''')?   # optional cycle point offset
+        (''' + _RE_TRIG + r''')?     # optional trigger type
     ''', re.X)
 
     REC_TRIG_QUAL = re.compile(r'''
-        (?:(?:!)?\w[\w\-+%@]*)   # node name (ignore)
-        (:[\w\-]+)?              # optional trigger type
+        (?:''' + _RE_NODE + r''')    # node name (ignore)
+        (''' + _RE_TRIG + r''')?     # optional trigger type
     ''', re.X)
 
     REC_COMMENT = re.compile('#.*$')
 
     # Detect presence of expansion parameters in a graph line.
-    REC_PARAMETERS = re.compile(r'<[\w,=\-+]+>')
+    REC_PARAMS = re.compile(_RE_PARAMS)
 
     # Detect and extract suite state polling task info.
     REC_SUITE_STATE = re.compile(
-        r'(\w+)(<([\w\.\-/]+)::(\w[\w\-+%@]*)(:\w+)?>)')
+        r'(' + TaskID.NAME_RE + ')(<([\w\.\-/]+)::(' + TaskID.NAME_RE + ')(' +
+        _RE_TRIG + ')?>)')
 
     def __init__(self, family_map=None, parameters=None):
         """Initializing the graph string parser.
@@ -236,7 +243,7 @@ class GraphParser(object):
         line_set = set()
         graph_expander = GraphExpander(self.parameters)
         for line in full_lines:
-            if not self.__class__.REC_PARAMETERS.search(line):
+            if not self.__class__.REC_PARAMS.search(line):
                 line_set.add(line)
                 continue
             for l in graph_expander.expand(line):

--- a/lib/cylc/graph_parser.py
+++ b/lib/cylc/graph_parser.py
@@ -123,7 +123,8 @@ class GraphParser(object):
     REC_PARAMETERS = re.compile(r'<[\w,=\-+]+>')
 
     # Detect and extract suite state polling task info.
-    REC_SUITE_STATE = re.compile('(\w+)(<([\w\.\-/]+)::(\w+)(:\w+)?>)')
+    REC_SUITE_STATE = re.compile(
+        r'(\w+)(<([\w\.\-/]+)::(\w[\w\-+%@]*)(:\w+)?>)')
 
     def __init__(self, family_map=None, parameters=None):
         """Initializing the graph string parser.

--- a/tests/suite-state/00-polling.t
+++ b/tests/suite-state/00-polling.t
@@ -52,8 +52,8 @@ __END__
 # check auto-generated task script for lgood
 cylc get-config --set UPSTREAM=$UPSTREAM -i '[runtime][lgood]script' $SUITE_NAME > lgood.script
 cmp_ok lgood.script << __END__
-echo cylc suite-state --task=good --point=\$CYLC_TASK_CYCLE_POINT --status=succeed --interval=2 --max-polls=20 $UPSTREAM
-cylc suite-state --task=good --point=\$CYLC_TASK_CYCLE_POINT --status=succeed --interval=2 --max-polls=20 $UPSTREAM
+echo cylc suite-state --task=good-stuff --point=\$CYLC_TASK_CYCLE_POINT --status=succeed --interval=2 --max-polls=20 $UPSTREAM
+cylc suite-state --task=good-stuff --point=\$CYLC_TASK_CYCLE_POINT --status=succeed --interval=2 --max-polls=20 $UPSTREAM
 __END__
 
 #-------------------------------------------------------------------------------

--- a/tests/suite-state/00-polling.t
+++ b/tests/suite-state/00-polling.t
@@ -49,9 +49,9 @@ echo cylc suite-state --task=bad --point=\$CYLC_TASK_CYCLE_POINT --status=fail -
 cylc suite-state --task=bad --point=\$CYLC_TASK_CYCLE_POINT --status=fail --interval=2 --max-polls=20 $UPSTREAM
 __END__
 
-# check auto-generated task script for lgood
-cylc get-config --set UPSTREAM=$UPSTREAM -i '[runtime][lgood]script' $SUITE_NAME > lgood.script
-cmp_ok lgood.script << __END__
+# check auto-generated task script for l-good
+cylc get-config --set UPSTREAM=$UPSTREAM -i '[runtime][l-good]script' $SUITE_NAME > l-good.script
+cmp_ok l-good.script << __END__
 echo cylc suite-state --task=good-stuff --point=\$CYLC_TASK_CYCLE_POINT --status=succeed --interval=2 --max-polls=20 $UPSTREAM
 cylc suite-state --task=good-stuff --point=\$CYLC_TASK_CYCLE_POINT --status=succeed --interval=2 --max-polls=20 $UPSTREAM
 __END__

--- a/tests/suite-state/01-polling.t
+++ b/tests/suite-state/01-polling.t
@@ -48,8 +48,8 @@ __END__
 # check auto-generated task script for lgood
 cylc get-config --set UPSTREAM=$UPSTREAM -i '[runtime][lgood]script' $SUITE_NAME > lgood.script
 cmp_ok lgood.script << __END__
-echo cylc suite-state --task=good --point=\$CYLC_TASK_CYCLE_POINT --status=succeed --interval=2 --max-polls=20 $UPSTREAM
-cylc suite-state --task=good --point=\$CYLC_TASK_CYCLE_POINT --status=succeed --interval=2 --max-polls=20 $UPSTREAM
+echo cylc suite-state --task=good-stuff --point=\$CYLC_TASK_CYCLE_POINT --status=succeed --interval=2 --max-polls=20 $UPSTREAM
+cylc suite-state --task=good-stuff --point=\$CYLC_TASK_CYCLE_POINT --status=succeed --interval=2 --max-polls=20 $UPSTREAM
 __END__
 
 #-------------------------------------------------------------------------------

--- a/tests/suite-state/01-polling.t
+++ b/tests/suite-state/01-polling.t
@@ -45,9 +45,9 @@ echo cylc suite-state --task=bad --point=\$CYLC_TASK_CYCLE_POINT --status=fail -
 cylc suite-state --task=bad --point=\$CYLC_TASK_CYCLE_POINT --status=fail --interval=2 --max-polls=20 $UPSTREAM
 __END__
 
-# check auto-generated task script for lgood
-cylc get-config --set UPSTREAM=$UPSTREAM -i '[runtime][lgood]script' $SUITE_NAME > lgood.script
-cmp_ok lgood.script << __END__
+# check auto-generated task script for l-good
+cylc get-config --set UPSTREAM=$UPSTREAM -i '[runtime][l-good]script' $SUITE_NAME > l-good.script
+cmp_ok l-good.script << __END__
 echo cylc suite-state --task=good-stuff --point=\$CYLC_TASK_CYCLE_POINT --status=succeed --interval=2 --max-polls=20 $UPSTREAM
 cylc suite-state --task=good-stuff --point=\$CYLC_TASK_CYCLE_POINT --status=succeed --interval=2 --max-polls=20 $UPSTREAM
 __END__

--- a/tests/suite-state/polling/reference.log
+++ b/tests/suite-state/polling/reference.log
@@ -1,4 +1,4 @@
 2013/10/04 16:54:07 INFO - Initial point: 1
 2013/10/04 16:54:07 INFO - Final point: 1
 2013/10/04 16:54:07 INFO - [lbad.1] -triggered off []
-2013/10/04 16:54:07 INFO - [lgood.1] -triggered off []
+2013/10/04 16:54:07 INFO - [l-good.1] -triggered off []

--- a/tests/suite-state/polling/suite.rc
+++ b/tests/suite-state/polling/suite.rc
@@ -6,7 +6,7 @@ title = "polls for success and failure tasks in another suite"
         live mode suite timeout = PT1M
 [scheduling]
     [[dependencies]]
-        graph = "lgood<{{UPSTREAM}}::good> & lbad<{{UPSTREAM}}::bad:fail>"
+        graph = "lgood<{{UPSTREAM}}::good-stuff> & lbad<{{UPSTREAM}}::bad:fail>"
 [runtime]
     [[lgood,lbad]]
         [[[suite state polling]]]

--- a/tests/suite-state/polling/suite.rc
+++ b/tests/suite-state/polling/suite.rc
@@ -6,9 +6,9 @@ title = "polls for success and failure tasks in another suite"
         live mode suite timeout = PT1M
 [scheduling]
     [[dependencies]]
-        graph = "lgood<{{UPSTREAM}}::good-stuff> & lbad<{{UPSTREAM}}::bad:fail>"
+        graph = "l-good<{{UPSTREAM}}::good-stuff> & lbad<{{UPSTREAM}}::bad:fail>"
 [runtime]
-    [[lgood,lbad]]
+    [[l-good,lbad]]
         [[[suite state polling]]]
             interval = PT2S
             max-polls = 20

--- a/tests/suite-state/upstream/suite.rc
+++ b/tests/suite-state/upstream/suite.rc
@@ -5,11 +5,11 @@ title = "One task takes 20 sec to succeed, another to fail."
 [scheduling]
     [[dependencies]]
         graph = """
-             good & bad
+             good-stuff & bad
           bad:fail => !bad
                 """
 [runtime]
-    [[good]]
+    [[good-stuff]]
         script = "sleep 20"
     [[bad]]
         script = "sleep 20; /bin/false"


### PR DESCRIPTION
Upstream task names are not following the latest convention.

Fix #2336.