### PR TITLE
cylc gui: fix broken by #2375

### DIFF
--- a/lib/cylc/gui/tailer.py
+++ b/lib/cylc/gui/tailer.py
@@ -56,7 +56,10 @@ class Tailer(threading.Thread):
         self.filename = filename
         self.cmd_tmpl = cmd_tmpl
         self.pollable = pollable
-        self.filters = [re.compile(f) for f in filters]
+        if filters:
+            self.filters = [re.compile(f) for f in filters]
+        else:
+            self.filters = None
 
         self.logbuffer = logview.get_buffer()
         self.quit = False

--- a/lib/cylc/gui/view_graph.py
+++ b/lib/cylc/gui/view_graph.py
@@ -180,7 +180,7 @@ Dependency graph suite control interface.
         menu.append(ungroup_item)
         menu.append(ungroup_rec_item)
 
-        if type == 'live task':
+        if type_ == 'live task':
             is_fam = (name in self.t.descendants)
             if is_fam:
                 if task_id not in self.t.fam_state_summary:


### PR DESCRIPTION
Log viewer tailer.
Graph view missing right click menu items.

Fix #2428.