### PR TITLE
group setting now in suite meta

### DIFF
--- a/bin/cylc-scan
+++ b/bin/cylc-scan
@@ -225,6 +225,7 @@ def main():
                 try:
                     value = suite_identity[KEY_META].get(key)
                 except KeyError:
+                    # KEY_UPDATE_TIME and Compat:<=7.5.0
                     value = suite_identity.get(key)
                 if value:
                     print "%s|%s|%s|%s|%s" % (
@@ -259,6 +260,7 @@ def main():
             try:
                 title = suite_identity[KEY_META].get(KEY_TITLE)
             except KeyError:
+                # Compat:<=7.5.0
                 title = suite_identity.get(KEY_TITLE)
             if title is None:
                 print indent + bold("(description and state totals withheld)")
@@ -273,6 +275,7 @@ def main():
             try:
                 description = suite_identity[KEY_META].get(KEY_DESCRIPTION)
             except KeyError:
+                # Compat:<=7.5.0
                 description = suite_identity.get(KEY_DESCRIPTION)
             print indent + bold("Description:")
             if description == "":

--- a/bin/cylc-scan
+++ b/bin/cylc-scan
@@ -48,6 +48,9 @@ from cylc.network.port_scan import scan_all
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.cfgspec.globalcfg import GLOBAL_CFG
 from cylc.suite_host import get_user
+from cylc.suite_status import (
+    KEY_DESCRIPTION, KEY_META, KEY_NAME, KEY_OWNER, KEY_STATES,
+    KEY_TASKS_BY_STATE, KEY_TITLE, KEY_UPDATE_TIME)
 from cylc.task_state import TASK_STATUSES_ORDERED
 from cylc.task_state_prop import get_status_prop
 
@@ -205,8 +208,8 @@ def main():
 
     skip_one = True
     for host, port, suite_identity in scan_all(args, options.comms_timeout):
-        name = suite_identity['name']
-        owner = suite_identity['owner']
+        name = suite_identity[KEY_NAME]
+        owner = suite_identity[KEY_OWNER]
 
         if not (re.match(pattern_name, name) and
                 re.match(pattern_owner, owner)):
@@ -218,24 +221,26 @@ def main():
 
         if options.raw_format:
             print "%s|%s|%s|port|%s" % (name, owner, host, port)
-            for property in ["title", "description", "update-time"]:
-                value = suite_identity.get(property, None)
+            for key in [KEY_TITLE, KEY_DESCRIPTION, KEY_UPDATE_TIME]:
+                try:
+                    value = suite_identity[KEY_META].get(key)
+                except KeyError:
+                    value = suite_identity.get(key)
                 if value:
                     print "%s|%s|%s|%s|%s" % (
-                        name, owner, host, property,
+                        name, owner, host, key,
                         str(value).replace("\n", " ")
                     )
-            totals = suite_identity.get('states', None)
+            totals = suite_identity.get(KEY_STATES)
             if totals is None:
                 continue
             point_state_lines = get_point_state_count_lines(
                 *totals, use_color=options.color)
             for point, state_line in point_state_lines:
-                property = "states"
+                key = KEY_STATES
                 if point:
-                    property = "states:%s" % point
-                print "%s|%s|%s|%s|%s" % (
-                    name, owner, host, property, state_line)
+                    key = "%s:%s" % (KEY_STATES, point)
+                print "%s|%s|%s|%s|%s" % (name, owner, host, key, state_line)
             continue
 
         line = '%s %s@%s:%s' % (name, owner, host, port)
@@ -251,7 +256,10 @@ def main():
             print line
 
         if options.describe:
-            title = suite_identity.get('title', None)
+            try:
+                title = suite_identity[KEY_META].get(KEY_TITLE)
+            except KeyError:
+                title = suite_identity.get(KEY_TITLE)
             if title is None:
                 print indent + bold("(description and state totals withheld)")
                 continue
@@ -262,7 +270,10 @@ def main():
                 line = '"%s"' % title
             print indent * 2 + line
 
-            description = suite_identity.get('description', None)
+            try:
+                description = suite_identity[KEY_META].get(KEY_DESCRIPTION)
+            except KeyError:
+                description = suite_identity.get(KEY_DESCRIPTION)
             print indent + bold("Description:")
             if description == "":
                 lines = "(no description)"
@@ -277,7 +288,7 @@ def main():
                 line1 = False
                 print indent * 2 + line
 
-        totals = suite_identity.get('states', None)
+        totals = suite_identity.get(KEY_STATES)
         if totals is not None:
             state_count_totals, state_count_cycles = totals
 
@@ -307,9 +318,9 @@ def get_point_state_count_lines(state_count_totals, state_count_cycles,
             line += '%s:%d ' % (state, tot)
     yield ("", line.strip())
 
-    for point_string in sorted(state_count_cycles.keys()):
+    for point_string, state_count_cycle in sorted(state_count_cycles.items()):
         line = ""
-        for state, tot in sorted(state_count_cycles[point_string].items()):
+        for state, tot in sorted(state_count_cycle.items()):
             if use_color:
                 subst = " %d " % tot
                 line += get_status_prop(state, 'ascii_ctrl', subst)

--- a/doc/src/cylc-user-guide/suiterc.tex
+++ b/doc/src/cylc-user-guide/suiterc.tex
@@ -13,17 +13,6 @@ overview of suite.rc files, including syntax (\ref{Syntax}).
 The only top level configuration items at present are the suite title
 and description.
 
-\subsubsection{group}
-
-A single line group name for a suite. It is displayed in the gscan
-window and can be used as a way of grouping related suites together.
-\lstinline=cylc show= command.
-
-\begin{myitemize}
-\item {\em type:} single line string
-\item {\em default:} (none)
-\end{myitemize}
-
 
 \subsection{[meta]}
 
@@ -68,6 +57,17 @@ task URLs (\ref{TaskURL}).
 \item {\em type:} string (URL)
 \item {\em default:} (none)
 \item {\em example:} \lstinline=http://suites/${CYLC_SUITE_NAME}/index.html=
+\end{myitemize}
+
+\subsubsection{group}{ [meta] \textrightarrow group}
+
+A single line group name for a suite. It is displayed in the gscan
+window and can be used as a way of grouping related suites together.
+\lstinline=cylc show= command.
+
+\begin{myitemize}
+\item {\em type:} single line string
+\item {\em default:} (none)
 \end{myitemize}
 
 \subsubsection[\_\_MANY\_\_]{ [meta] \textrightarrow \_\_MANY\_\_}

--- a/doc/src/cylc-user-guide/suiterc.tex
+++ b/doc/src/cylc-user-guide/suiterc.tex
@@ -61,9 +61,8 @@ task URLs (\ref{TaskURL}).
 
 \subsubsection{group}{ [meta] \textrightarrow group}
 
-A single line group name for a suite. It is displayed in the gscan
-window and can be used as a way of grouping related suites together with the
-\lstinline=cylc show= command.
+A group name for a suite. In the gscan GUI, suites with the same group name can
+be collapsed into a single state summary when the ``group'' column is displayed.
 
 \begin{myitemize}
 \item {\em type:} single line string

--- a/doc/src/cylc-user-guide/suiterc.tex
+++ b/doc/src/cylc-user-guide/suiterc.tex
@@ -62,7 +62,7 @@ task URLs (\ref{TaskURL}).
 \subsubsection{group}{ [meta] \textrightarrow group}
 
 A single line group name for a suite. It is displayed in the gscan
-window and can be used as a way of grouping related suites together.
+window and can be used as a way of grouping related suites together with the
 \lstinline=cylc show= command.
 
 \begin{myitemize}

--- a/lib/cylc/cfgspec/suite.py
+++ b/lib/cylc/cfgspec/suite.py
@@ -192,10 +192,10 @@ coercers['parameter_list'] = _coerce_parameter_list
 
 
 SPEC = {
-    'group': vdr(vtype='string', default="(ungrouped)"),
     'meta': {
-        'title': vdr(vtype='string', default=""),
         'description': vdr(vtype='string', default=""),
+        'group': vdr(vtype='string', default=""),
+        'title': vdr(vtype='string', default=""),
         'URL': vdr(vtype='string', default=""),
         '__MANY__': vdr(vtype='string', default=""),
     },
@@ -543,6 +543,10 @@ def upg(cfg, descr):
         '7.5.0',
         ['URL'],
         ['meta', 'URL'])
+    u.deprecate(
+        '7.6.0',
+        ['group'],
+        ['meta', 'group'])
     u.obsolete('7.2.2', ['cylc', 'dummy mode'])
     u.obsolete('7.2.2', ['cylc', 'simulation mode'])
     u.obsolete('7.2.2', ['runtime', '__MANY__', 'dummy mode'])

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -50,7 +50,7 @@ from cylc.suite_logging import SuiteLog, OUT, ERR, LOG
 from cylc.suite_srv_files_mgr import (
     SuiteSrvFilesManager, SuiteServiceFileError)
 from cylc.suite_status import (
-    KEY_DESCRIPTION, KEY_GROUP, KEY_NAME, KEY_OWNER, KEY_STATES,
+    KEY_DESCRIPTION, KEY_GROUP, KEY_META, KEY_NAME, KEY_OWNER, KEY_STATES,
     KEY_TASKS_BY_STATE, KEY_TITLE, KEY_UPDATE_TIME)
 from cylc.taskdef import TaskDef
 from cylc.task_id import TaskID
@@ -680,9 +680,9 @@ conditions; see `cylc conditions`.
             result[KEY_NAME] = self.suite
             result[KEY_OWNER] = self.owner
         if PRIVILEGE_LEVELS[1] in privileges:
-            result[KEY_TITLE] = self.config.cfg['meta'][KEY_TITLE]
-            result[KEY_DESCRIPTION] = self.config.cfg['meta'][KEY_DESCRIPTION]
-            result[KEY_GROUP] = self.config.cfg[KEY_GROUP]
+            result[KEY_META] = self.config.cfg[KEY_META]
+            for key in (KEY_TITLE, KEY_DESCRIPTION, KEY_GROUP):
+                result[key] = self.config.cfg[KEY_META].get(key)
         if PRIVILEGE_LEVELS[2] in privileges:
             result[KEY_UPDATE_TIME] = self.info_get_update_times()[0]
             result[KEY_STATES] = self.state_summary_mgr.get_state_totals()

--- a/lib/cylc/suite_status.py
+++ b/lib/cylc/suite_status.py
@@ -20,6 +20,7 @@
 # Keys for identify API call
 KEY_DESCRIPTION = "description"
 KEY_GROUP = "group"
+KEY_META = "meta"
 KEY_NAME = "name"
 KEY_OWNER = "owner"
 KEY_STATES = "states"


### PR DESCRIPTION
Migrate `group` setting to under `[meta]` as well.

On suite `identify` API call, return full set of suite `[meta]` settings on `description` privilege level.