### PR TITLE
Expand user@host for event handlers.

### DIFF
--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -830,6 +830,10 @@ class TaskEventsManager(object):
             # Custom event handler can be a command template string
             # or a command that takes 4 arguments (classic interface)
             # Note quote() fails on None, need str(None).
+            user_at_host = itask.summary['job_hosts'][itask.submit_num]
+            if '@' not in user_at_host:
+                # (only has 'user@' on the front if user is not suite owner).
+                user_at_host = '%s@%s' % (get_user(), user_at_host)
             try:
                 handler_data = {
                     "event": quote(event),
@@ -849,8 +853,7 @@ class TaskEventsManager(object):
                         str(itask.summary['started_time_string'])),
                     "finish_time": quote(
                         str(itask.summary['finished_time_string'])),
-                    "user@host": quote(
-                        str(itask.summary['job_hosts'][itask.submit_num]))
+                    "user@host": quote(user_at_host)
                 }
 
                 if self.suite_cfg:

--- a/tests/events/39-task-event-template-all/bin/checkargs
+++ b/tests/events/39-task-event-template-all/bin/checkargs
@@ -18,6 +18,8 @@ for line in open(alog):
         break
 
 del args['start_time']  # must exist, but value unreliable
+
+user_at_host = "%s@localhost" % os.environ['USER']
 assert args == {
     'suite_title': 'a test suite',
     'job_id': job_id.strip(),
@@ -32,7 +34,7 @@ assert args == {
     'suite_size': 'large',
     'suite': suite,
     'message': 'cheesy peas',
-    'user@host': 'localhost',
+    'user@host': user_at_host,
     'event': 'custom',
     'submit_time': submit_time,
     'name': 'foo'}


### PR DESCRIPTION
The new task event handler arg `%(user@host)s` is currently passed the internal variable `user_at_host`, which only has `<user>@` prepended if needed for ssh - i.e. if user is not suite owner.  This change preprends `<user>@` in that case.

Existing test updated accordingly.