### PR TITLE
Remove "cylc suite-state" cycle point template

### DIFF
--- a/bin/cylc-suite-state
+++ b/bin/cylc-suite-state
@@ -108,9 +108,7 @@ class SuitePoller(Poller):
             sys.stdout.write('\n')
 
         if connected and self.args['cycle']:
-            fmt = self.args['template']
-            if not fmt:
-                fmt = self.checker.get_remote_point_format()
+            fmt = self.checker.get_remote_point_format()
             if fmt:
                 my_parser = TimePointParser()
                 my_point = my_parser.parse(self.args['cycle'], dump_format=fmt)
@@ -145,9 +143,8 @@ def main():
 
     parser.add_option(
         "--template", metavar="TEMPLATE",
-        help="Cyclepoint template string, used to reformat cyclepoints for "
-             "querying suites",
-        action="store", dest="template")
+        help="Remote cyclepoint template (IGNORED - this is now determined "
+             "automatically).", action="store", dest="template")
 
     parser.add_option(
         "-d", "--run-dir",
@@ -199,6 +196,9 @@ def main():
     if options.offset and not options.cycle:
         sys.exit("ERROR: You must target a cycle point to use an offset")
 
+    if options.template:
+        print >> sys.stderr, "WARNING: ignoring --template (no longer needed)"
+
     # Attempt to apply specified offset to the targeted cycle
     if options.offset:
         my_parser = TimePointParser()
@@ -236,10 +236,6 @@ def main():
             options.status not in CylcSuiteDBChecker.STATE_ALIASES):
         sys.exit("ERROR: invalid status '" + options.status + "'")
 
-    # Reformat cycle point for querying targeted suite
-    if options.template and not options.cycle:
-        sys.exit("ERROR: No cycle point to reformat using template")
-
     # this only runs locally (use of --host or --user results in remote
     # re-invocation).
     run_dir = os.path.expandvars(
@@ -252,7 +248,6 @@ def main():
                 'cycle': options.cycle,
                 'status': options.status,
                 'message': options.msg,
-                'template': options.template
                 }
 
     spoller = SuitePoller("requested state",


### PR DESCRIPTION
I think there's no reason to keep the `--template` option for `cylc suite-state`.  The target suite cycle point format has been determined automatically since cylc-7.1.1, and no one should be polling cylc-6 suites with cylc-7 clients (which doesn't leave much of a compatibility gap) ... agree?