### PR TITLE
Python 2.6 compat

### DIFF
--- a/lib/cylc/state_summary_mgr.py
+++ b/lib/cylc/state_summary_mgr.py
@@ -130,9 +130,9 @@ class StateSummaryMgr(object):
         global_summary['reloading'] = schd.pool.do_reload
         global_summary['state totals'] = state_count_totals
         # Extract suite and task URLs from config.
-        global_summary['suite_urls'] = {
-            i: j['meta']['URL'] for (i, j) in
-            schd.config.cfg['runtime'].items()}
+        global_summary['suite_urls'] = dict(
+            (i, j['meta']['URL'])
+            for (i, j) in schd.config.cfg['runtime'].items())
         global_summary['suite_urls']['suite'] = schd.config.cfg['meta']['URL']
 
         # Construct a suite status string for use by monitoring clients.

--- a/tests/events/39-task-event-template-all/bin/checkargs
+++ b/tests/events/39-task-event-template-all/bin/checkargs
@@ -6,7 +6,7 @@ import os
 import sys
 from subprocess import Popen, PIPE
 
-args = dict([arg.split('=') for arg in sys.argv[1:]])
+args = dict([arg.split('=', 1) for arg in sys.argv[1:]])
 
 suite = os.environ['CYLC_SUITE_NAME']
 proc = Popen(['cylc', 'cat-log', '-la', suite, 'foo.1'], stdout=PIPE)
@@ -17,24 +17,23 @@ for line in open(alog):
         submit_time, _, job_id = line.split(' ') 
         break
 
+del args['start_time']  # must exist, but value unreliable
 assert args == {
-        'suite_title': 'a test suite',
-        'job_id': job_id.strip(),
-        'start_time': 'None',
-        'point': '1',
-        'URL': 'http://cheesy.peas',
-        'title': 'a task called foo',
-        'fish': 'trout',
-        'submit_num': '1',
-        'batch_sys_name': 'background',
-        'id': 'foo.1',
-        'finish_time': 'None',
-        'suite_size': 'large',
-        'suite': suite,
-        'message': 'cheesy peas',
-        'user@host': 'localhost',
-        'event': 'custom',
-        'submit_time': submit_time,
-        'name': 'foo'
-}
-print "OK: command line checks out"
+    'suite_title': 'a test suite',
+    'job_id': job_id.strip(),
+    'point': '1',
+    'URL': 'http://cheesy.peas',
+    'title': 'a task called foo',
+    'fish': 'trout',
+    'submit_num': '1',
+    'batch_sys_name': 'background',
+    'id': 'foo.1',
+    'finish_time': 'None',
+    'suite_size': 'large',
+    'suite': suite,
+    'message': 'cheesy peas',
+    'user@host': 'localhost',
+    'event': 'custom',
+    'submit_time': submit_time,
+    'name': 'foo'}
+print 'OK: command line checks out'

--- a/tests/events/39-task-event-template-all/bin/checkargs
+++ b/tests/events/39-task-event-template-all/bin/checkargs
@@ -4,15 +4,20 @@
 
 import os
 import sys
-import subprocess
+from subprocess import Popen, PIPE
 
 args = dict([arg.split('=') for arg in sys.argv[1:]])
 
 suite = os.environ['CYLC_SUITE_NAME']
-alog = subprocess.check_output(['cylc', 'cat-log', '-la', suite, 'foo.1'])
-start_time, _, job_id = (subprocess.check_output(['grep', 'STDOUT', alog.strip()])).split(' ') 
+proc = Popen(['cylc', 'cat-log', '-la', suite, 'foo.1'], stdout=PIPE)
+alog = proc.communicate()[0].strip()
+proc.wait()
+for line in open(alog):
+    if 'STDOUT' in line:
+        submit_time, _, job_id = line.split(' ') 
+        break
 
-expected_args = {
+assert args == {
         'suite_title': 'a test suite',
         'job_id': job_id.strip(),
         'start_time': 'None',
@@ -29,15 +34,7 @@ expected_args = {
         'message': 'cheesy peas',
         'user@host': 'localhost',
         'event': 'custom',
-        'submit_time': start_time,
+        'submit_time': submit_time,
         'name': 'foo'
 }
-
-
-if args == expected_args:
-    print "OK: command line checks out"
-else:
-    print >> sys.stderr, 'ERROR: unexpected event handler command line.'
-    print >> sys.stderr, "EXPECTED:", expected_args
-    print >> sys.stderr, "RECEIVED:", args
-    sys.exit(1)
+print "OK: command line checks out"

--- a/tests/events/39-task-event-template-all/suite.rc
+++ b/tests/events/39-task-event-template-all/suite.rc
@@ -11,7 +11,10 @@
         graph = "foo"
 [runtime]
     [[foo]]
-        script = cylc message -p CUSTOM "cheesy peas"
+        script = """
+wait "${CYLC_TASK_MESSAGE_STARTED_PID}" 2>/dev/null || true
+cylc message -p CUSTOM "cheesy peas"
+"""
         [[[events]]]
             custom handler = checkargs suite=%(suite)s job_id=%(batch_sys_job_id)s event=%(event)s point=%(point)s name=%(name)s submit_num=%(submit_num)s id=%(id)s batch_sys_name=%(batch_sys_name)s message=%(message)s fish=%(fish)s title=%(title)s URL=%(URL)s suite_title=%(suite_title)s suite_size=%(suite_size)s submit_time=%(submit_time)s start_time=%(start_time)s finish_time=%(finish_time)s user@host=%(user@host)s
         [[[meta]]]


### PR DESCRIPTION
Use of `subprocess.check_outputs` relies on Python 2.7, so test was failing in Python 2.6. Solution should be forward compatible.

Use of dict comprehension relies on Python 2.7 (PEP274), so code base fails in Python 2.6 at the moment.