### PR TITLE
Alow more task summary info as event handler args.

### DIFF
--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -87,7 +87,8 @@ class SuiteConfig(object):
     Q_DEFAULT = 'default'
     TASK_EVENT_TMPL_KEYS = (
         'event', 'suite', 'point', 'name', 'submit_num', 'id', 'message',
-        'batch_sys_name', 'batch_sys_job_id')
+        'batch_sys_name', 'batch_sys_job_id', 'submit_time', 'start_time',
+        'finish_time', 'user@host')
 
     def __init__(self, suite, fpath, template_vars=None,
                  owner=None, run_mode='live', is_validate=False, strict=False,

--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -842,7 +842,15 @@ class TaskEventsManager(object):
                     "batch_sys_name": quote(
                         str(itask.summary['batch_sys_name'])),
                     "batch_sys_job_id": quote(
-                        str(itask.summary['submit_method_id']))
+                        str(itask.summary['submit_method_id'])),
+                    "submit_time": quote(
+                        str(itask.summary['submitted_time_string'])),
+                    "start_time": quote(
+                        str(itask.summary['started_time_string'])),
+                    "finish_time": quote(
+                        str(itask.summary['finished_time_string'])),
+                    "user@host": quote(
+                        str(itask.summary['job_hosts'][itask.submit_num]))
                 }
 
                 if self.suite_cfg:

--- a/tests/events/39-task-event-template-all/bin/checkargs
+++ b/tests/events/39-task-event-template-all/bin/checkargs
@@ -2,19 +2,42 @@
 
 # Compare actual and expected event handler command lines.
 
+import os
 import sys
+import subprocess
 
-start = ['SUITE:', 'JID:']
-other = ['custom', '1', 'foo', '1', 'foo.1', 'background', 'cheesy peas', 'trout',
-         'a task called foo', 'http://cheesy.peas', 'a test suite', 'large']
-one = len(sys.argv) >= 3
-two = sys.argv[1].startswith(start[0])
-thr = sys.argv[2].startswith(start[1])
-fou = sys.argv[3:] == other
+args = dict([arg.split('=') for arg in sys.argv[1:]])
 
-if one and two and thr and fou:
+suite = os.environ['CYLC_SUITE_NAME']
+alog = subprocess.check_output(['cylc', 'cat-log', '-la', suite, 'foo.1'])
+start_time, _, job_id = (subprocess.check_output(['grep', 'STDOUT', alog.strip()])).split(' ') 
+
+expected_args = {
+        'suite_title': 'a test suite',
+        'job_id': job_id.strip(),
+        'start_time': 'None',
+        'point': '1',
+        'URL': 'http://cheesy.peas',
+        'title': 'a task called foo',
+        'fish': 'trout',
+        'submit_num': '1',
+        'batch_sys_name': 'background',
+        'id': 'foo.1',
+        'finish_time': 'None',
+        'suite_size': 'large',
+        'suite': suite,
+        'message': 'cheesy peas',
+        'user@host': 'localhost',
+        'event': 'custom',
+        'submit_time': start_time,
+        'name': 'foo'
+}
+
+
+if args == expected_args:
     print "OK: command line checks out"
-    sys.exit(0)
 else:
     print >> sys.stderr, 'ERROR: unexpected event handler command line.'
+    print >> sys.stderr, "EXPECTED:", expected_args
+    print >> sys.stderr, "RECEIVED:", args
     sys.exit(1)

--- a/tests/events/39-task-event-template-all/suite.rc
+++ b/tests/events/39-task-event-template-all/suite.rc
@@ -13,7 +13,7 @@
     [[foo]]
         script = cylc message -p CUSTOM "cheesy peas"
         [[[events]]]
-            custom handler = checkargs SUITE:%(suite)s JID:%(batch_sys_job_id)s %(event)s %(point)s %(name)s %(submit_num)s %(id)s %(batch_sys_name)s %(message)s %(fish)s %(title)s %(URL)s %(suite_title)s %(suite_size)s
+            custom handler = checkargs suite=%(suite)s job_id=%(batch_sys_job_id)s event=%(event)s point=%(point)s name=%(name)s submit_num=%(submit_num)s id=%(id)s batch_sys_name=%(batch_sys_name)s message=%(message)s fish=%(fish)s title=%(title)s URL=%(URL)s suite_title=%(suite_title)s suite_size=%(suite_size)s submit_time=%(submit_time)s start_time=%(start_time)s finish_time=%(finish_time)s user@host=%(user@host)s
         [[[meta]]]
             title = "a task called foo"
             URL = http://cheesy.peas


### PR DESCRIPTION
Following on from #2441 - allow remaining task summary data as event handler args: submit_time, start_time, finish_time, user@host.  This lets us use event handler scripts for routine reporting, at least until we hash out the details of #2442 

@cylc/core do you see any reason not to do this, before I go ahead with documentation and extending the tests?