### PR TITLE
Fix gsummary/gscan alias

### DIFF
--- a/bin/cylc-gsummary
+++ b/bin/cylc-gsummary
@@ -16,4 +16,4 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-exec $(dirname $0)/cylc scan "$@"
+exec $(dirname $0)/cylc gscan "$@"


### PR DESCRIPTION
Typo in one of the cylc commands: `gsummary` should call `cylc-gscan`, not `cylc-scan`.