### PR TITLE
Fix spawn kill mix-up.

### DIFF
--- a/lib/cylc/network/https/suite_command_server.py
+++ b/lib/cylc/network/https/suite_command_server.py
@@ -182,7 +182,7 @@ class SuiteCommandServer(BaseCommsServer):
     def spawn_tasks(self, items):
         if not isinstance(items, list):
             items = [items]
-        return self._put("kill_tasks", (items,))
+        return self._put("spawn_tasks", (items,))
 
     @cherrypy.expose
     @cherrypy.tools.json_out()


### PR DESCRIPTION
The (infrequently used!) spawn command was killing target tasks ... looks like a cut-n-paste error in the new network layer.

As this is a bug, and easily fixed, we'd better put it in next release.  Clearly we need `cylc spawn` tests with this - but I won't have time tonight.