### PR TITLE
t: authentication-08: improve timeout timing

### DIFF
--- a/tests/authentication/08-shared-fs/suite.rc
+++ b/tests/authentication/08-shared-fs/suite.rc
@@ -1,9 +1,11 @@
 #!jinja2
 [cylc]
     UTC mode=True
+    [[events]]
+        abort on inactivity = True
+        inactivity = P1M
     [[reference test]]
         expected task failures = t1.19700101T0000Z
-        live mode suite timeout = PT1M
 [scheduling]
     initial cycle point=1970
     final cycle point=1970


### PR DESCRIPTION
The test would fail pretty much every time in a busy environment, but
would pass on re-run (when the system would be much quieter). This
change should help.