### PR TITLE
Documented cylc__job_abort function.

### DIFF
--- a/doc/src/cylc-user-guide/cug.tex
+++ b/doc/src/cylc-user-guide/cug.tex
@@ -492,7 +492,7 @@ Make a symbolic link from \lstinline=cylc= to the latest installed version:
 \lstinline=ln -s /opt/cylc-7.4.0 /opt/cylc=. This will be invoked by the
 central wrapper if a specific version is not requested. Otherwise, the
 wrapper will attempt to invoke the Cylc version specified in
-\lstinline@$CYLC_VERSION@, e.g. \lstinline@CYLC_VERSION=7.4.0@. This variable
+\lstinline@$CYLC_VERSION@, e.g.\ \lstinline@CYLC_VERSION=7.4.0@. This variable
 is automatically set in task job scripts to ensure that jobs use the same Cylc
 version as their parent suite daemon.  It can also be set by users, manually or
 in login scripts, to fix the Cylc version in their environment.
@@ -1369,7 +1369,7 @@ A common use of this is to automate recovery from known modes of failure:
 \begin{lstlisting}
     graph = "goodbye:fail => really_goodbye"
 \end{lstlisting}
-i.e. if task \lstinline=goodbye= fails, trigger another task that
+i.e.\ if task \lstinline=goodbye= fails, trigger another task that
 (presumably) really says goodbye.
 
 Failure triggering generally requires use of {\em suicide triggers} as
@@ -2174,7 +2174,7 @@ configuration items grouped under several top level section headings:
     \item {\bf [cylc] } - {\em non task-specific suite configuration}
     \item {\bf [scheduling] } - {\em determines when tasks are ready to run}
         \begin{myitemize}
-            \item tasks with special behaviour, e.g. clock-trigger tasks
+            \item tasks with special behaviour, e.g.\ clock-trigger tasks
             \item the dependency graph, which defines the relationships
                 between tasks
         \end{myitemize}
@@ -2794,7 +2794,7 @@ The following examples show the various ways of writing graph headings in cylc.
 \label{AdvancedStartingUp}
 
 Dependencies that are only valid at the initial cycle point can be written
-using the \lstinline=R1= notation (e.g. as
+using the \lstinline=R1= notation (e.g.\ as
 in~\ref{initial-non-repeating-r1-tasks}. For example:
 \lstset{language=suiterc}
 \begin{lstlisting}
@@ -3529,7 +3529,7 @@ dependency can be written using the \lstinline=[offset]= syntax such as
 \lstinline=[-PT12H]= in \lstinline@foo[-PT12H] => foo@. This means that
 \lstinline=foo= at the current cycle point depends on a previous instance of
  \lstinline=foo= at 12 hours before the current cycle point. Unlike the
- cycling section headings (e.g. \lstinline=[[[T00,T12]]]=), dependencies
+ cycling section headings (e.g.\ \lstinline=[[[T00,T12]]]=), dependencies
  assume that relative times are relative to the current cycle point, not the
  initial cycle point.
 
@@ -4270,7 +4270,7 @@ CYLC_FAIL_SIGNALS               # List of signals trapped by the error trap
 CYLC_VACATION_SIGNALS           # List of signals trapped by the vacation trap
 CYLC_SUITE_WORK_DIR_ROOT        # Root directory above the suite work directory
                                 # in the job host
-CYLC_TASK_MESSAGE_STARTED_PID   # PID of "cylc task message started" command
+CYLC_TASK_MESSAGE_STARTED_PID   # PID of "cylc message started" command
 CYLC_TASK_WORK_DIR_BASE         # Alternate task work directory,
                                 # relative to the suite work directory
 \end{lstlisting}
@@ -5305,102 +5305,104 @@ tasks are detected.
 \section{Task Implementation}
 \label{TaskImplementation}
 
-Existing scripts or executables can be used as cylc tasks without any
-modification so long as they return standard exit status, i.e. zero on
-success and non-zero for failure, and do not internally spawn detaching
-processes (see~\ref{DetachingJobs}).
+Existing scripts and executables can be used as cylc tasks without modification
+so long as they return standard exit status - zero on success, non-zero
+for failure - and do not spawn detaching processes internally
+(see~\ref{DetachingJobs}).
 
 \subsection{Task Job Scripts}
 \label{JobScripts}
 
-When a task is ready cylc generates a {\em task job script} that encapsulates
-the runtime settings (environment and scripts) defined for it in the suite.rc
-file. The job script is submitted to run by the {\em batch system}
-chosen for the task (see~\ref{TaskJobSubmission}). A task job script also
-exports a set of environment variables prior to executing the task
-\lstinline=script= (see ~\ref{TaskExecutionEnvironment}).
+When the suite dameon determines that a task is ready to run it generates a
+{\em job script} that embodies the task runtime configuration in the suite.rc
+file, and submits it to the configured job host and batch system
+(see~\ref{TaskJobSubmission}).
 
-As shown in the Tutorial (\ref{RunningSuitesCLI}) job scripts are
-saved to the suite run directory; the commands used to submit them are
-printed to stdout by cylc in debug mode; and they can be printed with the
-\lstinline=cylc cat-log= command or new ones generated and printed with the
-\lstinline=cylc jobscript= command. Take a look at one to see exactly
-how cylc wraps and runs your tasks.
+Task job scripts are written to the suite's job log directory. They can be
+printed with \lstinline=cylc cat-log= or generated and printed with
+\lstinline=cylc jobscript=.
 
 \subsection{Inlined Tasks}
 
-Tasks that can be performed by simple commands written in \lstinline=bash= can
-be entirely implemented within the suite.rc file, as the task {\em script}
-items can be multi-line strings.
+Task {\em script} items can be multi-line strings of \lstinline=bash=  code, so
+many tasks can be entirely inlined in the suite.rc file. For anything more than
+a few lines of code, however, we recommend using external shell scripts to allow
+independent testing, re-use, and shell mode editing.
 
-\subsection{Returning Proper Error Status}
+\subsection{Custom Task Messages}
 
-A task job script in cylc automatically traps ERR (for errors) and EXIT (for
-unexpected exits). When the trap is triggered, the task job script will send a
-failed message back to the suite before aborting.
+Custom messages can be sent back to the suite daemon to report progress, 
+warnings, or critical events; and to trigger {\em warning} or {\em critical}
+event handlers (see~\ref{EventHandling}).
 
-Therefore, commands in user scripts should abort with non-zero exit status if a
-fatal error occurs (this is just good coding practice anyway). To prevent a
-command that expects a non-zero return code from triggering a trap, you can use
-a control statement such as:
+Normal priority messages are printed to \lstinline=job.out= and logged by the
+suite daemon:
+\lstset{language=bash}
+\begin{lstlisting}
+cylc message "Hello from ${CYLC_TASK_ID}"
+\end{lstlisting}
 
+Warning priority messages are printed to \lstinline=job.err=, logged by the
+suite daemon, and can be passed to {\em warning} event handlers
+(see~\ref{TaskEventHandling}):
+\begin{lstlisting}
+cylc message -p WARNING "Uh-oh, something's not right here."
+\end{lstlisting}
+
+Critical priority messages are printed to \lstinline=job.err=, logged by the
+suite daemon, and can be passed to {\em critical} event handlers
+(see~\ref{TaskEventHandling}):
+\begin{lstlisting}
+cylc message -p CRITICAL "ERROR occurred in process X!"
+\end{lstlisting}
+
+\subsection{Aborting Job Scripts on Error}
+
+Task job scripts use \lstinline=set -x= to abort on any error, and
+trap ERR, EXIT, and SIGTERM to send task failed messages back to the
+suite daemon before aborting. Other scripts called from job scripts should
+therefore abort with standard non-zero exit status on error, to
+trigger the job script error trap.
+
+To prevent a command that is expected to generate a non-zero exit status from
+triggering the exit trap, protect it with a control statement such as:
 \lstset{language=bash}
 \begin{lstlisting}
 if cmp FILE1 FILE2; then
-    :  # do stuff
+    :  # success: do stuff
 else
-    :  # do alternate stuff
+    :  # failure: do other stuff
 fi
 \end{lstlisting}
 
-In addition, the task job script has \lstinline=set -u= and
-\lstinline=set -o pipefail= turned on explicitly to ensure that any variable
-must be defined on reference (which is very useful for picking typos) and that
-a command fails if any part of a pipe fails.
+Task job scripts also use \lstinline=set -u= to abort on referencing any
+undefined variable (useful for picking up typos); and \lstinline=set -o pipefail=
+to abort if any part of a pipe fails (by default the shell only returns the
+exit status of the final command in a pipeline).
 
-\subsection{Other Task Messages}
+\subsubsection{Custom Failure Messages}
 
-General (non-output) messages can also be sent to report progress,
-warnings, and so on, e.g.:
-\lstset{language=bash}
+Critical events normally warrant aborting a job script rather than just sending
+a message. As described just above, \lstinline=exit 1= or any failing command
+not protected by the surrounding scripting will cause a job script to abort and
+report failure to the suite daemon, potentially triggering a {\em failed} task
+event handler.
+
+For failures detected by the scripting you could send a critical message back
+before aborting, potentially triggering a {\em critical} task event handler:
 \begin{lstlisting}
-#!/bin/bash
-# a warning message (this will be logged by the suite):
-cylc task message -p WARNING "oops, something's fishy here"
-# information (this will also be logged by the suite):
-cylc task message "Hello from task foo"
-\end{lstlisting}
-
-Explanatory messages can be sent before aborting on error:
-\lstset{language=bash}
-\begin{lstlisting}
-#!/bin/bash
-set -e  # abort on error
-if ! mkdir /illegal/dir; then
-    # (use inline error checking to avoid triggering the above 'set -e')
-    cylc task message -p CRITICAL "Failed to create directory /illegal/dir"
-    exit 1 # now abort non-zero exit status to trigger the task failed message
+if ! /bin/false; then
+  cylc message -p CRITICAL "ERROR: /bin/false failed!"
+  exit 1
 fi
 \end{lstlisting}
-Or equivalently, with different syntax:
-\lstset{language=bash}
+
+To abort a job script with a custom message that can be passed to a {\em
+failed} task event handler, use the built-in \lstinline=cylc__job_abort= shell
+function: 
 \begin{lstlisting}
-#!/bin/bash
-set -e
-mkdir /illegal/dir || {  # inline error checking using OR operator
-    cylc task message -p CRITICAL "Failed to create directory /illegal/dir"
-    exit 1
-}
-\end{lstlisting}
-But not this:
-\lstset{language=bash}
-\begin{lstlisting}
-#!/bin/bash
-set -e
-mkdir /illegal/dir  # aborted via ERR trap
-if [[ $? != 0 ]]; then  # so this will never be reached.
-    cylc task message -p CRITICAL "Failed to create directory /illegal/dir"
-    exit 1
+if ! /bin/false; then
+  cylc__job_abort "ERROR: /bin/false failed!"
 fi
 \end{lstlisting}
 
@@ -5717,7 +5719,7 @@ To specify an option with no argument, such as \lstinline=-V= in PBS or
 \lstinline=-cwd= in SGE you must give a null string as the directive value in
 the suite.rc file.
 
-The left hand side of a setting (i.e. the string before the first equal sign)
+The left hand side of a setting (i.e.\ the string before the first equal sign)
 must be unique. To specify multiple values using an option such as
 \lstinline=-l= option in PBS, SGE, etc., either specify all items in a single
 line:
@@ -6604,7 +6606,7 @@ commands.
 
 To send an email, you can use the built-in setting
 \lstinline=[[[events]]]mail events= to specify a list of events for which
-notifications should be sent. E.g. to send an email on (submission) failed and
+notifications should be sent. E.g.\ to send an email on (submission) failed and
 retry:
 
 \lstset{language=suiterc}
@@ -6654,23 +6656,24 @@ Task event handlers can be specified using the
     \item `submitted' - the job submit command was successful
     \item `submission failed' - the job submit command failed
     \item `submission timeout' - task job submission timed out
-    \item `submission retry' - task job submission failed, but will retry after a configured delay
+    \item `submission retry' - task job submission failed, but will retry after
+      a configured delay
     \item `started' - the task reported commencement of execution
     \item `succeeded' - the task reported successful completion
-    \item `warning' - the task reported a warning message
+    \item `warning' - the task reported a WARNING priority message
+    \item `critical' - the task reported a CRITICAL priority message
     \item `failed' - the task failed
-    \item `retry' - the task failed but will retry
+    \item `retry' - the task failed but will retry after a configured delay
     \item `execution timeout' - task execution timed out
 \end{myitemize}
 
 The value of each setting should be a list of command lines or command line
 templates (see below).
 
-Alternatively, task event handlers can be specified using the
-\lstinline=[[[events]]]handlers= and the \lstinline=[[[events]]]handler events=
-settings, where the former is a list of command lines or command line templates
-(see below) and the latter is a list of events for which these commands should
-be invoked.
+Alternatively you can use \lstinline=[[[events]]]handlers= and
+\lstinline=[[[events]]]handler events=, where the former is a list of command
+lines or command line templates (see below) and the latter is a list of events
+for which these commands should be invoked.
 
 A command line template may have any or all of these patterns which will be
 substituted with actual values:
@@ -6680,7 +6683,7 @@ substituted with actual values:
     \item \%(point)s: cycle point
     \item \%(name)s: task name
     \item \%(submit\_num)s: submit number
-    \item \%(id)s: task ID (i.e. \%(name)s.\%(point)s)
+    \item \%(id)s: task ID (i.e.\ \%(name)s.\%(point)s)
     \item \%(message)s: event message, if any
 \end{myitemize}
 
@@ -7385,7 +7388,7 @@ Pre-Cylc-6 & Cylc-6+ \\
 \end{table}
 
 This change is to reflect the fact that cycling in cylc 6+ can now be over
-e.g. integers instead of being purely based on date-time.
+e.g.\ integers instead of being purely based on date-time.
 
 Date-times written in \lstinline=initial cycle time= and
 \lstinline=final cycle time= were in a cylc-specific 10-digit (or less)

--- a/doc/src/cylc-user-guide/suiterc.tex
+++ b/doc/src/cylc-user-guide/suiterc.tex
@@ -1633,7 +1633,8 @@ A list of one or more event handlers to call when one of the following EVENTs oc
     \item {\bf retry}          - the task failed, but cylc will resubmit it
                                   after a configured delay
     \item {\bf execution timeout}        - the task timed out after execution commenced
-    \item {\bf warning}        - the task reported a warning priority message
+    \item {\bf warning}        - the task reported a WARNING priority message
+    \item {\bf critical}       - the task reported a CRITICAL priority message
 \end{myitemize}
 
 Item details:


### PR DESCRIPTION
Close #2401 

Documents `cylc__job_abort`.  And also the new "critical" task event handler.

@matthewrmshin - sounds like you're around Monday?  If not, one review is probably enough on this (doc only, small).