### PR TITLE
Fix HTTPS client host no domain issue

### DIFF
--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -42,7 +42,7 @@ import traceback
 
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.rundb import CylcSuiteDAO
-from cylc.suite_host import is_remote
+from cylc.hostuserutil import is_remote
 from cylc.suite_logging import get_logs
 from cylc.cfgspec.globalcfg import GLOBAL_CFG
 from cylc.task_id import TaskID

--- a/bin/cylc-documentation
+++ b/bin/cylc-documentation
@@ -47,7 +47,6 @@ from optparse import OptionParser
 import cylc.flags
 from cylc.cfgspec.globalcfg import GLOBAL_CFG
 from cylc.run_get_stdout import run_get_stdout
-from cylc.suite_host import get_hostname, get_user
 
 
 def main():
@@ -73,13 +72,13 @@ def main():
         "--user",
         help="Other user account name. This results in "
              "command reinvocation on the remote account.",
-        metavar="USER", default=get_user(), action="store", dest="owner")
+        metavar="USER", action="store", dest="owner")
 
     parser.add_option(
         "--host",
         help="Other host name. This results in "
              "command reinvocation on the remote account.",
-        metavar="HOST", action="store", default=get_hostname(), dest="host")
+        metavar="HOST", action="store", dest="host")
 
     parser.add_option(
         "--debug",

--- a/bin/cylc-gscan
+++ b/bin/cylc-gscan
@@ -43,7 +43,7 @@ gtk.settings_get_default().set_long_property(
 from cylc.cfgspec.globalcfg import GLOBAL_CFG
 from cylc.gui.gscan import ScanApp
 from cylc.option_parsers import CylcOptionParser as COP
-from cylc.suite_host import get_user
+from cylc.hostuserutil import get_user
 
 
 def main():

--- a/bin/cylc-scan
+++ b/bin/cylc-scan
@@ -44,13 +44,13 @@ if "--use-ssh" in sys.argv[1:]:
 
 import re
 
+from cylc.cfgspec.globalcfg import GLOBAL_CFG
+from cylc.hostuserutil import get_user
 from cylc.network.port_scan import scan_many
 from cylc.option_parsers import CylcOptionParser as COP
-from cylc.cfgspec.globalcfg import GLOBAL_CFG
-from cylc.suite_host import get_user
 from cylc.suite_status import (
     KEY_DESCRIPTION, KEY_META, KEY_NAME, KEY_OWNER, KEY_STATES,
-    KEY_TASKS_BY_STATE, KEY_TITLE, KEY_UPDATE_TIME)
+    KEY_TITLE, KEY_UPDATE_TIME)
 from cylc.task_state import TASK_STATUSES_ORDERED
 from cylc.task_state_prop import get_status_prop
 

--- a/doc/src/cylc-user-guide/siterc.tex
+++ b/doc/src/cylc-user-guide/siterc.tex
@@ -769,7 +769,7 @@ suite host; if it doesn't, adjust network settings or use one of the
 other methods. For the {\em address} method, cylc attempts to use a
 special external ``target address'' to determine the IP address of the
 suite host as seen by remote task hosts (in-source documentation in
-\lstinline=$CYLC_DIR/lib/cylc/suite_host.py= explains how this works).
+\lstinline=$CYLC_DIR/lib/cylc/hostuserutil.py= explains how this works).
 And finally, as a last resort, you can choose the {\em hardwired} method
 and manually specify the host name or IP address of the suite host.
 

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -28,7 +28,7 @@ from parsec.validate import validator as vdr
 from parsec.validate import coercers
 from parsec import ParsecError
 from parsec.upgrade import upgrader, converter
-from cylc.suite_host import is_remote_user
+from cylc.hostuserutil import is_remote_user
 from cylc.envvar import expandvars
 from cylc.mkdir_p import mkdir_p
 import cylc.flags

--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -29,7 +29,7 @@ from subprocess import Popen, PIPE, STDOUT
 from uuid import uuid4
 from isodatetime.parsers import TimePointParser
 
-from cylc.suite_host import is_remote, is_remote_host, is_remote_user
+from cylc.hostuserutil import is_remote, is_remote_host, is_remote_user
 from cylc.gui.dbchooser import dbchooser
 from cylc.gui.combo_logviewer import ComboLogViewer
 from cylc.gui.warning_dialog import warning_dialog, info_dialog

--- a/lib/cylc/gui/dbchooser.py
+++ b/lib/cylc/gui/dbchooser.py
@@ -28,7 +28,7 @@ from cylc.gui.util import get_icon, EntryTempText, EntryDialog
 from cylc.network.port_scan import scan_many
 from cylc.suite_srv_files_mgr import SuiteSrvFilesManager
 from cylc.run_get_stdout import run_get_stdout
-from cylc.suite_host import is_remote_host, is_remote_user
+from cylc.hostuserutil import is_remote_host, is_remote_user
 
 
 class db_updater(threading.Thread):

--- a/lib/cylc/gui/gpanel.py
+++ b/lib/cylc/gui/gpanel.py
@@ -35,7 +35,7 @@ from cylc.gui.dot_maker import DotMaker
 from cylc.gui.scanutil import (KEY_PORT, get_gpanel_scan_menu,
                                update_suites_info)
 from cylc.gui.util import get_icon, setup_icons
-from cylc.suite_host import get_user
+from cylc.hostuserutil import get_user
 from cylc.suite_status import KEY_STATES
 from cylc.task_state_prop import extract_group_state
 

--- a/lib/cylc/gui/updater.py
+++ b/lib/cylc/gui/updater.py
@@ -121,6 +121,7 @@ class Updater(threading.Thread):
         self.full_fam_state_summary = {}
         self.all_families = {}
         self.global_summary = {}
+        self.cfg.port = None
         self.client = None
         gobject.idle_add(self.app_window.set_title, str(self.cfg.suite))
 

--- a/lib/cylc/gui/updater.py
+++ b/lib/cylc/gui/updater.py
@@ -91,7 +91,6 @@ class Updater(threading.Thread):
         self.filt_task_ids = set()
 
         self.version_mismatch_warned = False
-        self.client = None
 
         self.client = None
         # Report sign-out on exit.

--- a/lib/cylc/gui/updater.py
+++ b/lib/cylc/gui/updater.py
@@ -91,6 +91,7 @@ class Updater(threading.Thread):
         self.filt_task_ids = set()
 
         self.version_mismatch_warned = False
+        self.client = None
 
         self.client = None
         # Report sign-out on exit.
@@ -120,30 +121,8 @@ class Updater(threading.Thread):
         self.full_fam_state_summary = {}
         self.all_families = {}
         self.global_summary = {}
-        self.cfg.port = None
         self.client = None
-
         gobject.idle_add(self.app_window.set_title, str(self.cfg.suite))
-
-        # Use info bar to display stop summary if available.
-        # Otherwise, just display the reconnect count down.
-        if self.cfg.suite and self.stop_summary is None:
-            stop_summary = get_stop_state_summary(
-                cat_state(self.cfg.suite, self.cfg.host, self.cfg.owner))
-            if stop_summary != self.stop_summary:
-                self.stop_summary = stop_summary
-                self.status = SUITE_STATUS_STOPPED
-                gobject.idle_add(
-                    self.info_bar.set_stop_summary, stop_summary)
-                self.last_update_time = time()
-        try:
-            update_time_str = time2str(self.stop_summary[0]["last_updated"])
-        except (AttributeError, IndexError, KeyError, TypeError):
-            update_time_str = None
-        gobject.idle_add(
-            self.info_bar.set_update_time,
-            update_time_str, self.info_bar.DISCONNECTED_TEXT)
-        gobject.idle_add(self.info_bar.prog_bar_stop)
 
     def set_status(self, status=None):
         """Update status bar."""

--- a/lib/cylc/host_select.py
+++ b/lib/cylc/host_select.py
@@ -22,7 +22,7 @@ import os
 import re
 from cylc.cfgspec.globalcfg import GLOBAL_CFG
 from cylc.run_get_stdout import run_get_stdout
-from cylc.suite_host import is_remote_host
+from cylc.hostuserutil import is_remote_host
 
 
 REC_COMMAND = re.compile(r"(`|\$\()\s*(.*)\s*(`|\))$")

--- a/lib/cylc/hostuserutil.py
+++ b/lib/cylc/hostuserutil.py
@@ -137,7 +137,8 @@ class HostUtil(object):
             hardwired = self._get_identification_cfg('host')
             method = self._get_identification_cfg('method')
             if method == 'address':
-                self._host = self._get_host_info()[2][0]
+                self._host = self.get_local_ip_address(
+                    self._get_identification_cfg('target'))
             elif method == 'hardwired' and hardwired:
                 self._host = hardwired
             else:  # if method == 'name':

--- a/lib/cylc/hostuserutil.py
+++ b/lib/cylc/hostuserutil.py
@@ -146,7 +146,7 @@ class HostUtil(object):
         return self._host
 
     def get_fqdn_by_host(self, target):
-        """Return the preferred fqdn name of the target host."""
+        """Return the fully qualified domain name of the target host."""
         return self._get_host_info(target)[0]
 
     def get_user(self):

--- a/lib/cylc/network/httpclient.py
+++ b/lib/cylc/network/httpclient.py
@@ -96,10 +96,6 @@ class SuiteRuntimeServiceClient(object):
         if not owner:
             owner = get_user()
         self.owner = owner
-        if host and host.split('.')[0] == 'localhost':
-            host = get_host()
-        elif host and '.' not in host:  # Not IP and no domain
-            host = get_fqdn_by_host(host)
         self.host = host
         self.port = port
         self.srv_files_mgr = SuiteSrvFilesManager()
@@ -254,16 +250,19 @@ class SuiteRuntimeServiceClient(object):
             self._load_contact_info()
         except (IOError, ValueError, SuiteServiceFileError):
             raise ClientInfoError(self.suite)
-        host = self.host
+        if self.host and self.host.split('.')[0] == 'localhost':
+            self.host = get_host()
+        elif self.host and '.' not in self.host:  # Not IP and no domain
+            self.host = get_fqdn_by_host(self.host)
         http_request_items = []
         try:
             # dictionary containing: url, payload, method
             http_request_items.append(self._compile_url(
-                func_dict, host, self.comms_protocol))
+                func_dict, self.host, self.comms_protocol))
         except (IndexError, ValueError, AttributeError):
             for f_dict in func_dicts:
                 http_request_items.append(self._compile_url(
-                    f_dict, host, self.comms_protocol))
+                    f_dict, self.host, self.comms_protocol))
         # Remove proxy settings from environment for now
         environ = {}
         for key in ("http_proxy", "https_proxy"):

--- a/lib/cylc/network/httpclient.py
+++ b/lib/cylc/network/httpclient.py
@@ -96,6 +96,10 @@ class SuiteRuntimeServiceClient(object):
         if not owner:
             owner = get_user()
         self.owner = owner
+        if host and host.split('.')[0] == 'localhost':
+            host = get_host()
+        elif host and '.' not in host:  # Not IP and no domain
+            host = get_fqdn_by_host(host)
         self.host = host
         self.port = port
         self.srv_files_mgr = SuiteSrvFilesManager()
@@ -251,11 +255,6 @@ class SuiteRuntimeServiceClient(object):
         except (IOError, ValueError, SuiteServiceFileError):
             raise ClientInfoError(self.suite)
         host = self.host
-        if host.split('.')[0] == 'localhost':
-            host = get_host()
-        elif host and '.' not in host:  # Not IP and no domain
-            host = get_fqdn_by_host(host)
-
         http_request_items = []
         try:
             # dictionary containing: url, payload, method

--- a/lib/cylc/network/httpserver.py
+++ b/lib/cylc/network/httpserver.py
@@ -36,7 +36,7 @@ import cylc.flags
 from cylc.network import (
     NO_PASSPHRASE, PRIVILEGE_LEVELS, PRIV_IDENTITY, PRIV_DESCRIPTION,
     PRIV_STATE_TOTALS, PRIV_FULL_READ, PRIV_SHUTDOWN, PRIV_FULL_CONTROL)
-from cylc.suite_host import get_suite_host
+from cylc.hostuserutil import get_host
 from cylc.suite_logging import ERR, LOG
 from cylc.suite_srv_files_mgr import (
     SuiteSrvFilesManager, SuiteServiceFileError)
@@ -121,7 +121,7 @@ class HTTPServer(object):
         """Start quick web service."""
         # cherrypy.config["tools.encode.on"] = True
         # cherrypy.config["tools.encode.encoding"] = "utf-8"
-        cherrypy.config["server.socket_host"] = get_suite_host()
+        cherrypy.config["server.socket_host"] = get_host()
         cherrypy.config["engine.autoreload.on"] = False
 
         if self.comms_method == "https":

--- a/lib/cylc/network/port_scan.py
+++ b/lib/cylc/network/port_scan.py
@@ -29,7 +29,7 @@ from cylc.network.httpclient import (
     SuiteRuntimeServiceClient, ClientError, ClientTimeout)
 from cylc.suite_srv_files_mgr import (
     SuiteSrvFilesManager, SuiteServiceFileError)
-from cylc.suite_host import is_remote_host, get_host_ip_by_name
+from cylc.hostuserutil import is_remote_host, get_host_ip_by_name
 
 CONNECT_TIMEOUT = 5.0
 INACTIVITY_TIMEOUT = 10.0

--- a/lib/cylc/option_parsers.py
+++ b/lib/cylc/option_parsers.py
@@ -20,7 +20,6 @@
 from optparse import OptionParser, OptionConflictError
 import os
 import cylc.flags
-from cylc.suite_host import get_user
 
 
 class CylcOptionParser(OptionParser):
@@ -115,8 +114,7 @@ Arguments:"""
                 "Other user account name. This results in "
                 "command reinvocation on the remote account."
             ),
-            metavar="USER", default=get_user(),
-            action="store", dest="owner")
+            metavar="USER", action="store", dest="owner")
         self.add_std_option(
             "--host",
             help="Other host name. This results in "

--- a/lib/cylc/remote.py
+++ b/lib/cylc/remote.py
@@ -67,7 +67,7 @@ class remrun(object):
         if self.owner is None and self.host is None:
             self.is_remote = False
         else:
-            from cylc.suite_host import is_remote
+            from cylc.hostuserutil import is_remote
             self.is_remote = is_remote(self.host, self.owner)
 
     def execute(self, force_required=False, env=None, path=None,

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -46,7 +46,7 @@ from cylc.state_summary_mgr import StateSummaryMgr
 from cylc.suite_db_mgr import SuiteDatabaseManager
 from cylc.suite_events import (
     SuiteEventContext, SuiteEventError, SuiteEventHandler)
-from cylc.suite_host import get_suite_host, get_user
+from cylc.hostuserutil import get_host, get_user
 from cylc.suite_logging import SuiteLog, ERR, LOG
 from cylc.suite_srv_files_mgr import (
     SuiteSrvFilesManager, SuiteServiceFileError)
@@ -149,7 +149,7 @@ class Scheduler(object):
         self.run_mode = self.options.run_mode
 
         self.owner = get_user()
-        self.host = get_suite_host()
+        self.host = get_host()
         self.port = None
 
         self.is_stalled = False

--- a/lib/cylc/suite_events.py
+++ b/lib/cylc/suite_events.py
@@ -23,7 +23,7 @@ from pipes import quote
 
 from cylc.cfgspec.globalcfg import GLOBAL_CFG
 from cylc.mp_pool import SuiteProcContext
-from cylc.suite_host import get_suite_host, get_user
+from cylc.hostuserutil import get_host, get_user
 from cylc.suite_logging import LOG
 
 
@@ -106,7 +106,7 @@ class SuiteEventHandler(object):
                     '-s', subject,
                     '-r', self.get_events_conf(
                         config,
-                        'mail from', 'notifications@' + get_suite_host()),
+                        'mail from', 'notifications@' + get_host()),
                     self.get_events_conf(config, 'mail to', get_user()),
                 ],
                 env=env,

--- a/lib/cylc/suite_srv_files_mgr.py
+++ b/lib/cylc/suite_srv_files_mgr.py
@@ -26,8 +26,8 @@ import sys
 
 import cylc.flags
 from cylc.mkdir_p import mkdir_p
-from cylc.suite_host import (
-    get_local_ip_address, get_suite_host, get_user, is_remote, is_remote_host)
+from cylc.hostuserutil import (
+    get_local_ip_address, get_host, get_user, is_remote, is_remote_host)
 
 
 class SuiteServiceFileError(Exception):
@@ -80,7 +80,7 @@ class SuiteSrvFilesManager(object):
         if owner is None:
             owner = get_user()
         if host is None:
-            host = get_suite_host()
+            host = get_host()
         path = self._get_cache_dir(reg, owner, host)
         self.cache[self.FILE_BASE_PASSPHRASE][(reg, owner, host)] = value
         # Dump to a file only for remote suites loaded via SSH.
@@ -237,7 +237,7 @@ To see if %(suite)s is running on '%(host)s:%(port)s':
             if my_owner is None:
                 my_owner = get_user()
             if my_host is None:
-                my_host = get_suite_host()
+                my_host = get_host()
             try:
                 return self.cache[item][(reg, my_owner, my_host)]
             except KeyError:
@@ -461,7 +461,7 @@ To see if %(suite)s is running on '%(host)s:%(port)s':
             # OpenSSL not installed, so we can't use HTTPS anyway.
             return
         # Use suite host as the 'common name', but no more than 64 chars.
-        host = get_suite_host()
+        host = get_host()
         common_name = host
         if len(common_name) > 64:
             common_name = common_name[:61] + "..."
@@ -569,7 +569,7 @@ To see if %(suite)s is running on '%(host)s:%(port)s':
                     if owner is None:
                         owner = get_user()
                     if host is None:
-                        host = get_suite_host()
+                        host = get_host()
                     host_value = data.get(self.KEY_HOST, "")
                     self.can_use_load_auths[(reg, owner, host)] = (
                         reg == data.get(self.KEY_NAME) and

--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -43,7 +43,7 @@ from cylc.cfgspec.globalcfg import GLOBAL_CFG
 import cylc.flags
 from cylc.mp_pool import SuiteProcContext
 from cylc.suite_logging import ERR, LOG
-from cylc.suite_host import get_suite_host, get_user
+from cylc.hostuserutil import get_host, get_user
 from cylc.task_action_timer import TaskActionTimer
 from cylc.task_message import TaskMessage
 from cylc.task_state import (
@@ -799,7 +799,7 @@ class TaskEventsManager(object):
                 self._get_events_conf(  # mail_from
                     itask,
                     "mail from",
-                    "notifications@" + get_suite_host(),
+                    "notifications@" + get_host(),
                 ),
                 self._get_events_conf(itask, "mail to", get_user()),  # mail_to
                 self._get_events_conf(itask, "mail smtp"),  # mail_smtp

--- a/lib/cylc/task_job_mgr.py
+++ b/lib/cylc/task_job_mgr.py
@@ -47,7 +47,7 @@ from cylc.host_select import get_task_host
 from cylc.job_file import JobFileWriter
 from cylc.mkdir_p import mkdir_p
 from cylc.mp_pool import SuiteProcPool, SuiteProcContext
-from cylc.suite_host import is_remote, is_remote_host, is_remote_user
+from cylc.hostuserutil import is_remote, is_remote_host, is_remote_user
 from cylc.suite_logging import LOG
 from cylc.task_events_mgr import TaskEventsManager
 from cylc.task_message import TaskMessage
@@ -364,7 +364,7 @@ class TaskJobManager(object):
                 del procs[user_at_host]
                 out, err = proc.communicate()
                 if proc.wait():
-                    ERR.warning(RemoteJobHostInitError(
+                    LOG.warning(RemoteJobHostInitError(
                         RemoteJobHostInitError.MSG_TIDY,
                         user_at_host, ' '.join(quote(item) for item in cmd),
                         proc.returncode, out, err))
@@ -376,7 +376,7 @@ class TaskJobManager(object):
                 pass
             out, err = proc.communicate()
             if proc.wait():
-                ERR.warning(RemoteJobHostInitError(
+                LOG.warning(RemoteJobHostInitError(
                     RemoteJobHostInitError.MSG_TIDY,
                     user_at_host, ' '.join(quote(item) for item in cmd),
                     proc.returncode, out, err))

--- a/tests/suite-host-self-id/00-address.t
+++ b/tests/suite-host-self-id/00-address.t
@@ -24,7 +24,7 @@ install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 get_local_ip_address() {
     python - "$1" <<'__PYTHON__'
 import sys
-from cylc.suite_host import get_local_ip_address
+from cylc.hostuserutil import get_local_ip_address
 sys.stdout.write("%s\n" % get_local_ip_address(sys.argv[1]))
 __PYTHON__
 }

--- a/tests/suite-host-self-id/01-unit.t
+++ b/tests/suite-host-self-id/01-unit.t
@@ -19,5 +19,5 @@
 . "$(dirname "$0")/test_header"
 set_test_number 1
 
-run_ok "${TEST_NAME_BASE}" python -m 'cylc.suite_host'
+run_ok "${TEST_NAME_BASE}" python -m 'cylc.hostuserutil'
 exit


### PR DESCRIPTION
A CLI specified host name with no domain part was causing the HTTPS
client to fail because it is unable to match the host name in the SSL
certificate (in which the host name has the domain name).

Rename `cylc.suite_host` to `cylc.hostuserutil` (as the module is now a generic utility for working with hosts and users).

Should fix #2422.