### PR TITLE
Limited client compat with 7.5.0 suites

### DIFF
--- a/bin/cylc-poll
+++ b/bin/cylc-poll
@@ -60,7 +60,13 @@ def main():
         options.comms_timeout, my_uuid=options.set_uuid,
         print_uuid=options.print_uuid)
     items = parser.parse_multitask_compat(options, args)
-    pclient.put_command('poll_tasks', items=items, poll_succ=options.poll_succ)
+    # Back compat: back_out introduced >7.5.0
+    # So don't call with "poll_succ" if not necessary to avoid breakage.
+    if options.poll_succ:
+        pclient.put_command(
+            'poll_tasks', items=items, poll_succ=options.poll_succ)
+    else:
+        pclient.put_command('poll_tasks', items=items)
 
 
 if __name__ == "__main__":

--- a/bin/cylc-trigger
+++ b/bin/cylc-trigger
@@ -192,7 +192,12 @@ def main():
 
     # Trigger the task proxy(s).
     items = parser.parse_multitask_compat(options, args)
-    pclient.put_command('trigger_tasks', items=items, back_out=aborted)
+    # Back compat: back_out introduced >7.5.0
+    # So don't call with "back_out" if not necessary to avoid breakage.
+    if aborted:
+        pclient.put_command('trigger_tasks', items=items, back_out=aborted)
+    else:
+        pclient.put_command('trigger_tasks', items=items)
 
 
 if __name__ == "__main__":

--- a/lib/cylc/network/httpserver.py
+++ b/lib/cylc/network/httpserver.py
@@ -47,6 +47,7 @@ from cylc.version import CYLC_VERSION
 class HTTPServer(object):
     """HTTP(S) server by cherrypy, for serving suite runtime API."""
 
+    API = 1
     LOG_CONNECT_DENIED_TMPL = "[client-connect] DENIED %s@%s:%s %s"
 
     def __init__(self, suite):
@@ -95,11 +96,10 @@ class HTTPServer(object):
                                 "Configure user's global.rc to use HTTP.")
         self.start()
 
-    def shutdown(self):
-        """Shutdown the web server."""
-        if hasattr(self, "engine"):
-            self.engine.exit()
-            self.engine.block()
+    @cherrypy.expose
+    def apiversion(self):
+        """Return API version."""
+        return str(self.API)
 
     @staticmethod
     def connect(schd):
@@ -116,6 +116,12 @@ class HTTPServer(object):
     def get_port(self):
         """Return the web server port."""
         return self.port
+
+    def shutdown(self):
+        """Shutdown the web server."""
+        if hasattr(self, "engine"):
+            self.engine.exit()
+            self.engine.block()
 
     def start(self):
         """Start quick web service."""

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -923,6 +923,7 @@ conditions; see `cylc conditions`.
         # Preserve contact data in memory, for regular health check.
         mgr = self.suite_srv_files_mgr
         contact_data = {
+            mgr.KEY_API: str(self.httpserver.API),
             mgr.KEY_DIR_ON_SUITE_HOST: os.environ['CYLC_DIR'],
             mgr.KEY_NAME: self.suite,
             mgr.KEY_HOST: self.host,

--- a/lib/cylc/suite_srv_files_mgr.py
+++ b/lib/cylc/suite_srv_files_mgr.py
@@ -47,6 +47,7 @@ class SuiteSrvFilesManager(object):
     FILE_BASE_SSL_CERT = "ssl.cert"
     FILE_BASE_SSL_PEM = "ssl.pem"
     FILE_BASE_SUITE_RC = "suite.rc"
+    KEY_API = "CYLC_API"
     KEY_COMMS_PROTOCOL = "CYLC_COMMS_PROTOCOL"  # default (or none?)
     KEY_DIR_ON_SUITE_HOST = "CYLC_DIR_ON_SUITE_HOST"
     KEY_HOST = "CYLC_SUITE_HOST"


### PR DESCRIPTION
This provides limited API backward compatibility between latest client with 7.0.0-7.5.0 suites.
* Set API version to 1 for now. Add this information to contact file.
* If API version is not found in contact file by the client, it will use the old API.
* `cylc gui` compat is not perfect or efficient, as the latest API relies on server side sessions and is more streamlined. 
* (Apart from the `identify` client function for `cylc scan` etc, an old client will still be unable to connect to a suite running on the latest version.)