### PR TITLE
Allow batch system name and job ID as event handler args.

### DIFF
--- a/doc/src/cylc-user-guide/cug.tex
+++ b/doc/src/cylc-user-guide/cug.tex
@@ -7111,7 +7111,7 @@ suite to finish and shut down.  Here's the complete suite log for this run:
 
 \lstset{language=transcript}
 \begin{lstlisting}
-$ cylc log SUITE-NAME
+$ cylc cat-log SUITE-NAME
 2017-03-30T09:46:10Z INFO - Suite starting: server=localhost:43086 pid=3483
 2017-03-30T09:46:10Z INFO - Run mode: live
 2017-03-30T09:46:10Z INFO - Initial point: 2017-01-01T00Z

--- a/doc/src/cylc-user-guide/suiterc.tex
+++ b/doc/src/cylc-user-guide/suiterc.tex
@@ -1612,7 +1612,7 @@ will be substituted with actual values:
     \item \%(submit\_num)s: submit number
     \item \%(id)s: task ID (i.e.\ \%(name)s.\%(point)s)
     \item \%(batch\_sys\_name)s: batch system name
-    \item \%(batch\_sys\_id)s: batch system job ID
+    \item \%(batch\_sys\_job\_id)s: batch system job ID
     \item \%(message)s: event message, if any
     \item any task [meta] item, e.g.:
     \begin{myitemize}

--- a/doc/src/cylc-user-guide/suiterc.tex
+++ b/doc/src/cylc-user-guide/suiterc.tex
@@ -1611,6 +1611,8 @@ will be substituted with actual values:
     \item \%(name)s: task name
     \item \%(submit\_num)s: submit number
     \item \%(id)s: task ID (i.e.\ \%(name)s.\%(point)s)
+    \item \%(batch\_sys\_name)s: batch system name
+    \item \%(batch\_sys\_id)s: batch system job ID
     \item \%(message)s: event message, if any
     \item any task [meta] item, e.g.:
     \begin{myitemize}

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -84,8 +84,8 @@ class SuiteConfig(object):
     """Class for suite configuration items and derived quantities."""
 
     Q_DEFAULT = 'default'
-    TASK_EVENT_TMPL_KEYS = (
-        'event', 'suite', 'point', 'name', 'submit_num', 'id', 'message')
+    TASK_EVENT_TMPL_KEYS = ('event', 'suite', 'point', 'name', 'submit_num',
+                            'id', 'message', 'batch_sys_name', 'batch_sys_id')
 
     def __init__(self, suite, fpath, template_vars=None,
                  owner=None, run_mode='live', is_validate=False, strict=False,

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -84,8 +84,9 @@ class SuiteConfig(object):
     """Class for suite configuration items and derived quantities."""
 
     Q_DEFAULT = 'default'
-    TASK_EVENT_TMPL_KEYS = ('event', 'suite', 'point', 'name', 'submit_num',
-                            'id', 'message', 'batch_sys_name', 'batch_sys_id')
+    TASK_EVENT_TMPL_KEYS = (
+        'event', 'suite', 'point', 'name', 'submit_num', 'id', 'message',
+        'batch_sys_name', 'batch_sys_job_id')
 
     def __init__(self, suite, fpath, template_vars=None,
                  owner=None, run_mode='live', is_validate=False, strict=False,

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -1382,8 +1382,9 @@ class SuiteConfig(object):
                 for key, value in self.cfg['meta'].items():
                     subs['suite_' + key.lower()] = value
                 subs.update(taskdef.rtconfig['meta'])
+                # Back compat.
                 try:
-                    subs['task_url'] = subs.pop('URL')
+                    subs['task_url'] = subs['URL']
                 except KeyError:
                     pass
                 for key, values in taskdef.rtconfig['events'].items():

--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -841,6 +841,8 @@ class TaskEventsManager(object):
                     "submit_num": itask.submit_num,
                     "id": quote(itask.identity),
                     "message": quote(message),
+                    "batch_sys_name": quote(itask.summary['batch_sys_name']),
+                    "batch_sys_id": quote(itask.summary['submit_method_id'])
                 }
 
                 if self.suite_cfg:

--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -681,10 +681,7 @@ class TaskEventsManager(object):
             "time_submit_exit": get_current_time_string(),
             "submit_status": 1,
         })
-        try:
-            del itask.summary['submit_method_id']
-        except KeyError:
-            pass
+        itask.summary['submit_method_id'] = None
         if (TASK_STATUS_SUBMIT_RETRYING not in itask.try_timers or
                 itask.try_timers[TASK_STATUS_SUBMIT_RETRYING].next() is None):
             # No submission retry lined up: definitive failure.
@@ -832,6 +829,7 @@ class TaskEventsManager(object):
                 continue
             # Custom event handler can be a command template string
             # or a command that takes 4 arguments (classic interface)
+            # Note quote() fails on None, need str(None).
             try:
                 handler_data = {
                     "event": quote(event),
@@ -841,9 +839,10 @@ class TaskEventsManager(object):
                     "submit_num": itask.submit_num,
                     "id": quote(itask.identity),
                     "message": quote(message),
-                    "batch_sys_name": quote(itask.summary['batch_sys_name']),
+                    "batch_sys_name": quote(
+                        str(itask.summary['batch_sys_name'])),
                     "batch_sys_job_id": quote(
-                        itask.summary['submit_method_id'])
+                        str(itask.summary['submit_method_id']))
                 }
 
                 if self.suite_cfg:

--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -842,7 +842,8 @@ class TaskEventsManager(object):
                     "id": quote(itask.identity),
                     "message": quote(message),
                     "batch_sys_name": quote(itask.summary['batch_sys_name']),
-                    "batch_sys_id": quote(itask.summary['submit_method_id'])
+                    "batch_sys_job_id": quote(
+                        itask.summary['submit_method_id'])
                 }
 
                 if self.suite_cfg:

--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -83,7 +83,6 @@ class TaskProxy(object):
         self.is_manual_submit = False
         self.summary = {
             'latest_message': "",
-            'submit_method_id': None,
             'submitted_time': None,
             'submitted_time_string': None,
             'submit_num': self.submit_num,

--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -98,6 +98,8 @@ class TaskProxy(object):
             'logfiles': [],
             'job_hosts': {},
             'execution_time_limit': None,
+            'batch_sys_name': None,
+            'submit_method_id': None
         }
 
         self.local_job_file_path = None

--- a/tests/events/39-task-event-template-all.t
+++ b/tests/events/39-task-event-template-all.t
@@ -1,0 +1,32 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Compare actual and expected event handler command args.
+
+. "$(dirname "$0")/test_header"
+set_test_number 3
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+
+suite_run_ok "${TEST_NAME_BASE}-run" cylc run --debug "${SUITE_NAME}"
+
+FOO_ACTIVITY_LOG="${SUITE_RUN_DIR}/log/job/1/foo/NN/job-activity.log"
+SUITE_LOG="${SUITE_RUN_DIR}/log/suite/log"
+grep_ok "OK: command line checks out" "${FOO_ACTIVITY_LOG}"
+
+purge_suite "${SUITE_NAME}"

--- a/tests/events/39-task-event-template-all/bin/checkargs
+++ b/tests/events/39-task-event-template-all/bin/checkargs
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+# Compare actual and expected event handler command lines.
+
+import sys
+
+start = ['SUITE:', 'JID:']
+other = ['custom', '1', 'foo', '1', 'foo.1', 'background', 'cheesy peas', 'trout',
+         'a task called foo', 'http://cheesy.peas', 'a test suite', 'large']
+one = len(sys.argv) >= 3
+two = sys.argv[1].startswith(start[0])
+thr = sys.argv[2].startswith(start[1])
+fou = sys.argv[3:] == other
+
+if one and two and thr and fou:
+    print "OK: command line checks out"
+    sys.exit(0)
+else:
+    print >> sys.stderr, 'ERROR: unexpected event handler command line.'
+    sys.exit(1)

--- a/tests/events/39-task-event-template-all/suite.rc
+++ b/tests/events/39-task-event-template-all/suite.rc
@@ -1,0 +1,20 @@
+# Test all the standard event handler command line template args.
+[meta]
+  title = a test suite
+  size = large
+[cylc]
+    [[events]]
+        inactivity = PT15S
+        abort on inactivity = True
+[scheduling]
+    [[dependencies]]
+        graph = "foo"
+[runtime]
+    [[foo]]
+        script = cylc message -p CUSTOM "cheesy peas"
+        [[[events]]]
+            custom handler = checkargs SUITE:%(suite)s JID:%(batch_sys_job_id)s %(event)s %(point)s %(name)s %(submit_num)s %(id)s %(batch_sys_name)s %(message)s %(fish)s %(title)s %(URL)s %(suite_title)s %(suite_size)s
+        [[[meta]]]
+            title = "a task called foo"
+            URL = http://cheesy.peas
+            fish = trout


### PR DESCRIPTION
(what it says)

Example:
```
[scheduling]
   [[dependencies]]
        graph = "foo"
[runtime]
   [[foo]]
       [[[events]]]
             succeeded handler = echo !!! %(batch_sys_name)s %(batch_sys_job_id)s 
```
run the suite, then
```
$ cylc cat-log -a test foo.1
[jobs-submit ret_code] 0
[jobs-submit out] 2017-10-09T21:47:01+13|2010/foo/01|0|11995
2017-10-09T21:47:01+13 [STDOUT] 11995
[(('event-handler-00', 'succeeded'), 1) cmd] echo !!! background 11995 succeeded
[(('event-handler-00', 'succeeded'), 1) ret_code] 0
[(('event-handler-00', 'succeeded'), 1) out] !!! background 11995 succeeded
```