### PR TITLE
Improve logging

### DIFF
--- a/lib/cylc/broadcast_mgr.py
+++ b/lib/cylc/broadcast_mgr.py
@@ -155,7 +155,7 @@ class BroadcastMgr(object):
     def load_db_broadcast_states(self, row_idx, row):
         """Load broadcast variables from runtime DB broadcast states row."""
         if row_idx == 0:
-            OUT.info("LOADING broadcast states")
+            LOG.info("LOADING broadcast states")
         point, namespace, key, value = row
         sections = []
         cur_key = key
@@ -170,7 +170,7 @@ class BroadcastMgr(object):
                 dict_.setdefault(section, {})
                 dict_ = dict_[section]
             dict_[cur_key] = value
-        OUT.info(CHANGE_FMT.strip() % {
+        LOG.info(CHANGE_FMT.strip() % {
             "change": CHANGE_PREFIX_SET,
             "point": point,
             "namespace": namespace,

--- a/lib/cylc/broadcast_mgr.py
+++ b/lib/cylc/broadcast_mgr.py
@@ -26,7 +26,7 @@ from cylc.broadcast_report import (
     get_broadcast_bad_options_report)
 from cylc.cycling import PointParsingError
 from cylc.cycling.loader import get_point, standardise_point_string
-from cylc.suite_logging import LOG, OUT
+from cylc.suite_logging import LOG
 from cylc.task_id import TaskID
 
 

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -1312,8 +1312,6 @@ conditions; see `cylc conditions`.
             if cylc.flags.iflag:
                 self.suite_db_mgr.put_task_pool(self.pool)
                 self.update_state_summary()  # Will reset cylc.flags.iflag
-
-            # Process suite DB queue
             self.process_suite_db_queue()
 
             # If public database is stuck, blast it away by copying the content

--- a/lib/cylc/suite_db_mgr.py
+++ b/lib/cylc/suite_db_mgr.py
@@ -33,7 +33,7 @@ from tempfile import mkstemp
 
 from cylc.broadcast_report import get_broadcast_change_iter
 from cylc.rundb import CylcSuiteDAO
-from cylc.suite_logging import ERR, LOG, OUT
+from cylc.suite_logging import ERR, LOG
 from cylc.wallclock import get_current_time_string
 
 

--- a/lib/cylc/suite_db_mgr.py
+++ b/lib/cylc/suite_db_mgr.py
@@ -457,7 +457,5 @@ class SuiteDatabaseManager(object):
             pri_dao = self.get_pri_dao()
 
         # Vacuum the primary/private database file
-        OUT.info("Vacuuming the suite db ...")
         pri_dao.vacuum()
-        OUT.info("...done")
         pri_dao.close()

--- a/lib/cylc/suite_events.py
+++ b/lib/cylc/suite_events.py
@@ -24,7 +24,7 @@ from pipes import quote
 from cylc.cfgspec.globalcfg import GLOBAL_CFG
 from cylc.mp_pool import SuiteProcContext
 from cylc.suite_host import get_suite_host, get_user
-from cylc.suite_logging import ERR, LOG
+from cylc.suite_logging import LOG
 
 
 class SuiteEventError(Exception):
@@ -177,7 +177,7 @@ class SuiteEventHandler(object):
         if proc_ctx.ret_code:
             msg = '%s EVENT HANDLER FAILED' % proc_ctx.cmd_key[1]
             LOG.error(str(proc_ctx))
-            ERR.error(msg)
+            LOG.error(msg)
             if abort_on_error:
                 raise SuiteEventError(msg)
         else:

--- a/lib/cylc/task_job_mgr.py
+++ b/lib/cylc/task_job_mgr.py
@@ -48,7 +48,7 @@ from cylc.job_file import JobFileWriter
 from cylc.mkdir_p import mkdir_p
 from cylc.mp_pool import SuiteProcPool, SuiteProcContext
 from cylc.suite_host import is_remote, is_remote_host, is_remote_user
-from cylc.suite_logging import ERR, LOG
+from cylc.suite_logging import LOG
 from cylc.task_events_mgr import TaskEventsManager
 from cylc.task_message import TaskMessage
 from cylc.task_outputs import (
@@ -832,7 +832,6 @@ class TaskJobManager(object):
             self.job_file_writer.write(local_job_file_path, job_conf)
         except Exception, exc:
             # Could be a bad command template.
-            ERR.error(traceback.format_exc())
             LOG.error(traceback.format_exc())
             self.task_events_mgr.log_task_job_activity(
                 SuiteProcContext(

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -349,7 +349,7 @@ class TaskPool(object):
         are polled to determine what their true status is.
         """
         if row_idx == 0:
-            OUT.info("LOADING task proxies")
+            LOG.info("LOADING task proxies")
         (cycle, name, spawned, status, hold_swap, submit_num, _,
          user_at_host, time_submit, time_run, timeout,
          outputs_str) = row
@@ -419,15 +419,15 @@ class TaskPool(object):
             if user_at_host:
                 itask.summary['job_hosts'][int(submit_num)] = user_at_host
             if hold_swap:
-                OUT.info("+ %s.%s %s (%s)" % (name, cycle, status, hold_swap))
+                LOG.info("+ %s.%s %s (%s)" % (name, cycle, status, hold_swap))
             else:
-                OUT.info("+ %s.%s %s" % (name, cycle, status))
+                LOG.info("+ %s.%s %s" % (name, cycle, status))
             self.add_to_runahead_pool(itask, is_restart=True)
 
     def load_db_task_action_timers(self, row_idx, row):
         """Load a task action timer, e.g. event handlers, retry states."""
         if row_idx == 0:
-            OUT.info("LOADING task action timers")
+            LOG.info("LOADING task action timers")
         (cycle, name, ctx_key_pickle, ctx_pickle, delays_pickle, num, delay,
          timeout) = row
         id_ = TaskID.get(name, cycle)
@@ -454,7 +454,7 @@ class TaskPool(object):
                 {"id": id_, "ctx_key": ctx_key})
             ERR.warning(traceback.format_exc())
             return
-        OUT.info("+ %s.%s %s" % (name, cycle, ctx_key))
+        LOG.info("+ %s.%s %s" % (name, cycle, ctx_key))
 
     def release_runahead_task(self, itask):
         """Release itask to the appropriate queue in the active pool."""

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -41,7 +41,7 @@ from cylc.cycling.loader import (
     get_interval, get_interval_cls, get_point, ISO8601_CYCLING_TYPE,
     standardise_point_string)
 import cylc.flags
-from cylc.suite_logging import ERR, LOG, OUT
+from cylc.suite_logging import ERR, LOG
 from cylc.task_action_timer import TaskActionTimer
 from cylc.task_id import TaskID
 from cylc.task_proxy import TaskProxy

--- a/tests/cylc-cat-log/00-local.t
+++ b/tests/cylc-cat-log/00-local.t
@@ -32,15 +32,15 @@ cylc stop --max-polls=10 --interval=2 $SUITE_NAME 2>'/dev/null'
 #-------------------------------------------------------------------------------
 TEST_NAME=${TEST_NAME_BASE}-suite-log-log
 cylc cat-log $SUITE_NAME >$TEST_NAME.out
-grep_ok 'Suite starting' $TEST_NAME.out
+cmp_ok "${TEST_NAME}.out" "${SUITE_RUN_DIR}/log/suite/log"
 #-------------------------------------------------------------------------------
 TEST_NAME=${TEST_NAME_BASE}-suite-log-out
 cylc cat-log -o $SUITE_NAME >$TEST_NAME.out
-grep_ok 'DONE' $TEST_NAME.out
+cmp_ok "${TEST_NAME}.out" "${SUITE_RUN_DIR}/log/suite/out"
 #-------------------------------------------------------------------------------
 TEST_NAME=${TEST_NAME_BASE}-suite-log-err
 cylc cat-log -e $SUITE_NAME >$TEST_NAME.out
-grep_ok 'marmite and squashed bananas' $TEST_NAME.out
+cmp_ok "${TEST_NAME}.out" "${SUITE_RUN_DIR}/log/suite/err"
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-task-out
 cylc cat-log -o $SUITE_NAME a-task.1 >$TEST_NAME.out

--- a/tests/job-file-trap/00-sigusr1.t
+++ b/tests/job-file-trap/00-sigusr1.t
@@ -76,13 +76,13 @@ run_tests() {
         cmp_ok "$TEST_NAME-db-t1" - <<<'succeeded'
         # Test reference
         TIMEOUT=$(($(date +%s) + 120))
-        while ! grep -q 'DONE' $SUITE_RUN_DIR/log/suite/out \
+        while ! grep -q 'DONE' "${SUITE_RUN_DIR}/log/suite/log" \
                 && (($TIMEOUT > $(date +%s)))
         do
             sleep 1
         done
     fi
-    grep_ok 'SUITE REFERENCE TEST PASSED' $SUITE_RUN_DIR/log/suite/out
+    grep_ok 'SUITE REFERENCE TEST PASSED' "${SUITE_RUN_DIR}/log/suite/log"
     purge_suite $SUITE_NAME
     exit
 }

--- a/tests/restart/15-state-to-db.t
+++ b/tests/restart/15-state-to-db.t
@@ -28,8 +28,8 @@ sqlite3 "${SUITE_RUN_DIR}/state/cylc-suite.db" <"cylc-suite-db.dump"
 cp -p 'state/state' "${SUITE_RUN_DIR}/state/"
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
 suite_run_ok "${TEST_NAME_BASE}-restart" cylc restart --debug "${SUITE_NAME}"
-sed -i 's/^.* INFO - //' "${TEST_NAME_BASE}-restart.stdout"
-contains_ok "${TEST_NAME_BASE}-restart.stdout" <<'__OUT__'
+sed 's/^.* INFO - //' "${SUITE_RUN_DIR}/log/suite/log" >'edited.log'
+contains_ok 'edited.log' <<'__OUT__'
 LOADING suite parameters
 + initial cycle point = 20000101T0000Z
 + final cycle point = 20030101T0000Z

--- a/tests/restart/20-event-retry.t
+++ b/tests/restart/20-event-retry.t
@@ -36,8 +36,8 @@ cmp_ok "${SUITED}/file" <<'__TEXT__'
 1
 2
 __TEXT__
-grep_ok 'LOADING task action timers' "${SUITED}/log/suite/out"
-grep_ok "+ t01\\.1 (('event-handler-00', 'succeeded'), 1)" "${SUITED}/log/suite/out"
+grep_ok 'LOADING task action timers' "${SUITED}/log/suite/log"
+grep_ok "+ t01\\.1 (('event-handler-00', 'succeeded'), 1)" "${SUITED}/log/suite/log"
 
 purge_suite "${SUITE_NAME}"
 exit

--- a/tests/restart/21-task-elapsed.t
+++ b/tests/restart/21-task-elapsed.t
@@ -41,7 +41,7 @@ suite_run_ok "${TEST_NAME_BASE}-run" cylc run "${SUITE_NAME}" --debug
 suite_run_ok "${TEST_NAME_BASE}-restart-1" \
     cylc restart "${SUITE_NAME}" --until=2028 --debug
 sed -n '/LOADING task run times/,+2{s/^.* INFO - //;s/[0-9]\(,\|$\)/%d\1/g;p}' \
-    "${RUND}/log/suite/out" >'restart-1.out'
+    "${RUND}/log/suite/log" >'restart-1.out'
 contains_ok 'restart-1.out' <<'__OUT__'
 LOADING task run times
 + t2: %d,%d,%d,%d,%d
@@ -50,7 +50,7 @@ __OUT__
 suite_run_ok "${TEST_NAME_BASE}-restart-2" \
     cylc restart "${SUITE_NAME}" --until=2030 --debug
 sed -n '/LOADING task run times/,+2{s/^.* INFO - //;s/[0-9]\(,\|$\)/%d\1/g;p}' \
-    "${RUND}/log/suite/out" >'restart-2.out'
+    "${RUND}/log/suite/log" >'restart-2.out'
 contains_ok 'restart-2.out' <<'__OUT__'
 LOADING task run times
 + t2: %d,%d,%d,%d,%d,%d,%d,%d,%d,%d

--- a/tests/restart/22-hold.t
+++ b/tests/restart/22-hold.t
@@ -31,7 +31,7 @@ else
     cmp_ok 't2-status.out' <<<'held|waiting'
 fi
 suite_run_ok "${TEST_NAME_BASE}-restart" cylc restart "${SUITE_NAME}" --debug
-grep_ok 'INFO - + t2\.2016 held (waiting)' "${SUITE_RUN_DIR}/log/suite/out"
+grep_ok 'INFO - + t2\.2016 held (waiting)' "${SUITE_RUN_DIR}/log/suite/log"
 if ! which sqlite3 > /dev/null; then
     skip 1 "sqlite3 not installed?"
 else

--- a/tests/restart/23-hold-retry.t
+++ b/tests/restart/23-hold-retry.t
@@ -36,7 +36,7 @@ __OUT__
 fi
 suite_run_ok "${TEST_NAME_BASE}-restart" \
     cylc restart "${SUITE_NAME}" --debug --until=2017
-grep_ok 'INFO - + t2\.2016 held (retrying)' "${SUITE_RUN_DIR}/log/suite/out"
+grep_ok 'INFO - + t2\.2016 held (retrying)' "${SUITE_RUN_DIR}/log/suite/log"
 if ! which sqlite3 > /dev/null; then
     skip 1 "sqlite3 not installed?"
 else


### PR DESCRIPTION
Avoid sending items to OUT from a running suite.

Ensure that the verbosity level makes sense for ERR. (E.g. `ERR.debug` never actually did anything before!)