### PR TITLE
Fixed a bug in a set_event_time call.

### DIFF
--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -1078,7 +1078,7 @@ class TaskPool(object):
                     itask.state.reset_state(status)
                     if status in [
                             TASK_STATUS_FAILED, TASK_STATUS_SUBMIT_FAILED]:
-                        itask.set_event_time('finished', time())
+                        itask.set_event_time('finished', get_current_time_string())
             if outputs:
                 for output in outputs:
                     is_completed = True

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -1078,7 +1078,8 @@ class TaskPool(object):
                     itask.state.reset_state(status)
                     if status in [
                             TASK_STATUS_FAILED, TASK_STATUS_SUBMIT_FAILED]:
-                        itask.set_event_time('finished', get_current_time_string())
+                        itask.set_event_time('finished',
+                                             get_current_time_string())
             if outputs:
                 for output in outputs:
                     is_completed = True


### PR DESCRIPTION
Fixed a bug introduced before 7.4.0, by (I think) #2157 - manual task state reset to failed results in a traceback (although the state reset still succeeds)
```
2017-08-13T08:18:07+12 WARNING - Traceback (most recent call last):
          File "/home/vagrant/cylc.git/lib/cylc/scheduler.py", line 527, in process_command_queue
            *args, **kwargs)
          File "/home/vagrant/cylc.git/lib/cylc/scheduler.py", line 1618, in command_reset_task_states
            return self.pool.reset_task_states(items, state, outputs)
          File "/home/vagrant/cylc.git/lib/cylc/task_pool.py", line 1081, in reset_task_states
            itask.set_event_time('finished', time())
          File "/home/vagrant/cylc.git/lib/cylc/task_proxy.py", line 241, in set_event_time
            get_unix_time_from_time_string(time_str))
          File "/home/vagrant/cylc.git/lib/cylc/wallclock.py", line 226, in get_unix_time_from_time_string
            datetime_string, DATE_TIME_FORMAT_EXTENDED + "Z")
        TypeError: strptime() argument 1 must be string, not float

2017-08-13T08:18:07+12 WARNING - strptime() argument 1 must be string, not float
2017-08-13T08:18:07+12 WARNING - Command failed: reset_task_states([u'qux.1'], outputs=None, state=failed)
2017-08-13T08:18:07+12 INFO - Processing 1 queued command(s)
+       reset_task_states([u'qux.1'], outputs=None, state=failed)
```