### PR TITLE
Improve suite log on job submission

### DIFF
--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -704,10 +704,14 @@ class TaskEventsManager(object):
 
     def _process_message_submitted(self, itask, event_time):
         """Helper for process_message, handle a submit-succeeded message."""
-        if itask.summary.get('submit_method_id') is not None:
+        try:
             LOG.info(
-                'submit_method_id=%s' % itask.summary['submit_method_id'],
+                ('job[%(submit_num)02d] submitted to'
+                 ' %(host)s:%(batch_sys_name)s[%(submit_method_id)s]') %
+                itask.summary,
                 itask=itask)
+        except KeyError:
+            pass
         self.suite_db_mgr.put_update_task_jobs(itask, {
             "time_submit_exit": event_time,
             "submit_status": 0,


### PR DESCRIPTION
Previously only display batch system ID (submit_method_id).

```
2017-08-17T16:08:24+01 INFO - [foo.1] -submit_method_id=29483
```

Now display submit number, [user@]host, batch system name and batch system ID.

```
2017-08-17T16:08:24+01 INFO - [foo.1] -job[01] submitted to localhost:background[29483]
```