### PR TITLE
Fix re-trigger after aborted edit run.

### DIFF
--- a/bin/cylc-trigger
+++ b/bin/cylc-trigger
@@ -176,7 +176,7 @@ def main():
         msg = "Trigger edited task %s?" % task_id
         if not prompt(msg, gui=options.geditor, no_force=True, no_abort=True):
             log_dir_symlink = os.path.dirname(jobfile_path)
-            real_log_dir = os.path.realpath(log_dir_symlink) 
+            real_log_dir = os.path.realpath(log_dir_symlink)
             prev_nn = "%02d" % (int(os.path.basename(real_log_dir)) - 1)
             os.unlink(log_dir_symlink)
             if int(prev_nn) == 0:
@@ -189,7 +189,7 @@ def main():
                            os.path.join(dirname, "NN"))
                 shutil.rmtree(real_log_dir)
             aborted = True
- 
+
     # Trigger the task proxy(s).
     items = parser.parse_multitask_compat(options, args)
     pclient.put_command('trigger_tasks', items=items, back_out=aborted)

--- a/bin/cylc-trigger
+++ b/bin/cylc-trigger
@@ -87,6 +87,7 @@ def main():
         options.comms_timeout, my_uuid=options.set_uuid,
         print_uuid=options.print_uuid)
 
+    aborted = False
     if options.edit_run:
         items = parser.parse_multitask_compat(options, args)
         task_id = items[0]
@@ -163,7 +164,6 @@ def main():
             print "Editing done. I'm popping up a confirmation dialog now."
 
         # Save a diff to record the changes made.
-        log_dir = os.path.dirname(jobfile_path)
         with open("%s-edit.diff" % jobfile_path, 'wb') as diff_file:
             for line in difflib.unified_diff(
                     open(jobfile_copy_path).readlines(),
@@ -173,20 +173,26 @@ def main():
                 diff_file.write(line)
         os.unlink(jobfile_copy_path)
 
-        log_dir = os.path.dirname(jobfile_path)
         msg = "Trigger edited task %s?" % task_id
         if not prompt(msg, gui=options.geditor, no_force=True, no_abort=True):
-            # Generate placeholder log files for the aborted run.
-            for log in ["job.out", "job.err"]:
-                lf = os.path.join(log_dir, log)
-                with open(lf, 'wb') as log_file:
-                    log_file.write("This edit run was aborted\n")
-                    print "Run aborted."
-                    sys.exit(0)
-
+            log_dir_symlink = os.path.dirname(jobfile_path)
+            real_log_dir = os.path.realpath(log_dir_symlink) 
+            prev_nn = "%02d" % (int(os.path.basename(real_log_dir)) - 1)
+            os.unlink(log_dir_symlink)
+            if int(prev_nn) == 0:
+                # No previous submit: delete the whole parent directory.
+                shutil.rmtree(os.path.dirname(real_log_dir))
+            else:
+                # Reset to previous NN symlink and delete the log directory.
+                dirname = os.path.dirname(real_log_dir)
+                os.symlink(os.path.join(dirname, prev_nn),
+                           os.path.join(dirname, "NN"))
+                shutil.rmtree(real_log_dir)
+            aborted = True
+ 
     # Trigger the task proxy(s).
     items = parser.parse_multitask_compat(options, args)
-    pclient.put_command('trigger_tasks', items=items)
+    pclient.put_command('trigger_tasks', items=items, back_out=aborted)
 
 
 if __name__ == "__main__":

--- a/lib/cylc/network/httpserver.py
+++ b/lib/cylc/network/httpserver.py
@@ -669,16 +669,17 @@ class SuiteRuntimeService(object):
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
-    def trigger_tasks(self, items):
+    def trigger_tasks(self, items, back_out=False):
         """Trigger submission of task jobs where possible.
 
         items is a list of identifiers for matching task proxies.
         """
         self._check_access_priv_and_report(PRIV_FULL_CONTROL)
+        back_out = self._literal_eval('back_out', back_out)
         if not isinstance(items, list):
             items = [items]
         items = [str(item) for item in items]
-        self.schd.command_queue.put(("trigger_tasks", (items,), {}))
+        self.schd.command_queue.put(("trigger_tasks", (items,), {"back_out": back_out}))
         return (True, 'Command queued')
 
     def _access_priv_ok(self, required_privilege_level):

--- a/lib/cylc/network/httpserver.py
+++ b/lib/cylc/network/httpserver.py
@@ -679,7 +679,8 @@ class SuiteRuntimeService(object):
         if not isinstance(items, list):
             items = [items]
         items = [str(item) for item in items]
-        self.schd.command_queue.put(("trigger_tasks", (items,), {"back_out": back_out}))
+        self.schd.command_queue.put(
+            ("trigger_tasks", (items,), {"back_out": back_out}))
         return (True, 'Command queued')
 
     def _access_priv_ok(self, required_privilege_level):

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -1601,9 +1601,9 @@ conditions; see `cylc conditions`.
         """Is the suite paused?"""
         return self.pool.is_held
 
-    def command_trigger_tasks(self, items):
+    def command_trigger_tasks(self, items, back_out=False):
         """Trigger tasks."""
-        return self.pool.trigger_tasks(items)
+        return self.pool.trigger_tasks(items, back_out)
 
     def command_dry_run_tasks(self, items):
         """Dry-run tasks, e.g. edit run."""

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -1118,11 +1118,16 @@ class TaskPool(object):
             self.remove(itask, 'by request')
         return len(bad_items)
 
-    def trigger_tasks(self, items):
+    def trigger_tasks(self, items, back_out=False):
         """Trigger tasks."""
         itasks, bad_items = self.filter_task_proxies(items)
         n_warnings = len(bad_items)
         for itask in itasks:
+            if back_out:
+                # (Aborted edit-run, reset for next trigger attempt).
+                itask.submit_num -= 1
+                itask.local_job_file_path = None
+                continue
             if itask.state.status in TASK_STATUSES_ACTIVE:
                 LOG.warning('%s: already triggered' % itask.identity)
                 n_warnings += 1

--- a/tests/cylc-trigger/07-edit-run-abort.t
+++ b/tests/cylc-trigger/07-edit-run-abort.t
@@ -1,0 +1,36 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+
+# Test that aborting an edit-run has no effect on the next run (GitHub #2461)
+
+. $(dirname $0)/test_header
+
+set_test_number 2
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+TEST_NAME="${TEST_NAME_BASE}-validate"
+run_ok "${TEST_NAME}" cylc validate "${SUITE_NAME}"
+
+# Configure a fake editor and run a suite with a task that does an edit run.
+create_test_globalrc '' '
+[editors]
+    terminal = my-edit'
+TEST_NAME="${TEST_NAME_BASE}-run"
+run_ok "${TEST_NAME}" cylc run --no-detach "${SUITE_NAME}"
+
+purge_suite "${SUITE_NAME}"

--- a/tests/cylc-trigger/07-edit-run-abort/bin/my-edit
+++ b/tests/cylc-trigger/07-edit-run-abort/bin/my-edit
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sed -i 's@echo HELLO@echo OOPS; /bin/false@' "$@"

--- a/tests/cylc-trigger/07-edit-run-abort/suite.rc
+++ b/tests/cylc-trigger/07-edit-run-abort/suite.rc
@@ -1,0 +1,25 @@
+[meta]
+    title = A suite to test an aborted edit run has no subsequent effect.
+    description = """
+A broken task will fail and cause the suite to abort on timeout, unless a
+second task fixes and retriggers it with an edit-run."""
+[cylc]
+    [[events]]
+        abort on timeout = True
+        timeout = PT20S
+[scheduling]
+    [[dependencies]]
+        graph = victim => perpetrator
+[runtime]
+    [[victim]]
+        script = echo HELLO
+    [[perpetrator]]
+        script = """
+# Edit run to break victim, but abort after the edit.
+cylc trigger --edit $CYLC_SUITE_NAME victim.1 << __END__
+n
+__END__
+# Then trigger victim - the original unedited task should run.
+cylc trigger $CYLC_SUITE_NAME victim.1
+"""
+

--- a/tests/cylc-trigger/07-edit-run-abort/suite.rc
+++ b/tests/cylc-trigger/07-edit-run-abort/suite.rc
@@ -1,8 +1,5 @@
 [meta]
     title = A suite to test an aborted edit run has no subsequent effect.
-    description = """
-A broken task will fail and cause the suite to abort on timeout, unless a
-second task fixes and retriggers it with an edit-run."""
 [cylc]
     [[events]]
         abort on timeout = True


### PR DESCRIPTION
The trivial bug fix part of #2460 

Once this goes in, we may want to just remove the bug label on #2460 but change the title and leave it open for the daemon-served job file solution, longer term.

~~TODO - add a test~~