### PR TITLE
Attempt to fix traceback on runahead task release

### DIFF
--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -84,6 +84,7 @@ class SuiteConfig(object):
     """Class for suite configuration items and derived quantities."""
 
     _INSTANCES = {}
+    Q_DEFAULT = 'default'
 
     @classmethod
     def get_inst(cls, suite=None, fpath=None, template_vars=None,
@@ -1082,7 +1083,7 @@ class SuiteConfig(object):
         queues = self.cfg['scheduling']['queues']
         for orphan in orphans:
             self.runtime['linearized ancestors'][orphan] = [orphan, 'root']
-            queues['default']['members'].append(orphan)
+            queues[self.Q_DEFAULT]['members'].append(orphan)
 
     def configure_queues(self):
         """Assign tasks to internal queues."""
@@ -1094,7 +1095,7 @@ class SuiteConfig(object):
 
         # First add all tasks to the default queue.
         all_task_names = self.get_task_name_list()
-        queues['default']['members'] = all_task_names
+        queues[self.Q_DEFAULT]['members'] = all_task_names
 
         # Then reassign to other queues as requested.
         warnings = []
@@ -1102,7 +1103,7 @@ class SuiteConfig(object):
         for key, queue in queues.copy().items():
             # queues.copy() is essential here to allow items to be removed from
             # the queues dict.
-            if key == 'default':
+            if key == self.Q_DEFAULT:
                 continue
             # Assign tasks to queue and remove them from default.
             qmembers = []
@@ -1114,7 +1115,7 @@ class SuiteConfig(object):
                         # This includes sub-families.
                         if qmember not in qmembers:
                             try:
-                                queues['default']['members'].remove(fmem)
+                                queues[self.Q_DEFAULT]['members'].remove(fmem)
                             except ValueError:
                                 if fmem in requeued:
                                     msg = "%s: ignoring %s from %s (%s)" % (
@@ -1131,7 +1132,7 @@ class SuiteConfig(object):
                     # Is a task.
                     if qmember not in qmembers:
                         try:
-                            queues['default']['members'].remove(qmember)
+                            queues[self.Q_DEFAULT]['members'].remove(qmember)
                         except ValueError:
                             if qmember in requeued:
                                 msg = "%s: ignoring '%s' (%s)" % (
@@ -1162,7 +1163,7 @@ class SuiteConfig(object):
         if cylc.flags.verbose and len(queues) > 1:
             log_msg = "Internal queues created:"
             for key, queue in queues.items():
-                if key == 'default':
+                if key == self.Q_DEFAULT:
                     continue
                 log_msg += "\n+ %s: %s" % (key, ', '.join(queue['members']))
             OUT.info(log_msg)

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -103,11 +103,9 @@ class TaskPool(object):
 
     def assign_queues(self):
         """self.myq[taskname] = qfoo"""
-        qconfig = self.config.cfg['scheduling']['queues']
-        self.myq = {}
-        for queue in qconfig:
-            for taskname in qconfig[queue]['members']:
-                self.myq[taskname] = queue
+        self.myq.clear()
+        for queue, qconfig in self.config.cfg['scheduling']['queues'].items():
+            self.myq.update((name, queue) for name in qconfig['members'])
 
     def insert_tasks(self, items, stop_point_str, no_check=False):
         """Insert tasks."""
@@ -244,8 +242,8 @@ class TaskPool(object):
 
         # Any finished tasks can be released immediately (this can happen at
         # restart when all tasks are initially loaded into the runahead pool).
-        for itask_id_maps in self.runahead_pool.values():
-            for itask in itask_id_maps.values():
+        for itask_id_maps in self.runahead_pool.copy().values():
+            for itask in itask_id_maps.copy().values():
                 if itask.state.status in [TASK_STATUS_FAILED,
                                           TASK_STATUS_SUCCEEDED,
                                           TASK_STATUS_EXPIRED]:
@@ -323,9 +321,9 @@ class TaskPool(object):
             latest_allowed_point = self.stop_point
 
         released = False
-        for point, itask_id_map in self.runahead_pool.items():
+        for point, itask_id_map in self.runahead_pool.copy().items():
             if point <= latest_allowed_point:
-                for itask in itask_id_map.values():
+                for itask in itask_id_map.copy().values():
                     self.release_runahead_task(itask)
                     released = True
         return released
@@ -449,9 +447,11 @@ class TaskPool(object):
 
     def release_runahead_task(self, itask):
         """Release itask to the appropriate queue in the active pool."""
-        queue = self.myq[itask.tdef.name]
-        if queue not in self.queues:
-            self.queues[queue] = {}
+        try:
+            queue = self.myq[itask.tdef.name]
+        except KeyError:
+            queue = self.config.Q_DEFAULT
+        self.queues.setdefault(queue, {})
         self.queues[queue][itask.identity] = itask
         self.pool.setdefault(itask.point, {})
         self.pool[itask.point][itask.identity] = itask


### PR DESCRIPTION
A user reported that a suite was brought down by a KeyError with `myq`. Unfortunately, we were unable to reproduce the condition for triggering this failure, so this change is only an attempt to reduce the likelihood of the problem happening again.

```
Traceback (most recent call last):
  File "/opt/cylc-7.4.0/lib/cylc/scheduler.py", line 232, in start
    self.run()
  File "/opt/cylc-7.4.0/lib/cylc/scheduler.py", line 1130, in run
    if self.pool.release_runahead_tasks():
  File "/opt/cylc-7.4.0/lib/cylc/task_pool.py", line 253, in release_runahead_tasks
    self.release_runahead_task(itask)
  File "/opt/cylc-7.4.0/lib/cylc/task_pool.py", line 447, in release_runahead_task
    queue = self.myq[itask.tdef.name]
KeyError: u'fcm_make_meto_xc40_cce_utils_serial_safe_omp'
```