### PR TITLE
1792 - task polling logic and state reset.

### DIFF
--- a/bin/cylc-poll
+++ b/bin/cylc-poll
@@ -51,6 +51,10 @@ def main():
             ('REG', 'Suite name'),
             ('[TASKID ...]', 'Task identifiers')])
 
+    parser.add_option(
+        "-s", "--succeeded", help="Allow polling of succeeded tasks.",
+        action="store_true", default=False, dest="poll_all")
+
     options, args = parser.parse_args()
 
     suite = args.pop(0)
@@ -63,7 +67,7 @@ def main():
         options.comms_timeout, my_uuid=options.set_uuid,
         print_uuid=options.print_uuid)
     items = parser.parse_multitask_compat(options, args)
-    pclient.put_command('poll_tasks', items=items)
+    pclient.put_command('poll_tasks', items=items, poll_all=options.poll_all)
 
 
 if __name__ == "__main__":

--- a/bin/cylc-poll
+++ b/bin/cylc-poll
@@ -53,7 +53,7 @@ def main():
 
     parser.add_option(
         "-s", "--succeeded", help="Allow polling of succeeded tasks.",
-        action="store_true", default=False, dest="poll_all")
+        action="store_true", default=False, dest="poll_succ")
 
     options, args = parser.parse_args()
 
@@ -67,7 +67,7 @@ def main():
         options.comms_timeout, my_uuid=options.set_uuid,
         print_uuid=options.print_uuid)
     items = parser.parse_multitask_compat(options, args)
-    pclient.put_command('poll_tasks', items=items, poll_all=options.poll_all)
+    pclient.put_command('poll_tasks', items=items, poll_succ=options.poll_succ)
 
 
 if __name__ == "__main__":

--- a/bin/cylc-poll
+++ b/bin/cylc-poll
@@ -18,17 +18,10 @@
 
 """cylc [control] poll [OPTIONS] ARGS
 
-Poll jobs of active tasks to verify or update their statuses.
+Poll (query) task jobs to verify and update their statuses.
 
-To poll one or more tasks, "cylc poll REG TASKID"; to poll all active
-tasks: "cylc poll REG".
-
-Note that automatic job polling can used to track task status on task hosts
-that do not allow any communication by HTTPS or ssh back to the suite host
-- see site/user config file documentation.
-
-Polling is also done automatically on restarting a suite, for any tasks that
-were recorded as submitted or running when the suite went down.
+Use "cylc poll REG" to poll all active tasks, or "cylc poll REG TASKID" to poll
+individual tasks or families, or groups of them.
 """
 
 import sys

--- a/conf/cylc.lang
+++ b/conf/cylc.lang
@@ -179,7 +179,6 @@
         <keyword>exclude at start-up</keyword>
         <keyword>exclude</keyword>
         <keyword>env-script</keyword>
-        <keyword>enable resurrection</keyword>
         <keyword>disable automatic shutdown</keyword>
         <keyword>description</keyword>
         <keyword>default node attributes</keyword>

--- a/conf/cylc.xml
+++ b/conf/cylc.xml
@@ -106,7 +106,6 @@
         <RegExpr attribute='Keyword' String=' exclude at start-up '/>
         <RegExpr attribute='Keyword' String=' exclude '/>
         <RegExpr attribute='Keyword' String=' env-script '/>
-        <RegExpr attribute='Keyword' String=' enable resurrection '/>
         <RegExpr attribute='Keyword' String=' dummy mode suite timeout '/>
         <RegExpr attribute='Keyword' String=' disable automatic shutdown '/>
         <RegExpr attribute='Keyword' String=' description '/>

--- a/doc/src/cylc-user-guide/cug.tex
+++ b/doc/src/cylc-user-guide/cug.tex
@@ -6757,36 +6757,20 @@ Some HPC facilities allow job preemption: the resource manager can kill
 or suspend running low priority jobs in order to make way for high
 priority jobs. The preempted jobs may then be automatically restarted
 by the resource manager, from the same point (if suspended) or requeued
-to run again from the start (if killed). If a running cylc task gets
-suspended or hard-killed
-(\lstinline=kill -9 <PID>= is not a trappable signal so cylc cannot detect
-task failure in this case) and then later restarted, it will just appear
-to cylc as if it takes longer than normal to run. If the job is
-soft-killed the signal will be trapped by the task job script and a
-failure message sent, resulting in cylc putting the task into the failed
-state. When the preempted task restarts and sends its started message
-cylc would normally treat this as an error condition (a dead task is not
-supposed to be sending messages) - a warning will be logged and the task
-will remain in the failed state. However, if you know that preemption is
-possible on your system you can tell cylc that affected tasks should be
-resurrected from the dead, to carry on as normal if progress messages
-start coming in again after a failure:
+to run again from the start (if killed).
 
-\lstset{language=suiterc}
-\begin{lstlisting}
-# ...
-[runtime]
-    [[HPC]]
-        enable resurrection = True
-    [[TaskFoo]]
-        inherit = HPC
-# ...
-\end{lstlisting}
-
-To test this in any suite, manually kill a running task then, after cylc
-registers the task failed, resubmit the killed job manually by
-cutting-and-pasting the original job submission command from the suite
-stdout stream.
+Suspended jobs will poll as still running (their job status file says they
+started running, and they still appear in the resource manager queue).
+Loadleveler jobs that are preempted by kill-and-requeue ("job vacation") are
+automatically returned to the submitted state by Cylc.  This is possible
+because Loadleveler sends the SIGUSR1 signal before SIGKILL for preemption.
+Other batch schedulers just send SIGTERM before SIGKILL as normal, so Cylc
+cannot distinguish a preemption job kill from a normal job kill. After this the
+job will poll as failed (correctly, because it was killed, and the job status
+file records that). To handle this kind of preemption automatically you could
+use a task failed or retry event handler that queries the batch scheduler queue
+(after an appropriate delay if necessary) and then, if the job has been
+requeued, uses \lstinline=cylc reset= to reset the task to the submitted state.
 
 \subsection{Manual Task Triggering and Edit-Run}
 

--- a/doc/src/cylc-user-guide/suiterc.tex
+++ b/doc/src/cylc-user-guide/suiterc.tex
@@ -1245,22 +1245,6 @@ Note that if you omit cycle point from the work sub-directory path successive
 instances of the task will share the same workspace.  Consider the effect on
 cycle point offset housekeeping of work directories before doing this.
 
-\paragraph[enable resurrection]{ [runtime] \textrightarrow [[\_\_NAME\_\_]] \textrightarrow enable resurrection}
-
-If a message is received from a failed task cylc will normally treat
-this as an error condition, issue a warning, and leave the task in the
-``failed'' state.  But if ``enable resurrection'' is switched on failed
-tasks can come back from the dead: if the same task job script is
-executed again cylc will put the task back into the running state and
-continue as normal when the started message is received. This can be
-used to handle HPC-style job preemption wherein a resource manager may
-kill a running task and reschedule it to run again later, to make way
-for a job with higher immediate priority. See also~\ref{PreemptionHPC}
-\begin{myitemize}
-\item {\em type:} boolean
-\item {\em default:} False
-\end{myitemize}
-
 \paragraph[{[[[}meta{]]]}]{[runtime] \textrightarrow [[\_\_NAME\_\_]] \textrightarrow [[[meta]]]}
 
 Section containing metadata items for this task or family namespace. Several items

--- a/lib/cylc/cfgspec/suite.py
+++ b/lib/cylc/cfgspec/suite.py
@@ -547,7 +547,7 @@ def upg(cfg, descr):
     u.obsolete('7.2.2', ['cylc', 'simulation mode'])
     u.obsolete('7.2.2', ['runtime', '__MANY__', 'dummy mode'])
     u.obsolete('7.2.2', ['runtime', '__MANY__', 'simulation mode'])
-    u.obsolete('7.5.0', ['runtime', '__MANY__', 'enable resurrection'])
+    u.obsolete('7.6.0', ['runtime', '__MANY__', 'enable resurrection'])
     u.upgrade()
 
 

--- a/lib/cylc/cfgspec/suite.py
+++ b/lib/cylc/cfgspec/suite.py
@@ -340,7 +340,6 @@ SPEC = {
             'script': vdr(vtype='string', default=""),
             'post-script': vdr(vtype='string', default=""),
             'extra log files': vdr(vtype='string_list', default=[]),
-            'enable resurrection': vdr(vtype='boolean', default=False),
             'work sub-directory': vdr(vtype='string'),
             'meta': {
                 'title': vdr(vtype='string', default=""),
@@ -548,6 +547,7 @@ def upg(cfg, descr):
     u.obsolete('7.2.2', ['cylc', 'simulation mode'])
     u.obsolete('7.2.2', ['runtime', '__MANY__', 'dummy mode'])
     u.obsolete('7.2.2', ['runtime', '__MANY__', 'simulation mode'])
+    u.obsolete('7.5.0', ['runtime', '__MANY__', 'enable resurrection'])
     u.upgrade()
 
 

--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -66,11 +66,10 @@ from cylc.cfgspec.globalcfg import GLOBAL_CFG
 from cylc.cfgspec.gcylc import gcfg
 from cylc.wallclock import get_current_time_string
 from cylc.task_state import (
-    TASK_STATUSES_ALL, TASK_STATUSES_RESTRICTED,
+    TASK_STATUSES_ALL, TASK_STATUSES_RESTRICTED, TASK_STATUSES_CAN_RESET_TO,
     TASK_STATUSES_WITH_JOB_SCRIPT, TASK_STATUSES_WITH_JOB_LOGS,
-    TASK_STATUSES_TRIGGERABLE, TASK_STATUSES_ACTIVE,
-    TASK_STATUS_WAITING, TASK_STATUS_HELD, TASK_STATUS_READY,
-    TASK_STATUS_RUNNING, TASK_STATUS_SUCCEEDED, TASK_STATUS_FAILED)
+    TASK_STATUSES_TRIGGERABLE, TASK_STATUSES_ACTIVE, TASK_STATUS_RUNNING,
+    TASK_STATUS_HELD, TASK_STATUS_FAILED)
 from cylc.task_state_prop import get_status_prop
 
 
@@ -1500,42 +1499,15 @@ been defined for this suite""").inform()
         # graph-view so use connect_right_click_sub_menu instead of
         # item.connect
 
-        reset_ready_item = gtk.ImageMenuItem('"%s"' % TASK_STATUS_READY)
-        reset_img = gtk.image_new_from_stock(
-            gtk.STOCK_CONVERT, gtk.ICON_SIZE_MENU)
-        reset_ready_item.set_image(reset_img)
-        reset_menu.append(reset_ready_item)
-        self.connect_right_click_sub_menu(is_graph_view, reset_ready_item,
-                                          self.reset_task_state, task_ids,
-                                          TASK_STATUS_READY)
-
-        reset_waiting_item = gtk.ImageMenuItem('"%s"' % TASK_STATUS_WAITING)
-        reset_img = gtk.image_new_from_stock(
-            gtk.STOCK_CONVERT, gtk.ICON_SIZE_MENU)
-        reset_waiting_item.set_image(reset_img)
-        reset_menu.append(reset_waiting_item)
-        self.connect_right_click_sub_menu(is_graph_view, reset_waiting_item,
-                                          self.reset_task_state, task_ids,
-                                          TASK_STATUS_WAITING)
-
-        reset_succeeded_item = gtk.ImageMenuItem(
-            '"%s"' % TASK_STATUS_SUCCEEDED)
-        reset_img = gtk.image_new_from_stock(gtk.STOCK_CONVERT,
-                                             gtk.ICON_SIZE_MENU)
-        reset_succeeded_item.set_image(reset_img)
-        reset_menu.append(reset_succeeded_item)
-        self.connect_right_click_sub_menu(is_graph_view, reset_succeeded_item,
-                                          self.reset_task_state, task_ids,
-                                          TASK_STATUS_SUCCEEDED)
-
-        reset_failed_item = gtk.ImageMenuItem('"%s"' % TASK_STATUS_FAILED)
-        reset_img = gtk.image_new_from_stock(gtk.STOCK_CONVERT,
-                                             gtk.ICON_SIZE_MENU)
-        reset_failed_item.set_image(reset_img)
-        reset_menu.append(reset_failed_item)
-        self.connect_right_click_sub_menu(is_graph_view, reset_failed_item,
-                                          self.reset_task_state, task_ids,
-                                          TASK_STATUS_FAILED)
+        for status in TASK_STATUSES_CAN_RESET_TO:
+            reset_item = gtk.ImageMenuItem('"%s"' % status)
+            reset_img = gtk.image_new_from_stock(
+                gtk.STOCK_CONVERT, gtk.ICON_SIZE_MENU)
+            reset_item.set_image(reset_img)
+            reset_menu.append(reset_item)
+            self.connect_right_click_sub_menu(is_graph_view, reset_item,
+                                              self.reset_task_state, task_ids,
+                                              status)
 
         spawn_item = gtk.ImageMenuItem('Force spawn')
         img = gtk.image_new_from_stock(gtk.STOCK_ADD, gtk.ICON_SIZE_MENU)

--- a/lib/cylc/network/httpserver.py
+++ b/lib/cylc/network/httpserver.py
@@ -476,8 +476,7 @@ class SuiteRuntimeService(object):
             items = [items]
         self.schd.command_queue.put(
             ("poll_tasks", (items,),
-                {"poll_succ": poll_succ in ['True', True]})
-            )
+                {"poll_succ": poll_succ in ['True', True]}))
         return (True, 'Command queued')
 
     @cherrypy.expose

--- a/lib/cylc/network/httpserver.py
+++ b/lib/cylc/network/httpserver.py
@@ -466,7 +466,7 @@ class SuiteRuntimeService(object):
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
-    def poll_tasks(self, items=None):
+    def poll_tasks(self, items=None, poll_all=False):
         """Poll task jobs.
 
         items is a list of identifiers for matching task proxies.
@@ -474,7 +474,8 @@ class SuiteRuntimeService(object):
         self._check_access_priv_and_report(PRIV_FULL_CONTROL)
         if items is not None and not isinstance(items, list):
             items = [items]
-        self.schd.command_queue.put(("poll_tasks", (items,), {}))
+        self.schd.command_queue.put(("poll_tasks", (items,),
+                                    {"poll_all": poll_all in ['True', True]})
         return (True, 'Command queued')
 
     @cherrypy.expose

--- a/lib/cylc/network/httpserver.py
+++ b/lib/cylc/network/httpserver.py
@@ -466,7 +466,7 @@ class SuiteRuntimeService(object):
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
-    def poll_tasks(self, items=None, poll_all=False):
+    def poll_tasks(self, items=None, poll_succ=False):
         """Poll task jobs.
 
         items is a list of identifiers for matching task proxies.
@@ -474,8 +474,10 @@ class SuiteRuntimeService(object):
         self._check_access_priv_and_report(PRIV_FULL_CONTROL)
         if items is not None and not isinstance(items, list):
             items = [items]
-        self.schd.command_queue.put(("poll_tasks", (items,),
-                                    {"poll_all": poll_all in ['True', True]})
+        self.schd.command_queue.put(
+            ("poll_tasks", (items,),
+                {"poll_succ": poll_succ in ['True', True]})
+            )
         return (True, 'Command queued')
 
     @cherrypy.expose

--- a/lib/cylc/option_parsers.py
+++ b/lib/cylc/option_parsers.py
@@ -28,8 +28,7 @@ class CylcOptionParser(OptionParser):
     """Common options for all cylc CLI commands."""
 
     MULTITASK_USAGE = """
-A TASKID is an identifier for matching individual task proxies and/or families
-of them. It can be written in these syntaxes:
+TASKID is a pattern to match task proxies or task families, or groups of them:
 * [CYCLE-POINT-GLOB/]TASK-NAME-GLOB[:TASK-STATE]
 * [CYCLE-POINT-GLOB/]FAMILY-NAME-GLOB[:TASK-STATE]
 * TASK-NAME-GLOB[.CYCLE-POINT-GLOB][:TASK-STATE]

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -765,7 +765,7 @@ conditions; see `cylc conditions`.
                 if itask.state.status in TASK_STATUSES_ACTIVE:
                     itask.state.reset_state(TASK_STATUS_FAILED)
             return len(bad_items)
-        self.task_job_mgr.kill_task_jobs(self.suite, itasks, items is not None)
+        self.task_job_mgr.kill_task_jobs(self.suite, itasks)
         return len(bad_items)
 
     def command_release_suite(self):

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -744,17 +744,17 @@ conditions; see `cylc conditions`.
         """Release tasks."""
         return self.pool.release_tasks(items)
 
-    def command_poll_tasks(self, items=None, poll_all=False):
+    def command_poll_tasks(self, items=None, poll_succ=False):
         """Poll pollable tasks or a task/family if options are provided.
 
-        Don't poll succeeded tasks unless poll_all is True.
+        Don't poll succeeded tasks unless poll_succ is True.
 
         """
         if self.run_mode == 'simulation':
             return
         itasks, bad_items = self.pool.filter_task_proxies(items)
-        self.task_job_mgr.poll_task_jobs(self.suite, itasks, items is not None,
-                                         poll_all=poll_all)
+        self.task_job_mgr.poll_task_jobs(self.suite, itasks,
+                                         poll_succ=poll_succ)
         return len(bad_items)
 
     def command_kill_tasks(self, items=None):

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -526,7 +526,8 @@ conditions; see `cylc conditions`.
             if itask.identity in task_id_messages:
                 for priority, message in task_id_messages[itask.identity]:
                     self.task_events_mgr.process_message(
-                        itask, priority, message, is_incoming=True)
+                        itask, priority, message,
+                        self.task_job_mgr.poll_task_jobs, is_incoming=True)
 
     def process_command_queue(self):
         """Process queued commands."""
@@ -743,12 +744,17 @@ conditions; see `cylc conditions`.
         """Release tasks."""
         return self.pool.release_tasks(items)
 
-    def command_poll_tasks(self, items=None):
-        """Poll all tasks or a task/family if options are provided."""
+    def command_poll_tasks(self, items=None, poll_all=False):
+        """Poll pollable tasks or a task/family if options are provided.
+
+        Don't poll succeeded tasks unless poll_all is True.
+
+        """
         if self.run_mode == 'simulation':
             return
         itasks, bad_items = self.pool.filter_task_proxies(items)
-        self.task_job_mgr.poll_task_jobs(self.suite, itasks, items is not None)
+        self.task_job_mgr.poll_task_jobs(self.suite, itasks, items is not None,
+                                         poll_all=poll_all)
         return len(bad_items)
 
     def command_kill_tasks(self, items=None):

--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -307,8 +307,8 @@ class TaskEventsManager(object):
         cylc.flags.iflag = True
 
         # Satisfy my output, if possible, and record the result.
-        an_output_was_satisfied = itask.state.outputs.set_completion(
-            message, True)
+        an_output_was_satisfied = itask.state.outputs.set_msg_trg_completion(
+            message=message, is_completed=True)
 
         if message == TASK_OUTPUT_STARTED:
             if self._poll_to_confirm(itask, TASK_STATUS_RUNNING, poll_func):

--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -47,10 +47,9 @@ from cylc.suite_host import get_suite_host, get_user
 from cylc.task_action_timer import TaskActionTimer
 from cylc.task_message import TaskMessage
 from cylc.task_state import (
-    TASK_STATUSES_ACTIVE, TASK_STATUS_READY, TASK_STATUS_SUBMITTED,
-    TASK_STATUS_SUBMIT_RETRYING, TASK_STATUS_SUBMIT_FAILED,
-    TASK_STATUS_RUNNING, TASK_STATUS_RETRYING, TASK_STATUS_FAILED,
-    TASK_STATUS_SUCCEEDED)
+    TASK_STATUS_READY, TASK_STATUS_SUBMITTED, TASK_STATUS_SUBMIT_RETRYING,
+    TASK_STATUS_SUBMIT_FAILED, TASK_STATUS_RUNNING, TASK_STATUS_RETRYING,
+    TASK_STATUS_FAILED, TASK_STATUS_SUCCEEDED)
 from cylc.task_outputs import (
     TASK_OUTPUT_SUBMITTED, TASK_OUTPUT_STARTED, TASK_OUTPUT_SUCCEEDED,
     TASK_OUTPUT_FAILED)
@@ -251,16 +250,24 @@ class TaskEventsManager(object):
             elif ctx.ctx_type == self.HANDLER_JOB_LOGS_RETRIEVE:
                 self._process_job_logs_retrieval(schd_ctx, ctx, id_keys)
 
-    def process_message(self, itask, priority, message, poll_event_time=None,
-                        is_incoming=False):
+    def process_message(self, itask, priority, message, poll_func,
+                        poll_event_time=None, is_incoming=False):
         """Parse an incoming task message and update task state.
 
-        Incoming is e.g. "succeeded at <TIME>".
+        Incoming, e.g. "succeeded at <TIME>", may be from task job or polling.
 
-        Correctly handle late (out of order) message which would otherwise set
-        the state backward in the natural order of events.
+        It is possible for my current state to be inconsistent with an incoming
+        message (whether normal or polled) e.g. due to a late poll result, or a
+        network outage, or manual state reset. To handle this, if a message
+        would take the task state backward, issue a poll to confirm instead of
+        changing state - then always believe the next message. Note that the
+        next message might not be the result of this confirmation poll, in the
+        unlikely event that a job emits a succession of messages very quickly,
+        but this is the best we can do without somehow uniquely associating
+        each poll with its result message.
 
         """
+
         is_polled = poll_event_time is not None
         # Log incoming messages with '>' to distinguish non-message log entries
         message_flag = ""
@@ -287,77 +294,77 @@ class TaskEventsManager(object):
             itask.summary['latest_message'] += " %s" % self.POLLED_INDICATOR
         cylc.flags.iflag = True
 
-        # Failed tasks do not send messages unless declared resurrectable
-        if itask.state.status == TASK_STATUS_FAILED:
-            if itask.tdef.rtconfig['enable resurrection']:
-                LOG.warning(
-                    'message received while in the failed state:' +
-                    ' I am returning from the dead!',
-                    itask=itask)
-            else:
-                LOG.warning(
-                    'message rejected while in the failed state:\n  %s' %
-                    message,
-                    itask=itask)
-                return
+        # Satisfy my output, if possible, and record the result.
+        an_output_was_satisfied = itask.state.outputs.set_completed(message)
 
-        if is_polled and itask.state.status not in TASK_STATUSES_ACTIVE:
-            # A poll result can come in after a task finishes.
-            LOG.warning(
-                "Ignoring late poll result: task is not active", itask=itask)
-            return
-
-        # Check registered outputs
-        output_has_changed = itask.state.outputs.set_completed(message)
-        if output_has_changed is False:  # Not True or None
-            # This output has already been reported complete. Not an error
-            # condition - maybe the network was down for a bit. Ok for
-            # polling as multiple polls *should* produce the same result.
-            if not is_polled:
-                LOG.debug(
-                    "ignore - output already completed:\n  %s" % message,
-                    itask=itask)
-            return
-
-        if (message == TASK_OUTPUT_STARTED and
-                itask.state.status in [
-                    TASK_STATUS_READY, TASK_STATUS_SUBMITTED,
-                    TASK_STATUS_SUBMIT_FAILED]):
+        poll_msg = "polling %s to confirm state reversal" % itask.identity
+        if message == TASK_OUTPUT_STARTED:
+            if (itask.state.is_greater_than(TASK_STATUS_RUNNING) and not
+                    itask.state.confirming_with_poll):
+                itask.state.confirming_with_poll = True
+                poll_func(self.suite, [itask], msg=poll_msg)
+            itask.state.confirming_with_poll = False
             self._process_message_started(itask, event_time)
-        elif (message == TASK_OUTPUT_SUCCEEDED and
-                itask.state.status in [
-                    TASK_STATUS_READY, TASK_STATUS_SUBMITTED,
-                    TASK_STATUS_SUBMIT_FAILED, TASK_STATUS_RUNNING,
-                    TASK_STATUS_FAILED]):
+        elif message == TASK_OUTPUT_SUCCEEDED:
+            if (itask.state.is_greater_than(TASK_STATUS_SUCCEEDED) and not
+                    itask.state.confirming_with_poll):
+                itask.state.confirming_with_poll = True
+                poll_func(self.suite, [itask], msg=poll_msg)
+                return
+            itask.state.confirming_with_poll = False
             self._process_message_succeeded(itask, event_time)
-        elif (message == TASK_OUTPUT_FAILED and
-                itask.state.status in [
-                    TASK_STATUS_READY, TASK_STATUS_SUBMITTED,
-                    TASK_STATUS_SUBMIT_FAILED, TASK_STATUS_RUNNING]):
-            # Generic fail message, via polling.
-            # (submit- states in case of very fast submission and execution).
+        elif message == TASK_OUTPUT_FAILED:
+            if (itask.state.is_greater_than(TASK_STATUS_FAILED) and not
+                    itask.state.confirming_with_poll):
+                itask.state.confirming_with_poll = True
+                poll_func(self.suite, [itask], msg=poll_msg)
+                return
+            itask.state.confirming_with_poll = False
             self._process_message_failed(itask, event_time, self.JOB_FAILED)
         elif message == self.EVENT_SUBMIT_FAILED:
+            if (itask.state.is_greater_than(TASK_STATUS_SUBMIT_FAILED) and not
+                    itask.state.confirming_with_poll):
+                itask.state.confirming_with_poll = True
+                poll_func(self.suite, [itask], msg=poll_msg)
+                return
+            itask.state.confirming_with_poll = False
             self._process_message_submit_failed(itask, event_time)
         elif message == TASK_OUTPUT_SUBMITTED:
+            if (itask.state.is_greater_than(TASK_STATUS_SUBMITTED) and not
+                    itask.state.confirming_with_poll):
+                itask.state.confirming_with_poll = True
+                poll_func(self.suite, [itask], msg=poll_msg)
+                return
+            itask.state.confirming_with_poll = False
             self._process_message_submitted(itask, event_time)
         elif message.startswith(TaskMessage.FAIL_MESSAGE_PREFIX):
-            # Task failed message
+            # Task received signal.
             signal = message[len(TaskMessage.FAIL_MESSAGE_PREFIX):]
             self._db_events_insert(itask, "signaled", signal)
             self.suite_db_mgr.put_update_task_jobs(
                 itask, {"run_signal": signal})
+            if (itask.state.is_greater_than(TASK_STATUS_FAILED) and not
+                    itask.state.confirming_with_poll):
+                itask.state.confirming_with_poll = True
+                poll_func(self.suite, [itask], msg=poll_msg)
+                return
+            itask.state.confirming_with_poll = False
             self._process_message_failed(itask, event_time, self.JOB_FAILED)
         elif message.startswith(TaskMessage.ABORT_MESSAGE_PREFIX):
             # Task aborted with message
-            signal = message[len(TaskMessage.ABORT_MESSAGE_PREFIX):]
+            aborted_with = message[len(TaskMessage.ABORT_MESSAGE_PREFIX):]
             self._db_events_insert(itask, "aborted", message)
             self.suite_db_mgr.put_update_task_jobs(
-                itask, {"run_signal": signal})
-            self._process_message_failed(itask, event_time, signal)
+                itask, {"run_signal": aborted_with})
+            if (itask.state.is_greater_than(TASK_STATUS_FAILED) and not
+                    itask.state.confirming_with_poll):
+                itask.state.confirming_with_poll = True
+                poll_func(self.suite, [itask], msg=poll_msg)
+                return
+            itask.state.confirming_with_poll = False
+            self._process_message_failed(itask, event_time, aborted_with)
         elif message.startswith(TaskMessage.VACATION_MESSAGE_PREFIX):
-            self.pflag = True
-            itask.state.reset_state(TASK_STATUS_SUBMITTED)
+            # Task job pre-empted into a vacation state
             self._db_events_insert(itask, "vacated", message)
             itask.set_event_time('started')  # reset
             if TASK_STATUS_SUBMIT_RETRYING in itask.try_timers:
@@ -369,8 +376,12 @@ class TaskEventsManager(object):
                     float(self._get_events_conf(itask, 'submission timeout')))
             except (TypeError, ValueError):
                 itask.timeout_timers[TASK_STATUS_SUBMITTED] = None
-        elif output_has_changed:
-            # Message of a custom task output
+            # Believe this and change state without polling (could poll?).
+            cylc.flags.pflag = True
+            itask.state.reset_state(TASK_STATUS_SUBMITTED)
+        elif an_output_was_satisfied:
+            # Message of an as-yet unreported custom task output.
+            # No state change.
             cylc.flags.pflag = True
             self.suite_db_mgr.put_update_task_outputs(itask)
         else:
@@ -378,6 +389,7 @@ class TaskEventsManager(object):
             #  * general non-output/progress messages
             #  * poll messages that repeat previous results
             # Note that all messages are logged already at the top.
+            # No state change.
             LOG.debug(
                 '(current: %s) unhandled: %s' % (itask.state.status, message),
                 itask=itask)

--- a/lib/cylc/task_outputs.py
+++ b/lib/cylc/task_outputs.py
@@ -138,28 +138,30 @@ class TaskOutputs(object):
         for value in self._by_message.values():
             value[_IS_COMPLETED] = True
 
-    def set_incomplete(self, message):
-        """Set output message to incomplete."""
-        if message in self._by_message:
-            self._by_message[message][_IS_COMPLETED] = False
-
     def set_all_incomplete(self):
         """Set all outputs to incomplete."""
         for value in self._by_message.values():
             value[_IS_COMPLETED] = False
 
-    def set_completed(self, message=None, trigger=None, is_completed=True):
-        """Set the output identified by message/trigger as completed.
+    def set_completion(self, message, is_completed):
+        """Set output message completion status to is_completed (bool)."""
+        if message in self._by_message:
+            self._by_message[message][_IS_COMPLETED] = is_completed
+
+    def set_msg_trg_completion(self, message=None, trigger=None,
+                               is_completed=True):
+        """Set the output identified by message/trigger to is_completed.
 
         Return True if completion flag is changed, False if completion is
         unchanged, or None if message/trigger is not found.
+
         """
         try:
             item = self._get_item(message, trigger)
             old_is_completed = item[_IS_COMPLETED]
             item[_IS_COMPLETED] = is_completed
         except KeyError:
-            pass
+            return None
         else:
             return bool(old_is_completed) != bool(is_completed)
 

--- a/lib/cylc/task_outputs.py
+++ b/lib/cylc/task_outputs.py
@@ -138,6 +138,11 @@ class TaskOutputs(object):
         for value in self._by_message.values():
             value[_IS_COMPLETED] = True
 
+    def set_incomplete(self, message):
+        """Set output message to incomplete."""
+        if message in self._by_message:
+            self._by_message[message][_IS_COMPLETED] = False
+
     def set_all_incomplete(self):
         """Set all outputs to incomplete."""
         for value in self._by_message.values():

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -411,8 +411,8 @@ class TaskPool(object):
                     TASK_STATUS_SUCCEEDED]:
                 try:
                     for output in outputs_str.splitlines():
-                        itask.state.outputs.set_completed(
-                            message=output.split("=", 1)[1])
+                        itask.state.outputs.set_completion(
+                            output.split("=", 1)[1], True)
                 except AttributeError:
                     pass
 
@@ -1089,10 +1089,10 @@ class TaskPool(object):
                         itask.state.outputs.set_all_incomplete()
                         LOG.info("reset all output to incomplete", itask=itask)
                     else:
-                        ret = itask.state.outputs.set_completed(
+                        ret = itask.state.outputs.set_msg_trg_completion(
                             message=output, is_completed=is_completed)
                         if ret is None:
-                            ret = itask.state.outputs.set_completed(
+                            ret = itask.state.outputs.set_msg_trg_completion(
                                 trigger=output, is_completed=is_completed)
                         if ret is None:
                             LOG.warning(

--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -74,7 +74,6 @@ class TaskProxy(object):
         self.identity = TaskID.get(self.tdef.name, self.point)
 
         self.has_spawned = has_spawned
-
         self.point_as_seconds = None
 
         # Manually inserted tasks may have a final cycle point set.
@@ -84,6 +83,7 @@ class TaskProxy(object):
         self.is_manual_submit = False
         self.summary = {
             'latest_message': "",
+            'submit_method_id': None,
             'submitted_time': None,
             'submitted_time_string': None,
             'submit_num': self.submit_num,

--- a/lib/cylc/task_state.py
+++ b/lib/cylc/task_state.py
@@ -324,19 +324,19 @@ class TaskState(object):
             self.outputs.set_all_incomplete()
         elif status == TASK_STATUS_SUBMITTED:
             self.set_prerequisites_all_satisfied()
-            self.outputs.set_completed(TASK_OUTPUT_SUBMITTED)
+            self.outputs.set_completion(TASK_OUTPUT_SUBMITTED, True)
             # In case of manual reset, set final outputs incomplete (but assume
             # completed message outputs remain completed).
-            self.outputs.set_incomplete(TASK_OUTPUT_SUCCEEDED)
-            self.outputs.set_incomplete(TASK_OUTPUT_FAILED)
+            self.outputs.set_completion(TASK_OUTPUT_SUCCEEDED, False)
+            self.outputs.set_completion(TASK_OUTPUT_FAILED, False)
         elif status == TASK_STATUS_RUNNING:
             self.set_prerequisites_all_satisfied()
-            self.outputs.set_completed(TASK_OUTPUT_SUBMITTED)
-            self.outputs.set_completed(TASK_OUTPUT_STARTED)
+            self.outputs.set_completion(TASK_OUTPUT_SUBMITTED, True)
+            self.outputs.set_completion(TASK_OUTPUT_STARTED, True)
             # In case of manual reset, set final outputs incomplete (but assume
             # completed message outputs remain completed).
-            self.outputs.set_incomplete(TASK_OUTPUT_SUCCEEDED)
-            self.outputs.set_incomplete(TASK_OUTPUT_FAILED)
+            self.outputs.set_completion(TASK_OUTPUT_SUCCEEDED, False)
+            self.outputs.set_completion(TASK_OUTPUT_FAILED, False)
         elif status == TASK_STATUS_SUBMIT_RETRYING:
             self.set_prerequisites_all_satisfied()
             self.outputs.remove(TASK_OUTPUT_SUBMITTED)
@@ -347,9 +347,9 @@ class TaskState(object):
         elif status == TASK_STATUS_SUCCEEDED:
             self.set_prerequisites_all_satisfied()
             self.unset_special_outputs()
-            self.outputs.set_completed(TASK_OUTPUT_SUBMITTED)
-            self.outputs.set_completed(TASK_OUTPUT_STARTED)
-            self.outputs.set_completed(TASK_OUTPUT_SUCCEEDED)
+            self.outputs.set_completion(TASK_OUTPUT_SUBMITTED, True)
+            self.outputs.set_completion(TASK_OUTPUT_STARTED, True)
+            self.outputs.set_completion(TASK_OUTPUT_SUCCEEDED, True)
         elif status == TASK_STATUS_RETRYING:
             self.set_prerequisites_all_satisfied()
             self.outputs.set_all_incomplete()

--- a/tests/cylc-get-config/00-simple/section2.stdout
+++ b/tests/cylc-get-config/00-simple/section2.stdout
@@ -1,6 +1,5 @@
 [[var_p2]]
     script = echo "RUN: run-var.sh"
-    enable resurrection = False
     env-script = 
     err-script = 
     extra log files = 
@@ -78,7 +77,6 @@
         execution time limit = 
 [[OPS]]
     script = echo "RUN: run-ops.sh"
-    enable resurrection = False
     env-script = 
     err-script = 
     extra log files = 
@@ -155,7 +153,6 @@
         execution time limit = 
 [[ops_s1]]
     script = echo "RUN: run-ops.sh"
-    enable resurrection = False
     env-script = 
     err-script = 
     extra log files = 
@@ -233,7 +230,6 @@
         execution time limit = 
 [[ops_s2]]
     script = echo "RUN: run-ops.sh"
-    enable resurrection = False
     env-script = 
     err-script = 
     extra log files = 
@@ -311,7 +307,6 @@
         execution time limit = 
 [[ops_p1]]
     script = echo "RUN: run-ops.sh"
-    enable resurrection = False
     env-script = 
     err-script = 
     extra log files = 
@@ -389,7 +384,6 @@
         execution time limit = 
 [[ops_p2]]
     script = echo "RUN: run-ops.sh"
-    enable resurrection = False
     env-script = 
     err-script = 
     extra log files = 
@@ -467,7 +461,6 @@
         execution time limit = 
 [[var_p1]]
     script = echo "RUN: run-var.sh"
-    enable resurrection = False
     env-script = 
     err-script = 
     extra log files = 
@@ -545,7 +538,6 @@
         execution time limit = 
 [[VAR]]
     script = echo "RUN: run-var.sh"
-    enable resurrection = False
     env-script = 
     err-script = 
     extra log files = 
@@ -622,7 +614,6 @@
         execution time limit = 
 [[var_s1]]
     script = echo "RUN: run-var.sh"
-    enable resurrection = False
     env-script = 
     err-script = 
     extra log files = 
@@ -699,7 +690,6 @@
         execution polling intervals = 
         execution time limit = 
 [[SERIAL]]
-    enable resurrection = False
     env-script = 
     err-script = 
     script = 
@@ -777,7 +767,6 @@
         execution polling intervals = 
         execution time limit = 
 [[root]]
-    enable resurrection = False
     env-script = 
     err-script = 
     script = 
@@ -854,7 +843,6 @@
         execution polling intervals = 
         execution time limit = 
 [[PARALLEL]]
-    enable resurrection = False
     env-script = 
     err-script = 
     script = 
@@ -933,7 +921,6 @@
         execution time limit = 
 [[var_s2]]
     script = echo "RUN: run-var.sh"
-    enable resurrection = False
     env-script = 
     err-script = 
     extra log files = 

--- a/tests/cylc-poll/12-reverse-state.t
+++ b/tests/cylc-poll/12-reverse-state.t
@@ -15,28 +15,18 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test for completion of custom outputs in dummy and sim modes.
-# And no duplication dummy outputs (GitHub #2064)
-. "$(dirname "$0")/test_header"
 
-set_test_number 6
+# Run a test suite to check that a seemingly-failed task that is actually still
+# running can be returned to the running state by polling, and other aspects of
+# PR #2396 on GitHub.
 
-install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+. $(dirname $0)/test_header
 
-run_ok "${TEST_NAME_BASE}-validate" \
-    cylc validate --debug ${SUITE_NAME}
+set_test_number 2
+install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 
-suite_run_fail "${TEST_NAME_BASE}-run-live" \
-    cylc run --reference-test --debug ${SUITE_NAME}
+run_ok ${TEST_NAME_BASE}-validate cylc validate $SUITE_NAME
 
-suite_run_ok "${TEST_NAME_BASE}-run-dummy" \
-    cylc run -m 'dummy' --reference-test --debug ${SUITE_NAME}
+suite_run_ok ${TEST_NAME_BASE}-run cylc run --debug $SUITE_NAME
 
-suite_run_ok "${TEST_NAME_BASE}-run-simulation" \
-    cylc run -m 'simulation' --reference-test --debug ${SUITE_NAME}
-
-LOG=$(cylc log --location $SUITE_NAME)
-count_ok '> meet' ${LOG} 1
-count_ok '> greet' ${LOG} 1
-
-purge_suite "${SUITE_NAME}"
+purge_suite $SUITE_NAME

--- a/tests/cylc-poll/12-reverse-state/reference.log
+++ b/tests/cylc-poll/12-reverse-state/reference.log
@@ -1,0 +1,4 @@
+2014/03/03 16:07:55 INFO - Initial point: 1
+2014/03/03 16:07:55 INFO - Final point: 1
+2014/03/03 16:07:55 INFO - [a.1] -triggered off []
+2014/03/03 16:07:58 INFO - [b.1] -triggered off ['a.1']

--- a/tests/cylc-poll/12-reverse-state/suite.rc
+++ b/tests/cylc-poll/12-reverse-state/suite.rc
@@ -1,0 +1,43 @@
+# For this suite to run successfully (exit 0) every operation by perpetrated by
+# task perpetrator must complete successfully, so that perpetrator succeeds and
+# the suite shuts down cleanly.
+
+[cylc]
+    [[events]]
+        timeout = PT10S
+        abort on timeout = True
+[scheduling]
+    [[dependencies]]
+        graph = victim & perpetrator
+[runtime]
+    [[victim]]
+        script = sleep 600
+    [[perpetrator]]
+        # Mess with victim.
+        script = """
+WAIT_A_BIT="--max-polls=5 --interval=2"
+sleep 2
+# Check victim is running (or fail).
+cylc suite-state -t victim -p 1 --status=running $WAIT_A_BIT $CYLC_SUITE_NAME
+# Force state to succeeded.
+cylc reset --state=succeeded $CYLC_SUITE_NAME victim.1
+# Check state is succeeded (or fail).
+cylc suite-state -t victim -p 1 --status=succeeded $WAIT_A_BIT $CYLC_SUITE_NAME
+# A poll should find that victim is really still running.
+cylc poll -s $CYLC_SUITE_NAME victim.1
+# Check the poll result (or fail).
+cylc suite-state -t victim -p 1 --status=running $WAIT_A_BIT $CYLC_SUITE_NAME
+# Kill victim now.
+cylc kill $CYLC_SUITE_NAME victim.1
+# Check victim is stone cold dead (or fail). 
+cylc suite-state -t victim -p 1 --status=failed $WAIT_A_BIT $CYLC_SUITE_NAME
+# Force state of dead victim to submitted.
+cylc reset --state=submitted $CYLC_SUITE_NAME victim.1
+# A poll should find that victim is really still dead.
+cylc poll $CYLC_SUITE_NAME victim.1
+# Check the poll result (or fail).
+cylc suite-state -t victim -p 1 --status=failed $WAIT_A_BIT $CYLC_SUITE_NAME
+sleep 2
+# Force to succeeded, to hide the evidence and allow clean suite shutdown.
+cylc reset --state=succeeded $CYLC_SUITE_NAME victim.1
+        """

--- a/tests/suite-state/05-message.t
+++ b/tests/suite-state/05-message.t
@@ -27,7 +27,7 @@ suite_run_ok $TEST_NAME cylc run --reference-test --debug $SUITE_NAME
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-cli-template
 run_ok $TEST_NAME cylc suite-state $SUITE_NAME -p 20100101T0000Z \
-        --message=hello --task=t1
+        --message=hello --task=t1 --max-polls=1
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME
 #-------------------------------------------------------------------------------

--- a/tests/suite-state/message/suite.rc
+++ b/tests/suite-state/message/suite.rc
@@ -11,8 +11,8 @@
 
 [runtime]
     [[t1]]
-        script = cylc task message 'hello'
-        [[[outputs]]] 
+        script = cylc task message "hello"
+        [[[outputs]]]
             out1 = "hello"
     [[t2]]
         script = true


### PR DESCRIPTION
Close #1792.

 * Allow reset to 'submitted' or 'running'.
 * Allow polling of 'succeeded' or 'failed' tasks (but not 'succeeded' by default).
 * Poll to confirm, if a message implies a state reversal (the message could be, e.g. a late - and therefore out-of-order - poll result)
 * Remove 'enable resurrection' - any task can return from failed.
 * Document how to handle preemption in light of these changes.

~~Not ready for review yet.  TODO~~
 * ~~tidy up code - callback args complicated by is_second_poll flag~~
 * ~~test: e.g. manually reset a long-running task to succeeded, then poll to return it to running~~
 * ~~don't automatically poll succeeded tasks~~