### PR TITLE
suite_state: don't return null db results

### DIFF
--- a/lib/cylc/dbstatecheck.py
+++ b/lib/cylc/dbstatecheck.py
@@ -107,7 +107,8 @@ class CylcSuiteDBChecker(object):
 
         res = []
         for row in self.conn.execute(stmt, stmt_args):
-            res.append(list(row))
+            if not all(v is None for v in row):
+                res.append(list(row))
 
         return res
 

--- a/tests/suite-state/07-message2.t
+++ b/tests/suite-state/07-message2.t
@@ -1,0 +1,35 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test suite-state message query on a waiting task - GitHub #2440.
+
+. $(dirname $0)/test_header
+set_test_number 4
+
+install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+
+run_ok ${TEST_NAME_BASE}-val cylc validate $SUITE_NAME
+
+suite_run_ok ${TEST_NAME_BASE}-run cylc run --debug $SUITE_NAME
+
+TEST_NAME=${TEST_NAME_BASE}-query
+run_fail ${TEST_NAME} cylc suite-state \
+  $SUITE_NAME -p 2013 -t foo --max-polls=1 -m "the quick brown fox"
+
+grep_ok "ERROR: condition not satisfied" ${TEST_NAME}.stderr
+
+purge_suite $SUITE_NAME

--- a/tests/suite-state/07-message2/suite.rc
+++ b/tests/suite-state/07-message2/suite.rc
@@ -1,0 +1,15 @@
+[cylc]
+    cycle point format = %Y
+[scheduling]
+    initial cycle point = 2010
+    final cycle point = 2012
+    [[dependencies]]
+        [[[P1Y]]]
+          graph = "foo:x => bar"
+[runtime]
+    [[foo]]
+        script = cylc message "the quick brown fox"
+        [[[outputs]]]
+            x = "the quick brown fox"
+    [[bar]]
+        script = true


### PR DESCRIPTION
`cylc suite-state` fails if querying a task output message from a task proxy that exists (or existed before suite shutdown) but which has not generated its message output yet.  E.g.:

```
[cylc]
    cycle point format = %Y
[scheduling]
    initial cycle point = 2010
    final cycle point = 2012
    [[dependencies]]
        [[[P1Y]]]
          graph = "foo:x => bar"
[runtime]
    [[foo]]
        script = cylc message "the quick brown fox"
        [[[outputs]]]
            x = "the quick brown fox"
    [[bar]]
        script = true
```

Run this suite to completion. It shuts down with waiting task proxies recorded in the final+1 cycle (2013):

```
$ cylc suite-state baz
foo, 2010, succeeded
bar, 2010, succeeded
foo, 2011, succeeded
foo, 2012, succeeded
bar, 2011, succeeded
foo, 2013, waiting  # <---
bar, 2012, succeeded
bar, 2013, waiting  # <---
```

Querying foo's output message is fine for succeeded instances, and non-existent instances:
```
$ cylc suite-state -t foo -p 2012 -m 'the quick brown fox' --max-polls=1 baz
checking for 'output: the quick brown fox': satisfied

$ cylc suite-state -t foo -p 2014 -m 'the quick brown fox' --max-polls=1 baz
checking for 'output: the quick brown fox'
ERROR: condition not satisfied
```

But not for the instance that exists but has not recorded an output yet:
```
cylc suite-state -t foo -p 2013 -m 'the quick brown fox' --max-polls=1 baz
checking for 'output: the quick brown fox''NoneType' object has no attribute 'splitlines'
```

This seems to be because the DB `task_outputs` table has a column for the messages of all existing task proxies that register outputs, unpopulated until the message is received, until which time a query  returns `(None, )` rather than `None`.

This change fixes it.