### PR TITLE
Configurable gscan menubar vis at start-up.

### DIFF
--- a/doc/src/cylc-user-guide/gcylcrc.tex
+++ b/doc/src/cylc-user-guide/gcylcrc.tex
@@ -1,5 +1,5 @@
 
-\section{Gcylc Config File Reference}
+\section{Gcylc GUI (cylc gui) Config File Reference}
 \label{GcylcRCReference}
 
 \lstset{language=bash}

--- a/doc/src/cylc-user-guide/gscanrc.tex
+++ b/doc/src/cylc-user-guide/gscanrc.tex
@@ -1,5 +1,5 @@
 
-\section{Cylc Gscan Config File Reference}
+\section{Gscan GUI (cylc gscan) Config File Reference}
 \label{GscanRCReference}
 
 \lstset{language=bash}
@@ -8,14 +8,14 @@ This section defines all legal items and values for the gscan config
 file which should be located in \lstinline=$HOME/.cylc/gscan.rc=. Some items
 also affect the gpanel panel app.
 
-The main menubar and toolbar appear when the mouse pointer is moved toward the
-top of the gscan window.  The View menu allows you to change which columns are
-displayed, which hosts to scan for running suites, and the task state icon
-theme.
+The main menubar can be hidden to maximise the display area. Its visibility
+can be toggled via the mouse right-click menu, or by typing Alt-m. When
+visible, the main View menu allows you to change properties such as the columns
+that are displayed, which hosts to scan for running suites, and the task state
+icon theme.
 
 At startup, the task state icon theme and icon size are taken from the gcylc
 config file \lstinline=$HOME/.cylc/gcylc.rc=.
-
 
 \subsection{Top Level Items}
 
@@ -82,11 +82,23 @@ in very busy suites.
 
 \subsubsection{window size}
 
-Sets the size in pixels of the \lstinline=cylc gscan= GUI at startup.
+Sets the size in pixels of the \lstinline=cylc gscan= GUI window at startup.
 
 \begin{myitemize}
     \item {\em type:} integer list: x, y
     \item {\em legal values:} positive integers
     \item {\em default:} 300, 200
     \item {\em example:} \lstinline@window size = 1000, 700@
+\end{myitemize}
+
+\subsubsection{hide main menubar}
+
+Hide the main menubar of the \lstinline=cylc gscan= GUI window at startup. By
+default, the menubar is initially hidden. Either way, you can toggle its
+visibility with Alt-m or via the right-click menu.
+
+\begin{myitemize}
+  \item {\em type:} boolean (True or False)
+    \item {\em default:} True
+    \item {\em example:} \lstinline@hide main menubar = False@
 \end{myitemize}

--- a/lib/cylc/cfgspec/gscan.py
+++ b/lib/cylc/cfgspec/gscan.py
@@ -37,6 +37,7 @@ SPEC = {
     'suite status update interval': vdr(
         vtype='interval', default=DurationFloat(15)),
     'window size': vdr(vtype='integer_list', default=[300, 200]),
+    'hide main menubar': vdr(vtype='boolean', default=True),
 }
 
 

--- a/lib/cylc/gui/gscan.py
+++ b/lib/cylc/gui/gscan.py
@@ -100,6 +100,7 @@ class ScanApp(object):
 
         # Visibility of columns
         vis_cols = gsfg.get(["columns"])
+        hide_main_menu_bar = gsfg.get(["hide main menubar"])
         # Doesn't make any sense without suite name column
         if gsfg.COL_SUITE not in vis_cols:
             vis_cols.append(gsfg.COL_SUITE.lower())
@@ -203,7 +204,8 @@ class ScanApp(object):
         self.menu_hbox.pack_start(self.menu_bar, expand=True, fill=True)
         self.menu_hbox.pack_start(self.tool_bar, expand=True, fill=True)
         self.menu_hbox.show_all()
-        self.menu_hbox.hide_all()
+        if hide_main_menu_bar:
+            self.menu_hbox.hide_all()
 
         scrolled_window = gtk.ScrolledWindow()
         scrolled_window.set_policy(gtk.POLICY_AUTOMATIC,


### PR DESCRIPTION
Small change after multiple user requests; seems reasonable.