### PR TITLE
Fix documentation of legacy cycle point format

### DIFF
--- a/doc/src/cylc-user-guide/cug.tex
+++ b/doc/src/cylc-user-guide/cug.tex
@@ -2635,16 +2635,16 @@ the following all run once at the final cycle point:
 \label{excluding-dates}
 \lstset{language=suiterc}
 
-Datetimes can be excluded from a recurrence by an exclamation mark for example
+Date-times can be excluded from a recurrence by an exclamation mark for example
 \lstinline=[[[ PT1D!20000101 ]]]= means run daily except on the
 first of January 2000.
 
-This syntax can be used to exclude one or multiple datetimes from a recurrence.
-Multiple datetimes are excluded using the syntax 
-\lstinline=[[[ PT1D!(20000101,20000102,...) ]]]=. All datetimes listed within
+This syntax can be used to exclude one or multiple date-times from a recurrence.
+Multiple date-times are excluded using the syntax 
+\lstinline=[[[ PT1D!(20000101,20000102,...) ]]]=. All date-times listed within
 the parentheses after the exclamation mark will be excluded. Note that the 
 \lstinline=^= and \lstinline=$= symbols (shorthand for the initial
-and final cycle points) are both datetimes so \lstinline=[[[ T12!$-PT1D ]]]=
+and final cycle points) are both date-times so \lstinline=[[[ T12!$-PT1D ]]]=
 is valid.
 
 If using a run limit in combination with an exclusion, the heading might not
@@ -2662,12 +2662,12 @@ suite \lstinline=foo= will only run once as its second run has been excluded.
 \lstset{language=transcript}
 
 \paragraph{Advanced exclusion syntax}
-In addition to excluding isolated datetime points or lists of datetime points
-from recurrences, exclusions themselves may be datetime recurrence sequences.
-Any partial datetime or sequence given after the exclamation mark will be 
+In addition to excluding isolated date-time points or lists of date-time points
+from recurrences, exclusions themselves may be date-time recurrence sequences.
+Any partial date-time or sequence given after the exclamation mark will be 
 excluded from the main sequence. 
 
-For example, partial datetimes can be excluded using the syntax:
+For example, partial date-times can be excluded using the syntax:
 \lstset{language=suiterc}
 \begin{lstlisting}
 [[[ PT1H ! T12 ]]]          # Run hourly but not at 12:00 from the inital
@@ -3035,7 +3035,7 @@ shown in Figure~\ref{fig-satellite}.
 
 The same syntax used to reference the initial and final cycle points
 (introduced in~\ref{referencing-the-initial-and-final-cycle-points}) for
-use with datetime cycling can also be used for integer cycling. For
+use with date-time cycling can also be used for integer cycling. For
 example you can write:
 
 \lstset{language=suiterc}

--- a/doc/src/cylc-user-guide/gcylcrc.tex
+++ b/doc/src/cylc-user-guide/gcylcrc.tex
@@ -219,7 +219,7 @@ Set default icon attributes for all state icons in this theme.
 \end{myitemize}
 
 For the attribute values, COLOR and FONTCOLOR can be color names from the X11
-rgb.txt file, e.g.\ \lstinline=SteelBlue=; or hexadecimal color codes, e.g.
+rgb.txt file, e.g.\ \lstinline=SteelBlue=; or hexadecimal color codes, e.g.\ 
 \lstinline@#ff0000@ for red; and STYLE can be ``filled'' or ``unfilled''.
 See \lstinline@gcylc.rc.eg@ and \lstinline@themes.rc@ in
 \lstinline@$CYLC_DIR/conf/gcylcrc/@ for examples.
@@ -238,7 +238,7 @@ submitted, submit-failed, running, succeeded, failed, retrying, submit-retrying}
 \end{myitemize}
 
 For the attribute values, COLOR and FONTCOLOR can be color names from the X11
-rgb.txt file, e.g.\ \lstinline=SteelBlue=; or hexadecimal color codes, e.g.
+rgb.txt file, e.g.\ \lstinline=SteelBlue=; or hexadecimal color codes, e.g.\ 
 \lstinline@#ff0000@ for red; and STYLE can be ``filled'' or ``unfilled''.
 See \lstinline@gcylc.rc.eg@ and \lstinline@themes.rc@ in
 \lstinline@$CYLC_DIR/conf/gcylcrc/@ for examples.

--- a/doc/src/cylc-user-guide/siterc.tex
+++ b/doc/src/cylc-user-guide/siterc.tex
@@ -82,7 +82,7 @@ cause the suite to hang while waiting for the command to finish. This setting
 sets a timeout for such a command to ensure that the suite can continue.
 
 \begin{myitemize}
-\item {\em type:} ISO 8601 duration/interval representation (e.g.
+\item {\em type:} ISO 8601 duration/interval representation (e.g.\ 
 \lstinline=PT10S=, 10 seconds, or \lstinline=PT1M=, 1 minute).
 \item {\em default: PT10S}
 \end{myitemize}
@@ -98,7 +98,7 @@ If a send fails, the messaging code will retry after a configured
 delay interval.
 
 \begin{myitemize}
-\item {\em type:} ISO 8601 duration/interval representation (e.g.
+\item {\em type:} ISO 8601 duration/interval representation (e.g.\ 
 \lstinline=PT10S=, 10 seconds, or \lstinline=PT1M=, 1 minute).
 \item {\em default:} PT5S
 \end{myitemize}
@@ -121,7 +121,7 @@ commands. Without a timeout remote connections to unresponsive
 suites can hang indefinitely (suites suspended with Ctrl-Z for instance).
 
 \begin{myitemize}
-\item {\em type:} ISO 8601 duration/interval representation (e.g.
+\item {\em type:} ISO 8601 duration/interval representation (e.g.\ 
 \lstinline=PT10S=, 10 seconds, or \lstinline=PT1M=, 1 minute).
 \item {\em default:} PT30S
 \end{myitemize}
@@ -343,7 +343,7 @@ supported for HTTPS, which alters HTTP Digest Auth to use the SHA1 hash
 algorithm rather than the standard MD5. This is more secure but is also
 less well supported by third party web clients including web browsers.
 You may need to add the 'SHA1' option if you are running on platforms
-where MD5 is discouraged (e.g. under FIPS).
+where MD5 is discouraged (e.g.\  under FIPS).
 
 \begin{myitemize}
 \item {\em type:} string\_list
@@ -469,7 +469,7 @@ polling near the beginning and end of the anticipated task run time.
 Multipliers can be used as shorthand as in the example below.
 
 \begin{myitemize}
-\item {\em type:} ISO 8601 duration/interval representation (e.g.
+\item {\em type:} ISO 8601 duration/interval representation (e.g.\ 
 \lstinline=PT10S=, 10 seconds, or \lstinline=PT1M=, 1 minute).
 \item {\em default:}
 \item {\em example:} \lstinline@execution polling intervals = 5*PT1M, 10*PT5M, 5*PT1M@
@@ -488,7 +488,7 @@ values can be specified as for execution polling (above) but a single
 value is probably sufficient for job submission polling.
 
 \begin{myitemize}
-\item {\em type:} ISO 8601 duration/interval representation (e.g.
+\item {\em type:} ISO 8601 duration/interval representation (e.g.\ 
 \lstinline=PT10S=, 10 seconds, or \lstinline=PT1M=, 1 minute).
 \item {\em default:}
 \item {\em example:} (see the execution polling example above)

--- a/doc/src/cylc-user-guide/suiterc.tex
+++ b/doc/src/cylc-user-guide/suiterc.tex
@@ -116,7 +116,7 @@ negative sign, thereafter following the ISO 8601 standard example notation
 except for fractional digits, which are represented as \lstinline=,ii= for
 \lstinline=hh=, \lstinline=,nn= for \lstinline=mm=, etc. For example, to write
 date-times as week dates with fractional hours, set cycle point format to
-\lstinline=CCYYWwwDThh,iiZ= e.g. \lstinline=1987W041T08,5Z= for 08:30 UTC on
+\lstinline=CCYYWwwDThh,iiZ= e.g.\  \lstinline=1987W041T08,5Z= for 08:30 UTC on
 Monday on the fourth ISO week of 1987.
 
 You can also use a subset of the strptime/strftime POSIX standard - supported
@@ -125,10 +125,12 @@ tokens are \lstinline=%F=, \lstinline=%H=, \lstinline=%M=, \lstinline=%S=,
 \lstinline=%s=, \lstinline=%z=.
 
 The pre cylc-6 legacy 10-digit date-time format YYYYMMDDHH is not ISO8601
-compliant and can no longer be used as the cycle point format. For job scripts
-that still require the old format use the \lstinline=cylc cyclepoint= utility
-to translate it from ISO8601 inside job scripts, like this:
+compliant and can no longer be used as the cycle point format. For job
+scripts that still require the old format, use the
+\lstinline=cylc cyclepoint= utility to translate the ISO8601 cycle point
+inside job scripts, e.g.:
 
+\lstset{language=suiterc}
 \begin{lstlisting}
 [runtime]
    [[root]]
@@ -167,12 +169,13 @@ zone offsets from UTC, such as \lstinline=+13=, \lstinline=+1300=,
 special \lstinline=+0000= case. Cycle points will be converted to the time
 zone you give and will be represented with this string at the end.
 
-Cycle points that are input without time zones (e.g. as an initial cycle point
+Cycle points that are input without time zones (e.g.\ as an initial cycle
+point
 setting) will use this time zone if set. If this isn't set (and UTC mode is
 also not set), then they will default to the current local time zone.
 
 Note that the ISO standard also allows writing the hour and minute separated
-by a ":" (e.g. \lstinline=+13:00=) - however, this is not recommended, given
+by a ":" (e.g.\ \lstinline=+13:00=) - however, this is not recommended, given
 that the time zone is used as part of task output filenames.
 
 \subsubsection[abort if any task fails]{[cylc] \textrightarrow abort if any task fails}
@@ -193,7 +196,7 @@ directory exists and that its contact file contains the expected information.
 If not, the suite will shut itself down automatically.
 
 \begin{myitemize}
-    \item {\em type:} ISO 8601 duration/interval representation (e.g.
+    \item {\em type:} ISO 8601 duration/interval representation (e.g.\ 
  \lstinline=PT5M=, 5 minutes (note: by contrast, \lstinline=P5M= means 5
  months, so remember the \lstinline=T=!)).
     \item {\em default:} PT10M
@@ -207,7 +210,7 @@ a given interval. This is useful to prevent flooding users' mail boxes when
 many task events occur within a short period of time.
 
 \begin{myitemize}
-  \item {\em type:} ISO 8601 duration/interval representation (e.g. \lstinline=PT10S=, 10 seconds, or \lstinline=PT1M=, 1 minute).
+  \item {\em type:} ISO 8601 duration/interval representation (e.g.\ \lstinline=PT10S=, 10 seconds, or \lstinline=PT1M=, 1 minute).
   \item {\em default: PT5M}
 \end{myitemize}
 
@@ -429,7 +432,7 @@ of time. The timer is set initially at suite start up. It is possible to set a
 default for this at the site level (see ~\ref{SiteCylcHooks}).
 
 \begin{myitemize}
-    \item {\em type:} ISO 8601 duration/interval representation (e.g.
+    \item {\em type:} ISO 8601 duration/interval representation (e.g.\ 
  \lstinline=PT5S=, 5 seconds, \lstinline=PT1S=, 1 second) - minimum 0 seconds.
     \item {\em default:} (none), unless set at the site level.
 \end{myitemize}
@@ -442,7 +445,7 @@ of time. The timer is set initially at suite start up. It is possible to set a
 default for this at the site level (see ~\ref{SiteCylcHooks}).
 
 \begin{myitemize}
-    \item {\em type:} ISO 8601 duration/interval representation (e.g.
+    \item {\em type:} ISO 8601 duration/interval representation (e.g.\  
  \lstinline=PT5S=, 5 seconds, \lstinline=PT1S=, 1 second) - minimum 0 seconds.
     \item {\em default:} (none), unless set at the site level.
 \end{myitemize}
@@ -620,7 +623,7 @@ cannot be done in live mode unless you define a value for this item, because
 it is not possible to arrive at a sensible default for all suites.
 
 \begin{myitemize}
-    \item {\em type:} ISO 8601 duration/interval representation, e.g.
+    \item {\em type:} ISO 8601 duration/interval representation, e.g.\ 
         \lstinline=PT5M= is 5 minutes (note: by contrast \lstinline=P5M= means 5
          months, so remember the \lstinline=T=!).
     \item {\em default:} PT1M (1 minute)
@@ -634,7 +637,7 @@ simulation mode unless you define a value for this item, because it is
 not possible to arrive at a sensible default for all suites.
 
 \begin{myitemize}
-    \item {\em type:} ISO 8601 duration/interval representation (e.g.
+    \item {\em type:} ISO 8601 duration/interval representation (e.g.\ 
  \lstinline=PT5M=, 5 minutes (note: by contrast, \lstinline=P5M= means 5
  months, so remember the \lstinline=T=!)).
     \item {\em default:} PT1M (1 minute)
@@ -648,7 +651,7 @@ cannot be done in dummy mode unless you define a value for this item, because
 it is not possible to arrive at a sensible default for all suites.
 
 \begin{myitemize}
-    \item {\em type:} ISO 8601 duration/interval representation (e.g.
+    \item {\em type:} ISO 8601 duration/interval representation (e.g.\ 
  \lstinline=PT5M=, 5 minutes (note: by contrast, \lstinline=P5M= means 5
  months, so remember the \lstinline=T=!)).
     \item {\em default:} PT1M (1 minute)
@@ -712,7 +715,7 @@ it will be assumed to be local time, or in UTC if~\ref{UTC-mode} is set, or in
 the time zone determined by \ref{cycle-point-time-zone} if that is set.
 
 \begin{myitemize}
-    \item {\em type:} ISO 8601 date-time point representation (e.g.
+    \item {\em type:} ISO 8601 date-time point representation (e.g.\ 
  \lstinline=CCYYMMDDThhmm=, 19951231T0630) or ``now''.
     \item {\em default:} (none)
 \end{myitemize}
@@ -734,9 +737,9 @@ it will be assumed to be local time, or in UTC if \ref{UTC-mode} is set, or in
 the \ref{cycle-point-time-zone} if that is set.
 
 \begin{myitemize}
-    \item {\em type:} ISO 8601 date-time point representation (e.g.
+    \item {\em type:} ISO 8601 date-time point representation (e.g.\ 
  \lstinline=CCYYMMDDThhmm=, 19951231T1230) or ISO 8601 date-time offset
-    (e.g. +P1D+PT6H)
+    (e.g.\  +P1D+PT6H)
     \item {\em default:} (none)
 \end{myitemize}
 
@@ -749,7 +752,7 @@ constraints.
 
 \begin{myitemize}
     \item {\em type:} Comma-separated list of ISO 8601 truncated time point
-        representations (e.g. T00, T06, T-30).
+        representations (e.g.\  T00, T06, T-30).
     \item {\em default:} (none)
 \end{myitemize}
 
@@ -762,7 +765,7 @@ constraints.
 
 \begin{myitemize}
     \item {\em type:} Comma-separated list of ISO 8601 truncated time point
-        representations (e.g. T00, T06, T-30).
+        representations (e.g.\  T00, T06, T-30).
     \item {\em default:} (none)
 \end{myitemize}
 
@@ -784,7 +787,7 @@ slowest and fastest tasks. It is deprecated in favour of the newer default
 limiting by \lstinline=max active cycle points= (\ref{max active cycle points}).
 
 \begin{myitemize}
-    \item {\em type:} Cycle interval string e.g. \lstinline=PT12H=
+    \item {\em type:} Cycle interval string e.g.\  \lstinline=PT12H=
     for a 12 hour limit under ISO 8601 cycling.
     \item {\em default:} (none)
 \end{myitemize}
@@ -819,7 +822,7 @@ additional task proxies both in terms of memory and cpu for the cylc daemon as
 well as overheads in rendering all the additional tasks in gcylc. Also, use
 of the setting may highlight any issues with suite design relying on the
 default behaviour where downstream tasks would otherwise be waiting on ones
-upstream submitting and the suite would have stalled e.g. a housekeeping task
+upstream submitting and the suite would have stalled e.g.\  a housekeeping task
 at a later cycle deleting an earlier cycle's data before that cycle has had
 chance to run where previously the task would not have been spawned until its
 predecessor had been submitted.
@@ -878,7 +881,7 @@ specified as an offset from their own cycle point.
 \begin{myitemize}
     \item {\em type:} Comma-separated list of task or family names with
         associated date-time offsets expressed as ISO8601 interval strings,
-        positive or negative, e.g. \lstinline=PT1H= for 1 hour.  The offset
+        positive or negative, e.g.\  \lstinline=PT1H= for 1 hour.  The offset
         specification may be omitted to trigger right on the cycle point.
     \item {\em default:} (none)
     \item {\em example:}
@@ -898,7 +901,7 @@ see~\ref{ClockExpireTasks}.
 \begin{myitemize}
     \item {\em type:} Comma-separated list of task or family names with
         associated date-time offsets expressed as ISO8601 interval strings,
-        positive or negative, e.g. \lstinline=PT1H= for 1 hour.  The offset
+        positive or negative, e.g.\  \lstinline=PT1H= for 1 hour.  The offset
         may be omitted if it is zero.
     \item {\em default:} (none)
     \item {\em example:}
@@ -1621,7 +1624,7 @@ Item details:
 If a task has not started after the specified ISO 8601 duration/interval, the
 {\em submission timeout} event handler(s) will be called.
 \begin{myitemize}
-    \item {\em type:} ISO 8601 duration/interval representation (e.g.
+    \item {\em type:} ISO 8601 duration/interval representation (e.g.\ 
  \lstinline=PT30M=, 30 minutes or \lstinline=P1D=, 1 day).
     \item {\em default:} (none)
 \end{myitemize}
@@ -1632,7 +1635,7 @@ If a task has not started after the specified ISO 8601 duration/interval, the
 If a task has not finished after the specified ISO 8601 duration/interval, the
 {\em execution timeout} event handler(s) will be called.
 \begin{myitemize}
-    \item {\em type:} ISO 8601 duration/interval representation (e.g.
+    \item {\em type:} ISO 8601 duration/interval representation (e.g.\ 
  \lstinline=PT4H=, 4 hours or \lstinline=P1D=, 1 day).
     \item {\em default:} (none)
 \end{myitemize}
@@ -1824,7 +1827,7 @@ individually overridden at lower levels of the runtime namespace hierarchy.
 
 \subparagraph[\_\_DIRECTIVE\_\_ ]{[runtime] \textrightarrow [[\_\_NAME\_\_]] \textrightarrow [[[directives]]] \textrightarrow \_\_DIRECTIVE\_\_}
 
-Replace \_\_DIRECTIVE\_\_ with each directive assignment, e.g.
+Replace \_\_DIRECTIVE\_\_ with each directive assignment, e.g.\ 
 \lstinline@class = parallel@
 
 \begin{myitemize}
@@ -1868,7 +1871,7 @@ taken from the graph notation.
 \subparagraph[run-dir]{[runtime] \textrightarrow [[\_\_NAME\_\_]] \textrightarrow [[[suite state polling]]] \textrightarrow run-dir}
 
 For your own suites the run database location is determined by your
-site/user config. For other suites, e.g. those owned by others, or
+site/user config. For other suites, e.g.\  those owned by others, or
 mirrored suite databases, use this item to specify the location
 of the top level cylc run directory (the database should be a
 suite-name sub-directory of this location).
@@ -1892,7 +1895,7 @@ Cycle point template of the target suite, if different from that of the polling 
 
 Polling interval expressed as an ISO 8601 duration/interval.
 \begin{myitemize}
-    \item {\em type:} ISO 8601 duration/interval representation (e.g.
+    \item {\em type:} ISO 8601 duration/interval representation (e.g.\ 
  \lstinline=PT10S=, 10 seconds, or \lstinline=PT1M=, 1 minute).
     \item {\em default:} PT1M
 \end{myitemize}
@@ -1950,7 +1953,7 @@ The default simulated job run length, if \lstinline=[job]execution time limit=
 and \lstinline=[simulation]speedup factor= are not set.
 
 \begin{myitemize}
-    \item {\em type:} ISO 8601 duration/interval representation (e.g.
+    \item {\em type:} ISO 8601 duration/interval representation (e.g.\ 
  \lstinline=PT10S=, 10 seconds, or \lstinline=PT1M=, 1 minute).
     \item {\em default:} \lstinline=PT10S=
 \end{myitemize}
@@ -1973,7 +1976,7 @@ simulated task run length plus this buffer interval, to avoid job kill due to
 exceeding the time limit.
 
 \begin{myitemize}
-    \item {\em type:} ISO 8601 duration/interval representation (e.g.
+    \item {\em type:} ISO 8601 duration/interval representation (e.g.\ 
  \lstinline=PT10S=, 10 seconds, or \lstinline=PT1M=, 1 minute).
     \item {\em default:} PT10S
 \end{myitemize}
@@ -2024,7 +2027,7 @@ and so on can be found at http://www.graphviz.org/Documentation.php.
 
 The initial cycle point for graph plotting.
 \begin{myitemize}
-    \item {\em type:} ISO 8601 date-time representation (e.g. CCYYMMDDThhmm)
+    \item {\em type:} ISO 8601 date-time representation (e.g.\  CCYYMMDDThhmm)
     \item {\em default:} the suite initial cycle point
 \end{myitemize}
 The visualization initial cycle point gets adjusted up if necessary to the
@@ -2035,7 +2038,7 @@ suite initial cycling point.
 An explicit final cycle point for graph plotting. If used, this overrides the
 preferred {\em number of cycle points} (below).
 \begin{myitemize}
-    \item {\em type:} ISO 8601 date-time representation (e.g. CCYYMMDDThhmm)
+    \item {\em type:} ISO 8601 date-time representation (e.g.\  CCYYMMDDThhmm)
     \item {\em default:} (none)
 \end{myitemize}
 The visualization final cycle point gets adjusted down if necessary to the

--- a/doc/src/cylc-user-guide/suiterc.tex
+++ b/doc/src/cylc-user-guide/suiterc.tex
@@ -94,14 +94,14 @@ this can be set at the site level (see ~\ref{SiteUTCMode}).
 \subsubsection[cycle point format]{ [cylc] \textrightarrow cycle point format}
 \label{cycle-point-format}
 
-To just alter the timezone used in the date/time cycle point format, see
+To just alter the timezone used in the date-time cycle point format, see
 \ref{cycle-point-time-zone}. To just alter the number of expanded year digits
 (for years below 0 or above 9999), see
 \ref{cycle-point-num-expanded-year-digits}.
 
 Cylc usually uses a \lstinline=CCYYMMDDThhmmZ= (\lstinline=Z= in the special
 case of UTC) or \lstinline=CCYYMMDDThhmm+hhmm= format (\lstinline=+= standing
-for \lstinline=+= or \lstinline=-= here) for writing down date/time cycle
+for \lstinline=+= or \lstinline=-= here) for writing down date-time cycle
 points, which follows one of the basic formats outlined in the ISO 8601
 standard. For example, a cycle point on the 3rd of February 2001 at 4:50 in
 the morning, UTC (+0000 timezone), would be written
@@ -115,23 +115,26 @@ decadal year, \lstinline=+X= for expanded year digits and their positive or
 negative sign, thereafter following the ISO 8601 standard example notation
 except for fractional digits, which are represented as \lstinline=,ii= for
 \lstinline=hh=, \lstinline=,nn= for \lstinline=mm=, etc. For example, to write
-date/times as week dates with fractional hours, set cycle point format to
+date-times as week dates with fractional hours, set cycle point format to
 \lstinline=CCYYWwwDThh,iiZ= e.g. \lstinline=1987W041T08,5Z= for 08:30 UTC on
 Monday on the fourth ISO week of 1987.
 
 You can also use a subset of the strptime/strftime POSIX standard - supported
-tokens are \lstinline=\%F=, \lstinline=\%H=, \lstinline=\%M=, \lstinline=\%S=,
-\lstinline=\%Y=, \lstinline=\%d=, \lstinline=\%j=, \lstinline=\%m=,
-\lstinline=\%s=, \lstinline=\%z=.
+tokens are \lstinline=%F=, \lstinline=%H=, \lstinline=%M=, \lstinline=%S=,
+\lstinline=%Y=, \lstinline=%d=, \lstinline=%j=, \lstinline=%m=,
+\lstinline=%s=, \lstinline=%z=.
 
-To use the old cylc date-time format (e.g. \lstinline=2014020106= for 06:00
-on the 1st of February 2014), set cycle point format to
-\lstinline=\%Y\%m\%d\%H=.
+The pre cylc-6 legacy 10-digit date-time format YYYYMMDDHH is not ISO8601
+compliant and can no longer be used as the cycle point format. For job scripts
+that still require the old format use the \lstinline=cylc cyclepoint= utility
+to translate it from ISO8601 inside job scripts, like this:
 
-Please note that using characters like "/" is not allowed, as it will break
-task output files ("/" is a reserved character in POSIX file and directory
-naming). Using ":" is also not allowed, as it is likely to interfere with
-usage of commands like "rsync" when applied to task output files.
+\begin{lstlisting}
+[runtime]
+   [[root]]
+      [[[environment]]]
+         CYCLE_TIME = $(cylc cyclepoint --template=%Y%m%d%H)
+\end{lstlisting}
 
 \subsubsection[cycle point num expanded year digits]{ [cylc] \textrightarrow
 cycle point num expanded year digits}
@@ -158,7 +161,7 @@ If you set UTC mode to True (\ref{UTC-mode}) then this will default to
 timezone choice) here as well.
 
 You may set your own time zone choice here, which will be used for all
-date/time cycle point dumping. Time zones should be expressed as ISO 8601 time
+date-time cycle point dumping. Time zones should be expressed as ISO 8601 time
 zone offsets from UTC, such as \lstinline=+13=, \lstinline=+1300=,
 \lstinline=-0500= or \lstinline=+0645=, with \lstinline=Z= representing the
 special \lstinline=+0000= case. Cycle points will be converted to the time
@@ -709,7 +712,7 @@ it will be assumed to be local time, or in UTC if~\ref{UTC-mode} is set, or in
 the time zone determined by \ref{cycle-point-time-zone} if that is set.
 
 \begin{myitemize}
-    \item {\em type:} ISO 8601 date/time point representation (e.g.
+    \item {\em type:} ISO 8601 date-time point representation (e.g.
  \lstinline=CCYYMMDDThhmm=, 19951231T0630) or ``now''.
     \item {\em default:} (none)
 \end{myitemize}
@@ -731,8 +734,8 @@ it will be assumed to be local time, or in UTC if \ref{UTC-mode} is set, or in
 the \ref{cycle-point-time-zone} if that is set.
 
 \begin{myitemize}
-    \item {\em type:} ISO 8601 date/time point representation (e.g.
- \lstinline=CCYYMMDDThhmm=, 19951231T1230) or ISO 8601 date/time offset
+    \item {\em type:} ISO 8601 date-time point representation (e.g.
+ \lstinline=CCYYMMDDThhmm=, 19951231T1230) or ISO 8601 date-time offset
     (e.g. +P1D+PT6H)
     \item {\em default:} (none)
 \end{myitemize}
@@ -1568,7 +1571,7 @@ substituted with actual values:
     \item \%(task\_url)s: task URL
     \item \%(importance)s: importance value (priority of task)
     \item \%(submit\_num)s: submit number
-    \item \%(id)s: task ID (i.e. \%(name)s.\%(point)s)
+    \item \%(id)s: task ID (i.e.\ \%(name)s.\%(point)s)
     \item \%(message)s: event message, if any
 \end{myitemize}
 
@@ -1882,7 +1885,7 @@ Cycle point template of the target suite, if different from that of the polling 
 \begin{myitemize}
     \item {\em type:} string
     \item {\em default:} cycle point format of the polling suite
-    \item {\em example:} \lstinline=\%Y-\%m-\%dT\%H=
+    \item {\em example:} \lstinline=%Y-%m-%dT%H=
 \end{myitemize}
 
 \subparagraph[interval]{[runtime] \textrightarrow [[\_\_NAME\_\_]] \textrightarrow [[[suite state polling]]] \textrightarrow interval}
@@ -2021,7 +2024,7 @@ and so on can be found at http://www.graphviz.org/Documentation.php.
 
 The initial cycle point for graph plotting.
 \begin{myitemize}
-    \item {\em type:} ISO 8601 date/time representation (e.g. CCYYMMDDThhmm)
+    \item {\em type:} ISO 8601 date-time representation (e.g. CCYYMMDDThhmm)
     \item {\em default:} the suite initial cycle point
 \end{myitemize}
 The visualization initial cycle point gets adjusted up if necessary to the
@@ -2032,7 +2035,7 @@ suite initial cycling point.
 An explicit final cycle point for graph plotting. If used, this overrides the
 preferred {\em number of cycle points} (below).
 \begin{myitemize}
-    \item {\em type:} ISO 8601 date/time representation (e.g. CCYYMMDDThhmm)
+    \item {\em type:} ISO 8601 date-time representation (e.g. CCYYMMDDThhmm)
     \item {\em default:} (none)
 \end{myitemize}
 The visualization final cycle point gets adjusted down if necessary to the

--- a/doc/src/cylc-user-guide/suiterc.tex
+++ b/doc/src/cylc-user-guide/suiterc.tex
@@ -124,6 +124,10 @@ tokens are \lstinline=%F=, \lstinline=%H=, \lstinline=%M=, \lstinline=%S=,
 \lstinline=%Y=, \lstinline=%d=, \lstinline=%j=, \lstinline=%m=,
 \lstinline=%s=, \lstinline=%z=.
 
+The ISO8601 extended date-time format can be used
+(\lstinline=%Y-%m-%dT%H:%M=) but
+note that the `-' and `:' characters end up in job log directory paths.
+
 The pre cylc-6 legacy 10-digit date-time format YYYYMMDDHH is not ISO8601
 compliant and can no longer be used as the cycle point format. For job
 scripts that still require the old format, use the


### PR DESCRIPTION
As revealed by @trwhitcomb, we're still saying its possible to use YYYYMMDDHH (which it isn't).

While I was at it, also made consistent use of:
 * `e.g.\ `  (short trailing space as it's not end of sentence)
 * "date-time" (vs "date/time" vs "date time")

And removed some erroneous escaping of `%` in string formatting docs (% doesn't start a LaTeX comment inside an lst environment).