### PR TITLE
Update signal for gscan menu dialog.

### DIFF
--- a/lib/cylc/gui/gscan.py
+++ b/lib/cylc/gui/gscan.py
@@ -343,8 +343,8 @@ class ScanApp(object):
         hosts_item.set_image(img)
         hosts_item.show()
         hosts_item.connect(
-            "button-press-event",
-            lambda b, e: launch_hosts_dialog(
+            "activate",
+            lambda w: launch_hosts_dialog(
                 self.hosts, self.updater.set_hosts))
         view_menu.append(hosts_item)
 


### PR DESCRIPTION
With the configure hosts dialog moved to a proper menu in Cylc 7,
the dialog would not display for some users.  Investigation showed
that the function to create and display the dialog was not called,
because the button press signal was not being registered.  Replacing
button press with "activate" signal resulted in the dialog displaying
properly.