### PR TITLE
GUI browse URL improvements

### DIFF
--- a/bin/cylc-documentation
+++ b/bin/cylc-documentation
@@ -18,21 +18,21 @@
 
 """cylc [info] documentation|browse [OPTIONS] [SUITE]
 
-Open cylc or suite documentation in your browser or PDF viewer (as defined
-in cylc global config files).
+View documentation in browser or PDF viewer, as per Cylc global config.
 
 % cylc doc [OPTIONS]
-   Open local or internet [--www] cylc documentation (locations must be
-specified in cylc global config files).
+   View local or internet [--www] Cylc documentation URLs.
 
-% cylc doc -u [-t TASK] SUITE
-    Open suite or task documentation if corresponding URL items are specified
-in the suite definition.
+% cylc doc [-t TASK] SUITE
+    View suite or task documentation, if URLs are specified in the suite. This
+parses the suite definition to extract the requested URL. Note that running
+suite daemons also hold suite URLs for access from the Cylc GUI.
 
 Arguments:
    [TARGET]    File, URL, or suite name"""
 
 import sys
+
 for arg in sys.argv[1:]:
     if arg.startswith('--host=') or arg.startswith('--user='):
         from cylc.remote import remrun
@@ -85,6 +85,11 @@ def main():
         help="Print exception traceback on error.",
         action="store_true", default=False, dest="debug")
 
+    parser.add_option(
+        "--url",
+        help="URL to view in your configured browser.",
+        metavar="URL", default=None, action="store", dest="url")
+
     (options, args) = parser.parse_args()
     cylc.flags.debug = options.debug
 
@@ -101,6 +106,9 @@ def main():
             # Force PDF.
             viewer = pdf_viewer
             target = pdf_file
+        elif options.url:
+            viewer = html_viewer
+            target = options.url
         else:
             # HTML documentation index.
             viewer = html_viewer

--- a/doc/src/cylc-user-guide/cug.tex
+++ b/doc/src/cylc-user-guide/cug.tex
@@ -6205,15 +6205,6 @@ To customize the environment more generally for Cylc on jobs hosts,
 use of \lstinline=job-init-env.sh= is described in Section~\ref{Configure
 Environment on Job Hosts}.
 
-\subsection{The Suite Contact File}
-\label{The Suite Contact File}
-
-At start-up, suite daemons write a {\em suite contact file}
-\lstinline=$HOME/cylc-run/<SUITE>/.service/contact= that records suite host,
-user, port number, process ID, Cylc version, and other information. Client
-commands can read this file, if they have access to it, to find the target
-suite daemon.
-
 \subsection{Tracking Task State}
 \label{TaskComms}
 
@@ -6362,6 +6353,22 @@ tracking (see these with \lstinline=cylc get-site-config=):
         default polling interval in minutes = 1.0
 \end{lstlisting}
 
+\subsection{The Suite Service Directory}
+\label{The Suite Service Directory}
+\label{The Suite Contact File}
+
+At registration time a {\em suite service directory},
+\lstinline=$HOME/cylc-run/<SUITE>/.service/=, is created and populated
+with a private passphrase file (containing random text), a self-signed
+SSL certificate (see~\ref{ConnectionAuthentication}, and a symlink to the suite
+source directory.  An existing passphrase file will not be overwritten
+if a suite is re-registered.
+
+At run time, the private suite run database is also written to the service
+directory, along with a {\em suite contact file} that records the host,
+user, port number, process ID, Cylc version, and other information about the
+suite daemon. Client commands automatically read daemon targetting information
+from the contact file, if they have access to it.
 
 \subsection{Client-Server Interaction}
 \label{ConnectionAuthentication}
@@ -6372,18 +6379,15 @@ and GUIs).
 
 Use \lstinline=cylc scan= to see which suites are listening on which ports on
 scanned hosts (this lists your own suites, by default, but it can show others
-too).
+too - see \lstinline=cylc scan --help=).
 
-Cylc currently supports two kinds of access to suite daemons:
+Cylc supports two kinds of access to suite daemons:
 \begin{myitemize}
     \item {\em public} (non-authenticated) - the amount of information
       revealed is configurable, see~\ref{PublicAccess}
     \item {\em control} (authenticated) - full control, suite passphrase
       required, see~\ref{passphrases}
 \end{myitemize}
-
-{\em Note in both cases the suite {\em SSL certificate} is required to
-establish the HTTPS connection.}
 
 \subsubsection{Public Access - No Passphrase}
 \label{PublicAccess}
@@ -6405,28 +6409,28 @@ The \lstinline=cylc scan= command can print descriptions and task state totals
 in addition to basic suite identity, if you have the right passphrases or if
 the requested information is revealed publicly.
 
-
 \subsubsection{Full Control - With Passphrase}
 \label{passphrases}
 
-Suite passphrases, which give full control over a suite, are loaded by the
-suite daemon at start-up and used to authenticate connections from client
-programs. They are used in a secure encrypted challenge-response scheme, never
+Suite passphrases, which give full control over a suite, are loaded from the
+suite service directory (see~\ref{The Suite Service Directory}) by the suite
+daemon at start-up, and used to authenticate subsequent client connections.
+Passphrases are used in a secure encrypted challenge-response scheme, never
 sent in plain text over the network.
 
-A random passphrase file (called \lstinline=passphrase=) and SSL certificate
-(\lstinline=ssl.cert=) are generated automatically with owner-only permissions
-at suite registration time, in the suite service directory
-\lstinline=$HOME/cylc-run/<SUITE>/.service/=.
+If two users need access to the same suite daemon, they must both possess the
+same suite passphrase file. Fine-grained access to a single suite daemon via
+multiple distinct ``user accounts'' is not currently supported.
 
-On submission of the first job to another host a suite daemon automatically
-install these and the {\em suite contact file} (see~\ref{The Suite Contact File})
-to the remote suite run directory, via scp, to enable task jobs to connect to
-the suite.
+Suite daemons automatically install their auth and contact files to job hosts,
+by scp, to enable task jobs to connect to the suite daemon with client commands,
+e.g.\ for task messaging.
 
-Client programs invoked by the user on the suite host will load this
-information too, from the suite service directory, to allow automatic
-connection to suites.
+Client programs invoked by the suite owner automatically load the passphrase,
+SSL certificate, and contact file too, for automatic connection to suites.
+
+{\em Manual installation of suite auth files is only needed for remote control
+- see below.}
 
 \subsubsection{Remote Control}
 \label{RemoteControl}
@@ -6439,32 +6443,23 @@ hosts, the suite SSL certificate and passphrase must be installed under your
 $HOME/.cylc/auth/OWNER@HOST/SUITE/
       ssl.cert
       passphrase
+      contact  # (optional - see below)
 \end{lstlisting}
-where \lstinline=OWNER@HOST= is the suite daemon account and \lstinline=SUITE=
-is the suite name. Then invoke client commands with the \lstinline=--user=
-and \lstinline=--host= options:
+where \lstinline=OWNER@HOST= is the suite host account and \lstinline=SUITE=
+is the suite name. Client commands should then be invoked with the
+\lstinline=--user= and \lstinline=--host= options, e.g.:
 \lstset{language=transcript}
 \begin{lstlisting}
 $ cylc monitor --user=OWNER --host=HOST SUITE
 \end{lstlisting}
 
-The suite contact file (see~\ref{The Suite Contact File}) can also be
-installed in the same place:
-\lstset{language=transcript}
-\begin{lstlisting}
-$HOME/.cylc/auth/OWNER@HOST/SUITE/
-      contact
-\end{lstlisting}
-but note this is not necessary if the remote suite run directory is in the
-standard location and you have read access to the contact file via the local
-filesystem, or via non-interactive ssh to the suite host - client commands
-will automatically read it.
-
-If you do not have access to these files the suite owner must give you the
-SSL certificate (for any connection) and the passphrase (for control). The
-contact file would also be useful, but note that without it you can still
-determine the port number with \lstinline=cylc scan= and then use it with
-\lstinline=--port= on the client command line.
+The suite contact file (see~\ref{The Suite Contact File}) is not needed if 
+you have read-access to the remote suite run directory via the local
+filesystem or non-interactive ssh to the suite host account - client commands
+will automatically read it. If you do install the contact file in your auth
+directory note that the port number will need to be updated if the suite gets
+restarted on a different port. Otherwise use \lstinline=cylc scan= to determine
+the suite port number and use the \lstinline=--port= client command option.
 
 {\em WARNING: possession of a suite passphrase gives full control over the
 target suite, including {\em edit run} functionality - which lets you run
@@ -6472,6 +6467,32 @@ arbitrary scripting on job hosts as the suite owner. Further,
 non-interactive ssh gives full access to the target user account, so we
 recommended that this is only used to interact with suites running on
 accounts to which you already have full access. }
+
+\subsection{Non-client Cylc Suite Commands}
+\label{Suite-parsing Commands}
+
+Some Cylc commands do not interact with running suite daemons as described
+above, but they parse suite definitions or access files such as suite logs on
+the suite host account.
+
+If the target suite is owned by another user then these non-client commands
+require non-interactive ssh access to the suite host account. Use of the
+\lstinline=--host= and \lstinline=--user= command options will result in the
+command being re-invoked, via ssh, on the suite host account (this includes
+the \lstinline=cylc run= and \lstinline=cylc restart= commands to start up a
+suite daemon).
+
+\subsection{GUI Suite Interaction}
+\label{GUI Suite Interaction}
+
+The gcylc GUI includes both client and non-client command functionality. This
+is completely transparent to the user if the GUI is running on the suite host
+account, but full GUI functionality for remote suites requires auth file
+installation (for connecting to the suite daemon) {\em and} non-interactive ssh
+access to the suite host account in order for file parsing and retrieval - such
+as viewing or graphing the suite definition and retrieving log files. Without
+ssh access you will see ``permission denied'' errors in command pop-up windows
+when attempting file access.
 
 \subsection{Task States Explained}
 

--- a/doc/src/cylc-user-guide/cug.tex
+++ b/doc/src/cylc-user-guide/cug.tex
@@ -6419,25 +6419,77 @@ Passphrases are used in a secure encrypted challenge-response scheme, never
 sent in plain text over the network.
 
 If two users need access to the same suite daemon, they must both possess the
-same suite passphrase file. Fine-grained access to a single suite daemon via
-multiple distinct ``user accounts'' is not currently supported.
+passphrase file for that suite. Fine-grained access to a single suite daemon
+via distinct user accounts is not currently supported.
 
-Suite daemons automatically install their auth and contact files to job hosts,
-by scp, to enable task jobs to connect to the suite daemon with client commands,
-e.g.\ for task messaging.
+Suite daemons automatically install their auth and contact files to job hosts
+by scp, to enable task jobs to connect back to the suite daemon for task
+messaging.
 
 Client programs invoked by the suite owner automatically load the passphrase,
 SSL certificate, and contact file too, for automatic connection to suites.
 
-{\em Manual installation of suite auth files is only needed for remote control
-- see below.}
+{\em Manual installation of suite auth files is only needed for remote control,
+if you do not have a shared filesystem - see below.}
 
-\subsubsection{Remote Control}
+\subsection{File-Reading Commands}
+
+Some Cylc commands and GUI actions parse the suite definition file or read
+other files, such as suite logs, from the suite host account rather than
+communicate with a suite daemon over the network.  In the future we plan to
+have suite daemons serve up these files to clients, but for the moment this
+functionality requires read-access to the relevant files on the suite host.
+
+\subsubsection{On A Shared Filesystem}
+
+If you are logged into the suite host account, suite-parsing commands will just
+work. The same goes if you are logged into another host that shares the same
+filesystem as the suite host - which is often the case in an HPC environment.
+Specifically, the two accounts must see the same home directory.
+
+\subsubsection{Without A Shared Filesystem}
+
+If you are logged into another host that does not see the same filesystem as
+the suite host you must have non-interactive ssh configured to the suite host
+account, and use the \lstinline=--host= and \lstinline=--user= command options
+to re-invoke (via ssh) suite-parsing commands on the suite host. The GUI should
+automatically do this when it invokes suite-parsing commands.
+
+\subsection{GUI-to-Suite Interaction}
+\label{GUI-to-Suite Interaction}
+
+The gcylc GUI is mainly a network client to retrieve and display suite status
+information from the suite daemon, but it can also invoke suite-parsing
+commands to view and graph the suite definition and so on. This is entirely
+transparent if the GUI is running on the suite host account, but full
+functionality for remote suites requires either a shared filesystem, or 
+(see~\ref{RemoteControl}) auth file installation {\em and} non-interactive ssh
+access to the suite host.  Without the auth files you will not be able to connect
+to the suite, and without ssh you will see ``permission denied'' errors on
+attempting file access.
+
+\subsection{Remote Control}
 \label{RemoteControl}
 
+Cylc client programs - command line and GUI - can interact with suite daemons
+running on other accounts or hosts. How this works depends on whether or not
+you have:
+\begin{myitemize}
+  \item a {\em shared filesystem} such that you see the same home directory on
+    both hosts.
+  \item {\em non-interactive ssh} from the client account to the server
+    account.
+\end{myitemize}
+
+With a shared filesystem, a suite registered on the remote (server) host is
+also - in effect - registered on the local (client) host.  In this case you
+can invoke client commands without the \lstinline=--host= option; the client
+will automatically read the host and port from the contact file in the
+suite service directory. 
+
 To interact with suite daemons running under other user accounts or on other
-hosts, the suite SSL certificate and passphrase must be installed under your
-\lstinline=$HOME/.cylc/= directory:
+hosts without a shared filesystem, the suite SSL certificate and passphrase
+must be installed under your \lstinline=$HOME/.cylc/= directory:
 \lstset{language=transcript}
 \begin{lstlisting}
 $HOME/.cylc/auth/OWNER@HOST/SUITE/
@@ -6467,32 +6519,6 @@ arbitrary scripting on job hosts as the suite owner. Further,
 non-interactive ssh gives full access to the target user account, so we
 recommended that this is only used to interact with suites running on
 accounts to which you already have full access. }
-
-\subsection{Non-client Cylc Suite Commands}
-\label{Suite-parsing Commands}
-
-Some Cylc commands do not interact with running suite daemons as described
-above, but they parse suite definitions or access files such as suite logs on
-the suite host account.
-
-If the target suite is owned by another user then these non-client commands
-require non-interactive ssh access to the suite host account. Use of the
-\lstinline=--host= and \lstinline=--user= command options will result in the
-command being re-invoked, via ssh, on the suite host account (this includes
-the \lstinline=cylc run= and \lstinline=cylc restart= commands to start up a
-suite daemon).
-
-\subsection{GUI Suite Interaction}
-\label{GUI Suite Interaction}
-
-The gcylc GUI includes both client and non-client command functionality. This
-is completely transparent to the user if the GUI is running on the suite host
-account, but full GUI functionality for remote suites requires auth file
-installation (for connecting to the suite daemon) {\em and} non-interactive ssh
-access to the suite host account in order for file parsing and retrieval - such
-as viewing or graphing the suite definition and retrieving log files. Without
-ssh access you will see ``permission denied'' errors in command pop-up windows
-when attempting file access.
 
 \subsection{Task States Explained}
 

--- a/doc/src/cylc-user-guide/suiterc.tex
+++ b/doc/src/cylc-user-guide/suiterc.tex
@@ -48,15 +48,14 @@ A multi-line description of the suite. It can be retrieved at run time with the
 \label{SuiteURL}
 
 A web URL to suite documentation.  If present it can be browsed with the
-\lstinline=cylc doc= command, or from the gcylc Suite menu.  The variable
-\lstinline=${CYLC_SUITE_NAME}= will be replaced with the actual suite name
-(note this is not a shell environment variable in this context). See also
-task URLs (\ref{TaskURL}).
+\lstinline=cylc doc= command, or from the gcylc Suite menu. The string
+template \lstinline=%(suite_name)s= will be replaced with the actual suite
+name. See also task URLs (\ref{TaskURL}).
 
 \begin{myitemize}
 \item {\em type:} string (URL)
 \item {\em default:} (none)
-\item {\em example:} \lstinline=http://suites/${CYLC_SUITE_NAME}/index.html=
+\item {\em example:} \lstinline=http://my-site.com/suites/%(suite_name)s/index.html=
 \end{myitemize}
 
 \subsubsection{group}{ [meta] \textrightarrow group}
@@ -1287,10 +1286,9 @@ A multi-line description of this namespace, retrievable from running tasks with 
 
 A web URL to task documentation for this suite.  If present it can be browsed
 with the \lstinline=cylc doc= command, or by right-clicking on the task in
-gcylc.  The variables \lstinline=${CYLC_SUITE_NAME}= and
-\lstinline=${CYLC_TASK_NAME}= will be replaced with the actual suite and task
-names (note that these are not environment variables in this context). See also
-suite URLs (\ref{SuiteURL}).
+gcylc. The string templates \lstinline=%(suite_name)s= and
+\lstinline=%(task_name)s= will be replaced with the actual suite and task names.
+See also suite URLs (\ref{SuiteURL}).
 
 \begin{myitemize}
 \item {\em type:} string (URL)
@@ -1301,12 +1299,12 @@ suite URLs (\ref{SuiteURL}).
 [runtime]
     [[root]]
         [[[meta]]]
-            URL = http://suites/${CYLC_SUITE_NAME}/${CYLC_TASK_NAME}.html
+            URL = http://my-site.com/suites/%(suite_name)s/%(task_name)s.html
     \end{lstlisting}
 \end{myitemize}
 
-(Note that URLs containing the suite comment delimiter
-\lstinline=#= must be protected by quotes).
+(Note that URLs containing the comment delimiter \lstinline=#= must be
+protected by quotes).
 
 \subparagraph[\_\_MANY\_\_]{[runtime] \textrightarrow [[\_\_NAME\_\_]] \textrightarrow [[[meta]]] \textrightarrow \_\_MANY\_\_}
 

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -666,18 +666,21 @@ class SuiteConfig(object):
             if vfcp > final_point:
                 self.cfg['visualization']['final cycle point'] = str(
                     final_point)
-        # Replace suite name in suite  URL.
-        url = self.cfg['meta']['URL']
-        if url is not '':
-            self.cfg['meta']['URL'] = RE_SUITE_NAME_VAR.sub(self.suite, url)
 
-        # Replace suite and task name in task URLs.
+        # Replace suite and task name in suite and task URLs.
+        self.cfg['meta']['URL'] = self.cfg['meta']['URL'] % {
+            'suite_name': self.suite}
+        # back-compat $CYLC_SUITE_NAME:
+        self.cfg['meta']['URL'] = RE_SUITE_NAME_VAR.sub(
+            self.suite, self.cfg['meta']['URL'])
         for name, cfg in self.cfg['runtime'].items():
-            if cfg['meta']['URL']:
-                cfg['meta']['URL'] = RE_TASK_NAME_VAR.sub(
-                    name, cfg['meta']['URL'])
-                cfg['meta']['URL'] = RE_SUITE_NAME_VAR.sub(
-                    self.suite, cfg['meta']['URL'])
+            cfg['meta']['URL'] = cfg['meta']['URL'] % {
+                'suite_name': self.suite, 'task_name': name}
+            # back-compat $CYLC_SUITE_NAME and $CYLC_TASK_NAME:
+            cfg['meta']['URL'] = RE_SUITE_NAME_VAR.sub(
+                self.suite, cfg['meta']['URL'])
+            cfg['meta']['URL'] = RE_TASK_NAME_VAR.sub(
+                name, cfg['meta']['URL'])
 
         if is_validate:
             self.mem_log("config.py: before _check_circular()")

--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -1213,18 +1213,21 @@ been defined for this suite""").inform()
         about.destroy()
 
     def _gcapture_cmd(self, command, xdim=400, ydim=400, title=None):
+        """Run given command and capture its stdout and stderr in a window."""
         foo = gcapture_tmpfile(command, self.cfg.cylc_tmpdir,
                                xdim, ydim, title=title)
         self.gcapture_windows.append(foo)
         foo.run()
 
     def view_task_descr(self, w, e, task_id, *args):
+        """Run 'cylc show SUITE TASK' and capture output in a viewer window."""
         self._gcapture_cmd(
             "cylc show %s %s %s" % (
                 self.get_remote_run_opts(), self.cfg.suite, task_id),
             600, 400)
 
     def view_in_editor(self, w, e, task_id, choice):
+        """View various job logs in your configured text editor."""
         try:
             task_state_summary = self.updater.full_state_summary[task_id]
         except KeyError:
@@ -1252,6 +1255,7 @@ been defined for this suite""").inform()
                 command_opt, self.cfg.suite, task_id))
 
     def view_task_info(self, w, e, task_id, choice):
+        """Viewer window with a drop-down list of job logs to choose from."""
         try:
             task_state_summary = self.updater.full_state_summary[task_id]
         except KeyError:
@@ -1265,7 +1269,7 @@ been defined for this suite""").inform()
         return False
 
     def connect_right_click_sub_menu(self, is_graph_view, item, x, y, z):
-        """Handle right-clicks in sub-menus"""
+        """Handle right-clicks in sub-menus."""
         if is_graph_view:
             item.connect('button-release-event', x, y, z)
         else:
@@ -1602,11 +1606,13 @@ been defined for this suite""").inform()
         window.show_all()
 
     def window_show_all(self):
+        """Show all window widgets."""
         self.window.show_all()
         if not self.info_bar.prog_bar_active():
             self.info_bar.prog_bar.hide()
 
     def change_runahead(self, w, entry, window):
+        """Change the suite runahead limit."""
         ent = entry.get_text()
         if ent == '':
             limit = None
@@ -1623,6 +1629,7 @@ been defined for this suite""").inform()
         self.put_comms_command('set_runahead', interval=limit)
 
     def update_tb(self, tb, line, tags=None):
+        """Update a text view buffer."""
         if tags:
             tb.insert_with_tags(tb.get_end_iter(), line, *tags)
         else:
@@ -1702,11 +1709,13 @@ shown here in the state they were in at the time of triggering.''')
         window.show_all()
 
     def on_popup_quit(self, b, lv, w):
+        """Destroy a popup window on quit."""
         lv.quit()
         self.quitters.remove(lv)
         w.destroy()
 
     def get_confirmation(self, question, force_prompt=False):
+        """Pop up a confirmation prompt window."""
         if self.cfg.no_prompt and not force_prompt:
             return True
         prompt = gtk.MessageDialog(self.window, gtk.DIALOG_MODAL,
@@ -1743,9 +1752,7 @@ shown here in the state they were in at the time of triggering.''')
         self.put_comms_command('trigger_tasks', items=task_ids)
 
     def trigger_task_edit_run(self, b, task_id):
-        """
-        Do an edit-run by invoking 'cylc trigger --edit' on the suite host.
-        """
+        """Trigger an edit run with 'cylc trigger --edit'."""
         if not self.get_confirmation("Edit run %s?" % task_id):
             return
         self._gcapture_cmd(
@@ -1807,6 +1814,7 @@ shown here in the state they were in at the time of triggering.''')
         self.put_comms_command('remove_tasks', items=task_ids, spawn=spawn)
 
     def stopsuite_popup(self, b):
+        """Suite shutdown dialog window popup."""
         window = gtk.Window()
         window.modify_bg(gtk.STATE_NORMAL,
                          gtk.gdk.color_parse(self.log_colors.get_color()))
@@ -1959,6 +1967,7 @@ shown here in the state they were in at the time of triggering.''')
         window.show_all()
 
     def stop_method(self, b, meth, st_box, sc_box, tt_box):
+        """Determine the suite stop method."""
         for ch in (
                 st_box.get_children() +
                 sc_box.get_children() +
@@ -1981,6 +1990,7 @@ shown here in the state they were in at the time of triggering.''')
             box.set_sensitive(True)
 
     def startup_method(self, b, meth, ic_box, is_box):
+        """Determine the suite start-up method."""
         if meth in ['cold', 'warm']:
             for ch in ic_box.get_children():
                 ch.set_sensitive(True)
@@ -1994,6 +2004,7 @@ shown here in the state they were in at the time of triggering.''')
                 ch.set_sensitive(True)
 
     def startsuite_popup(self, b):
+        """Suite start-up dialog window popup."""
         window = gtk.Window()
         window.modify_bg(gtk.STATE_NORMAL,
                          gtk.gdk.color_parse(self.log_colors.get_color()))
@@ -2146,6 +2157,7 @@ shown here in the state they were in at the time of triggering.''')
         window.show_all()
 
     def point_string_entry_popup(self, b, callback, title):
+        """Cycle point entry popup."""
         window = gtk.Window()
         window.modify_bg(gtk.STATE_NORMAL,
                          gtk.gdk.color_parse(self.log_colors.get_color()))
@@ -2263,11 +2275,13 @@ shown here in the state they were in at the time of triggering.''')
         self.put_comms_command('poll_tasks')
 
     def reload_suite(self, w):
+        """Tell the suite daemon to reload."""
         if not self.get_confirmation("Reload suite definition?"):
             return
         self.put_comms_command('reload_suite')
 
     def nudge_suite(self, w):
+        """Nudge the suite daemon."""
         if not self.get_confirmation("Nudge suite?"):
             return
         self.put_comms_command('nudge')
@@ -2395,6 +2409,7 @@ shown here in the state they were in at the time of triggering.''')
         return (submit_num, base, head)
 
     def _set_tooltip(self, widget, tip_text):
+        """Set a tool-tip text."""
         tooltip = gtk.Tooltips()
         tooltip.enable()
         tooltip.set_tip(widget, tip_text)
@@ -2902,6 +2917,7 @@ to reduce network traffic.""")
                     self.get_remote_run_opts(), self.cfg.suite), 800, 400)
 
     def search_suite_popup(self, w):
+        """Pop up a suite source dir search dialog."""
         reg = self.cfg.suite
         window = gtk.Window()
         window.set_border_width(5)
@@ -2945,6 +2961,7 @@ to reduce network traffic.""")
         window.show_all()
 
     def search_suite(self, w, reg, yesbin_cb, pattern_entry):
+        """Run 'cylc search', capture output in a viewer window."""
         pattern = pattern_entry.get_text()
         options = ''
         if not yesbin_cb.get_active():
@@ -3061,6 +3078,7 @@ This is what my suite does:..."""
                                  command + " --help")
 
     def check_task_filter_buttons(self, tb=None):
+        """Action task state filter settings."""
         task_states = []
         for subbox in self.state_filter_box.get_children():
             for ebox in subbox.get_children():
@@ -3089,6 +3107,7 @@ This is what my suite does:..."""
             self.refresh_views()
 
     def select_state_filters(self, w, arg):
+        """Process task state filter settings."""
         for subbox in self.state_filter_box.get_children():
             for ebox in subbox.get_children():
                 box = ebox.get_children()[0]
@@ -3103,10 +3122,12 @@ This is what my suite does:..."""
         self.check_task_filter_buttons()
 
     def reset_filter_entry(self, w):
+        """Reset task state filter settings."""
         self.filter_entry.set_text("")
         self.check_filter_entry()
 
     def check_filter_entry(self, e=None):
+        """Check the task name filter entry."""
         filter_text = self.filter_entry.get_text()
         try:
             re.compile(filter_text)
@@ -3128,11 +3149,13 @@ This is what my suite does:..."""
         self.refresh_views()
 
     def refresh_views(self):
+        """Refresh all live views."""
         for view in self.current_views:
             if view is not None:
                 view.refresh()
 
     def create_task_filter_widgets(self):
+        """Create task filter widgets - state and name."""
         self.filter_widgets = gtk.VBox()
         self.filter_widgets.pack_start(
             gtk.Label("Filter by task state"))
@@ -3365,6 +3388,7 @@ For more Stop options use the Control menu.""")
         self.run_pause_toolbutton.click_func = click_func
 
     def create_info_bar(self):
+        """Create the window info bar."""
         self.info_bar = InfoBar(
             self.cfg.host, self.theme, self.dot_size,
             self.filter_states_excl,
@@ -3374,6 +3398,7 @@ For more Stop options use the Control menu.""")
         self._set_info_bar()
 
     def popup_uuid_dialog(self, w):
+        """Pop up the client UUID info."""
         info_dialog(
             "Client UUID %s\n"
             "(this identifies a client instance to the suite daemon)" % (
@@ -3422,6 +3447,7 @@ For more Stop options use the Control menu.""")
         self.theme_legend_window = None
 
     def put_comms_command(self, command, **kwargs):
+        """Put a command to the suite client interface."""
         try:
             success, msg = self.updater.client.put_command(
                 command, **kwargs)
@@ -3432,6 +3458,7 @@ For more Stop options use the Control menu.""")
                 warning_dialog(msg, self.window).warn()
 
     def run_suite_validate(self, w):
+        """Validate the suite and capture output in a viewer window."""
         self._gcapture_cmd(
             "cylc validate -v %s %s %s" % (
                 self.get_remote_run_opts(), self.cfg.template_vars_opts,
@@ -3439,6 +3466,7 @@ For more Stop options use the Control menu.""")
         return False
 
     def run_suite_edit(self, w, inlined=False):
+        """Run 'cylc edit' and capture output in a viewer window."""
         extra = ''
         if inlined:
             extra = '-i '
@@ -3449,6 +3477,7 @@ For more Stop options use the Control menu.""")
         return False
 
     def run_suite_graph(self, w, show_ns=False):
+        """Run 'cylc graph' and capture output in a viewer window."""
         if show_ns:
             self._gcapture_cmd(
                 "cylc graph -n %s %s %s" % (
@@ -3463,17 +3492,20 @@ For more Stop options use the Control menu.""")
                 parent_window=self.window)
 
     def run_suite_info(self, w):
+        """Run 'cylc show SUITE' and capture output in a viewer window."""
         self._gcapture_cmd(
             "cylc show %s %s" % (
                 self.get_remote_run_opts(), self.cfg.suite), 600, 400)
 
     def run_suite_list(self, w, opt=''):
+        """Run 'cylc list' and capture output in a viewer window."""
         self._gcapture_cmd(
             "cylc list %s %s %s %s" % (
                 self.get_remote_run_opts(), opt, self.cfg.template_vars_opts,
                 self.cfg.suite), 600, 600)
 
     def run_suite_log(self, w, type_='log'):
+        """Run 'cylc cat-log' and capture its output in a viewer window."""
         if is_remote(self.cfg.host, self.cfg.owner):
             if type_ == 'out':
                 xopts = ' --stdout '
@@ -3493,6 +3525,7 @@ For more Stop options use the Control menu.""")
         self.quitters.append(foo)
 
     def run_suite_view(self, w, method):
+        """Run 'cylc view' and capture its output in a viewer window."""
         extra = ''
         if method == 'inlined':
             extra = ' -i'
@@ -3518,9 +3551,11 @@ For more Stop options use the Control menu.""")
         return ret
 
     def browse_doc(self, b, *args):
+        """Run 'cylc doc' and capture its output."""
         self._gcapture_cmd('cylc doc %s' % ' '.join(args), 700)
 
     def browse_suite(self, _, target='suite'):
+        """Browse the suite or task URL, if any."""
         if not self.updater.global_summary:
             # Suite not running, revert to parsing (can only be suite URL).
             self._gcapture_cmd('cylc doc %s %s' % (
@@ -3536,4 +3571,5 @@ For more Stop options use the Control menu.""")
         self._gcapture_cmd('cylc doc --url=%s' % url, 700)
 
     def command_help(self, w, cat='', com=''):
+        """Run 'cylc help' commands, and capture output in a viewer window."""
         self._gcapture_cmd("cylc %s %s" % (cat, com), 700, 600)

--- a/lib/cylc/state_summary_mgr.py
+++ b/lib/cylc/state_summary_mgr.py
@@ -90,7 +90,7 @@ class StateSummaryMgr(object):
                 if state is None:
                     continue
                 try:
-                    famcfg = schd.config.cfg['runtime']['meta'][fam]
+                    famcfg = schd.config.cfg['runtime'][fam]['meta']
                 except KeyError:
                     famcfg = {}
                 description = famcfg.get('description')
@@ -129,6 +129,11 @@ class StateSummaryMgr(object):
             schd.config.ns_defn_order)
         global_summary['reloading'] = schd.pool.do_reload
         global_summary['state totals'] = state_count_totals
+        # Extract suite and task URLs from config.
+        global_summary['suite_urls'] = {
+            i: j['meta']['URL'] for (i, j) in
+            schd.config.cfg['runtime'].items()}
+        global_summary['suite_urls']['suite'] = schd.config.cfg['meta']['URL']
 
         # Construct a suite status string for use by monitoring clients.
         if schd.pool.is_held:

--- a/tests/cylc-doc/02-suite-urls-new.t
+++ b/tests/cylc-doc/02-suite-urls-new.t
@@ -16,40 +16,27 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 
-# Test cylc-doc on suite and task URLs: old back-compat form with pseudo
-# environment vars rather than string templating. (c.f. 02-suite-urls.t).
+# Test cylc-doc on suite and task URLs: new form with string templating rather
+# than pseudo-environment variables (c.f. 01-suite-urls.t).
 
 . $(dirname $0)/test_header
-#-------------------------------------------------------------------------------
+
 set_test_number 3
-#-------------------------------------------------------------------------------
-create_test_globalrc "" "
-[documentation]
-   [[files]]
-      pdf user guide = ${PWD}/doc/pdf/cug-pdf.pdf
-      multi-page html user guide = /home/bob/cylc/cylc.git/doc/html/multi/cug-html.html
-      html index = /home/bob/cylc/cylc.git/doc/index.html
-      single-page html user guide = /home/bob/cylc/cylc.git/doc/html/single/cug-html.html
-   [[urls]]
-      internet homepage = http://cylc.github.com/cylc/
-      local index = http://localhost/cylc/index.html"
-#-------------------------------------------------------------------------------
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
-#-------------------------------------------------------------------------------
+
 TEST_NAME=${TEST_NAME_BASE}-validate
 run_ok $TEST_NAME cylc validate "$SUITE_NAME"
-#-------------------------------------------------------------------------------
+
 TEST_NAME=${TEST_NAME_BASE}-suite-url
 cylc doc -s $SUITE_NAME > stdout1.txt
 cmp_ok stdout1.txt <<__END__
 http://localhost/suite-docs/${SUITE_NAME}.html
 __END__
-#-------------------------------------------------------------------------------
+
 TEST_NAME=${TEST_NAME_BASE}-task-url
 cylc doc -s -t bar $SUITE_NAME > stdout2.txt
 cmp_ok stdout2.txt <<__END__
 http://localhost/suite-docs/${SUITE_NAME}.html#bar
 __END__
-#-------------------------------------------------------------------------------
+
 purge_suite $SUITE_NAME
-#-------------------------------------------------------------------------------

--- a/tests/cylc-doc/02-suite-urls-new/suite.rc
+++ b/tests/cylc-doc/02-suite-urls-new/suite.rc
@@ -1,0 +1,12 @@
+[meta]
+    URL = http://localhost/suite-docs/%(suite_name)s.html
+[scheduling]
+   [[dependencies]]
+        graph = foo => FAM
+[runtime]
+    [[root]]
+        [[[meta]]]
+            URL = 'http://localhost/suite-docs/%(suite_name)s.html#%(task_name)s'
+    [[FAM]]
+    [[bar,baz]]
+        inherit = FAM


### PR DESCRIPTION
A user reminded me that browsing suite and task URLs from the GUI does not work if (a) the GUI is not running on the suite host account; *and* (b) the GUI account does not have non-interactive ssh access to the suite host account.  Reason: the GUI simply invokes the `cylc doc` / `cylc browse` command, which parses the suite definition - which can't be done from a remote account with no non-interactive ssh access to the suite host account.

Main change in this PR:
 * store suite and task URLs in the daemon state summary, for use by the GUI

Also:
 * allow use of string templates to replace suite and task names in URLs (was our old-style pseudo environment variable syntax, retained as well for back-compatibility) 
 * tidy some associated GUI code a little
 * User Guide: document exact requirements for remote access to suite-parsing and file-retrieval commands, including via the GUI; and clarify the same for suite client commands