### PR TITLE
Default to localhost in srv files mgr.

### DIFF
--- a/bin/cylc
+++ b/bin/cylc
@@ -140,6 +140,12 @@ category_help_command() {
     exec "${COMMAND}" "categories"
 }
 
+command_help_command() {
+# Special case for printing all commands (used in CUG Makefile)
+    local COMMAND="${CYLC_HOME_BIN}/cylc-help"
+    exec "${COMMAND}" "commands"
+}
+
 path_lead() {
 # Ensure that ITEM_STR is at the beginning of PATH_STR
     local PATH_STR="$1"
@@ -229,6 +235,10 @@ version|--version|-V|-v)
     :;;
 categories)
     category_help_command "$@"
+    exit 0
+    :;;
+commands)
+    command_help_command "$@"
     exit 0
     :;;
 esac

--- a/bin/cylc-email-suite
+++ b/bin/cylc-email-suite
@@ -19,6 +19,8 @@
 usage() {
     echo "Usage: cylc [hook] email-suite EVENT SUITE MESSAGE"
     echo ""
+    echo "THIS COMMAND IS OBSOLETE - use built-in email event hooks."
+    echo ""
     echo "This is a simple suite event hook script that sends an email."
     echo "The command line arguments are supplied automatically by cylc."
     echo ""

--- a/bin/cylc-email-task
+++ b/bin/cylc-email-task
@@ -19,7 +19,9 @@
 usage() {
     echo "Usage: cylc [hook] email-task EVENT SUITE TASKID MESSAGE"
     echo ""
-    echo "This is a simple task event hook handler script that sends an email."
+    echo "THIS COMMAND IS OBSOLETE - use built-in email event hooks."
+    echo ""
+    echo "A simple task event hook handler script that sends an email."
     echo "The command line arguments are supplied automatically by cylc."
     echo ""
     echo "For example, to get an email alert whenever any task fails:"

--- a/bin/cylc-help
+++ b/bin/cylc-help
@@ -284,7 +284,6 @@ utility_commands['ls-checkpoints'] = ['ls-checkpoints']
 hook_commands = {}
 hook_commands['email-suite'] = ['email-suite']
 hook_commands['email-task'] = ['email-task']
-hook_commands['job-logs-retrieve'] = ['job-logs-retrieve']
 hook_commands['check-triggering'] = ['check-triggering']
 
 admin_commands = {}
@@ -434,8 +433,6 @@ comsum['ls-checkpoints'] = 'Display task pool etc at given events'
 # hook
 comsum['email-task'] = 'A task event hook script that sends email alerts'
 comsum['email-suite'] = 'A suite event hook script that sends email alerts'
-comsum['job-logs-retrieve'] = (
-    '(Internal) Retrieve logs from a remote host for a task job')
 comsum['check-triggering'] = 'A suite shutdown event hook for cylc testing'
 
 

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -521,10 +521,10 @@ class GlobalConfig(config):
             modify_dirs = True
         if value is not None and 'directory' in item:
             if replace_home and (modify_dirs or owner != USER):
-                # replace local home dir with $HOME for evaluation on other host
+                # replace local home dir with $HOME for eval'n on other host
                 value = value.replace(os.environ['HOME'], '$HOME')
             elif owner != USER:
-                # replace USER with owner for direct access via local filesystem
+                # replace USER with owner for direct access via local filesys
                 value = value.replace('/%s/' % USER, '/%s/' % owner)
         return value
 

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -521,11 +521,13 @@ class GlobalConfig(config):
             modify_dirs = True
         if value is not None and 'directory' in item:
             if replace_home and (modify_dirs or owner != USER):
-                # replace local home dir with $HOME for eval'n on other host
+                # Replace local home dir with $HOME for eval'n on other host.
                 value = value.replace(os.environ['HOME'], '$HOME')
             elif owner != USER:
-                # replace USER with owner for direct access via local filesys
-                value = value.replace('/%s/' % USER, '/%s/' % owner)
+                # Replace USER with owner for direct access via local filesys
+                # (works for standard cylc-run directory location).
+                value = value.replace(
+                    os.environ['HOME'], os.path.expanduser('~%s' % owner))
         return value
 
     def roll_directory(self, d, name, archlen=0):

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -446,15 +446,17 @@ class GlobalConfig(config):
         return cls._DEFAULT
 
     def get_derived_host_item(
-            self, suite, item, host=None, owner=None, replace=False):
+            self, suite, item, host=None, owner=None, replace_home=False):
         """Compute hardwired paths relative to the configurable top dirs."""
 
         # suite run dir
         srdir = os.path.join(
-            self.get_host_item('run directory', host, owner, replace), suite)
+            self.get_host_item('run directory', host, owner, replace_home),
+            suite)
         # suite workspace
         swdir = os.path.join(
-            self.get_host_item('work directory', host, owner, replace), suite)
+            self.get_host_item('work directory', host, owner, replace_home),
+            suite)
 
         if item == 'suite run directory':
             value = srdir
@@ -482,7 +484,7 @@ class GlobalConfig(config):
 
         return value
 
-    def get_host_item(self, item, host=None, owner=None, replace=False):
+    def get_host_item(self, item, host=None, owner=None, replace_home=False):
         """This allows hosts with no matching entry in the config file
         to default to appropriately modified localhost settings."""
 
@@ -509,7 +511,7 @@ class GlobalConfig(config):
                         host_key = cfg_host
                         break
         modify_dirs = False
-        if host_key:
+        if host_key is not None:
             # entry exists, any unset items under it have already
             # defaulted to modified localhost values (see site cfgspec)
             value = cfg['hosts'][host_key][item]
@@ -517,12 +519,13 @@ class GlobalConfig(config):
             # no entry so default to localhost and modify appropriately
             value = cfg['hosts']['localhost'][item]
             modify_dirs = True
-
-        if value and ('directory' in item) and (
-                modify_dirs or owner != USER or replace):
-            # replace local home dir with $HOME for evaluation on other host
-            value = value.replace(os.environ['HOME'], '$HOME')
-
+        if value is not None and 'directory' in item:
+            if replace_home and (modify_dirs or owner != USER):
+                # replace local home dir with $HOME for evaluation on other host
+                value = value.replace(os.environ['HOME'], '$HOME')
+            elif owner != USER:
+                # replace USER with owner for direct access via local filesystem
+                value = value.replace('/%s/' % USER, '/%s/' % owner)
         return value
 
     def roll_directory(self, d, name, archlen=0):

--- a/lib/cylc/suite_srv_files_mgr.py
+++ b/lib/cylc/suite_srv_files_mgr.py
@@ -589,6 +589,8 @@ To see if %(suite)s is running on '%(host)s:%(port)s':
 
     def _load_remote_item(self, item, reg, owner, host):
         """Load content of service item from remote [owner@]host via SSH."""
+        if host is None:
+            host = 'localhost'
         if not is_remote_host(host) and not is_remote_user(owner):
             return
         # Prefix STDOUT to ensure returned content is relevant


### PR DESCRIPTION
Close #2340 
Close #526

 * default to localhost in service files manager (currently just falls over if `--user` specified but not `--host`)
 * if localhost, attempt to read remote (i.e. other user) suite contact file via the local filesystem first, so that non-interactive ssh is not needed to the suite account.

