### PR TITLE
Allow insert cycle with 500+ tasks

### DIFF
--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -165,8 +165,10 @@ class TaskPool(object):
                     continue
 
             submit_num = submit_nums.get(key)
-            self.add_to_runahead_pool(TaskProxy(
+            itask = self.add_to_runahead_pool(TaskProxy(
                 taskdef, point, stop_point=stop_point, submit_num=submit_num))
+            if itask:
+                LOG.info("inserted", itask=itask)
         return n_warnings
 
     def add_to_runahead_pool(self, itask, is_restart=False):
@@ -213,7 +215,6 @@ class TaskPool(object):
         # add to the runahead pool
         self.runahead_pool.setdefault(itask.point, {})
         self.runahead_pool[itask.point][itask.identity] = itask
-        LOG.info("inserted", itask=itask)
         self.rhpool_changed = True
 
         if is_restart:

--- a/tests/cylc-insert/12-cycle-500-tasks.t
+++ b/tests/cylc-insert/12-cycle-500-tasks.t
@@ -1,0 +1,40 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test cylc insert command, with wildcard in a task name string
+. "$(dirname "$0")/test_header"
+set_test_number 4
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+run_ok "${TEST_NAME_BASE}" cylc run --hold "${SUITE_NAME}"
+LOG="${SUITE_RUN_DIR}/log/suite/log"
+poll "! grep -q -F 'Held on start-up' '${LOG}' 2>'/dev/null'"
+run_ok "${TEST_NAME_BASE}-insert" cylc insert "${SUITE_NAME}" '2008/*'
+poll "! grep -q -F 'Command succeeded: insert_tasks' '${LOG}' 2>'/dev/null'"
+cylc stop --max-polls=10 --interval=6 "${SUITE_NAME}" 2>'/dev/null'
+cut -d' ' -f 2- "${LOG}" >'trimmed-log'
+{
+    for I in {001..500}; do
+        echo "INFO - [v_i${I}.2008] -inserted"
+    done
+    echo "INFO - Command succeeded: insert_tasks([u'2008/*'], stop_point_string=None, no_check=False)"
+} >'expected-log'
+contains_ok 'trimmed-log' 'expected-log'
+
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/cylc-insert/12-cycle-500-tasks/reference.log
+++ b/tests/cylc-insert/12-cycle-500-tasks/reference.log
@@ -1,0 +1,5 @@
+2016-05-23T12:22:35+01 INFO - Initial point: 1
+2016-05-23T12:22:35+01 INFO - Final point: 1
+2016-05-23T12:22:35+01 INFO - [i1.1] -triggered off []
+2016-05-23T12:22:39+01 INFO - [t1.1] -triggered off ['i1.1']
+2016-05-23T12:22:43+01 INFO - [t2.1] -triggered off ['i1.1']

--- a/tests/cylc-insert/12-cycle-500-tasks/suite.rc
+++ b/tests/cylc-insert/12-cycle-500-tasks/suite.rc
@@ -1,0 +1,13 @@
+[cylc]
+    cycle point format = %Y
+    [[parameters]]
+        i = 1..500
+[scheduling]
+    initial cycle point = 2000
+    final cycle point = 2010
+    [[dependencies]]
+        [[[P1Y]]]
+            graph="""v<i>[-P1Y] => v<i>"""
+[runtime]
+    [[v<i>]]
+        script=true


### PR DESCRIPTION
This would have caused an error with SQLite, which does not like >999 arguments in its prepared statement.

On `cylc insert SUITE '*.CYCLE'`, and `CYCLE` has 500 or more tasks, we would get a traceback in the suite log similar to the following:
```
Traceback (most recent call last):
  File "/opt/cylc-7.3.0/lib/cylc/scheduler.py", line 704, in process_command_queue
    *args, **kwargs)
  File "/opt/cylc-7.3.0/lib/cylc/scheduler.py", line 917, in command_insert_tasks
    return self.pool.insert_tasks(items, stop_point_string, no_check)
  File "/opt/cylc-7.3.0/lib/cylc/task_pool.py", line 209, in insert_tasks
    ["submit_num"], task_ids)
  File "/opt/cylc-7.3.0/lib/cylc/rundb.py", line 614, in select_task_states_by_task_ids
    for row in self.connect().execute(stmt, stmt_args):
OperationalError: too many SQL variables
```

This change fixes the issue by using the original glob wildcard for matching task names in the suite database. It also improves diagnostics, etc.