### PR TITLE
Fix 'at TIME' stripping from multi-line task messages

### DIFF
--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -105,7 +105,7 @@ class TaskEventsManager(object):
     NN = "NN"
     POLLED_INDICATOR = "(polled)"
     RE_MESSAGE_TIME = re.compile(
-        '\A(.+) at (' + RE_DATE_TIME_FORMAT_EXTENDED + ')\Z')
+        '\A(.+) at (' + RE_DATE_TIME_FORMAT_EXTENDED + ')\Z', re.DOTALL)
 
     def __init__(self, suite, proc_pool, suite_db_mgr, broadcast_mgr=None):
         self.suite = suite

--- a/tests/cylc-message/01-newline.t
+++ b/tests/cylc-message/01-newline.t
@@ -1,0 +1,44 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#------------------------------------------------------------------------------
+# Test "cylc message" with multi-line messages. The RE to strip 'at <TIME>' off
+# task messages was assuming a single line string.
+
+. "$(dirname "$0")/test_header"
+
+set_test_number 3
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+
+suite_run_ok "${TEST_NAME_BASE}-run" cylc run --debug "${SUITE_NAME}"
+
+LOG="${SUITE_RUN_DIR}/log/job/1/foo/01/job-activity.log"
+sed -n '/event-handler-00/,$p' "${LOG}" >'edited-job-activity.log'
+
+cmp_ok 'edited-job-activity.log' - <<__LOG__
+[(('event-handler-00', 'custom'), 1) cmd]
+echo 'the quick brown fox
+jumped over the lazy dog'
+[(('event-handler-00', 'custom'), 1) ret_code] 0
+[(('event-handler-00', 'custom'), 1) out]
+the quick brown fox
+jumped over the lazy dog
+__LOG__
+
+purge_suite "${SUITE_NAME}"

--- a/tests/cylc-message/01-newline/suite.rc
+++ b/tests/cylc-message/01-newline/suite.rc
@@ -1,0 +1,11 @@
+[scheduling]
+    [[dependencies]]
+        graph = foo
+[runtime]
+    [[foo]]
+        script = """
+cylc message -p CUSTOM "the quick brown fox
+jumped over the lazy dog"
+"""
+        [[[events]]]
+            custom handler = echo %(message)s


### PR DESCRIPTION
A user was wondering why "MESSAGE at TIME" was delivered to her event handler via `custom handler = %(message)s`, rather than the expected "MESSAGE".  

The message contained newlines, and our time stripping regex was assuming a single-line string.