### PR TITLE
cylc scan: list suites via file system by default

### DIFF
--- a/bin/cylc-gscan
+++ b/bin/cylc-gscan
@@ -82,7 +82,7 @@ def main():
     options, args = parser.parse_args()
 
     if options.all_ports:
-        args = GLOBAL_CFG.get(["suite host scanning", "hosts"])
+        args.extend(GLOBAL_CFG.get(["suite host scanning", "hosts"]))
     scan_app = ScanApp(
         hosts=args,
         patterns_name=options.patterns_name,

--- a/bin/cylc-scan
+++ b/bin/cylc-scan
@@ -18,14 +18,18 @@
 
 """cylc [discovery] scan [OPTIONS] [HOSTS ...]
 
-Print information about cylc suites currently running on scanned hosts. The
-list of hosts to scan is determined by the global configuration "[suite host
-scanning]" setting, or hosts can be specified explicitly on the command line.
+Print information about running suites.
 
-By default, just your own suites are listed (this assumes your username is the
-same on all scanned hosts). Use -a/--all-suites to see all suites on all hosts,
-or restrict suites displayed with the -o/--owner and -n/--name options (with
---name the default owner restriction (i.e. just your own suites) is disabled.
+By default, it will obtain a listing of running suites for the current user
+from the file system, before connecting to the suites to obtain information.
+Use the -o/--suite-owner option to get information of running suites for other
+users.
+
+If a list of HOSTS is specified, it will obtain a listing of running suites by
+scanning all ports in the relevant range for running suites on the specified
+hosts. If the -a/--all option is specified, it will use the global
+configuration "[suite host scanning]" setting to determine a list of hosts to
+scan.
 
 Suite passphrases are not needed to get identity information (name and owner).
 Titles, descriptions, state totals, and cycle point state totals may also be
@@ -46,7 +50,7 @@ import re
 
 from cylc.cfgspec.globalcfg import GLOBAL_CFG
 from cylc.hostuserutil import get_user
-from cylc.network.port_scan import scan_many
+from cylc.network.port_scan import scan_many, get_scan_items_from_fs
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.suite_status import (
     KEY_DESCRIPTION, KEY_META, KEY_NAME, KEY_OWNER, KEY_STATES,
@@ -55,16 +59,18 @@ from cylc.task_state import TASK_STATUSES_ORDERED
 from cylc.task_state_prop import get_status_prop
 
 
-NO_BOLD = False
+class TitleFormatter(object):
+    """Format title line, in bold or not if .no_bold set to False."""
 
+    def __init__(self, no_bold=False):
+        self.no_bold = no_bold
 
-def bold(line):
-    """Add terminal control characters for bold text."""
-    global NO_BOLD
-    if NO_BOLD:
-        return line
-    else:
-        return "\033[1m" + line + "\033[0m"
+    def __call__(self, line):
+        """Add terminal control characters for bold text, if .no_bold=False"""
+        if self.no_bold:
+            return line
+        else:
+            return "\033[1m" + line + "\033[0m"
 
 
 def main():
@@ -78,10 +84,9 @@ def main():
     )
 
     parser.add_option(
-        "-a", "--all", "--all-suites",
-        help="List all suites found on all scanned hosts (the default is "
-             "just your own suites).",
-        action="store_true", default=False, dest="all_suites")
+        "-a", "--all",
+        help="Scan all port ranges in known hosts.",
+        action="store_true", default=False, dest="all_ports")
 
     parser.add_option(
         "-n", "--name",
@@ -157,9 +162,7 @@ def main():
 
     indent = "   "
 
-    global NO_BOLD
-    if options.no_bold:
-        NO_BOLD = True
+    bold = TitleFormatter(options.no_bold)
 
     if options.print_full:
         options.describe = options.print_totals = True
@@ -172,31 +175,6 @@ def main():
         parser.error(
             "--raw-format cannot be used with other format options.")
 
-    if options.all_suites:
-        if options.patterns_name != []:
-            parser.error("-a and -n are mutually exclusive.")
-        if options.patterns_owner != []:
-            parser.error("-a and -o are mutually exclusive.")
-        patterns_name = ['.*']  # Any name.
-        patterns_owner = ['.*']  # Any owner.
-    else:
-        if options.patterns_name:
-            patterns_name = options.patterns_name
-        else:
-            # Any suite name.
-            patterns_name = ['.*']
-        if options.patterns_owner:
-            patterns_owner = options.patterns_owner
-        else:
-            if options.patterns_name:
-                # Any suite owner.
-                patterns_owner = ['.*']
-            else:
-                # Just the user's suites.
-                patterns_owner = [get_user()]
-    pattern_name = "(" + ")|(".join(patterns_name) + ")"
-    pattern_owner = "(" + ")|(".join(patterns_owner) + ")"
-
     state_legend = ""
     if options.color:
         n_states = len(TASK_STATUSES_ORDERED)
@@ -206,13 +184,44 @@ def main():
                 state_legend += "\n"
         state_legend = state_legend.rstrip()
 
+    if options.patterns_name:
+        patterns_name = options.patterns_name
+    else:
+        # Any suite name.
+        patterns_name = ['.*']
+    if options.patterns_owner:
+        patterns_owner = options.patterns_owner
+    else:
+        # Just the user's suites.
+        patterns_owner = [get_user()]
+    # Compile and check "name" and "owner" regular expressions
+    cres = {}
+    for key, patterns in [
+            ('name', patterns_name), ('suite-owner', patterns_owner)]:
+        try:
+            cres[key] = re.compile(r'(' + r')|('.join(patterns) + r')')
+        except re.error:
+            for pattern in patterns:
+                try:
+                    re.compile(pattern)
+                except re.error:
+                    parser.error(
+                        '--%s=%s: bad regular expression' % (key, pattern))
+    if options.all_ports:
+        args.extend(GLOBAL_CFG.get(["suite host scanning", "hosts"]))
+    if not args:
+        args = get_scan_items_from_fs(cres['suite-owner'])
+    if not args:
+        return
+
     skip_one = True
     for host, port, suite_identity in scan_many(args, options.comms_timeout):
         name = suite_identity[KEY_NAME]
         owner = suite_identity[KEY_OWNER]
 
-        if not (re.match(pattern_name, name) and
-                re.match(pattern_owner, owner)):
+        if not cres['name'].match(name):
+            continue
+        if not cres['suite-owner'].match(owner):
             continue
 
         if options.old_format:

--- a/lib/cylc/gui/dbchooser.py
+++ b/lib/cylc/gui/dbchooser.py
@@ -25,10 +25,11 @@ import threading
 
 from cylc.gui.warning_dialog import warning_dialog, info_dialog
 from cylc.gui.util import get_icon, EntryTempText, EntryDialog
-from cylc.network.port_scan import scan_many
+from cylc.network.port_scan import scan_many, get_scan_items_from_fs
 from cylc.suite_srv_files_mgr import SuiteSrvFilesManager
 from cylc.run_get_stdout import run_get_stdout
 from cylc.hostuserutil import is_remote_host, is_remote_user
+from cylc.suite_status import KEY_NAME, KEY_OWNER
 
 
 class db_updater(threading.Thread):
@@ -109,12 +110,13 @@ class db_updater(threading.Thread):
 
         # Scan for running suites
         choices = []
-        for host, port, suite_identity in scan_many(timeout=self.timeout):
-            name = suite_identity['name']
-            owner = suite_identity['owner']
+        for host, port, suite_identity in scan_many(
+                get_scan_items_from_fs(), timeout=self.timeout):
+            name = suite_identity[KEY_NAME]
+            owner = suite_identity[KEY_OWNER]
             if is_remote_user(owner):
                 continue  # current user only
-            auth = "%s:%d" % (host, port)
+            auth = "%s:%s" % (host, port)
             choices.append((name, auth))
         choices.sort()
         self.next_scan_time = time() + self.SCAN_INTERVAL

--- a/lib/cylc/network/httpclient.py
+++ b/lib/cylc/network/httpclient.py
@@ -175,7 +175,9 @@ class SuiteRuntimeServiceClient(object):
 
     def identify(self):
         """Return suite identity."""
-        return self._call_server('identify', method=self.METHOD_GET)
+        # Note on compat: Suites on 7.6.0 or above can just call "identify",
+        # but has compat for "id/identity".
+        return self._call_server('id/identify', method=self.METHOD_GET)
 
     def put_broadcast(self, **kwargs):
         """Put/set broadcast runtime task settings."""

--- a/tests/authentication/01-description.t
+++ b/tests/authentication/01-description.t
@@ -41,11 +41,11 @@ SRV_D="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/.service"
 mv "${SRV_D}/passphrase" "${SRV_D}/passphrase.DIS"
 
 # Check scan output.
+HOST="$(sed -n 's/^CYLC_SUITE_HOST=//p' "${SRV_D}/contact")"
 PORT="$(sed -n 's/^CYLC_SUITE_PORT=//p' "${SRV_D}/contact")"
-cylc scan --comms-timeout=5 -fb -n "${SUITE_NAME}" 'localhost' \
-    >'scan.out' 2>'/dev/null'
-cmp_ok scan.out << __END__
-${SUITE_NAME} ${USER}@localhost:${PORT}
+cylc scan --comms-timeout=5 -fb -n "${SUITE_NAME}" >'scan.out' 2>'/dev/null'
+cmp_ok 'scan.out' <<__END__
+${SUITE_NAME} ${USER}@${HOST}:${PORT}
    Title:
       "Authentication test suite."
    Description:

--- a/tests/authentication/02-state-totals.t
+++ b/tests/authentication/02-state-totals.t
@@ -41,11 +41,11 @@ SRV_D="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/.service"
 mv "${SRV_D}/passphrase" "${SRV_D}/passphrase.DIS"
 
 # Check scan output.
+HOST="$(sed -n 's/^CYLC_SUITE_HOST=//p' "${SRV_D}/contact")"
 PORT="$(sed -n 's/^CYLC_SUITE_PORT=//p' "${SRV_D}/contact")"
-cylc scan --comms-timeout=5 -fb -n "${SUITE_NAME}" 'localhost' \
-    >'scan.out'
-cmp_ok scan.out << __END__
-${SUITE_NAME} ${USER}@localhost:${PORT}
+cylc scan --comms-timeout=5 -fb -n "${SUITE_NAME}" >'scan.out' 2>'/dev/null'
+cmp_ok 'scan.out' <<__END__
+${SUITE_NAME} ${USER}@${HOST}:${PORT}
    Title:
       "Authentication test suite."
    Description:

--- a/tests/authentication/03-full-read.t
+++ b/tests/authentication/03-full-read.t
@@ -41,11 +41,11 @@ SRV_D="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/.service"
 mv "${SRV_D}/passphrase" "${SRV_D}/passphrase.DIS"
 
 # Check scan output.
+HOST="$(sed -n 's/^CYLC_SUITE_HOST=//p' "${SRV_D}/contact")"
 PORT="$(sed -n 's/^CYLC_SUITE_PORT=//p' "${SRV_D}/contact")"
-cylc scan --comms-timeout=5 -fb -n "${SUITE_NAME}" 'localhost' \
-    >'scan.out' 2>'/dev/null'
-cmp_ok scan.out << __END__
-${SUITE_NAME} ${USER}@localhost:${PORT}
+cylc scan --comms-timeout=5 -fb -n "${SUITE_NAME}" >'scan.out' 2>'/dev/null'
+cmp_ok 'scan.out' <<__END__
+${SUITE_NAME} ${USER}@${HOST}:${PORT}
    Title:
       "Authentication test suite."
    Description:

--- a/tests/authentication/04-shutdown.t
+++ b/tests/authentication/04-shutdown.t
@@ -40,11 +40,11 @@ cylc suite-state "${SUITE_NAME}" --task=foo --status=failed --point=1 \
 SRV_D="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/.service"
 mv "${SRV_D}/passphrase" "${SRV_D}/passphrase.DIS"
 
+HOST="$(sed -n 's/^CYLC_SUITE_HOST=//p' "${SRV_D}/contact")"
 PORT="$(sed -n 's/^CYLC_SUITE_PORT=//p' "${SRV_D}/contact")"
-cylc scan --comms-timeout=5 -fb -n "${SUITE_NAME}" 'localhost' \
-    >'scan.out' 2>'/dev/null'
-cmp_ok scan.out << __END__
-${SUITE_NAME} ${USER}@localhost:${PORT}
+cylc scan --comms-timeout=5 -fb -n "${SUITE_NAME}" >'scan.out' 2>'/dev/null'
+cmp_ok 'scan.out' <<__END__
+${SUITE_NAME} ${USER}@${HOST}:${PORT}
    Title:
       "Authentication test suite."
    Description:

--- a/tests/authentication/05-full-control.t
+++ b/tests/authentication/05-full-control.t
@@ -39,11 +39,11 @@ cylc suite-state "${SUITE_NAME}" --task=foo --status=failed --point=1 \
 
 # Check scan output.
 SRV_D="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/.service"
+HOST="$(sed -n 's/^CYLC_SUITE_HOST=//p' "${SRV_D}/contact")"
 PORT="$(sed -n 's/^CYLC_SUITE_PORT=//p' "${SRV_D}/contact")"
-cylc scan --comms-timeout=5 -fb -n "${SUITE_NAME}" 'localhost' \
-    >'scan.out' 2>'/dev/null'
-cmp_ok scan.out << __END__
-${SUITE_NAME} ${USER}@localhost:${PORT}
+cylc scan --comms-timeout=5 -fb -n "${SUITE_NAME}" >'scan.out' 2>'/dev/null'
+cmp_ok 'scan.out' <<__END__
+${SUITE_NAME} ${USER}@${HOST}:${PORT}
    Title:
       "Authentication test suite."
    Description:

--- a/tests/authentication/06-suite-override.t
+++ b/tests/authentication/06-suite-override.t
@@ -41,11 +41,11 @@ cylc suite-state "${SUITE_NAME}" --task=foo --status=failed --point=1 \
 SRV_D="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/.service"
 mv "${SRV_D}/passphrase" "${SRV_D}/passphrase.DIS"
 
+HOST="$(sed -n 's/^CYLC_SUITE_HOST=//p' "${SRV_D}/contact")"
 PORT="$(sed -n 's/^CYLC_SUITE_PORT=//p' "${SRV_D}/contact")"
-cylc scan --comms-timeout=5 -fb -n "${SUITE_NAME}" 'localhost' \
-    >'scan.out' 2>'/dev/null'
-cmp_ok scan.out << __END__
-${SUITE_NAME} ${USER}@localhost:${PORT}
+cylc scan --comms-timeout=5 -fb -n "${SUITE_NAME}" >'scan.out' 2>'/dev/null'
+cmp_ok 'scan.out' <<__END__
+${SUITE_NAME} ${USER}@${HOST}:${PORT}
    Title:
       "Authentication test suite."
    Description:

--- a/tests/authentication/07-sha-hash.t
+++ b/tests/authentication/07-sha-hash.t
@@ -42,11 +42,11 @@ cylc suite-state "${SUITE_NAME}" --task=foo --status=failed --point=1 \
 
 # Check scan output.
 SRV_D="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/.service"
+HOST="$(sed -n 's/^CYLC_SUITE_HOST=//p' "${SRV_D}/contact")"
 PORT="$(sed -n 's/^CYLC_SUITE_PORT=//p' "${SRV_D}/contact")"
-cylc scan --comms-timeout=5 -fb -n "${SUITE_NAME}" 'localhost' \
-    >'scan.out' 2>'/dev/null'
-cmp_ok scan.out << __END__
-${SUITE_NAME} ${USER}@localhost:${PORT}
+cylc scan --comms-timeout=5 -fb -n "${SUITE_NAME}">'scan.out' 2>'/dev/null'
+cmp_ok 'scan.out' <<__END__
+${SUITE_NAME} ${USER}@${HOST}:${PORT}
    Title:
       "Authentication test suite."
    Description:


### PR DESCRIPTION
Unify `cylc scan` logic with `cylc gscan` - get list of running suites via file system by default.
* `--all` option now used to scan all known hosts.
* Also apply to `cylc gui` *Open Another Suite...* dialog.

Check regular expressions in `--name=PATTERN` and `--suite-owner=PATTERN`
before use.

Use object attr instead of `global` to configure callable in `bin/cylc-scan`.

(Follow on from #2430.)