### PR TITLE
Update signal for gscan About dialog.

### DIFF
--- a/lib/cylc/gui/gscan.py
+++ b/lib/cylc/gui/gscan.py
@@ -366,8 +366,8 @@ class ScanApp(object):
         info_item.set_image(img)
         info_item.show()
         info_item.connect(
-            "button-press-event",
-            lambda b, e: launch_about_dialog("cylc gscan", self.hosts)
+            "activate",
+            lambda w: launch_about_dialog("cylc gscan", self.hosts)
         )
         help_menu.append(info_item)
 


### PR DESCRIPTION
The Help...About dialog was not displaying properly for some users.
Change the signal for the Help...About menu item so the dialog
box is properly displayed.

See #2374 

Also, like in #2374 I had to change this to get it to work on my system, so I haven't been able to check and make sure it didn't break on other platforms.  Low probability  of damage, considering that the same change in #2374 worked just fine.