### PR TITLE
Export user variables before their definition

### DIFF
--- a/tests/env-filter/00-filter.t
+++ b/tests/env-filter/00-filter.t
@@ -91,32 +91,36 @@ cmp_ok $TEST_NAME.stderr - </dev/null
 TEST_NAME=$TEST_NAME_BASE-jobscript
 
 cylc jobscript $SUITE_NAME foo.1 2> /dev/null | \
-    perl -0777 -ne 'print $1 if /# TASK RUNTIME ENVIRONMENT:\n(.*?)    export/s' \
+    perl -0777 -ne 'print $1 if /# TASK RUNTIME ENVIRONMENT:\n(.*?)\}/s' \
     >'foo.1.stdout'
 cmp_ok 'foo.1.stdout' - <<__OUT__
+    export FOO BAR
     FOO="foo"
     BAR="bar"
 __OUT__
 
 cylc jobscript $SUITE_NAME bar.1 2> /dev/null | \
-    perl -0777 -ne 'print $1 if /# TASK RUNTIME ENVIRONMENT:\n(.*?)    export/s' \
+    perl -0777 -ne 'print $1 if /# TASK RUNTIME ENVIRONMENT:\n(.*?)\}/s' \
     >'bar.1.stdout'
 cmp_ok 'bar.1.stdout' - <<__OUT__
+    export BAR
     BAR="bar"
 __OUT__
 
 cylc jobscript $SUITE_NAME baz.1 2> /dev/null | \
-    perl -0777 -ne 'print $1 if /# TASK RUNTIME ENVIRONMENT:\n(.*?)    export/s' \
+    perl -0777 -ne 'print $1 if /# TASK RUNTIME ENVIRONMENT:\n(.*?)\}/s' \
     >'baz.1.stdout'
 cmp_ok 'baz.1.stdout' - <<__OUT__
+    export BAZ QUX
     BAZ="baz"
     QUX="qux"
 __OUT__
 
 cylc jobscript $SUITE_NAME qux.1 2> /dev/null | \
-    perl -0777 -ne 'print $1 if /# TASK RUNTIME ENVIRONMENT:\n(.*?)    export/s' \
+    perl -0777 -ne 'print $1 if /# TASK RUNTIME ENVIRONMENT:\n(.*?)\}/s' \
     >'qux.1.stdout'
 cmp_ok 'qux.1.stdout' - <<__OUT__
+    export FOO BAR BAZ QUX
     FOO="foo"
     BAR="bar"
     BAZ="baz"

--- a/tests/jobscript/00-torture/foo.ref-jobfile
+++ b/tests/jobscript/00-torture/foo.ref-jobfile
@@ -30,12 +30,12 @@ cylc__job__inst__cylc_env() {
 
 cylc__job__inst__user_env() {
     # TASK RUNTIME ENVIRONMENT:
+    export E_ONE E_TWO E_THR E_FOU E_FIV
     E_ONE="$(( RANDOM % 10 ))"
     E_TWO="$VAR_IS"
     E_THR="$CYLC_SUITE_SHARE_PATH"
     E_FOU="$CYLC_TASK_NAME"
     E_FIV="$( foo.sh )"
-    export E_ONE E_TWO E_THR E_FOU E_FIV
 }
 
 cylc__job__inst__init_script() {


### PR DESCRIPTION
It would be useful to have user environment variables exported as soon as they are defined, so they could be used in further definitions like so:
```
FOO='foo'
BAR=$(script_using_FOO)
```
instead of:
```
FOO='foo'
BAR=$(export FOO; script_using_FOO)
```
This pull request moves the export of variables before their definition, which makes them exported as soon as they are defined.