### PR TITLE
graph: ghost node detection fix

### DIFF
--- a/tests/graphing/10-ghost-nodes/graph.plain.ref
+++ b/tests/graphing/10-ghost-nodes/graph.plain.ref
@@ -1,15 +1,7 @@
-edge "BAR.1" "BAR.2" solid
-edge "BAR.3" "BAR.4" solid
-edge "BAR.4" "BAR.5" solid
 edge "foo.1" "foo.2" solid
 edge "foo.3" "foo.4" solid
 edge "foo.4" "foo.5" solid
 graph
-node "BAR.1" "BAR\n1" unfilled doubleoctagon black
-node "BAR.2" "BAR\n2" unfilled doubleoctagon black
-node "BAR.3" "BAR\n3" unfilled #888888 #eeeeee
-node "BAR.4" "BAR\n4" unfilled doubleoctagon black
-node "BAR.5" "BAR\n5" unfilled doubleoctagon black
 node "foo.1" "foo\n1" unfilled ellipse black
 node "foo.2" "foo\n2" unfilled ellipse black
 node "foo.3" "foo\n3" unfilled #888888 #eeeeee

--- a/tests/graphing/10-ghost-nodes/suite.rc
+++ b/tests/graphing/10-ghost-nodes/suite.rc
@@ -4,14 +4,7 @@
     [[dependencies]]
         [[[P1!3]]]
             graph = foo[-P1] => foo
-        [[[P1!3]]]
-            graph = BAR[-P1]:succeed-all => BAR
-        [[[R1/3]]]
-            graph = pub
 [runtime]
     [[foo]]
-    [[BAR]]
-    [[bar, pub]]
-        inherit = BAR
 [visualization]
-    number of cycle points = 5
+    number of cycle points = 4


### PR DESCRIPTION
Follow-on fix from #2346

This PR fixes the somewhat over-zealous detection of ghost nodes and handles the case that a task is defined but not used.

Detection of ghost-families has been removed as it is doesn't make sense without analysing the suite's triggers individually which is perhaps beyond the scope of `cylc graph`.