### PR TITLE
Fixed a test.

### DIFF
--- a/tests/events/task/suite.rc
+++ b/tests/events/task/suite.rc
@@ -57,7 +57,7 @@ fi"""
         [[[job]]]
             submission retry delays = PT3S
         [[[remote]]]
-            host = NOHOST
+            host = NOHOST.NODOMAIN
 
      [[baz]]
         # submitted, submission timeout, started, failed


### PR DESCRIPTION
On my laptop VM, `tests/events/01-task.t` always passes at home, and always fails when on the work network because an expected job submission timeout event apparently does not occur.

The test suite uses `[remote]host = NOHOST` for one task.  During job host init, `ssh NOHOST ...` returns immediately with "Name or service not known" at home, but it takes 10 seconds to time out and return at work.  Adding a non-existent domain name as well makes it return immediately, and the test passes.
