### PR TITLE
Fix job polling for SGE

### DIFF
--- a/lib/cylc/batch_sys_handlers/sge.py
+++ b/lib/cylc/batch_sys_handlers/sge.py
@@ -62,9 +62,8 @@ class SGEHandler(object):
 
     def get_poll_many_cmd(cls, job_ids):
         """Return poll command"""
-        # "qstat jobid" invalid for SGE.
-        # Use plain "qstat" and let batch_sys_manager._jobs_poll_batch_sys 
-        # check for requested id in the list. 
+        # No way to run POLL_CMD on specific job id(s). List all user's jobs.
+        # batch_sys_manager._jobs_poll_batch_sys checks requested id in list. 
         return [cls.POLL_CMD]
 
 BATCH_SYS_HANDLER = SGEHandler()

--- a/lib/cylc/batch_sys_handlers/sge.py
+++ b/lib/cylc/batch_sys_handlers/sge.py
@@ -60,5 +60,11 @@ class SGEHandler(object):
                 lines.append("%s%s" % (self.DIRECTIVE_PREFIX, key))
         return lines
 
+    def get_poll_many_cmd(cls, job_ids):
+        """Return poll command"""
+        # "qstat jobid" invalid for SGE.
+        # Use plain "qstat" and let batch_sys_manager._jobs_poll_batch_sys 
+        # check for requested id in the list. 
+        return [cls.POLL_CMD]
 
 BATCH_SYS_HANDLER = SGEHandler()

--- a/lib/cylc/batch_sys_handlers/sge.py
+++ b/lib/cylc/batch_sys_handlers/sge.py
@@ -63,7 +63,7 @@ class SGEHandler(object):
     def get_poll_many_cmd(cls, job_ids):
         """Return poll command"""
         # No way to run POLL_CMD on specific job id(s). List all user's jobs.
-        # batch_sys_manager._jobs_poll_batch_sys checks requested id in list. 
+        # batch_sys_manager._jobs_poll_batch_sys checks requested id in list.
         return [cls.POLL_CMD]
 
 BATCH_SYS_HANDLER = SGEHandler()


### PR DESCRIPTION
Closes #2439

The default `qstat <jobid>` is no longer valid syntax for SGE.  There is no option to query a specific job id and return tabular output which cylc is currently relying on.

Add `get_poll_many_cmd` method to sge handler. This will use `qstat` with no arguments to list the user's jobs in the required format and then the code already in `batch_sys_manager._jobs_poll_batch_sys()` will check that any of the submitted or running jobs is the one requested.