### PR TITLE
Fix to cylc-check-software

### DIFF
--- a/bin/cylc-check-software
+++ b/bin/cylc-check-software
@@ -92,7 +92,7 @@ done
 HTTPS_MODL="OpenSSL"
 echo -n " + ${HTTPS_MODL} ... "
 if ! python -c "import ${HTTPS_MODL}" > /dev/null 2>&1; then
-    echo "NOT FOUND...Configure cylc to run in http mode."
+    echo "NOT FOUND...Cylc must be configured to run in http mode."
 else
     echo "ok"
 fi

--- a/bin/cylc-check-software
+++ b/bin/cylc-check-software
@@ -92,7 +92,8 @@ done
 HTTPS_MODL="OpenSSL"
 echo -n " + ${HTTPS_MODL} ... "
 if ! python -c "import ${HTTPS_MODL}" > /dev/null 2>&1; then
-    echo "NOT FOUND...Cylc must be configured to run in http mode."
+    echo "NOT FOUND...Install it, or else configure Cylc to run in http mode."
+
 else
     echo "ok"
 fi

--- a/bin/cylc-check-software
+++ b/bin/cylc-check-software
@@ -88,13 +88,12 @@ for ITEM in ${PKGS}; do
     fi
 done
 
+# Check for the OpenSSL python package
 HTTPS_MODL="OpenSSL"
-if ! grep -Pq "^(?=[\s]*+[^#])[^#]*(\bmethod=http\b)|(\bmethod = http\b)" ${HOME}/.cylc/global.rc; then
-#if ! grep -q "\bmethod=http\b" ${HOME}/.cylc/global.rc; then
-    echo -n " + ${HTTPS_MODL} ... "
-    if ! python -c "import ${HTTPS_MODL}" > /dev/null 2>&1; then
-        echo "NOT FOUND...Configure cylc to run in http mode."
-    else
-        echo "ok"
-    fi
+echo -n " + ${HTTPS_MODL} ... "
+if ! python -c "import ${HTTPS_MODL}" > /dev/null 2>&1; then
+    echo "NOT FOUND...Configure cylc to run in http mode."
+else
+    echo "ok"
 fi
+

--- a/bin/cylc-check-software
+++ b/bin/cylc-check-software
@@ -93,7 +93,6 @@ HTTPS_MODL="OpenSSL"
 echo -n " + ${HTTPS_MODL} ... "
 if ! python -c "import ${HTTPS_MODL}" > /dev/null 2>&1; then
     echo "NOT FOUND...Install it, or else configure Cylc to run in http mode."
-
 else
     echo "ok"
 fi


### PR DESCRIPTION
Always checks for OpenSSL now, regardless of global.rc config. (as raised by @dpmatthews)