### PR TITLE
Suite Design Guide: Add entries for symlink+ and file referencing in apps

### DIFF
--- a/doc/src/suite-design-guide/general-principles.tex
+++ b/doc/src/suite-design-guide/general-principles.tex
@@ -95,7 +95,10 @@ install tasks to copy files to the self-contained suite run directory at
 start-up.  Install tasks are preferred for time-consuming installations because
 they don't slow the suite start-up process, they can be monitored in the GUI,
 they can run directly on target platforms, and you can rerun them later without
-restarting the suite. 
+restarting the suite. If you are using symbolic links to install files under
+your suite directory it is recommended that the linking should be set up to
+fail if the source is missing e.g. by using {\em mode=symlink+} for file
+installation in a rose app.
 
 \subsubsection{Confining Ouput To The Run Directory}
 
@@ -286,7 +289,8 @@ queues}, respectively.
 \subsubsection{Runahead Limiting}
 \label{Runahead Limiting}
 
-By default Cylc allows a maximum of three cycle points to be active at the same time, but this value is configurable:
+By default Cylc allows a maximum of three cycle points to be active at the same
+time, but this value is configurable:
 
 \lstset{language=suiterc}
 \begin{lstlisting}

--- a/doc/src/suite-design-guide/portable-suites.tex
+++ b/doc/src/suite-design-guide/portable-suites.tex
@@ -24,6 +24,8 @@ The recommended way to do this, which we expand on below, is:
   \item Use ``optional optional'' app config files for site-specific variations
     in the core suite's Rose apps.
   \item (Make minimal use of inlined site switches too, if necessary).
+  \item When referencing files, reference them within the suite structure and
+  use an install task to link external files in.
 \end{itemize}
 
 The result should actually be tidier than the original in one respect: all
@@ -262,6 +264,16 @@ version. The site switch itself has to be set of course, but there may be other
 settings too such as model parameters for a standard local test domain. Just
 put these settings in \lstinline=opt/rose-suite-niwa.conf= (for site ``niwa'')
 and run the suite with \lstinline=rose suite-run -O niwa=.
+
+\subsection{Site-Agnostic File Paths in App Configs}
+
+Where possible apps should be configured to reference files within the suite
+structure itself rather than outside of it. This makes the apps themselves
+portable and it becomes the job of the install task to ensure all required
+source files are available within the suite structure e.g. via symlink into
+the share directory. Additionally, by moving the responsibility of linking
+files into the suite to an install task you gain the added benefit of knowing
+if a file is missing at the start of a suite rather than part way into a run.
 
 \subsection{Site-Specific Optional App Configs}
 


### PR DESCRIPTION
Following a discussion with @dpmatthews, we think it would be good to make the following recommendations in the suite design guide:

 * When symlinking files in via an install task have it fail if the source is missing - if done via rose file install this can be achieved using `mode=symlink+`
 * Where possible have your apps point to files within the suite structure rather than possible external ones. Use linking to bring the external files in instead.

Both the above should make apps more portable and help ensure that you don't get several hours into a run before noticing an external file is missing (something which can be easier to diagnose as missing by waiting to hit a runtime failure in some suites as things stand).

@hjoliver - please review and see if you agree.