### PR TITLE
Fix shebang in one file, and surround with quotes to avoid problems with white spaces (for Shell scripts)

### DIFF
--- a/admin/make-tarball
+++ b/admin/make-tarball
@@ -23,7 +23,7 @@ dirty tree.
 eof
 }
 
-for ARG in $@; do
+for ARG in "$@"; do
     if [[ $ARG == '--help' || $ARG == "help" ]]; then
         usage
         exit 0

--- a/bin/cylc
+++ b/bin/cylc
@@ -79,13 +79,13 @@ help_util() {
         exec "${CYLC_HOME_BIN}"/cylc-help
     fi
     # for cases 'cylc --help CATEGORY COMMAND'
-    if [[ (( $# > 1 )) &&  "${HELP_OPTS[*]} " == *"$UTIL"* && \
+    if [[ (( $# -gt 1 )) &&  "${HELP_OPTS[*]} " == *"$UTIL"* && \
           "${CATEGORIES[*]} " == *" $1 "* ]]; then
         local COMMAND="${CYLC_HOME_BIN}/cylc-$2"
         exec "${COMMAND}" "--help"  
     fi
     # Check if this is a help command, not containing a category qualifier
-    if [[ $# > 1  && "${HELP_OPTS[*]} " == *"${UTIL}"* && 
+    if [[ $# -gt 1  && "${HELP_OPTS[*]} " == *"${UTIL}"* && 
           "${CATEGORIES[*]} " != *" $1 "* &&
           "${CATEGORIES[*]} " != *" $2 "* ]]; then
         local COMMAND="${CYLC_HOME_BIN}/cylc-${UTIL}"
@@ -95,7 +95,7 @@ help_util() {
     # make this deal with 'cylc help CATEGORY' only
     if [[ " ${CATEGORIES[*]} " == *" ${UTIL} "* \
           || " ${HELP_OPTS[*]} " == *" ${UTIL} "* \
-          && $# > 0 && ( "${CATEGORIES[*]} " == *" $1 "* \
+          && $# -gt 0 && ( "${CATEGORIES[*]} " == *" $1 "* \
           || " ${HELP_OPTS[*]} " == *" $1 "* ) ]]; then
         local COMMAND="${CYLC_HOME_BIN}/cylc-help"
         exec "${COMMAND}" "$@"
@@ -113,7 +113,7 @@ help_util() {
         fi
     fi
     # If category name is used as arg, call the help func with the category
-    if [[ $# > 1  &&  ( "${CATEGORIES[*]} " == *" $1 "* 
+    if [[ $# -gt 1  &&  ( "${CATEGORIES[*]} " == *" $1 "* 
             || " ${HELP_OPTS[*]} " == *" $1 "* ) ]]; then
         local COMMAND="${CYLC_HOME_BIN}/cylc-help"
         exec "${COMMAND}" "$@"
@@ -254,7 +254,7 @@ elif (( "$num_commands_match" == 1 )); then
 # Abort if the command wildcard match is ambiguous, unless it is itself a 
 # command, e.g. "cylc graph" matches "cylc-graph" and "cylc-graph-diff",
 # but the command should not abort in this case.  
-elif [[ (("$num_commands_match" > 1)) \
+elif [[ (("$num_commands_match" -gt 1)) \
         && -f "${CYLC_HOME_BIN}/cylc-${UTIL}" ]] ; then
     exec "${CYLC_HOME_BIN}/cylc-${UTIL}" "@"
 else

--- a/bin/cylc
+++ b/bin/cylc
@@ -79,7 +79,7 @@ help_util() {
         exec "${CYLC_HOME_BIN}"/cylc-help
     fi
     # for cases 'cylc --help CATEGORY COMMAND'
-    if [[ (( $# -gt 1 )) &&  "${HELP_OPTS[*]} " == *"$UTIL"* && \
+    if [[ $# -gt 1 &&  "${HELP_OPTS[*]} " == *"$UTIL"* && \
           "${CATEGORIES[*]} " == *" $1 "* ]]; then
         local COMMAND="${CYLC_HOME_BIN}/cylc-$2"
         exec "${COMMAND}" "--help"  
@@ -119,7 +119,7 @@ help_util() {
         exec "${COMMAND}" "$@"
     fi
     # Deal with cases like 'cylc --help [COMMAND/CATEGORY]'
-    if [[ (( $# -gt 1 )) && -f "$(ls cylc-${2}* 2>/dev/null)" ]]; then
+    if [[ $# -gt 1 && -f "$(ls cylc-${2}* 2>/dev/null)" ]]; then
         local COMMAND="${CYLC_HOME_BIN}/$(ls "cylc-$2"*)"
         exec "${COMMAND}" "--help"
     fi
@@ -254,7 +254,7 @@ elif (( "$num_commands_match" == 1 )); then
 # Abort if the command wildcard match is ambiguous, unless it is itself a 
 # command, e.g. "cylc graph" matches "cylc-graph" and "cylc-graph-diff",
 # but the command should not abort in this case.  
-elif [[ (("$num_commands_match" -gt 1)) \
+elif [[ "$num_commands_match" -gt 1 \
         && -f "${CYLC_HOME_BIN}/cylc-${UTIL}" ]] ; then
     exec "${CYLC_HOME_BIN}/cylc-${UTIL}" "@"
 else

--- a/bin/cylc-email-suite
+++ b/bin/cylc-email-suite
@@ -42,7 +42,7 @@ if [[ $# = 1 ]]; then
     fi
 fi
 
-if [[ $# < 3 ]]; then
+if [[ $# -lt 3 ]]; then
     usage
     exit 1
 fi

--- a/bin/cylc-email-task
+++ b/bin/cylc-email-task
@@ -44,7 +44,7 @@ if [[ $# = 1 ]]; then
     fi
 fi
 
-if [[ $# < 4 ]]; then
+if [[ $# -lt 4 ]]; then
     usage
     exit 1
 fi

--- a/bin/cylc-import-examples
+++ b/bin/cylc-import-examples
@@ -41,7 +41,7 @@ if [[ -z $CYLC_DIR ]]; then
     exit 1
 fi
 
-if [[ $# > 2 ]] || [[ $# < 1 ]]; then
+if [[ $# -gt 2 ]] || [[ $# -lt 1 ]]; then
     usage >&2
     exit 1
 fi

--- a/bin/cylc-test-battery
+++ b/bin/cylc-test-battery
@@ -136,9 +136,9 @@ if perl -e 'use Test::Harness 3.00' 2>/dev/null; then
     if [[ -z "${NPROC}" ]]; then
         NPROC=$(python -c 'import multiprocessing as mp; print mp.cpu_count()')
     fi
-    exec prove -j "$NPROC" -s -r ${@:-tests}
+    exec prove -j "$NPROC" -s -r "${@:-tests}"
 else
     echo "WARNING: cannot run tests in parallel (Test::Harness < 3.00)" >&2
-    exec prove -s -r ${@:-tests}
+    exec prove -s -r "${@:-tests}"
 fi
 

--- a/lib/cylc/cylc_xdot.py
+++ b/lib/cylc/cylc_xdot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env
+#!/usr/bin/env python
 
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
 # Copyright (C) 2008-2017 NIWA


### PR DESCRIPTION
One file (cylc_xdot.py) with a wrong shebang - I think - and some minor fixes for the "red" errors in `shellcheck`.

```
grep -r -H '#!/bin/bash' . | awk -F: '{print $1}' | sort | uniq | grep -v '/tests/' | xargs -I {} shellcheck {}
```

I've had a few issues recently with scripts for Linux *and* for Mac, and found that shellcheck helps a lot to write scripts that just work on multiple platforms (normally, until you find a command with different syntax in GNU/BSD/etc... then you have to put a bunch of if's :-) )