### PR TITLE
Fix cylc message by SSH

### DIFF
--- a/bin/cylc-message
+++ b/bin/cylc-message
@@ -45,6 +45,10 @@ def main():
         action="store", dest="priority", default="NORMAL")
 
     parser.add_option(
+        "--env", help="Override environment variables", action="append",
+        default=[], dest="env")
+
+    parser.add_option(
         "-v", "--verbose", help="Verbose output mode.", action="store_true",
         default=False, dest="verbose")
 
@@ -52,6 +56,9 @@ def main():
     if not args:
         parser.error("No task message supplied")
 
+    for item in options.env:
+        key, value = item.split('=', 1)
+        os.environ[key] = value
     task_message = TaskMessage(priority=options.priority)
     if (task_message.env_map.get('CYLC_VERBOSE') in ["True", "true"] or
             options.verbose):

--- a/lib/cylc/suite_srv_files_mgr.py
+++ b/lib/cylc/suite_srv_files_mgr.py
@@ -221,7 +221,7 @@ To see if %(suite)s is running on '%(host)s:%(port)s':
                 env_keys.append('CYLC_SUITE_RUN_DIR')
             elif self.KEY_SUITE_RUN_DIR_ON_SUITE_HOST in os.environ:
                 # 1(b)/ Task messaging call via ssh messaging.
-                env_keys.append(self.SUITE_RUN_DIR_ON_SUITE_HOST)
+                env_keys.append(self.KEY_SUITE_RUN_DIR_ON_SUITE_HOST)
             for key in env_keys:
                 path = os.path.join(os.environ[key], self.DIR_BASE_SRV)
                 if content:

--- a/lib/cylc/task_message.py
+++ b/lib/cylc/task_message.py
@@ -192,7 +192,7 @@ class TaskMessage(object):
             # always be present in the task execution environment)
             try:
                 env[var] = self.env_map[var]
-            except:
+            except KeyError:
                 pass
 
         # The path to cylc/bin on the remote end may be required:

--- a/lib/cylc/task_message.py
+++ b/lib/cylc/task_message.py
@@ -187,7 +187,7 @@ class TaskMessage(object):
                 SuiteSrvFilesManager.KEY_DIR_ON_SUITE_HOST,
                 'CYLC_TASK_ID',
                 'CYLC_UTC',
-                'CYLC_VERBOSE',]:
+                'CYLC_VERBOSE']:
             # (no exception handling here as these variables should
             # always be present in the task execution environment)
             try:

--- a/lib/cylc/task_message.py
+++ b/lib/cylc/task_message.py
@@ -85,10 +85,10 @@ class TaskMessage(object):
                 import traceback
                 traceback.print_exc()
             return
-        if (self.env_map.get('CYLC_TASK_COMMS_METHOD') == 'ssh' and
-                self._send_by_ssh()):
-            return
-        self._send_by_remote_port(messages)
+        if self.env_map.get('CYLC_TASK_COMMS_METHOD') == 'ssh':
+            self._send_by_ssh()
+        else:
+            self._send_by_remote_port(messages)
 
     def _print_messages(self, messages):
         """Print message to send."""
@@ -183,16 +183,17 @@ class TaskMessage(object):
         # this code block.
         env = {}
         for var in [
-                'CYLC_MODE', 'CYLC_TASK_ID', 'CYLC_VERBOSE',
-                'CYLC_SUITE_RUN_DIR',
-                'CYLC_SUITE_RUN_DIR_ON_SUITE_HOST',
-                'CYLC_SUITE_NAME', 'CYLC_SUITE_OWNER',
-                'CYLC_SUITE_HOST', 'CYLC_SUITE_PORT', 'CYLC_UTC',
-                'CYLC_TASK_MSG_MAX_TRIES', 'CYLC_TASK_MSG_TIMEOUT',
-                'CYLC_TASK_MSG_RETRY_INTVL']:
+                SuiteSrvFilesManager.KEY_NAME,
+                SuiteSrvFilesManager.KEY_DIR_ON_SUITE_HOST,
+                'CYLC_TASK_ID',
+                'CYLC_UTC',
+                'CYLC_VERBOSE',]:
             # (no exception handling here as these variables should
             # always be present in the task execution environment)
-            env[var] = self.env_map.get(var, 'UNSET')
+            try:
+                env[var] = self.env_map[var]
+            except:
+                pass
 
         # The path to cylc/bin on the remote end may be required:
         path = os.path.join(self.env_map['CYLC_DIR_ON_SUITE_HOST'], 'bin')
@@ -201,10 +202,7 @@ class TaskMessage(object):
         # otherwise drop through to local messaging.
         # Note: do not sys.exit(0) here as the commands do, it
         # will cause messaging failures on the remote host.
-        try:
-            return remrun().execute(env=env, path=[path])
-        except SystemExit:
-            return
+        remrun().execute(env=env, path=[path])
 
     def _update_job_status_file(self, messages):
         """Write messages to job status file."""

--- a/tests/cylc-message/00-ssh.t
+++ b/tests/cylc-message/00-ssh.t
@@ -27,14 +27,12 @@ if [[ -z "${CYLC_TEST_HOST}" ]]; then
 fi
 set_test_number 3
 
-create_test_globalrc '' '
+create_test_globalrc '' "
 [hosts]
     [[${CYLC_TEST_HOST}]]
-        task communication method = ssh'
+        task communication method = ssh"
 
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
-# Note: Don't install passphrase on remote host. Message should only return via
-# SSH.
 
 run_ok "${TEST_NAME_BASE}-validate" \
     cylc validate "${SUITE_NAME}" -s "CYLC_TEST_HOST=${CYLC_TEST_HOST}"


### PR DESCRIPTION
Fix #2463 (no frills). Main points:
* Handle `cylc message --env=KEY=VALUE ...`.
* Fix typo that causes the logic in `cylc.suite_srv_files_mgr` to fail to load contact file on the server side.
* Don't `scp` passphrase and SSL certificate files if remote host is on SSH+HTTP(S) messaging.
* Ensure `cylc message` on remote host fails when it fails to talk back via SSH communication.
* Fix broken test.