### PR TITLE
Smarter network client logic

### DIFF
--- a/lib/cylc/network/httpclient.py
+++ b/lib/cylc/network/httpclient.py
@@ -148,16 +148,16 @@ class SuiteRuntimeServiceClient(object):
     def get_info(self, command, *args, **kwargs):
         """Return suite info."""
         kwargs['method'] = self.METHOD_GET
-        return self._call_server_func(command, *args, **kwargs)
+        return self._call_server(command, *args, **kwargs)
 
     def get_latest_state(self, full_mode):
         """Return latest state of the suite (for the GUI)."""
-        return self._call_server_func(
+        return self._call_server(
             'get_latest_state', method=self.METHOD_GET, full_mode=full_mode)
 
     def get_suite_state_summary(self):
         """Return the global, task, and family summary data structures."""
-        return utf8_enforce(self._call_server_func(
+        return utf8_enforce(self._call_server(
             'get_suite_state_summary', method=self.METHOD_GET))
 
     def get_tasks_by_state(self):
@@ -197,7 +197,7 @@ class SuiteRuntimeServiceClient(object):
 
     def signout(self, *args, **kwargs):
         """Tell server to forget this client."""
-        return self._call_server_func('signout')
+        return self._call_server('signout')
 
     def _get_protocol_from_contact_file(self):
         """Find out the communications protocol (http/https) from the

--- a/lib/cylc/network/httpclient.py
+++ b/lib/cylc/network/httpclient.py
@@ -203,32 +203,15 @@ class SuiteRuntimeServiceClient(object):
         """Tell server to forget this client."""
         return self._call_server('signout')
 
-    def _get_protocol_from_contact_file(self):
-        """Find out the communications protocol (http/https) from the
-        suite contact file."""
-        try:
-            comms_prtcl = self.srv_files_mgr.get_auth_item(
-                self.srv_files_mgr.KEY_COMMS_PROTOCOL,
-                self.suite, content=True)
-            if comms_prtcl is None or comms_prtcl == "":
-                raise TypeError("Comms protocol is not in suite contact file")
-            else:
-                return comms_prtcl
-        except (AttributeError, KeyError, TypeError, ValueError):
-            raise KeyError("No suite contact info for comms protocol found")
-
     def _compile_request(self, func_dict, host, comms_protocol=None):
         """Build request URL."""
         payload = func_dict.pop("payload", None)
         method = func_dict.pop("method", self.METHOD)
         function = func_dict.pop("function", None)
         if comms_protocol is None:
-            try:
-                comms_protocol = self._get_protocol_from_contact_file()
-            except (KeyError, TypeError, SuiteServiceFileError):
-                # Use standard setting from global configuration
-                from cylc.cfgspec.globalcfg import GLOBAL_CFG
-                comms_protocol = GLOBAL_CFG.get(['communication', 'method'])
+            # Use standard setting from global configuration
+            from cylc.cfgspec.globalcfg import GLOBAL_CFG
+            comms_protocol = GLOBAL_CFG.get(['communication', 'method'])
         url = '%s://%s:%s/%s' % (comms_protocol, host, self.port, function)
         # If there are any parameters left in the dict after popping,
         # append them to the url.

--- a/lib/cylc/network/httpclient.py
+++ b/lib/cylc/network/httpclient.py
@@ -276,8 +276,9 @@ class SuiteRuntimeServiceClient(object):
             # Cannot connect, perhaps suite is no longer running and is leaving
             # behind a contact file?
             try:
-                self.srv_files_mgr.detect_old_contact_file(self.suite)
-            except SuiteServiceFileError:
+                self.srv_files_mgr.detect_old_contact_file(
+                    self.suite, (self.host, self.port))
+            except (AssertionError, SuiteServiceFileError):
                 raise exc
             else:
                 # self.srv_files_mgr.detect_old_contact_file should delete left

--- a/lib/cylc/network/port_scan.py
+++ b/lib/cylc/network/port_scan.py
@@ -25,11 +25,12 @@ from uuid import uuid4
 
 from cylc.cfgspec.globalcfg import GLOBAL_CFG
 import cylc.flags
+from cylc.hostuserutil import is_remote_host, get_host_ip_by_name
 from cylc.network.httpclient import (
     SuiteRuntimeServiceClient, ClientError, ClientTimeout)
 from cylc.suite_srv_files_mgr import (
     SuiteSrvFilesManager, SuiteServiceFileError)
-from cylc.hostuserutil import is_remote_host, get_host_ip_by_name
+from cylc.suite_status import (KEY_NAME, KEY_OWNER, KEY_STATES)
 
 CONNECT_TIMEOUT = 5.0
 INACTIVITY_TIMEOUT = 10.0
@@ -70,9 +71,9 @@ def _scan_item(timeout, my_uuid, srv_files_mgr, item):
     except ClientError:
         return (host, port, None)
     else:
-        owner = result.get('owner')
-        name = result.get('name')
-        states = result.get('states', None)
+        owner = result.get(KEY_OWNER)
+        name = result.get(KEY_NAME)
+        states = result.get(KEY_STATES, None)
         if cylc.flags.debug:
             sys.stderr.write('   suite: %s %s\n' % (name, owner))
         if states is None:
@@ -88,7 +89,6 @@ def _scan_item(timeout, my_uuid, srv_files_mgr, item):
                 if pphrase:
                     client.suite = name
                     client.owner = owner
-                    client.host = host
                     client.auth = None
                     try:
                         result = client.identify()

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -118,8 +118,8 @@ class Scheduler(object):
         self.suite_srv_files_mgr = SuiteSrvFilesManager()
         try:
             self.suite_srv_files_mgr.register(self.suite, options.source)
-        except SuiteServiceFileError:
-            sys.exit(1)
+        except SuiteServiceFileError as exc:
+            sys.exit(exc)
         # Register suite if not already done
         self.suite_dir = self.suite_srv_files_mgr.get_suite_source_dir(
             self.suite)

--- a/lib/cylc/suite_srv_files_mgr.py
+++ b/lib/cylc/suite_srv_files_mgr.py
@@ -622,7 +622,7 @@ To start a new run, stop the old one first with one or more of these:
             # Attempt to read suite contact file via the local filesystem.
             path = r'%(run_d)s/%(srv_base)s' % {
                 'run_d': GLOBAL_CFG.get_derived_host_item(
-                    reg, 'suite run directory', host, owner,
+                    reg, 'suite run directory', 'localhost', owner,
                     replace_home=False),
                 'srv_base': self.DIR_BASE_SRV,
             }

--- a/tests/shutdown/18-client-on-dead-suite.t
+++ b/tests/shutdown/18-client-on-dead-suite.t
@@ -1,0 +1,53 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test suite shuts down with error on missing port file
+. "$(dirname "$0")/test_header"
+set_test_number 5
+init_suite "${TEST_NAME_BASE}" <<'__SUITERC__'
+[scheduling]
+    [[dependencies]]
+        graph = t1
+[runtime]
+    [[t1]]
+        script = true
+__SUITERC__
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+cylc run --hold "${SUITE_NAME}" 1>'cylc-run.out' 2>&1
+RUND="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}"
+MYPID=$(sed -n 's/^CYLC_SUITE_PROCESS=\([0-9]\+\) .*$/\1/p' \
+    "${RUND}/.service/contact")
+kill "${MYPID}"
+# Should leave behind the contact file
+sleep 1
+while ps "${MYPID}" 1>'/dev/null' 2>&1; do
+    sleep 1
+done
+MYHTTP=$(sed -n 's/^CYLC_COMMS_PROTOCOL=\(.\+\)$/\1/p' "${RUND}/.service/contact")
+MYHOST=$(sed -n 's/^CYLC_SUITE_HOST=\(.\+\)$/\1/p' "${RUND}/.service/contact")
+MYPORT=$(sed -n 's/^CYLC_SUITE_PORT=\(.\+\)$/\1/p' "${RUND}/.service/contact")
+run_fail "${TEST_NAME_BASE}-1" cylc ping "${SUITE_NAME}"
+contains_ok "${TEST_NAME_BASE}-1.stderr" <<__ERR__
+Cannot connect: ${MYHTTP}://${MYHOST}:${MYPORT}/ping_suite: suite "${SUITE_NAME}" already stopped
+__ERR__
+run_fail "${TEST_NAME_BASE}-2" cylc ping "${SUITE_NAME}"
+contains_ok "${TEST_NAME_BASE}-2.stderr" <<__ERR__
+Contact info not found for suite "${SUITE_NAME}", suite not running?
+__ERR__
+purge_suite "${SUITE_NAME}"
+exit


### PR DESCRIPTION
On a failed connection, the client will check if the suite has stopped based on the information of the contact file. If the client is sure that the suite is no longer running, it will remove the contact file and report that the suite has stopped.

Adjust general error message on detection of a contact file of an active suite - more information on the old suite is and how to shut it down.

Run `fsync` on writing a contact file.

The client running in HTTP protocol will no longer attempt to fetch the non-existent SSL certificate file.

If contact file is loaded, always use the values in it to avoid conflicting host strings in SSL certificate file, etc.