### PR TITLE
Allow debug output to include shell sources

### DIFF
--- a/lib/cylc/job.sh
+++ b/lib/cylc/job.sh
@@ -43,7 +43,11 @@ cylc__job__main() {
         "${CYLC_DIR}/conf/job-init-env-default.sh"
     do
         if [[ -f "${file_name}" ]]; then
-            . "${file_name}" 1>'/dev/null' 2>&1
+            if "${CYLC_DEBUG:-false}"; then
+                . "${file_name}"
+            else
+                . "${file_name}" 1>'/dev/null' 2>&1
+            fi
             break
         fi
     done


### PR DESCRIPTION
The current shell script will source files and redirect all output
to /dev/null - this works very nicely unless there is an error hiding
in one of those files (or, more specifically, in a users ~/.profile or
~/.bashrc or equivalent).

Create verbose output when sourcing other files if the debug flag is
enabled to give at least some information when trying to trace errors.
First choice was to check error codes, but I can't make that work with
sourcing files (rather than calling them as scripts).