### PR TITLE
Improve handling of custom task outputs

### DIFF
--- a/bin/cylc-suite-state
+++ b/bin/cylc-suite-state
@@ -49,6 +49,7 @@ to poll. This is useful when you want to use cylc suite-state in a cylc task.
 """
 
 import os
+import sqlite3
 import sys
 from time import sleep, time
 
@@ -59,8 +60,7 @@ if remrun().execute():
 
 import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
-from cylc.dbstatecheck import (
-    CylcSuiteDBChecker, DBNotFoundError, DBOperationError)
+from cylc.dbstatecheck import CylcSuiteDBChecker
 from cylc.cfgspec.globalcfg import GLOBAL_CFG
 from cylc.command_polling import Poller
 from cylc.task_state import TASK_STATUSES_ORDERED
@@ -98,7 +98,7 @@ class SuitePoller(Poller):
                 connected = True
                 # ... but ensure at least one poll after connection:
                 self.n_polls -= 1
-            except (DBOperationError, DBNotFoundError):
+            except (OSError, sqlite3.Error):
                 if self.n_polls >= max_polls:
                     raise
                 if cylc.flags.verbose:
@@ -118,16 +118,10 @@ class SuitePoller(Poller):
         return connected, self.args['cycle']
 
     def check(self):
-        # return True if desired suite state achieved, else False
-        if self.args['message']:
-            return self.checker.task_state_met(self.args['task'],
-                                               self.args['cycle'],
-                                               self.args['message'],
-                                               True)
-        else:
-            return self.checker.task_state_met(self.args['task'],
-                                               self.args['cycle'],
-                                               self.args['status'])
+        """Return True if desired suite state achieved, else False"""
+        return self.checker.task_state_met(
+            self.args['task'], self.args['cycle'],
+            self.args['status'], self.args['message'])
 
 
 def main():
@@ -183,8 +177,8 @@ def main():
         action="store", dest="status", default=None)
 
     parser.add_option(
-        "-m", "--message",
-        help="Specify a particular message to check for.",
+        "-O", "--output", "-m", "--message",
+        help="Check custom task output by message string or trigger string.",
         action="store", dest="msg", default=None)
 
     SuitePoller.add_to_cmd_options(parser)
@@ -231,7 +225,7 @@ def main():
 
     # Exit if both task state and message are to being polled
     if options.status and options.msg:
-        sys.exit("ERROR: cannot poll both status and message")
+        sys.exit("ERROR: cannot poll both status and custom output")
 
     if options.msg and not options.task and not options.cycle:
         sys.exit("ERROR: need a taskname and cyclepoint")
@@ -277,8 +271,8 @@ def main():
         if not spoller.poll():
             sys.exit(1)
     elif options.msg:
-        """Check for a task message"""
-        spoller.condition = "message: %s" % options.msg
+        """Check for a custom task output"""
+        spoller.condition = "output: %s" % options.msg
         if not spoller.poll():
             sys.exit(1)
     else:

--- a/lib/cylc/rundb.py
+++ b/lib/cylc/rundb.py
@@ -450,7 +450,7 @@ class CylcSuiteDAO(object):
             if cylc.flags.debug:
                 traceback.print_exc()
             err_log = (
-                "cannot execute database statement:\n" +
+                "cannot execute database statement:\n"
                 "file=%(file)s:\nstmt=%(stmt)s"
             ) % {"file": self.db_file_name, "stmt": stmt}
             for i, stmt_args in enumerate(stmt_args_list):
@@ -552,14 +552,14 @@ class CylcSuiteDAO(object):
             for column in self.tables[self.TABLE_TASK_JOBS].columns[3:]:
                 keys.append(column.name)
         if submit_num in [None, "NN"]:
-            stmt = (r"SELECT %(keys_str)s FROM %(table)s" +
-                    r" WHERE cycle==? AND name==?" +
+            stmt = (r"SELECT %(keys_str)s FROM %(table)s"
+                    r" WHERE cycle==? AND name==?"
                     r" ORDER BY submit_num DESC LIMIT 1") % {
                 "keys_str": ",".join(keys),
                 "table": self.TABLE_TASK_JOBS}
             stmt_args = [cycle, name]
         else:
-            stmt = (r"SELECT %(keys_str)s FROM %(table)s" +
+            stmt = (r"SELECT %(keys_str)s FROM %(table)s"
                     r" WHERE cycle==? AND name==? AND submit_num==?") % {
                 "keys_str": ",".join(keys),
                 "table": self.TABLE_TASK_JOBS}
@@ -584,12 +584,12 @@ class CylcSuiteDAO(object):
         of each task on restart.
         """
         stmt = (
-            r"SELECT" +
-            r" name," +
-            r" GROUP_CONCAT(" +
-            r"     CAST(strftime('%s', time_run_exit) AS NUMERIC) -" +
-            r"     CAST(strftime('%s', time_run) AS NUMERIC))" +
-            r" FROM task_jobs" +
+            r"SELECT"
+            r" name,"
+            r" GROUP_CONCAT("
+            r"     CAST(strftime('%s', time_run_exit) AS NUMERIC) -"
+            r"     CAST(strftime('%s', time_run) AS NUMERIC))"
+            r" FROM task_jobs"
             r" WHERE run_status==0 GROUP BY name ORDER BY time_run_exit")
         for row_idx, row in enumerate(self.connect().execute(stmt)):
             callback(row_idx, list(row))
@@ -655,39 +655,40 @@ class CylcSuiteDAO(object):
         select from task_pool table if id_key == CHECKPOINT_LATEST_ID.
         Otherwise select from task_pool_checkpoints where id == id_key.
         """
-        form_stmt = (
-            r"SELECT " +
-            r"    %(task_pool)s.cycle," +
-            r"    %(task_pool)s.name," +
-            r"    %(task_pool)s.spawned,"
-            r"    %(task_pool)s.status," +
-            r"    %(task_pool)s.hold_swap," +
-            r"    %(task_states)s.submit_num," +
-            r"    %(task_jobs)s.try_num," +
-            r"    %(task_jobs)s.user_at_host," +
-            r"    %(task_jobs)s.time_submit," +
-            r"    %(task_jobs)s.time_run," +
-            r"    %(task_timeout_timers)s.timeout, " +
-            r"    %(task_outputs)s.outputs " +
-            r"FROM " +
-            r"    %(task_pool)s " +
-            r"JOIN " +
-            r"    %(task_states)s " +
-            r"ON  %(task_pool)s.cycle == %(task_states)s.cycle AND " +
-            r"    %(task_pool)s.name == %(task_states)s.name " +
-            r"LEFT OUTER JOIN " +
-            r"    %(task_jobs)s " +
-            r"ON  %(task_pool)s.cycle == %(task_jobs)s.cycle AND " +
-            r"    %(task_pool)s.name == %(task_jobs)s.name AND " +
-            r"    %(task_states)s.submit_num == %(task_jobs)s.submit_num " +
-            r"LEFT OUTER JOIN " +
-            r"    %(task_timeout_timers)s " +
-            r"ON  %(task_pool)s.cycle == %(task_timeout_timers)s.cycle AND " +
-            r"    %(task_pool)s.name == %(task_timeout_timers)s.name " +
-            r"LEFT OUTER JOIN " +
-            r"    %(task_outputs)s " +
-            r"ON  %(task_pool)s.cycle == %(task_outputs)s.cycle AND " +
-            r"    %(task_pool)s.name == %(task_outputs)s.name")
+        form_stmt = r"""
+            SELECT
+                %(task_pool)s.cycle,
+                %(task_pool)s.name,
+                %(task_pool)s.spawned,
+                %(task_pool)s.status,
+                %(task_pool)s.hold_swap,
+                %(task_states)s.submit_num,
+                %(task_jobs)s.try_num,
+                %(task_jobs)s.user_at_host,
+                %(task_jobs)s.time_submit,
+                %(task_jobs)s.time_run,
+                %(task_timeout_timers)s.timeout,
+                %(task_outputs)s.outputs
+            FROM
+                %(task_pool)s
+            JOIN
+                %(task_states)s
+            ON  %(task_pool)s.cycle == %(task_states)s.cycle AND
+                %(task_pool)s.name == %(task_states)s.name
+            LEFT OUTER JOIN
+                %(task_jobs)s
+            ON  %(task_pool)s.cycle == %(task_jobs)s.cycle AND
+                %(task_pool)s.name == %(task_jobs)s.name AND
+                %(task_states)s.submit_num == %(task_jobs)s.submit_num
+            LEFT OUTER JOIN
+                %(task_timeout_timers)s
+            ON  %(task_pool)s.cycle == %(task_timeout_timers)s.cycle AND
+                %(task_pool)s.name == %(task_timeout_timers)s.name
+            LEFT OUTER JOIN
+                %(task_outputs)s
+            ON  %(task_pool)s.cycle == %(task_outputs)s.cycle AND
+                %(task_pool)s.name == %(task_outputs)s.name
+        """
         form_data = {
             "task_pool": self.TABLE_TASK_POOL,
             "task_states": self.TABLE_TASK_STATES,

--- a/lib/cylc/rundb.py
+++ b/lib/cylc/rundb.py
@@ -181,6 +181,7 @@ class CylcSuiteDAO(object):
     TABLE_TASK_EVENTS = "task_events"
     TABLE_TASK_ACTION_TIMERS = "task_action_timers"
     TABLE_CHECKPOINT_ID = "checkpoint_id"
+    TABLE_TASK_OUTPUTS = "task_outputs"
     TABLE_TASK_POOL = "task_pool"
     TABLE_TASK_POOL_CHECKPOINTS = "task_pool_checkpoints"
     TABLE_TASK_STATES = "task_states"
@@ -264,6 +265,11 @@ class CylcSuiteDAO(object):
             ["submit_num", {"datatype": "INTEGER"}],
             ["event"],
             ["message"],
+        ],
+        TABLE_TASK_OUTPUTS: [
+            ["cycle", {"is_primary_key": True}],
+            ["name", {"is_primary_key": True}],
+            ["outputs"],
         ],
         TABLE_TASK_POOL: [
             ["cycle", {"is_primary_key": True}],
@@ -661,7 +667,8 @@ class CylcSuiteDAO(object):
             r"    %(task_jobs)s.user_at_host," +
             r"    %(task_jobs)s.time_submit," +
             r"    %(task_jobs)s.time_run," +
-            r"    %(task_timeout_timers)s.timeout " +
+            r"    %(task_timeout_timers)s.timeout, " +
+            r"    %(task_outputs)s.outputs " +
             r"FROM " +
             r"    %(task_pool)s " +
             r"JOIN " +
@@ -676,12 +683,17 @@ class CylcSuiteDAO(object):
             r"LEFT OUTER JOIN " +
             r"    %(task_timeout_timers)s " +
             r"ON  %(task_pool)s.cycle == %(task_timeout_timers)s.cycle AND " +
-            r"    %(task_pool)s.name == %(task_timeout_timers)s.name")
+            r"    %(task_pool)s.name == %(task_timeout_timers)s.name " +
+            r"LEFT OUTER JOIN " +
+            r"    %(task_outputs)s " +
+            r"ON  %(task_pool)s.cycle == %(task_outputs)s.cycle AND " +
+            r"    %(task_pool)s.name == %(task_outputs)s.name")
         form_data = {
             "task_pool": self.TABLE_TASK_POOL,
             "task_states": self.TABLE_TASK_STATES,
             "task_timeout_timers": self.TABLE_TASK_TIMEOUT_TIMERS,
             "task_jobs": self.TABLE_TASK_JOBS,
+            "task_outputs": self.TABLE_TASK_OUTPUTS,
         }
         if id_key is None or id_key == self.CHECKPOINT_LATEST_ID:
             stmt = form_stmt % form_data

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -1508,7 +1508,7 @@ conditions; see `cylc conditions`.
         try:
             self.suite_db_mgr.process_queued_ops()
             self.suite_db_mgr.on_suite_shutdown()
-        except StandardError:
+        except StandardError as exc:
             ERR.error(str(exc))
 
         if getattr(self, "config", None) is not None:

--- a/lib/cylc/suite_db_mgr.py
+++ b/lib/cylc/suite_db_mgr.py
@@ -46,6 +46,7 @@ class SuiteDatabaseManager(object):
     TABLE_SUITE_TEMPLATE_VARS = CylcSuiteDAO.TABLE_SUITE_TEMPLATE_VARS
     TABLE_TASK_ACTION_TIMERS = CylcSuiteDAO.TABLE_TASK_ACTION_TIMERS
     TABLE_TASK_POOL = CylcSuiteDAO.TABLE_TASK_POOL
+    TABLE_TASK_OUTPUTS = CylcSuiteDAO.TABLE_TASK_OUTPUTS
     TABLE_TASK_STATES = CylcSuiteDAO.TABLE_TASK_STATES
     TABLE_TASK_TIMEOUT_TIMERS = CylcSuiteDAO.TABLE_TASK_TIMEOUT_TIMERS
 
@@ -63,6 +64,7 @@ class SuiteDatabaseManager(object):
             self.TABLE_SUITE_PARAMS: [],
             self.TABLE_TASK_POOL: [],
             self.TABLE_TASK_ACTION_TIMERS: [],
+            self.TABLE_TASK_OUTPUTS: [],
             self.TABLE_TASK_TIMEOUT_TIMERS: []}
         self.db_inserts_map = {
             self.TABLE_INHERITANCE: [],
@@ -71,6 +73,7 @@ class SuiteDatabaseManager(object):
             self.TABLE_CHECKPOINT_ID: [],
             self.TABLE_TASK_POOL: [],
             self.TABLE_TASK_ACTION_TIMERS: [],
+            self.TABLE_TASK_OUTPUTS: [],
             self.TABLE_TASK_TIMEOUT_TIMERS: []}
         self.db_updates_map = {}
 
@@ -314,6 +317,10 @@ class SuiteDatabaseManager(object):
         """Put INSERT statement for task_states table."""
         self._put_insert_task_x(CylcSuiteDAO.TABLE_TASK_STATES, itask, args)
 
+    def put_insert_task_outputs(self, itask):
+        """Reset custom outputs for a task."""
+        self._put_insert_task_x(CylcSuiteDAO.TABLE_TASK_OUTPUTS, itask, {})
+
     def _put_insert_task_x(self, table_name, itask, args):
         """Put INSERT statement for a task_* table."""
         args.update({
@@ -328,6 +335,15 @@ class SuiteDatabaseManager(object):
         """Put UPDATE statement for task_jobs table."""
         self._put_update_task_x(
             CylcSuiteDAO.TABLE_TASK_JOBS, itask, set_args)
+
+    def put_update_task_outputs(self, itask):
+        """Put UPDATE statement for task_outputs table."""
+        items = []
+        for item in sorted(itask.state.outputs.get_completed_customs()):
+            items.append("%s=%s" % item)
+        self._put_update_task_x(
+            CylcSuiteDAO.TABLE_TASK_OUTPUTS,
+            itask, {"outputs": "\n".join(items)})
 
     def put_update_task_states(self, itask, set_args):
         """Put UPDATE statement for task_states table."""

--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -293,32 +293,23 @@ class TaskEventsManager(object):
                     itask=itask)
                 return
 
-        # Check registered outputs.
-        if itask.state.outputs.exists(message):
-            if not itask.state.outputs.is_completed(message):
-                cylc.flags.pflag = True
-                itask.state.outputs.set_completed(message)
-                self._db_events_insert(itask, "output completed", message)
-            elif not is_polled:
-                # This output has already been reported complete. Not an error
-                # condition - maybe the network was down for a bit. Ok for
-                # polling as multiple polls *should* produce the same result.
-                LOG.warning(
-                    "Unexpected output (already completed):\n  %s" % message,
-                    itask=itask)
-
         if is_polled and itask.state.status not in TASK_STATUSES_ACTIVE:
             # A poll result can come in after a task finishes.
             LOG.warning(
-                "Ignoring late poll result: task is not active",
-                itask=itask)
+                "Ignoring late poll result: task is not active", itask=itask)
             return
 
-        if priority == TaskMessage.WARNING:
-            self.setup_event_handlers(itask, "warning", message)
-
-        elif priority == TaskMessage.CRITICAL:
-            self.setup_event_handlers(itask, "critical", message)
+        # Check registered outputs
+        output_has_changed = itask.state.outputs.set_completed(message)
+        if output_has_changed is False:  # Not True or None
+            # This output has already been reported complete. Not an error
+            # condition - maybe the network was down for a bit. Ok for
+            # polling as multiple polls *should* produce the same result.
+            if not is_polled:
+                LOG.debug(
+                    "ignore - output already completed:\n  %s" % message,
+                    itask=itask)
+            return
 
         if (message == TASK_OUTPUT_STARTED and
                 itask.state.status in [
@@ -330,7 +321,7 @@ class TaskEventsManager(object):
                     TASK_STATUS_READY, TASK_STATUS_SUBMITTED,
                     TASK_STATUS_SUBMIT_FAILED, TASK_STATUS_RUNNING,
                     TASK_STATUS_FAILED]):
-            self._process_message_succeeded(itask, event_time, is_polled)
+            self._process_message_succeeded(itask, event_time)
         elif (message == TASK_OUTPUT_FAILED and
                 itask.state.status in [
                     TASK_STATUS_READY, TASK_STATUS_SUBMITTED,
@@ -343,18 +334,21 @@ class TaskEventsManager(object):
         elif message == TASK_OUTPUT_SUBMITTED:
             self._process_message_submitted(itask, event_time)
         elif message.startswith(TaskMessage.FAIL_MESSAGE_PREFIX):
-            # capture and record signals sent to task proxy
-            self._db_events_insert(itask, "signaled", message)
-            signal = message.replace(TaskMessage.FAIL_MESSAGE_PREFIX, "")
-            self.suite_db_mgr.put_update_task_jobs(itask, {
-                "run_signal": signal})
+            # Task failed message
+            signal = message[len(TaskMessage.FAIL_MESSAGE_PREFIX):]
+            self._db_events_insert(itask, "signaled", signal)
+            self.suite_db_mgr.put_update_task_jobs(
+                itask, {"run_signal": signal})
             self._process_message_failed(itask, event_time, self.JOB_FAILED)
         elif message.startswith(TaskMessage.ABORT_MESSAGE_PREFIX):
-            # Abort with message.
-            self._process_message_failed(
-                itask, event_time,
-                message.replace(TaskMessage.ABORT_MESSAGE_PREFIX, ''))
+            # Task aborted with message
+            signal = message[len(TaskMessage.ABORT_MESSAGE_PREFIX):]
+            self._db_events_insert(itask, "aborted", message)
+            self.suite_db_mgr.put_update_task_jobs(
+                itask, {"run_signal": signal})
+            self._process_message_failed(itask, event_time, signal)
         elif message.startswith(TaskMessage.VACATION_MESSAGE_PREFIX):
+            # Task job pre-empted into a vacation state
             cylc.flags.pflag = True
             itask.state.reset_state(TASK_STATUS_SUBMITTED)
             self._db_events_insert(itask, "vacated", message)
@@ -368,6 +362,10 @@ class TaskEventsManager(object):
                     float(self._get_events_conf(itask, 'submission timeout')))
             except (TypeError, ValueError):
                 itask.timeout_timers[TASK_STATUS_SUBMITTED] = None
+        elif output_has_changed:
+            # Message of a custom task output
+            cylc.flags.pflag = True
+            self.suite_db_mgr.put_update_task_outputs(itask)
         else:
             # Unhandled messages. These include:
             #  * general non-output/progress messages
@@ -380,6 +378,9 @@ class TaskEventsManager(object):
                 priority = getLevelName(priority)
             self._db_events_insert(
                 itask, ("message %s" % str(priority).lower()), message)
+
+        if priority in [TaskMessage.WARNING, TaskMessage.CRITICAL]:
+            self.setup_event_handlers(itask, priority.lower(), message)
 
     def setup_event_handlers(self, itask, event, message):
         """Set up handlers for a task event."""
@@ -594,7 +595,7 @@ class TaskEventsManager(object):
         itask.set_event_time('finished', event_time)
         self.suite_db_mgr.put_update_task_jobs(itask, {
             "run_status": 1,
-            "time_run_exit": itask.summary['finished_time_string'],
+            "time_run_exit": event_time,
         })
         if (TASK_STATUS_RETRYING not in itask.try_timers or
                 itask.try_timers[TASK_STATUS_RETRYING].next() is None):
@@ -644,13 +645,13 @@ class TaskEventsManager(object):
         self.setup_event_handlers(itask, 'started', 'job started')
         self.set_poll_time(itask)
 
-    def _process_message_succeeded(self, itask, event_time, is_polled=False):
+    def _process_message_succeeded(self, itask, event_time):
         """Helper for process_message, handle a succeeded message."""
         cylc.flags.pflag = True
         itask.set_event_time('finished', event_time)
         self.suite_db_mgr.put_update_task_jobs(itask, {
             "run_status": 0,
-            "time_run_exit": itask.summary['finished_time_string'],
+            "time_run_exit": event_time,
         })
         # Update mean elapsed time only on task succeeded.
         if itask.summary['started_time'] is not None:
@@ -658,18 +659,10 @@ class TaskEventsManager(object):
                 itask.summary['finished_time'] -
                 itask.summary['started_time'])
         if not itask.state.outputs.all_completed():
-            err = "Succeeded with unreported outputs:"
-            for msg in itask.state.outputs.get_not_completed():
-                err += "\n  " + msg
-            LOG.warning(err, itask=itask)
-            if not is_polled:
-                # A succeeded task MUST have submitted and started.
-                # TODO - just poll for outputs in the job status file?
-                for output in [TASK_OUTPUT_SUBMITTED, TASK_OUTPUT_STARTED]:
-                    if not itask.state.outputs.is_completed(output):
-                        LOG.warning(
-                            "Assuming output completed:  \n %s" % output,
-                            itask=itask)
+            message = "Succeeded with unreported outputs:"
+            for output in itask.state.outputs.get_not_completed():
+                message += "\n  " + output
+            LOG.info(message, itask=itask)
         itask.state.reset_state(TASK_STATUS_SUCCEEDED)
         self.setup_event_handlers(itask, "succeeded", "job succeeded")
 
@@ -717,7 +710,7 @@ class TaskEventsManager(object):
                 'submit_method_id=%s' % itask.summary['submit_method_id'],
                 itask=itask)
         self.suite_db_mgr.put_update_task_jobs(itask, {
-            "time_submit_exit": get_unix_time_from_time_string(event_time),
+            "time_submit_exit": event_time,
             "submit_status": 0,
             "batch_sys_job_id": itask.summary.get('submit_method_id')})
 

--- a/lib/cylc/task_job_mgr.py
+++ b/lib/cylc/task_job_mgr.py
@@ -913,6 +913,8 @@ class TaskJobManager(object):
                     itask.poll_timers[key] = TaskActionTimer(delays=values)
 
         self.init_host(suite, itask.task_host, itask.task_owner)
+        if itask.state.outputs.has_custom_triggers():
+            self.suite_db_mgr.put_update_task_outputs(itask)
         self.suite_db_mgr.put_update_task_jobs(itask, {
             "user_at_host": user_at_host,
             "batch_sys_name": itask.summary['batch_sys_name'],

--- a/lib/cylc/task_outputs.py
+++ b/lib/cylc/task_outputs.py
@@ -93,6 +93,21 @@ class TaskOutputs(object):
                 ret.append(value[_MESSAGE])
         return ret
 
+    def get_completed_customs(self):
+        """Return all completed custom outputs.
+
+        Return a list in this form: [(trigger1, message1), ...]
+        """
+        ret = []
+        for value in self.get_all():
+            if value[_IS_COMPLETED] and value[_TRIGGER] not in _SORT_ORDERS:
+                ret.append((value[_TRIGGER], value[_MESSAGE]))
+        return ret
+
+    def has_custom_triggers(self):
+        """Return True if it has any custom triggers."""
+        return any(key not in _SORT_ORDERS for key in self._by_trigger)
+
     def get_not_completed(self):
         """Return all not-completed output messages."""
         ret = []
@@ -129,7 +144,11 @@ class TaskOutputs(object):
             value[_IS_COMPLETED] = False
 
     def set_completed(self, message=None, trigger=None, is_completed=True):
-        """Set the output identified by message/trigger as completed."""
+        """Set the output identified by message/trigger as completed.
+
+        Return True if completion flag is changed, False if completion is
+        unchanged, or None if message/trigger is not found.
+        """
         try:
             item = self._get_item(message, trigger)
             old_is_completed = item[_IS_COMPLETED]

--- a/lib/cylc/task_state.py
+++ b/lib/cylc/task_state.py
@@ -326,6 +326,10 @@ class TaskState(object):
         elif status == TASK_STATUS_SUBMITTED:
             self.set_prerequisites_all_satisfied()
             self.outputs.set_completed(TASK_OUTPUT_SUBMITTED)
+        elif status == TASK_STATUS_RUNNING:
+            self.set_prerequisites_all_satisfied()
+            self.outputs.set_completed(TASK_OUTPUT_SUBMITTED)
+            self.outputs.set_completed(TASK_OUTPUT_STARTED)
         elif status == TASK_STATUS_SUBMIT_RETRYING:
             self.set_prerequisites_all_satisfied()
             self.outputs.remove(TASK_OUTPUT_SUBMITTED)
@@ -360,6 +364,9 @@ class TaskState(object):
         o_status, o_hold_swap = self.status, self.hold_swap
         if status == TASK_STATUS_HELD:
             self.hold_swap = self.status
+        elif status in TASK_STATUSES_ACTIVE:
+            if self.status == TASK_STATUS_HELD:
+                self.hold_swap = TASK_STATUS_HELD
         elif (self.hold_swap == TASK_STATUS_HELD and
                 status not in TASK_STATUSES_FINAL):
             self.hold_swap = status

--- a/tests/database/00-simple.t
+++ b/tests/database/00-simple.t
@@ -17,7 +17,7 @@
 #-------------------------------------------------------------------------------
 # Suite database content, a basic non-cycling suite of 3 tasks
 . "$(dirname "$0")/test_header"
-set_test_number 9
+set_test_number 21
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
@@ -55,6 +55,16 @@ sqlite3 "${DB_FILE}" \
      FROM task_jobs ORDER BY name' \
     >"${NAME}"
 cmp_ok "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/${NAME}" "${NAME}"
+
+NAME='select-task-jobs-times.out'
+sqlite3 "${DB_FILE}" \
+    'SELECT time_submit,time_submit_exit,time_run,time_run_exit FROM task_jobs' \
+    >"${NAME}"
+for DATE_TIME_STR in $(sed 's/[|]/ /g' "${NAME}"); do
+    # Parse each string with "date --date=..." without the T
+    run_ok "${NAME}-${DATE_TIME_STR}" \
+        date --date="$(sed 's/T/ /' <<<"${DATE_TIME_STR}")"
+done
 
 NAME='select-task-pool.out'
 sqlite3 "${DB_FILE}" 'SELECT name, cycle, spawned FROM task_pool ORDER BY name' \

--- a/tests/database/00-simple/schema.out
+++ b/tests/database/00-simple/schema.out
@@ -9,6 +9,7 @@ CREATE TABLE suite_template_vars(key TEXT, value TEXT, PRIMARY KEY(key));
 CREATE TABLE task_action_timers(cycle TEXT, name TEXT, ctx_key_pickle TEXT, ctx_pickle TEXT, delays_pickle TEXT, num INTEGER, delay TEXT, timeout TEXT, PRIMARY KEY(cycle, name, ctx_key_pickle));
 CREATE TABLE task_events(name TEXT, cycle TEXT, time TEXT, submit_num INTEGER, event TEXT, message TEXT);
 CREATE TABLE task_jobs(cycle TEXT, name TEXT, submit_num INTEGER, is_manual_submit INTEGER, try_num INTEGER, time_submit TEXT, time_submit_exit TEXT, submit_status INTEGER, time_run TEXT, time_run_exit TEXT, run_signal TEXT, run_status INTEGER, user_at_host TEXT, batch_sys_name TEXT, batch_sys_job_id TEXT, PRIMARY KEY(cycle, name, submit_num));
+CREATE TABLE task_outputs(cycle TEXT, name TEXT, outputs TEXT, PRIMARY KEY(cycle, name));
 CREATE TABLE task_pool(cycle TEXT, name TEXT, spawned INTEGER, status TEXT, hold_swap TEXT, PRIMARY KEY(cycle, name));
 CREATE TABLE task_pool_checkpoints(id INTEGER, cycle TEXT, name TEXT, spawned INTEGER, status TEXT, hold_swap TEXT, PRIMARY KEY(id, cycle, name));
 CREATE TABLE task_states(name TEXT, cycle TEXT, time_created TEXT, time_updated TEXT, submit_num INTEGER, status TEXT, PRIMARY KEY(name, cycle));

--- a/tests/database/00-simple/select-task-events.out
+++ b/tests/database/00-simple/select-task-events.out
@@ -1,18 +1,9 @@
-foo|1|output completed|submitted
 foo|1|submitted|
-foo|1|output completed|started
 foo|1|started|
-foo|1|output completed|succeeded
 foo|1|succeeded|
-bar|1|output completed|submitted
 bar|1|submitted|
-bar|1|output completed|started
 bar|1|started|
-bar|1|output completed|succeeded
 bar|1|succeeded|
-baz|1|output completed|submitted
 baz|1|submitted|
-baz|1|output completed|started
 baz|1|started|
-baz|1|output completed|succeeded
 baz|1|succeeded|

--- a/tests/execution-time-limit/00-background/suite.rc
+++ b/tests/execution-time-limit/00-background/suite.rc
@@ -1,5 +1,9 @@
 #!jinja2
 [cylc]
+   abort if any task fails = True
+   [[events]]
+       abort on inactivity = True
+       inactivity = PT2M
    [[reference test]]
        required run mode = live
        live mode suite timeout = PT30S

--- a/tests/execution-time-limit/04-poll/suite.rc
+++ b/tests/execution-time-limit/04-poll/suite.rc
@@ -1,5 +1,9 @@
 #!jinja2
 [cylc]
+   abort if any task fails = True
+   [[events]]
+       abort on inactivity = True
+       inactivity = PT2M
    [[reference test]]
        required run mode = live
        live mode suite timeout = PT2M

--- a/tests/job-file-trap/02-pipefail.t
+++ b/tests/job-file-trap/02-pipefail.t
@@ -18,7 +18,7 @@
 # Test pipefail cylc/cylc#1783
 . "$(dirname "$0")/test_header"
 
-set_test_number 3
+set_test_number 4
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 TEST_NAME=$TEST_NAME_BASE-validate
 run_ok "${TEST_NAME}-validate" cylc validate "${SUITE_NAME}"
@@ -31,6 +31,7 @@ T1_STATUS_FILE="${SUITE_RUN_DIR}/log/job/1/t1/01/job.status"
 contains_ok "${T1_STATUS_FILE}" <<'__STATUS__'
 CYLC_JOB_EXIT=EXIT
 __STATUS__
+grep_ok 'CYLC_JOB_EXIT_TIME=' "${T1_STATUS_FILE}"
 
 purge_suite "${SUITE_NAME}"
 exit

--- a/tests/restart/25-hold-suite/suite.rc
+++ b/tests/restart/25-hold-suite/suite.rc
@@ -2,10 +2,10 @@
 [cylc]
     UTC mode=True
     cycle point format = %Y
+    abort if any task fails = True
     [[events]]
-        abort on stalled = True
         abort on inactivity = True
-        inactivity = P1M
+        inactivity = P2M
 [scheduling]
     initial cycle point = 2016
     final cycle point = 2017

--- a/tests/restart/30-outputs.t
+++ b/tests/restart/30-outputs.t
@@ -1,0 +1,49 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test task outputs status is retained on restart
+. "$(dirname "$0")/test_header"
+
+set_test_number 6
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+suite_run_fail "${TEST_NAME_BASE}-run" cylc run --no-detach "${SUITE_NAME}"
+if which sqlite3 > '/dev/null'; then
+    sqlite3 "${SUITE_RUN_DIR}/log/db" 'SELECT outputs FROM task_outputs' \
+        >'sqlite3.out'
+    cmp_ok 'sqlite3.out' <<<'hello=hello'
+else
+    skip 1 'sqlite3 not installed?'
+fi
+suite_run_fail "${TEST_NAME_BASE}-restart-1" \
+    cylc restart --no-detach "${SUITE_NAME}"
+sed -i 's/#\(startup handler\)/\1/' 'suite.rc'
+suite_run_ok "${TEST_NAME_BASE}-restart-2" \
+    cylc restart --debug --reference-test "${SUITE_NAME}"
+if which sqlite3 > '/dev/null'; then
+    sqlite3 "${SUITE_RUN_DIR}/log/db" 'SELECT outputs FROM task_outputs' \
+        >'sqlite3.out'
+    cmp_ok 'sqlite3.out' <<'__OUT__'
+greet=greeting
+hello=hello
+__OUT__
+else
+    skip 1 'sqlite3 not installed?'
+fi
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/restart/30-outputs/reference.log
+++ b/tests/restart/30-outputs/reference.log
@@ -1,0 +1,3 @@
+2017-07-19T14:54:42+01 INFO - Initial point: 1
+2017-07-19T14:54:42+01 INFO - Final point: 1
+2017-07-19T14:54:43+01 INFO - [t3.1] -triggered off ['t1.1']

--- a/tests/restart/30-outputs/suite.rc
+++ b/tests/restart/30-outputs/suite.rc
@@ -1,0 +1,18 @@
+[cylc]
+    [[events]]
+        abort on stalled = True
+        #startup handler = cylc reset '%(suite)s' -O greet 't1.1'
+[scheduling]
+    [[dependencies]]
+        graph = """
+t1:hello => t2
+t1:greet => t3
+"""
+[runtime]
+    [[t1]]
+        script = cylc message 'hello'
+        [[[outputs]]]
+            hello = hello
+            greet = greeting
+    [[t2, t3]]
+        script = true


### PR DESCRIPTION
Store custom outputs in separate DB table `task_outputs`.
* Each task proxy (that has custom outputs) has a single row in the new table. The completed outputs are stored as a single value in the `outputs` column of the row. The value is a multi-line string, each line is a `trigger=message` pair.
* Remove custom outputs and duplicated outputs from the `task_events` table.
  * Update `cylc suite-state` to query the new table instead of `task_events`.

Correctly load completed custom outputs on restart.
* For running, succeeded and failed tasks, which may have some completed outputs.
* Instead of setting all outputs to completed only for succeeded tasks.

Fix `job.status` exit time on failure.
* This was lost, as we no longer pass the `failed` argument to `cylc message` on failure.
Fix DB task jobs run exit time format.

Close #2361. Close #2362.