### PR TITLE
Add namespace to multi inheritance error message

### DIFF
--- a/lib/cylc/c3mro.py
+++ b/lib/cylc/c3mro.py
@@ -95,7 +95,7 @@ class C3(object):
     def __init__(self, tree={}):
         self.tree = tree
 
-    def merge(self, seqs):
+    def merge(self, seqs, label=None):
         # print '\n\nCPL[%s]=%s' % (seqs[0][0],seqs),
         res = []
         i = 0
@@ -112,9 +112,14 @@ class C3(object):
                 else:
                     break
             if not cand:
+                prefix = ""
+                if label:
+                    prefix = "{0}: ".format(label)
                 raise Exception(
-                    "ERROR: bad runtime namespace inheritance hierarchy.\n"
-                    "See the cylc documentation on multiple inheritance.")
+                    "ERROR: {0}".format(prefix) +
+                    "bad runtime namespace inheritance hierarchy.\n" +
+                    "See the cylc documentation on multiple inheritance."
+                )
             res.append(cand)
             for seq in nonemptyseqs:  # remove cand
                 if seq[0] == cand:
@@ -124,7 +129,9 @@ class C3(object):
         """Compute the precedence list (mro) according to C3"""
         # copy() required here for tree to remain unchanged
         return self.merge(
-            [[C]] + map(self.mro, self.tree[C]) + [copy(self.tree[C])])
+            [[C]] + map(self.mro, self.tree[C]) + [copy(self.tree[C])],
+            label=C)
+
 
 if __name__ == "__main__":
     parents = {}

--- a/tests/inheritance/02-bad-reinherit.t
+++ b/tests/inheritance/02-bad-reinherit.t
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Check circular inheritance fails validation with the correct error message.
+# Check bad multi inheritance fails validation with the correct error message.
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 set_test_number 2

--- a/tests/inheritance/02-bad-reinherit.t
+++ b/tests/inheritance/02-bad-reinherit.t
@@ -1,0 +1,34 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Check circular inheritance fails validation with the correct error message.
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 2
+#-------------------------------------------------------------------------------
+install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-validate
+run_fail $TEST_NAME cylc validate $SUITE_NAME
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-cmp
+cmp_ok $TEST_NAME_BASE-validate.stderr <<__ERR__
+ERROR: foo: bad runtime namespace inheritance hierarchy.
+See the cylc documentation on multiple inheritance.
+__ERR__
+#-------------------------------------------------------------------------------
+purge_suite $SUITE_NAME

--- a/tests/inheritance/02-bad-reinherit/suite.rc
+++ b/tests/inheritance/02-bad-reinherit/suite.rc
@@ -1,0 +1,15 @@
+[meta]
+    title = a suite with a task that multiply inherits from the same family
+    description = should fail validation
+
+[scheduling]
+   [[dependencies]]
+      graph = foo
+
+[runtime]
+   [[A]]
+   [[B]]
+      inherit = C, A
+   [[C]]
+   [[foo]]
+      inherit = A, B


### PR DESCRIPTION
The current error message for bad multiple inheritance doesn't include the name of the family or task that led to the error - this change adds it.
