### PR TITLE
Fix selected issues reported by Codacy

### DIFF
--- a/bin/cylc-broadcast
+++ b/bin/cylc-broadcast
@@ -75,7 +75,7 @@ import sys
 if '--use-ssh' in sys.argv[1:]:
     sys.argv.remove('--use-ssh')
     from cylc.remote import remrun
-    if remrun().execute(force_required=True):
+    if remrun():
         sys.exit(0)
 
 import re

--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -331,7 +331,7 @@ def main():
                 '%s:%s' % (user_at_host, filename), viewfile]
         else:
             cp = ['cp', filename, viewfile]
-        proc = Popen(cp, stderr=PIPE, stdout=PIPE)
+        proc = Popen(cp, stdin=open(os.devnull), stderr=PIPE, stdout=PIPE)
         err = proc.communicate()[1]
         ret_code = proc.wait()
         if ret_code:
@@ -365,7 +365,7 @@ def main():
             sys.stderr.write(
                 " ".join(quote(item) for item in command) + "\n")
             stderr = None
-        proc = Popen(command, stderr=stderr)
+        proc = Popen(command, stdin=open(os.devnull), stderr=stderr)
         err = proc.communicate()[1]
         ret_code = proc.wait()
         if ret_code == 0:

--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -29,7 +29,7 @@ window, or 'View in Editor' opens a temporary copy of it in your editor."""
 
 import sys
 from cylc.remote import remrun
-if remrun().execute():
+if remrun():
     sys.exit(0)
 
 import os

--- a/bin/cylc-cat-state
+++ b/bin/cylc-cat-state
@@ -23,7 +23,7 @@ This command is deprecated; use "cylc ls-checkpoints" instead."""
 
 import sys
 from cylc.remote import remrun
-if remrun().execute():
+if remrun():
     sys.exit(0)
 
 import os

--- a/bin/cylc-check-versions
+++ b/bin/cylc-check-versions
@@ -35,7 +35,7 @@ User -v/--verbose to see the command invoked to determine the remote version
 site dependent -- see cylc global config documentation."""
 
 import sys
-import subprocess
+from subprocess import Popen, PIPE
 
 import cylc.flags
 from cylc.remote import remrun
@@ -99,11 +99,9 @@ def main():
             user_at_host = host
         if verbose:
             print "%s: %s" % (user_at_host, ' '.join(argv))
-        p = subprocess.Popen(
-            argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        out, err = p.communicate()
-        res = p.wait()
-        if res == 0:
+        proc = Popen(argv, stdin=open(os.devnull), stdout=PIPE, stderr=PIPE)
+        out, err = proc.communicate()
+        if proc.wait() == 0:
             if verbose:
                 print "   %s" % out
             contacted += 1

--- a/bin/cylc-check-versions
+++ b/bin/cylc-check-versions
@@ -38,7 +38,6 @@ import sys
 from subprocess import Popen, PIPE
 
 import cylc.flags
-from cylc.remote import remrun
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.version import CYLC_VERSION
 from cylc.config import SuiteConfig, SuiteConfigError

--- a/bin/cylc-checkpoint
+++ b/bin/cylc-checkpoint
@@ -25,7 +25,7 @@ import sys
 if "--use-ssh" in sys.argv[1:]:
     sys.argv.remove("--use-ssh")
     from cylc.remote import remrun
-    if remrun().execute(force_required=True):
+    if remrun():
         sys.exit(0)
 
 import cylc.flags

--- a/bin/cylc-diff
+++ b/bin/cylc-diff
@@ -30,7 +30,7 @@ suite definition directory are not currently differenced."""
 
 import sys
 from cylc.remote import remrun
-if remrun().execute():
+if remrun():
     sys.exit(0)
 
 import cylc.flags

--- a/bin/cylc-documentation
+++ b/bin/cylc-documentation
@@ -36,7 +36,7 @@ import sys
 for arg in sys.argv[1:]:
     if arg.startswith('--host=') or arg.startswith('--user='):
         from cylc.remote import remrun
-        if remrun().execute(force_required=True, forward_x11=True):
+        if remrun(forward_x11=True):
             sys.exit(0)
 
 import os

--- a/bin/cylc-documentation
+++ b/bin/cylc-documentation
@@ -41,7 +41,7 @@ for arg in sys.argv[1:]:
 
 import os
 import re
-import subprocess
+from subprocess import call
 from optparse import OptionParser
 
 import cylc.flags
@@ -168,7 +168,7 @@ def main():
         sys.exit(0)
 
     try:
-        retcode = subprocess.call(command_list)
+        retcode = call(command_list, stdin=open(os.devnull))
     except OSError as exc:
         print >> sys.stderr, 'ERROR, failed to execute: %s' % command
         if cylc.flags.debug:

--- a/bin/cylc-dump
+++ b/bin/cylc-dump
@@ -36,7 +36,7 @@ import sys
 if '--use-ssh' in sys.argv[1:]:
     sys.argv.remove('--use-ssh')
     from cylc.remote import remrun
-    if remrun().execute():
+    if remrun():
         sys.exit(0)
 
 import cylc.flags

--- a/bin/cylc-edit
+++ b/bin/cylc-edit
@@ -64,7 +64,7 @@ if remrun().execute(forward_x11=True):
 import os
 import re
 import datetime
-import subprocess
+from subprocess import call
 from shutil import copy
 
 import cylc.flags
@@ -124,7 +124,7 @@ def main():
         command_list.append(suiterc)
         command = ' '.join(command_list)
         # THIS BLOCKS UNTIL THE COMMAND COMPLETES
-        retcode = subprocess.call(command_list)
+        retcode = call(command_list, stdin=open(os.devnull))
         if retcode != 0:
             # the command returned non-zero exist status
             print >> sys.stderr, command, 'failed:', retcode
@@ -172,7 +172,7 @@ def main():
     command_list.append(suiterc)
     command = ' '.join(command_list)
     # THIS BLOCKS UNTIL THE COMMAND COMPLETES
-    retcode = subprocess.call(command_list)
+    retcode = call(command_list, stdin=open(os.devnull))
     if retcode != 0:
         # the command returned non-zero exist status
         print >> sys.stderr, command, 'failed:', retcode

--- a/bin/cylc-edit
+++ b/bin/cylc-edit
@@ -58,7 +58,7 @@ See also 'cylc [prep] view'."""
 
 import sys
 from cylc.remote import remrun
-if remrun().execute(forward_x11=True):
+if remrun(forward_x11=True):
     sys.exit(0)
 
 import os

--- a/bin/cylc-get-directory
+++ b/bin/cylc-get-directory
@@ -28,7 +28,7 @@ from cylc.suite_srv_files_mgr import SuiteSrvFilesManager
 import cylc.flags
 
 from cylc.remote import remrun
-if remrun().execute():
+if remrun():
     sys.exit(0)
 
 

--- a/bin/cylc-get-suite-config
+++ b/bin/cylc-get-suite-config
@@ -53,7 +53,7 @@ $ cylc get-suite-config --item=[runtime][modelX] SUITE
 
 import sys
 from cylc.remote import remrun
-if remrun().execute():
+if remrun():
     sys.exit(0)
 
 import re

--- a/bin/cylc-get-suite-contact
+++ b/bin/cylc-get-suite-contact
@@ -22,7 +22,7 @@ Print contact information of running suite REG."""
 
 import sys
 from cylc.remote import remrun
-if remrun().execute():
+if remrun():
     sys.exit(0)
 
 from cylc.option_parsers import CylcOptionParser as COP

--- a/bin/cylc-get-suite-version
+++ b/bin/cylc-get-suite-version
@@ -26,7 +26,7 @@ import sys
 if '--use-ssh' in sys.argv[1:]:
     sys.argv.remove('--use-ssh')
     from cylc.remote import remrun
-    if remrun().execute():
+    if remrun():
         sys.exit(0)
 
 import cylc.flags

--- a/bin/cylc-graph
+++ b/bin/cylc-graph
@@ -70,7 +70,7 @@ from cylc.suite_srv_files_mgr import SuiteSrvFilesManager
 from cylc.task_id import TaskID
 from cylc.templatevars import load_template_vars
 
-if remrun().execute(forward_x11=True):
+if remrun(forward_x11=True):
     sys.exit(0)
 
 from cylc.option_parsers import CylcOptionParser as COP

--- a/bin/cylc-gscan
+++ b/bin/cylc-gscan
@@ -28,7 +28,7 @@ import sys
 if "--use-ssh" in sys.argv[1:]:
     sys.argv.remove("--use-ssh")
     from cylc.remote import remrun
-    if remrun().execute(forward_x11=True):
+    if remrun(forward_x11=True):
         sys.exit(0)
 
 import gtk

--- a/bin/cylc-gui
+++ b/bin/cylc-gui
@@ -42,7 +42,7 @@ import sys
 if '--use-ssh' in sys.argv[1:]:
     sys.argv.remove('--use-ssh')
     from cylc.remote import remrun
-    if remrun().execute(forward_x11=True):
+    if remrun(forward_x11=True):
         sys.exit(0)
 
 import os

--- a/bin/cylc-hold
+++ b/bin/cylc-hold
@@ -30,7 +30,7 @@ import sys
 if '--use-ssh' in sys.argv[1:]:
     sys.argv.remove('--use-ssh')
     from cylc.remote import remrun
-    if remrun().execute(force_required=True):
+    if remrun():
         sys.exit(0)
 
 import cylc.flags

--- a/bin/cylc-insert
+++ b/bin/cylc-insert
@@ -37,7 +37,7 @@ import sys
 if '--use-ssh' in sys.argv[1:]:
     sys.argv.remove('--use-ssh')
     from cylc.remote import remrun
-    if remrun().execute(force_required=True):
+    if remrun():
         sys.exit(0)
 
 import cylc.flags

--- a/bin/cylc-jobs-kill
+++ b/bin/cylc-jobs-kill
@@ -38,7 +38,7 @@ def main():
     BatchSysManager().jobs_kill(args[0], args[1:])
 
 
-if __name__ == "__main__" and not remrun().execute():
+if __name__ == "__main__" and not remrun():
     from cylc.option_parsers import CylcOptionParser as COP
     from cylc.batch_sys_manager import BatchSysManager
     main()

--- a/bin/cylc-jobs-poll
+++ b/bin/cylc-jobs-poll
@@ -37,7 +37,7 @@ def main():
     BatchSysManager().jobs_poll(args[0], args[1:])
 
 
-if __name__ == "__main__" and not remrun().execute():
+if __name__ == "__main__" and not remrun():
     from cylc.option_parsers import CylcOptionParser as COP
     from cylc.batch_sys_manager import BatchSysManager
     main()

--- a/bin/cylc-jobs-submit
+++ b/bin/cylc-jobs-submit
@@ -42,7 +42,7 @@ def main():
         args[0], args[1:], remote_mode=opts.remote_mode)
 
 
-if __name__ == "__main__" and not remrun().execute():
+if __name__ == "__main__" and not remrun():
     from cylc.option_parsers import CylcOptionParser as COP
     from cylc.batch_sys_manager import BatchSysManager
     main()

--- a/bin/cylc-kill
+++ b/bin/cylc-kill
@@ -28,7 +28,7 @@ import sys
 if '--use-ssh' in sys.argv[1:]:
     sys.argv.remove('--use-ssh')
     from cylc.remote import remrun
-    if remrun().execute(force_required=True):
+    if remrun():
         sys.exit(0)
 
 import cylc.flags

--- a/bin/cylc-list
+++ b/bin/cylc-list
@@ -29,7 +29,7 @@ viewer tool. To visualize the full multiple inheritance hierarchy use:
 import os
 import sys
 from cylc.remote import remrun
-if remrun().execute():
+if remrun():
     sys.exit(0)
 
 from cylc.config import SuiteConfig

--- a/bin/cylc-ls-checkpoints
+++ b/bin/cylc-ls-checkpoints
@@ -25,7 +25,7 @@ parameters, task pool and broadcast states in the suite runtime database.
 
 import sys
 from cylc.remote import remrun
-if remrun().execute():
+if remrun():
     sys.exit(0)
 
 import os

--- a/bin/cylc-nudge
+++ b/bin/cylc-nudge
@@ -33,7 +33,7 @@ import sys
 if '--use-ssh' in sys.argv[1:]:
     sys.argv.remove('--use-ssh')
     from cylc.remote import remrun
-    if remrun().execute():
+    if remrun():
         sys.exit(0)
 
 import cylc.flags

--- a/bin/cylc-ping
+++ b/bin/cylc-ping
@@ -25,7 +25,7 @@ import sys
 if '--use-ssh' in sys.argv[1:]:
     sys.argv.remove('--use-ssh')
     from cylc.remote import remrun
-    if remrun().execute():
+    if remrun():
         sys.exit(0)
 
 import cylc.flags

--- a/bin/cylc-poll
+++ b/bin/cylc-poll
@@ -28,7 +28,7 @@ import sys
 if '--use-ssh' in sys.argv[1:]:
     sys.argv.remove('--use-ssh')
     from cylc.remote import remrun
-    if remrun().execute(force_required=True):
+    if remrun():
         sys.exit(0)
 
 import cylc.flags

--- a/bin/cylc-print
+++ b/bin/cylc-print
@@ -29,7 +29,7 @@ to prevent this ('foo$' matches only literal 'foo')."""
 
 import sys
 from cylc.remote import remrun
-if remrun().execute():
+if remrun():
     sys.exit(0)
 
 import os

--- a/bin/cylc-register
+++ b/bin/cylc-register
@@ -45,7 +45,7 @@ The suite can subsequently be started and targeted by cylc commands using
 
 import sys
 from cylc.remote import remrun
-if remrun().execute():
+if remrun():
     sys.exit(0)
 
 from cylc.option_parsers import CylcOptionParser as COP

--- a/bin/cylc-release
+++ b/bin/cylc-release
@@ -29,7 +29,7 @@ import sys
 if '--use-ssh' in sys.argv[1:]:
     sys.argv.remove('--use-ssh')
     from cylc.remote import remrun
-    if remrun().execute(force_required=True):
+    if remrun():
         sys.exit(0)
 
 import cylc.flags

--- a/bin/cylc-reload
+++ b/bin/cylc-reload
@@ -43,7 +43,7 @@ import sys
 if '--use-ssh' in sys.argv[1:]:
     sys.argv.remove('--use-ssh')
     from cylc.remote import remrun
-    if remrun().execute():
+    if remrun():
         sys.exit(0)
 
 import cylc.flags

--- a/bin/cylc-remove
+++ b/bin/cylc-remove
@@ -28,7 +28,7 @@ import sys
 if '--use-ssh' in sys.argv[1:]:
     sys.argv.remove('--use-ssh')
     from cylc.remote import remrun
-    if remrun().execute(force_required=True):
+    if remrun():
         sys.exit(0)
 
 import cylc.flags

--- a/bin/cylc-report-timings
+++ b/bin/cylc-report-timings
@@ -49,7 +49,7 @@ the database query to obtain the timing information may take some time.
 
 import sys
 from cylc.remote import remrun
-if remrun().execute():
+if remrun():
     sys.exit(0)
 
 import cStringIO as StringIO

--- a/bin/cylc-reset
+++ b/bin/cylc-reset
@@ -33,7 +33,7 @@ import sys
 if '--use-ssh' in sys.argv[1:]:
     sys.argv.remove('--use-ssh')
     from cylc.remote import remrun
-    if remrun().execute(force_required=True):
+    if remrun():
         sys.exit(0)
 
 import cylc.flags

--- a/bin/cylc-restart
+++ b/bin/cylc-restart
@@ -20,7 +20,7 @@
 
 import sys
 from cylc.remote import remrun
-if remrun().execute():
+if remrun():
     sys.exit(0)
 
 from cylc.scheduler_cli import main

--- a/bin/cylc-run
+++ b/bin/cylc-run
@@ -20,7 +20,7 @@
 
 import sys
 from cylc.remote import remrun
-if remrun().execute():
+if remrun():
     sys.exit(0)
 
 

--- a/bin/cylc-scan
+++ b/bin/cylc-scan
@@ -43,7 +43,7 @@ import sys
 if "--use-ssh" in sys.argv[1:]:
     sys.argv.remove("--use-ssh")
     from cylc.remote import remrun
-    if remrun().execute():
+    if remrun():
         sys.exit(0)
 
 import re

--- a/bin/cylc-search
+++ b/bin/cylc-search
@@ -33,7 +33,7 @@ For case insenstive matching use '(?i)PATTERN'."""
 
 import sys
 from cylc.remote import remrun
-if remrun().execute():
+if remrun():
     sys.exit(0)
 
 import os

--- a/bin/cylc-set-verbosity
+++ b/bin/cylc-set-verbosity
@@ -28,7 +28,7 @@ import sys
 if '--use-ssh' in sys.argv[1:]:
     sys.argv.remove('--use-ssh')
     from cylc.remote import remrun
-    if remrun().execute(force_required=True):
+    if remrun():
         sys.exit(0)
 
 import cylc.flags

--- a/bin/cylc-show
+++ b/bin/cylc-show
@@ -26,7 +26,7 @@ import sys
 if '--use-ssh' in sys.argv[1:]:
     sys.argv.remove('--use-ssh')
     from cylc.remote import remrun
-    if remrun().execute():
+    if remrun():
         sys.exit(0)
 
 import cylc.flags

--- a/bin/cylc-spawn
+++ b/bin/cylc-spawn
@@ -27,7 +27,7 @@ import sys
 if '--use-ssh' in sys.argv[1:]:
     sys.argv.remove('--use-ssh')
     from cylc.remote import remrun
-    if remrun().execute(force_required=True):
+    if remrun():
         sys.exit(0)
 
 import cylc.flags

--- a/bin/cylc-stop
+++ b/bin/cylc-stop
@@ -42,7 +42,7 @@ import sys
 if '--use-ssh' in sys.argv[1:]:
     sys.argv.remove('--use-ssh')
     from cylc.remote import remrun
-    if remrun().execute(force_required=True):
+    if remrun():
         sys.exit(0)
 
 import cylc.flags

--- a/bin/cylc-submit
+++ b/bin/cylc-submit
@@ -31,7 +31,7 @@ same time - both instances will attempt to write to the same job logs."""
 
 import sys
 from cylc.remote import remrun
-if remrun().execute():
+if remrun():
     sys.exit(0)
 
 import os

--- a/bin/cylc-suite-state
+++ b/bin/cylc-suite-state
@@ -55,7 +55,7 @@ from time import sleep, time
 
 from cylc.remote import remrun
 
-if remrun().execute():
+if remrun():
     sys.exit(0)
 
 import cylc.flags

--- a/bin/cylc-trigger
+++ b/bin/cylc-trigger
@@ -38,7 +38,7 @@ if '--host' in sys.argv[1:] and '--edit' in sys.argv[1:]:
 if '--use-ssh' in sys.argv[1:]:
     sys.argv.remove('--use-ssh')
     from cylc.remote import remrun
-    if remrun().execute(force_required=True, forward_x11=True):
+    if remrun(forward_x11=True):
         sys.exit(0)
 
 import re

--- a/bin/cylc-trigger
+++ b/bin/cylc-trigger
@@ -46,7 +46,7 @@ import os
 import time
 import shutil
 import difflib
-import subprocess
+from subprocess import call
 
 import cylc.flags
 from cylc.prompt import prompt
@@ -150,7 +150,7 @@ def main():
         command = ' '.join(command_list)
         try:
             # Block until the editor exits.
-            retcode = subprocess.call(command_list)
+            retcode = call(command_list, stdin=open(os.devnull))
             if retcode != 0:
                 sys.exit(
                     'ERROR, command failed with %d:\n %s' % (retcode, command))

--- a/bin/cylc-validate
+++ b/bin/cylc-validate
@@ -27,7 +27,7 @@ will correspond to the inlined version seen by the parser; use
 
 import sys
 from cylc.remote import remrun
-if remrun().execute():
+if remrun():
     sys.exit(0)
 
 import cylc.flags

--- a/bin/cylc-version
+++ b/bin/cylc-version
@@ -30,7 +30,7 @@ For the cylc version of running a suite daemon see
 import sys
 import os
 from cylc.remote import remrun
-if remrun().execute():
+if remrun():
     sys.exit(0)
 
 import cylc.flags

--- a/bin/cylc-view
+++ b/bin/cylc-view
@@ -33,7 +33,7 @@ See also 'cylc [prep] edit'."""
 
 import sys
 from cylc.remote import remrun
-if remrun().execute(forward_x11=True):
+if remrun(forward_x11=True):
     sys.exit(0)
 
 import os

--- a/bin/cylc-view
+++ b/bin/cylc-view
@@ -39,7 +39,7 @@ if remrun().execute(forward_x11=True):
 import os
 from tempfile import NamedTemporaryFile
 import shlex
-import subprocess
+from subprocess import call
 
 import cylc.flags
 from cylc.cfgspec.globalcfg import GLOBAL_CFG
@@ -154,7 +154,7 @@ def main():
     command_list.append(viewfile.name)
     command = ' '.join(command_list)
     # THIS BLOCKS UNTIL THE COMMAND COMPLETES
-    retcode = subprocess.call(command_list)
+    retcode = call(command_list, open(os.devnull))
     if retcode != 0:
         # the command returned non-zero exist status
         print >> sys.stderr, command, 'failed:', retcode

--- a/lib/cylc/batch_sys_handlers/lsf.py
+++ b/lib/cylc/batch_sys_handlers/lsf.py
@@ -58,12 +58,12 @@ class LSFHandler(object):
         return lines
 
     @classmethod
-    def get_fail_signals(cls, job_conf):
+    def get_fail_signals(cls, _):
         """Return a list of failure signal names to trap."""
         return ["EXIT", "ERR", "XCPU", "TERM", "INT", "SIGUSR2"]
 
     @classmethod
-    def get_submit_stdin(cls, job_file_path, submit_opts):
+    def get_submit_stdin(cls, job_file_path, _):
         """Return proc_stdin_arg, proc_stdin_value."""
         return (open(job_file_path), None)
 

--- a/lib/cylc/batch_sys_handlers/sge.py
+++ b/lib/cylc/batch_sys_handlers/sge.py
@@ -60,7 +60,8 @@ class SGEHandler(object):
                 lines.append("%s%s" % (self.DIRECTIVE_PREFIX, key))
         return lines
 
-    def get_poll_many_cmd(cls, job_ids):
+    @classmethod
+    def get_poll_many_cmd(cls, _):
         """Return poll command"""
         # No way to run POLL_CMD on specific job id(s). List all user's jobs.
         # batch_sys_manager._jobs_poll_batch_sys checks requested id in list.

--- a/lib/cylc/batch_sys_handlers/slurm.py
+++ b/lib/cylc/batch_sys_handlers/slurm.py
@@ -40,7 +40,8 @@ class SLURMHandler(object):
         # non-zero exit code or return blank text.
         return out.strip()
 
-    def format_directives(self, job_conf):
+    @classmethod
+    def format_directives(cls, job_conf):
         """Format the job directives for a job file."""
         job_file_path = re.sub(r'\$HOME/', '', job_conf['job_file_path'])
         directives = job_conf['directives'].__class__()
@@ -58,12 +59,13 @@ class SLURMHandler(object):
         lines = []
         for key, value in directives.items():
             if value:
-                lines.append("%s%s=%s" % (self.DIRECTIVE_PREFIX, key, value))
+                lines.append("%s%s=%s" % (cls.DIRECTIVE_PREFIX, key, value))
             else:
-                lines.append("%s%s" % (self.DIRECTIVE_PREFIX, key))
+                lines.append("%s%s" % (cls.DIRECTIVE_PREFIX, key))
         return lines
 
-    def get_fail_signals(self, job_conf):
+    @staticmethod
+    def get_fail_signals(job_conf):
         """Return a list of failure signal names to trap.
 
         Do not include SIGTERM trapping, as SLURM tries to kill the
@@ -80,6 +82,7 @@ class SLURMHandler(object):
         """
         return ["EXIT", "ERR", "XCPU"]
 
+    @classmethod
     def get_poll_many_cmd(cls, job_ids):
         """Return the poll command for a list of job IDs."""
         return shlex.split(cls.POLL_CMD) + ["-j", ",".join(job_ids)]

--- a/lib/cylc/batch_sys_handlers/slurm.py
+++ b/lib/cylc/batch_sys_handlers/slurm.py
@@ -34,7 +34,7 @@ class SLURMHandler(object):
     SUBMIT_CMD_TMPL = "sbatch '%(job)s'"
 
     @classmethod
-    def filter_poll_output(cls, out, job_id):
+    def filter_poll_output(cls, out, _):
         """Return True if job_id is in the queueing system."""
         # squeue -h -j JOB_ID when JOB_ID has stopped can either exit with
         # non-zero exit code or return blank text.
@@ -65,7 +65,7 @@ class SLURMHandler(object):
         return lines
 
     @staticmethod
-    def get_fail_signals(job_conf):
+    def get_fail_signals(_):
         """Return a list of failure signal names to trap.
 
         Do not include SIGTERM trapping, as SLURM tries to kill the

--- a/lib/cylc/batch_sys_manager.py
+++ b/lib/cylc/batch_sys_manager.py
@@ -389,7 +389,8 @@ class BatchSysManager(object):
                     command = shlex.split(
                         batch_sys.KILL_CMD_TMPL % {"job_id": job_id})
                     try:
-                        proc = Popen(command, stderr=PIPE)
+                        proc = Popen(
+                            command, stdin=open(os.devnull), stderr=PIPE)
                     except OSError as exc:
                         # subprocess.Popen has a bad habit of not setting the
                         # filename of the executable when it raises an OSError.
@@ -517,7 +518,8 @@ class BatchSysManager(object):
                 # Simple poll command that takes a list of job IDs
                 cmd = [batch_sys.POLL_CMD] + exp_ids
             try:
-                proc = Popen(cmd, stderr=PIPE, stdout=PIPE)
+                proc = Popen(
+                    cmd, stdin=open(os.devnull), stderr=PIPE, stdout=PIPE)
             except OSError as exc:
                 # subprocess.Popen has a bad habit of not setting the
                 # filename of the executable when it raises an OSError.
@@ -591,7 +593,7 @@ class BatchSysManager(object):
         # Submit job
         batch_sys = self._get_sys(batch_sys_name)
         proc_stdin_arg = None
-        proc_stdin_value = None
+        proc_stdin_value = open(os.devnull)
         if hasattr(batch_sys, "get_submit_stdin"):
             proc_stdin_arg, proc_stdin_value = batch_sys.get_submit_stdin(
                 job_file_path, submit_opts)

--- a/lib/cylc/c3mro.py
+++ b/lib/cylc/c3mro.py
@@ -98,7 +98,8 @@ class C3(object):
             tree = {}
         self.tree = tree
 
-    def merge(self, seqs, label=None):
+    @staticmethod
+    def merge(seqs, label=None):
         # print '\n\nCPL[%s]=%s' % (seqs[0][0],seqs),
         res = []
         i = 0

--- a/lib/cylc/c3mro.py
+++ b/lib/cylc/c3mro.py
@@ -102,12 +102,10 @@ class C3(object):
     def merge(seqs, label=None):
         # print '\n\nCPL[%s]=%s' % (seqs[0][0],seqs),
         res = []
-        i = 0
-        while 1:
+        while True:
             nonemptyseqs = [seq for seq in seqs if seq]
             if not nonemptyseqs:
                 return res
-            i += 1  # print '\n',i,'round: candidates...',
             for seq in nonemptyseqs:  # find merge candidates among seq heads
                 cand = seq[0]  # print ' ',cand,
                 nothead = [s for s in nonemptyseqs if cand in s[1:]]

--- a/lib/cylc/c3mro.py
+++ b/lib/cylc/c3mro.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from copy import copy
-
 """
 The C3 algorithm is used to linearize multiple inheritance hierarchies
 in Python and other languages (MRO = Method Resolution Order). The code
@@ -91,8 +89,13 @@ print_mro(ex_9.Z)
 """
 
 
+from copy import copy
+
+
 class C3(object):
-    def __init__(self, tree={}):
+    def __init__(self, tree=None):
+        if not tree:
+            tree = {}
         self.tree = tree
 
     def merge(self, seqs, label=None):

--- a/lib/cylc/cfgspec/gcylc.py
+++ b/lib/cylc/cfgspec/gcylc.py
@@ -218,7 +218,7 @@ class gconfig(config):
                 "WARNING: no initial views defined, defaulting to 'text'")
             cfg['initial views'] = ['text']
 
-    def parse_state(self, theme, name, cfglist=[]):
+    def parse_state(self, theme, name, cfglist):
         allowed_keys = ['style', 'color', 'fontcolor']
         cfg = {}
         for item in cfglist:
@@ -245,14 +245,16 @@ class gconfig(config):
             else:
                 target[item] = source[item]
 
-    def dump(self, keys=[], sparse=False, pnative=False, prefix='',
+    def dump(self, keys, sparse=False, pnative=False, prefix='',
              none_str=''):
-        # override parse.config.dump() to restore the list-nature of
-        # theme state items
+        """Override parse.config.dump().
+
+        To restore the list-nature of theme state items.
+        """
         cfg = deepcopy(self.get([], sparse))
         try:
             for theme in cfg['themes'].values():
-                for state in theme.keys():
+                for state in theme:
                     clist = []
                     for attr, val in theme[state].items():
                         clist.append('%s=%s' % (attr, val))

--- a/lib/cylc/cfgspec/gcylc.py
+++ b/lib/cylc/cfgspec/gcylc.py
@@ -218,7 +218,8 @@ class gconfig(config):
                 "WARNING: no initial views defined, defaulting to 'text'")
             cfg['initial views'] = ['text']
 
-    def parse_state(self, theme, name, cfglist):
+    @staticmethod
+    def parse_state(theme, name, cfglist):
         allowed_keys = ['style', 'color', 'fontcolor']
         cfg = {}
         for item in cfglist:

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -534,30 +534,32 @@ class GlobalConfig(config):
             value = cfg['communication']['method']
         return value
 
-    def roll_directory(self, d, name, archlen=0):
-        """
-        Create a directory after rolling back any previous instances of it.
-        e.g. if archlen = 2 we keep: d, d.1, d.2. If 0 keep no old ones.
+    def roll_directory(self, dir_, name, archlen=0):
+        """Create a directory after rolling back any previous instances of it.
+
+        E.g. if archlen = 2 we keep:
+            dir_, dir_.1, dir_.2. If 0 keep no old ones.
         """
         for n in range(archlen, -1, -1):  # archlen...0
             if n > 0:
-                dpath = d + '.' + str(n)
+                dpath = dir_ + '.' + str(n)
             else:
-                dpath = d
+                dpath = dir_
             if os.path.exists(dpath):
                 if n >= archlen:
                     # remove oldest backup
                     shutil.rmtree(dpath)
                 else:
                     # roll others over
-                    os.rename(dpath, d + '.' + str(n + 1))
-        self.create_directory(d, name)
+                    os.rename(dpath, dir_ + '.' + str(n + 1))
+        self.create_directory(dir_, name)
 
-    def create_directory(self, d, name):
+    @staticmethod
+    def create_directory(dir_, name):
         """Create directory. Raise GlobalConfigError on error."""
         try:
-            mkdir_p(d)
-        except Exception, exc:
+            mkdir_p(dir_)
+        except OSError as exc:
             print >> sys.stderr, str(exc)
             raise GlobalConfigError(
                 'Failed to create directory "' + name + '"')

--- a/lib/cylc/cfgspec/gscan.py
+++ b/lib/cylc/cfgspec/gscan.py
@@ -62,13 +62,13 @@ class GScanConfig(config):
         if 'columns' in cfg:
             for column in cfg['columns']:
                 if column not in self.COLS:
-                    print >> sys.stderr, (
-                        "WARNING: illegal column name '%s'" % column)
+                    sys.stderr.write(
+                        "WARNING: illegal column name '%s'\n" % column)
                     cfg['columns'].remove(column)
             if not cfg['columns']:
-                print >> sys.stderr, (
+                sys.stderr.write(
                     'WARNING: at least one column must be specified,' +
-                    ' defaulting to "%s, %s"' % self.COLS_DEFAULT)
+                    ' defaulting to "%s, %s"\n' % self.COLS_DEFAULT)
                 cfg['columns'] = list(self.COLS_DEFAULT)
 
 

--- a/lib/cylc/conditional_simplifier.py
+++ b/lib/cylc/conditional_simplifier.py
@@ -108,10 +108,10 @@ class ConditionalSimplifier(object):
     def nest_by_oper(cls, nest_me, oper):
         """Nest a list based on a specified logical operation"""
         found = False
-        for item in nest_me:
-            if isinstance(item, list):
-                item[:] = cls.nest_by_oper(item, oper)
-            if item == oper:
+        for i in range(len(nest_me)):
+            if isinstance(nest_me[i], list):
+                nest_me[i] = cls.nest_by_oper(nest_me[i], oper)
+            if nest_me[i] == oper:
                 found = i
                 break
         if len(nest_me) <= 3:
@@ -175,9 +175,9 @@ class ConditionalSimplifier(object):
     def flatten_nested_expr(cls, expr):
         """Convert a logical expression in a nested list back to a string"""
         flattened = copy.deepcopy(expr)
-        for i, item in enumerate(flattened):
-            if isinstance(item, list):
-                item[:] = cls.flatten_nested_expr(item)
+        for i in range(len(flattened)):
+            if isinstance(flattened[i], list):
+                flattened[i] = cls.flatten_nested_expr(flattened[i])
         if isinstance(flattened, list):
             flattened = (" ").join(flattened)
         flattened = "(" + flattened

--- a/lib/cylc/conditional_simplifier.py
+++ b/lib/cylc/conditional_simplifier.py
@@ -108,10 +108,10 @@ class ConditionalSimplifier(object):
     def nest_by_oper(cls, nest_me, oper):
         """Nest a list based on a specified logical operation"""
         found = False
-        for i in range(len(nest_me)):
-            if isinstance(nest_me[i], list):
-                nest_me[i] = cls.nest_by_oper(nest_me[i], oper)
-            if nest_me[i] == oper:
+        for item in nest_me:
+            if isinstance(item, list):
+                item[:] = cls.nest_by_oper(item, oper)
+            if item == oper:
                 found = i
                 break
         if len(nest_me) <= 3:
@@ -175,9 +175,9 @@ class ConditionalSimplifier(object):
     def flatten_nested_expr(cls, expr):
         """Convert a logical expression in a nested list back to a string"""
         flattened = copy.deepcopy(expr)
-        for i in range(len(flattened)):
-            if isinstance(flattened[i], list):
-                flattened[i] = cls.flatten_nested_expr(flattened[i])
+        for i, item in enumerate(flattened):
+            if isinstance(item, list):
+                item[:] = cls.flatten_nested_expr(item)
         if isinstance(flattened, list):
             flattened = (" ").join(flattened)
         flattened = "(" + flattened

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -92,7 +92,7 @@ class SuiteConfig(object):
 
     def __init__(self, suite, fpath, template_vars=None,
                  owner=None, run_mode='live', is_validate=False, strict=False,
-                 collapsed=[], cli_initial_point_string=None,
+                 collapsed=None, cli_initial_point_string=None,
                  cli_start_point_string=None, cli_final_point_string=None,
                  is_reload=False, output_fname=None,
                  vis_start_string=None, vis_stop_string=None,
@@ -481,10 +481,12 @@ class SuiteConfig(object):
                     'ERROR [visualization]collapsed families: '
                     '%s is not a first parent' % fam)
 
-        if is_reload:
+        if is_reload and collapsed:
             # on suite reload retain an existing state of collapse
             # (used by the "cylc graph" viewer)
             self.closed_families = collapsed
+        elif is_reload:
+            self.closed_families = []
         else:
             self.closed_families = self.collapsed_families_rc
         for cfam in self.closed_families:

--- a/lib/cylc/cycling/__init__.py
+++ b/lib/cylc/cycling/__init__.py
@@ -314,7 +314,6 @@ class SequenceBase(object):
     Subclasses should provide values for TYPE and TYPE_SORT_KEY.
     They should also provide get_async_expr, get_interval,
     get_offset & set_offset (deprecated), is_on_sequence,
-    _get_point_in_bounds, is_valid, get_prev_point,
     get_nearest_prev_point, get_next_point,
     get_next_point_on_sequence, get_first_point, and
     get_stop_point.
@@ -369,10 +368,6 @@ class SequenceBase(object):
     def is_on_sequence(self, point):
         """Is point on-sequence, disregarding bounds?"""
         pass
-
-    def _get_point_in_bounds(self, point):
-        """Return point, or None if out of bounds."""
-        raise NotImplementedError("Not implemented yet")
 
     @abstractmethod
     def is_valid(self, point):

--- a/lib/cylc/cycling/__init__.py
+++ b/lib/cylc/cycling/__init__.py
@@ -433,7 +433,7 @@ class ExclusionBase(object):
         self.exclusion_end_point = end_point
 
     @abstractmethod
-    def build_exclusions(self):
+    def build_exclusions(self, excl_points):
         """Constructs the set of exclusion sequences or points"""
         pass
 

--- a/lib/cylc/cycling/integer.py
+++ b/lib/cylc/cycling/integer.py
@@ -109,6 +109,8 @@ RECURRENCE_FORMAT_RECS = [
         (r"^%(reps_1)s//%(end)s$", 4)
     ]
 ]
+del regex, format_num
+
 
 REC_RELATIVE_POINT = re.compile("^[-+]P\d+$")
 REC_INTERVAL = re.compile("^[-+]?P\d+$")
@@ -283,6 +285,8 @@ class IntegerSequence(SequenceBase):
         might not be. If computed start and stop points are out of bounds,
         they will be set to None. Context is used only initially to define
         the sequence bounds."""
+        SequenceBase.__init__(
+            self, dep_section, p_context_start, p_context_stop)
 
         # start context always exists
         self.p_context_start = IntegerPoint(p_context_start)
@@ -409,7 +413,7 @@ class IntegerSequence(SequenceBase):
                 int(self.p_context_stop - self.p_start) % int(self.i_step))
             self.p_stop = (
                 self.p_context_stop - self.i_step +
-                IntegerInterval.from_interval(remainder)
+                IntegerInterval.from_integer(remainder)
             )
             # if i_step is None here, points will just be None (out of bounds)
 
@@ -577,7 +581,7 @@ class IntegerSequence(SequenceBase):
                 self.exclusions == other.exclusions
 
 
-def init_from_cfg(cfg):
+def init_from_cfg(_):
     """Placeholder function required by all cycling modules."""
     pass
 

--- a/lib/cylc/cycling/iso8601.py
+++ b/lib/cylc/cycling/iso8601.py
@@ -415,12 +415,12 @@ class ISO8601Sequence(SequenceBase):
         """Deprecated: return the offset used for this sequence."""
         return self.offset
 
-    def set_offset(self, offset):
-        """Deprecated: alter state to offset the entire sequence."""
+    def set_offset(self, i_offset):
+        """Deprecated: alter state to i_offset the entire sequence."""
         if self.recurrence.start_point is not None:
-            self.recurrence.start_point += interval_parse(str(offset))
+            self.recurrence.start_point += interval_parse(str(i_offset))
         if self.recurrence.end_point is not None:
-            self.recurrence.end_point += interval_parse(str(offset))
+            self.recurrence.end_point += interval_parse(str(i_offset))
         self._cached_first_point_values = {}
         self._cached_next_point_values = {}
         self._cached_valid_point_booleans = {}

--- a/lib/cylc/cycling/iso8601.py
+++ b/lib/cylc/cycling/iso8601.py
@@ -722,16 +722,14 @@ def init(num_expanded_year_digits=0, custom_dump_format=None, time_zone=None,
 def get_point_relative(offset_string, base_point):
     """Create a point from offset_string applied to base_point."""
     try:
-        interval = ISO8601Interval(
-            str(interval_parse(offset_string)))
-    except Exception:
-        pass
+        interval = ISO8601Interval(str(interval_parse(offset_string)))
+    except ValueError:
+        return ISO8601Point(str(
+            SuiteSpecifics.abbrev_util.parse_timepoint(
+                offset_string, context_point=_point_parse(base_point.value))
+        ))
     else:
         return base_point + interval
-    return ISO8601Point(str(
-        SuiteSpecifics.abbrev_util.parse_timepoint(
-            offset_string, context_point=_point_parse(base_point.value))
-    ))
 
 
 def interval_parse(interval_string):

--- a/lib/cylc/cycling/iso8601.py
+++ b/lib/cylc/cycling/iso8601.py
@@ -342,6 +342,8 @@ class ISO8601Sequence(SequenceBase):
 
     def __init__(self, dep_section, context_start_point=None,
                  context_end_point=None):
+        SequenceBase.__init__(
+            self, dep_section, context_start_point, context_end_point)
         self.dep_section = dep_section
 
         if context_start_point is None:

--- a/lib/cylc/cylc_xdot.py
+++ b/lib/cylc/cylc_xdot.py
@@ -15,6 +15,11 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Cylc-modified xdot windows for the "cylc graph" command.
+
+TODO - factor more commonality out of MyDotWindow, MyDotWindow2
+"""
+
 
 import gtk
 import os
@@ -28,11 +33,6 @@ from cylc.gui import util
 from cylc.task_id import TaskID
 from cylc.suite_logging import ERR
 
-"""
-Cylc-modified xdot windows for the "cylc graph" command.
-TODO - factor more commonality out of MyDotWindow, MyDotWindow2
-"""
-
 
 def style_ghost_node(node):
     """Apply default style to a ghost node."""
@@ -42,6 +42,10 @@ def style_ghost_node(node):
 
 
 class CylcDotViewerCommon(xdot.DotWindow):
+
+    def __init__(self, *args, **kwargs):
+        xdot.DotWindow.__init__(self, *args, **kwargs)
+        self.suiterc = None
 
     def load_config(self):
         """Load the suite config."""

--- a/lib/cylc/cylc_xdot.py
+++ b/lib/cylc/cylc_xdot.py
@@ -133,17 +133,13 @@ class MyDotWindow2(CylcDotViewerCommon):
         util.setup_icons()
 
         gtk.Window.__init__(self)
-
         self.graph = xdot.Graph()
-
-        window = self
-
-        window.set_title('Cylc Suite Runtime Inheritance Graph Viewer')
-        window.set_default_size(512, 512)
-        window.set_icon(util.get_icon())
+        self.set_title('Cylc Suite Runtime Inheritance Graph Viewer')
+        self.set_default_size(512, 512)
+        self.set_icon(util.get_icon())
 
         vbox = gtk.VBox()
-        window.add(vbox)
+        self.add(vbox)
 
         self.widget = xdot.DotWidget()
 
@@ -152,7 +148,7 @@ class MyDotWindow2(CylcDotViewerCommon):
 
         # Add the accelerator group to the toplevel window
         accelgroup = uimanager.get_accel_group()
-        window.add_accel_group(accelgroup)
+        self.add_accel_group(accelgroup)
 
         # Create an ActionGroup
         actiongroup = gtk.ActionGroup('Actions')

--- a/lib/cylc/envvar.py
+++ b/lib/cylc/envvar.py
@@ -22,14 +22,6 @@ import os
 import re
 
 
-class EnvVarError(Exception):
-    def __init__(self, msg):
-        self.msg = msg
-
-    def __str__(self):
-        return repr(self.msg)
-
-
 def check_varnames(env):
     """ check a bunch of putative environment names for legality,
     returns a list of bad names (empty implies success)."""

--- a/lib/cylc/graph_parser.py
+++ b/lib/cylc/graph_parser.py
@@ -15,13 +15,12 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Module for parsing cylc graph strings."""
 
 import re
 import unittest
 from cylc.param_expand import GraphExpander, ParamExpandError
 from cylc.task_id import TaskID
-
-"""Module for parsing cylc graph strings."""
 
 
 ARROW = '=>'

--- a/lib/cylc/graphing.py
+++ b/lib/cylc/graphing.py
@@ -38,19 +38,6 @@ class CGraphPlain(pygraphviz.AGraph):
             suite_polling_tasks = {}
         self.suite_polling_tasks = suite_polling_tasks
 
-    def node_attr_by_taskname(self, node_string):
-        try:
-            name = TaskID.split(node_string)[0]
-        except ValueError:
-            # Special node?
-            if node_string.startswith("__remove_"):
-                return []
-            raise
-        if name in self.task_attr:
-            return self.task_attr[name]
-        else:
-            return []
-
     def style_edge(self, left, right):
         pass
 
@@ -314,6 +301,19 @@ class CGraph(CGraphPlain):
                     if item not in self.task_attr:
                         self.task_attr[item] = []
                     self.task_attr[item].append(attr)
+
+    def node_attr_by_taskname(self, node_string):
+        try:
+            name = TaskID.split(node_string)[0]
+        except ValueError:
+            # Special node?
+            if node_string.startswith("__remove_"):
+                return []
+            raise
+        if name in self.task_attr:
+            return self.task_attr[name]
+        else:
+            return []
 
     def style_node(self, node_string):
         CGraphPlain.style_node(self, node_string)

--- a/lib/cylc/graphing.py
+++ b/lib/cylc/graphing.py
@@ -28,12 +28,14 @@ from cylc.task_id import TaskID
 class CGraphPlain(pygraphviz.AGraph):
     """Directed Acyclic Graph class for cylc dependency graphs."""
 
-    def __init__(self, title, suite_polling_tasks={}):
+    def __init__(self, title, suite_polling_tasks=None):
         self.title = title
         pygraphviz.AGraph.__init__(self, directed=True, strict=True)
         # graph attributes
         # - label (suite name)
         self.graph_attr['label'] = title
+        if suite_polling_tasks is None:
+            suite_polling_tasks = {}
         self.suite_polling_tasks = suite_polling_tasks
 
     def node_attr_by_taskname(self, node_string):
@@ -275,11 +277,13 @@ class CGraph(CGraphPlain):
     This class automatically adds node and edge attributes
     according to the suite.rc file visualization config."""
 
-    def __init__(self, title, suite_polling_tasks={}, vizconfig={}):
+    def __init__(self, title, suite_polling_tasks=None, vizconfig=None):
 
         # suite.rc visualization config section
-        self.vizconfig = vizconfig
         CGraphPlain.__init__(self, title, suite_polling_tasks)
+        if vizconfig is None:
+            vizconfig = {}
+        self.vizconfig = vizconfig
 
         # graph attributes
         # - default node attributes
@@ -312,7 +316,7 @@ class CGraph(CGraphPlain):
                     self.task_attr[item].append(attr)
 
     def style_node(self, node_string):
-        super(self.__class__, self).style_node(node_string)
+        CGraphPlain.style_node(self, node_string)
         node = self.get_node(node_string)
         node.attr['shape'] = 'ellipse'  # Default shape.
         for item in self.node_attr_by_taskname(node_string):
@@ -323,7 +327,7 @@ class CGraph(CGraphPlain):
         node.attr['penwidth'] = self.vizconfig['node penwidth']
 
     def style_edge(self, left, right):
-        super(self.__class__, self).style_edge(left, right)
+        CGraphPlain.style_edge(self, node_string)
         left_node = self.get_node(left)
         edge = self.get_edge(left, right)
         if self.vizconfig['use node color for edges']:

--- a/lib/cylc/graphing.py
+++ b/lib/cylc/graphing.py
@@ -327,7 +327,7 @@ class CGraph(CGraphPlain):
         node.attr['penwidth'] = self.vizconfig['node penwidth']
 
     def style_edge(self, left, right):
-        CGraphPlain.style_edge(self, node_string)
+        CGraphPlain.style_edge(self, left, right)
         left_node = self.get_node(left)
         edge = self.get_edge(left, right)
         if self.vizconfig['use node color for edges']:

--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -431,7 +431,8 @@ Use *Connect Now* button to reconnect immediately.""")
                 self.reconnect_interval_widget.set_text,
                 " (next connect: %s) " % next_update_dt_str)
 
-    def _set_tooltip(self, widget, text):
+    @staticmethod
+    def _set_tooltip(widget, text):
         tooltip = gtk.Tooltips()
         tooltip.enable()
         tooltip.set_tip(widget, text)
@@ -1268,7 +1269,8 @@ been defined for this suite""").inform()
             self._popup_logview(task_id, task_state_summary, choice)
         return False
 
-    def connect_right_click_sub_menu(self, is_graph_view, item, x, y, z):
+    @staticmethod
+    def connect_right_click_sub_menu(is_graph_view, item, x, y, z):
         """Handle right-clicks in sub-menus."""
         if is_graph_view:
             item.connect('button-release-event', x, y, z)
@@ -1284,10 +1286,10 @@ been defined for this suite""").inform()
         # connect_right_click_sub_menu should be used in preference to
         # item.connect to handle this
 
-        if type(task_is_family) is bool:
+        if isinstance(task_is_family, bool):
             task_is_family = [task_is_family] * len(task_ids)
-        if (type(task_ids) is not list or type(t_states) is not list or
-                type(task_is_family) is not list):
+        if any(not isinstance(item, list)
+               for item in (task_ids, t_states, task_is_family)):
             return False
 
         # Consistency check.
@@ -1567,7 +1569,8 @@ been defined for this suite""").inform()
         if not self.info_bar.prog_bar_active():
             self.info_bar.prog_bar.hide()
 
-    def update_tb(self, tb, line, tags=None):
+    @staticmethod
+    def update_tb(tb, line, tags=None):
         """Update a text view buffer."""
         if tags:
             tb.insert_with_tags(tb.get_end_iter(), line, *tags)
@@ -1666,7 +1669,7 @@ shown here in the state they were in at the time of triggering.''')
 
     def hold_task(self, b, task_ids, stop=True):
         """Hold or release a task."""
-        if type(task_ids) is not list:
+        if not isinstance(task_ids, list):
             task_ids = [task_ids]
 
         if stop:
@@ -1682,7 +1685,7 @@ shown here in the state they were in at the time of triggering.''')
 
     def trigger_task_now(self, b, task_ids):
         """Trigger task via the suite daemon's command interface."""
-        if type(task_ids) is not list:
+        if not isinstance(task_ids, list):
             task_ids = [task_ids]
 
         for task_id in task_ids:
@@ -1700,7 +1703,7 @@ shown here in the state they were in at the time of triggering.''')
 
     def poll_task(self, b, task_ids):
         """Poll a task/family."""
-        if type(task_ids) is not list:
+        if not isinstance(task_ids, list):
             task_ids = [task_ids]
 
         for task_id in task_ids:
@@ -1710,7 +1713,7 @@ shown here in the state they were in at the time of triggering.''')
 
     def kill_task(self, b, task_ids):
         """Kill a task/family."""
-        if type(task_ids) is not list:
+        if not isinstance(task_ids, list):
             task_ids = [task_ids]
 
         for task_id in task_ids:
@@ -1721,7 +1724,7 @@ shown here in the state they were in at the time of triggering.''')
 
     def spawn_task(self, b, task_ids):
         """For tasks to spawn their successors."""
-        if type(task_ids) is not list:
+        if not isinstance(task_ids, list):
             task_ids = [task_ids]
 
         for task_id in task_ids:
@@ -1731,7 +1734,7 @@ shown here in the state they were in at the time of triggering.''')
 
     def reset_task_state(self, b, e, task_ids, state):
         """Reset the state of a task/family."""
-        if type(task_ids) is not list:
+        if not isinstance(task_ids, list):
             task_ids = [task_ids]
 
         for task_id in task_ids:
@@ -1905,7 +1908,8 @@ shown here in the state they were in at the time of triggering.''')
         window.add(vbox)
         window.show_all()
 
-    def stop_method(self, b, meth, st_box, sc_box, tt_box):
+    @staticmethod
+    def stop_method(b, meth, st_box, sc_box, tt_box):
         """Determine the suite stop method."""
         for ch in (
                 st_box.get_children() +
@@ -1922,13 +1926,15 @@ shown here in the state they were in at the time of triggering.''')
             for ch in tt_box.get_children():
                 ch.set_sensitive(True)
 
-    def hold_cb_toggled(self, b, box):
+    @staticmethod
+    def hold_cb_toggled(b, box):
         if b.get_active():
             box.set_sensitive(False)
         else:
             box.set_sensitive(True)
 
-    def startup_method(self, b, meth, ic_box, is_box):
+    @staticmethod
+    def startup_method(b, meth, ic_box, is_box):
         """Determine the suite start-up method."""
         if meth in ['cold', 'warm']:
             for ch in ic_box.get_children():
@@ -2338,7 +2344,8 @@ shown here in the state they were in at the time of triggering.''')
                     continue
         return ret
 
-    def _sort_key_func(self, log_path):
+    @staticmethod
+    def _sort_key_func(log_path):
         """Sort key for a task job log path."""
         head, submit_num, base = log_path.rsplit("/", 2)
         try:
@@ -2347,7 +2354,8 @@ shown here in the state they were in at the time of triggering.''')
             pass
         return (submit_num, base, head)
 
-    def _set_tooltip(self, widget, tip_text):
+    @staticmethod
+    def _set_tooltip(widget, tip_text):
         """Set a tool-tip text."""
         tooltip = gtk.Tooltips()
         tooltip.enable()

--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -76,7 +76,9 @@ from cylc.task_state_prop import get_status_prop
 
 def run_get_stdout(command, filter_=False):
     try:
-        popen = Popen(command, shell=True, stderr=PIPE, stdout=PIPE)
+        popen = Popen(
+            command,
+            shell=True, stdin=open(os.devnull), stderr=PIPE, stdout=PIPE)
         out = popen.stdout.read()
         err = popen.stderr.read()
         res = popen.wait()
@@ -1189,7 +1191,7 @@ been defined for this suite""").inform()
         print command
 
         try:
-            Popen([command], shell=True)
+            Popen([command], shell=True, stdin=open(os.devnull))
         except OSError:
             warning_dialog('Error: failed to start ' + self.cfg.suite,
                            self.window).warn()
@@ -2992,15 +2994,18 @@ This is what my suite does:..."""
         cat_menu.append(cylc_help_item)
         cylc_help_item.connect('activate', self.command_help)
 
-        cout = Popen(["cylc", "categories"], stdout=PIPE).communicate()[0]
+        cout = Popen(
+            ["cylc", "categories"],
+            stdin=open(os.devnull), stdout=PIPE).communicate()[0]
         categories = cout.rstrip().split()
         for category in categories:
             foo_item = gtk.MenuItem(category)
             cat_menu.append(foo_item)
             com_menu = gtk.Menu()
             foo_item.set_submenu(com_menu)
-            proc = Popen(["cylc-help", "category=" + category], stdout=PIPE)
-            cout = proc.communicate()[0]
+            cout = Popen(
+                ["cylc-help", "category=" + category],
+                stdin=open(os.devnull), stdout=PIPE).communicate()[0]
             commands = cout.rstrip().split()
             for command in commands:
                 bar_item = gtk.MenuItem(command)
@@ -3106,16 +3111,16 @@ This is what my suite does:..."""
         if n_states % PER_ROW:
             n_rows += 1
         dotm = DotMaker(self.theme, size=self.dot_size)
-        for row in range(0, n_rows):
+        for row in range(n_rows):
             subbox = gtk.HBox(homogeneous=True)
             self.state_filter_box.pack_start(subbox)
-            for i in range(0, PER_ROW):
+            for i in range(PER_ROW):
                 ebox = gtk.EventBox()
                 box = gtk.HBox()
                 ebox.add(box)
                 try:
                     st = self.legal_task_states[row * PER_ROW + i]
-                except Exception:
+                except IndexError:
                     pass
                 else:
                     icon = dotm.get_image(st)

--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -37,9 +37,10 @@ from cylc.gui.warning_dialog import warning_dialog, info_dialog
 try:
     from cylc.gui.view_graph import ControlGraph
     from cylc.gui.graph import graph_suite_popup
-except ImportError, x:
+except ImportError as exc:
     # pygraphviz not installed
-    warning_dialog("WARNING: graph view disabled\n" + str(x)).warn()
+    warning_dialog("WARNING: graph view disabled\n%s" % exc).warn()
+    del exc
     graphing_disabled = True
 else:
     graphing_disabled = False
@@ -156,6 +157,7 @@ Class to hold initialisation data.
         )
         self.imagedir = get_image_dir()
         self.my_uuid = uuid4()
+        self.logdir = None
 
     def reset(self, suite, auth=None):
         self.suite = suite

--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -58,7 +58,7 @@ from cylc.task_id import TaskID
 from cylc.task_state_prop import extract_group_state
 from cylc.version import CYLC_VERSION
 from cylc.gui.option_group import controlled_option_group
-from cylc.gui.color_rotator import rotator
+from cylc.gui.color_rotator import ColorRotator
 from cylc.gui.cylc_logviewer import cylc_logviewer
 from cylc.gui.gcapture import gcapture_tmpfile
 from cylc.suite_srv_files_mgr import SuiteSrvFilesManager
@@ -542,7 +542,7 @@ Main Control GUI that displays one or more views or interfaces to the suite.
         self.quitters = []
         self.gcapture_windows = []
 
-        self.log_colors = rotator()
+        self.log_colors = ColorRotator()
         hcolor = gcfg.get(['task filter highlight color'])
         try:
             self.filter_highlight_color = gtk.gdk.color_parse(hcolor)

--- a/lib/cylc/gui/cat_state.py
+++ b/lib/cylc/gui/cat_state.py
@@ -39,7 +39,9 @@ def cat_state(suite, host=None, owner=None):
         stderr = PIPE
     cmd.append(suite)
     try:
-        proc = Popen(cmd, stderr=stderr, stdout=PIPE, preexec_fn=os.setpgrp)
+        proc = Popen(
+            cmd, stdin=open(os.devnull), stderr=stderr, stdout=PIPE,
+            preexec_fn=os.setpgrp)
     except OSError:
         return []
     else:

--- a/lib/cylc/gui/cat_state.py
+++ b/lib/cylc/gui/cat_state.py
@@ -45,7 +45,7 @@ def cat_state(suite, host=None, owner=None):
     except OSError:
         return []
     else:
-        out, err = proc.communicate()
+        out = proc.communicate()[0]
         if proc.wait():  # non-zero return code
             return []
         return out.splitlines()

--- a/lib/cylc/gui/color_rotator.py
+++ b/lib/cylc/gui/color_rotator.py
@@ -17,8 +17,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-class rotator(object):
-    def __init__(self, colors=['#fcc', '#cfc', '#bbf', '#ffb']):
+class ColorRotator(object):
+
+    COLORS = ('#fcc', '#cfc', '#bbf', '#ffb')
+
+    def __init__(self, colors=COLORS):
         self.colors = colors
         self.current_color = 0
 

--- a/lib/cylc/gui/dbchooser.py
+++ b/lib/cylc/gui/dbchooser.py
@@ -247,7 +247,8 @@ class db_updater(threading.Thread):
         else:
             return (fg_, bg_, bg_)
 
-    def search_level(self, model, iter_, func, data):
+    @staticmethod
+    def search_level(model, iter_, func, data):
         while iter_:
             if func(model, iter_, data):
                 return iter_
@@ -265,7 +266,8 @@ class db_updater(threading.Thread):
             iter_ = model.iter_next(iter_)
         return None
 
-    def match_func(self, model, iter_, data):
+    @staticmethod
+    def match_func(model, iter_, data):
         column, key = data
         value = model.get_value(iter_, column)
         return value == key

--- a/lib/cylc/gui/gcapture.py
+++ b/lib/cylc/gui/gcapture.py
@@ -23,7 +23,7 @@ import pango
 import tempfile
 from warning_dialog import warning_dialog, info_dialog
 from util import get_icon
-import subprocess
+from subprocess import Popen, STDOUT
 
 # unit test: see the command $CYLC_DIR/bin/gcapture
 
@@ -141,9 +141,9 @@ are displayed in red.
     def run(self):
         proc = None
         if not self.ignore_command:
-            proc = subprocess.Popen(
-                self.command, stdout=self.stdout, stderr=subprocess.STDOUT,
-                shell=True)
+            proc = Popen(
+                self.command, stdin=open(os.devnull), stdout=self.stdout,
+                stderr=STDOUT, shell=True)
             self.proc = proc
             gobject.timeout_add(40, self.pulse_proc_progress)
         self.stdout_updater = Tailer(

--- a/lib/cylc/gui/gcapture.py
+++ b/lib/cylc/gui/gcapture.py
@@ -16,14 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from cylc.gui.tailer import Tailer
-import gtk
 import gobject
+import gtk
+import os
 import pango
-import tempfile
-from warning_dialog import warning_dialog, info_dialog
-from util import get_icon
 from subprocess import Popen, STDOUT
+import tempfile
+
+from cylc.gui.tailer import Tailer
+from cylc.gui.util import get_icon
+from cylc.gui.warning_dialog import warning_dialog, info_dialog
 
 # unit test: see the command $CYLC_DIR/bin/gcapture
 
@@ -45,6 +47,8 @@ are displayed in red.
         self.command = command
         self.ignore_command = ignore_command
         self.stdout = stdoutfile
+        self.stdout_updater = None
+        self.proc = None
         self.window = gtk.Window(gtk.WINDOW_TOPLEVEL)
         self.window.set_border_width(5)
         if title is None:

--- a/lib/cylc/gui/gpanel.py
+++ b/lib/cylc/gui/gpanel.py
@@ -154,7 +154,7 @@ class ScanPanelAppletUpdater(object):
 
     def set_hosts(self, new_hosts):
         del self.hosts[:]
-        self.hosts.extend(gethostbyname_ex(host)[0] for host in new_hosts)
+        self.hosts.extend(new_hosts)
         self.update_now()
 
     def start(self):

--- a/lib/cylc/gui/gpanel.py
+++ b/lib/cylc/gui/gpanel.py
@@ -17,7 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import re
 from subprocess import Popen, STDOUT
 import sys
 from time import time
@@ -27,7 +26,6 @@ import gtk
 import gobject
 import warnings
 
-from cylc.cfgspec.globalcfg import GLOBAL_CFG
 from cylc.cfgspec.gcylc import gcfg
 from cylc.cfgspec.gscan import gsfg
 import cylc.flags
@@ -350,13 +348,12 @@ class ScanPanelAppletUpdater(object):
         return True
 
     def _set_exception_hook(self):
-        # Handle an uncaught exception.
-        old_hook = sys.excepthook
-        sys.excepthook = (lambda *a:
-                          self._handle_exception(*a, old_hook=old_hook))
+        """Handle an uncaught exception."""
+        sys.excepthook = lambda e_type, e_value, e_traceback: (
+            self._handle_exception(
+                e_type, e_value, e_traceback, sys.excepthook))
 
-    def _handle_exception(self, e_type, e_value, e_traceback,
-                          old_hook=None):
+    def _handle_exception(self, e_type, e_value, e_traceback, old_hook):
         self.gcylc_image.set_from_stock(gtk.STOCK_DIALOG_ERROR,
                                         gtk.ICON_SIZE_MENU)
         exc_lines = traceback.format_exception(e_type, e_value, e_traceback)

--- a/lib/cylc/gui/gpanel.py
+++ b/lib/cylc/gui/gpanel.py
@@ -71,7 +71,8 @@ class ScanPanelApplet(object):
         """Return the topmost widget for embedding in the panel."""
         return self.top_hbox
 
-    def stop(self, widget):
+    @staticmethod
+    def stop(_):
         """Handle a stop."""
         sys.exit()
 
@@ -80,7 +81,8 @@ class ScanPanelApplet(object):
             self.updater.launch_context_menu(event)
             return False
 
-    def _set_tooltip(self, widget, text):
+    @staticmethod
+    def _set_tooltip(widget, text):
         tooltip = gtk.Tooltips()
         tooltip.enable()
         tooltip.set_tip(widget, text)
@@ -343,7 +345,8 @@ class ScanPanelAppletUpdater(object):
     def _on_button_press_event_gscan(self, widget, event):
         self.launch_gscan()
 
-    def _on_img_tooltip_query(self, widget, x, y, kbd, tooltip, tip_widget):
+    @staticmethod
+    def _on_img_tooltip_query(widget, x, y, kbd, tooltip, tip_widget):
         tooltip.set_custom(tip_widget)
         return True
 

--- a/lib/cylc/gui/gpanel.py
+++ b/lib/cylc/gui/gpanel.py
@@ -335,7 +335,7 @@ class ScanPanelAppletUpdater(object):
             command = ["cylc", "gscan"]
         if self.hosts:
             command += self.hosts
-        Popen(command, stdout=stdout, stderr=stderr)
+        Popen(command, stdin=open(os.devnull), stdout=stdout, stderr=stderr)
 
     def _on_button_press_event(self, widget, event):
         if event.button == 1:

--- a/lib/cylc/gui/graph.py
+++ b/lib/cylc/gui/graph.py
@@ -28,8 +28,8 @@ def graph_suite_popup(reg, cmd_help, defstartc, defstopc, graph_opts,
     """Popup a dialog to allow a user to configure their suite graphing."""
     try:
         import xdot
-    except Exception, x:
-        warning_dialog(str(x) + "\nGraphing disabled.", parent_window).warn()
+    except ImportError as exc:
+        warning_dialog(str(exc) + "\nGraphing disabled.", parent_window).warn()
         return False
 
     window = gtk.Window()

--- a/lib/cylc/gui/graph.py
+++ b/lib/cylc/gui/graph.py
@@ -18,8 +18,8 @@
 
 import gtk
 
-from gcapture import gcapture_tmpfile
-from warning_dialog import warning_dialog
+from cylc.gui.gcapture import gcapture_tmpfile
+from cylc.gui.warning_dialog import warning_dialog
 
 
 def graph_suite_popup(reg, cmd_help, defstartc, defstopc, graph_opts,

--- a/lib/cylc/gui/gscan.py
+++ b/lib/cylc/gui/gscan.py
@@ -188,8 +188,10 @@ class ScanApp(object):
         self.updater.start()
 
         self.dot_size = gcfg.get(['dot icon size'])
+        self.dots = None
         self._set_dots()
 
+        self.menu_bar = None
         self.create_menubar()
 
         accelgroup = gtk.AccelGroup()
@@ -198,6 +200,7 @@ class ScanApp(object):
         accelgroup.connect_group(
             key, modifier, gtk.ACCEL_VISIBLE, self._toggle_hide_menu_bar)
 
+        self.tool_bar = None
         self.create_tool_bar()
 
         self.menu_hbox = gtk.HBox()

--- a/lib/cylc/gui/logviewer.py
+++ b/lib/cylc/gui/logviewer.py
@@ -34,6 +34,11 @@ class logviewer(object):
         self.find_current_iter = None
         self.search_warning_done = False
 
+        self.freeze_button = None
+        self.log_label = None
+        self.logview = None
+        self.hbox = None
+        self.vbox = None
         self.create_gui_panel()
         self.logview.get_buffer()
 

--- a/lib/cylc/gui/tailer.py
+++ b/lib/cylc/gui/tailer.py
@@ -96,7 +96,8 @@ class Tailer(threading.Thread):
         command += shlex.split(cmd_tmpl % {"filename": filename})
         try:
             self.proc = Popen(
-                command, stdout=PIPE, stderr=STDOUT, preexec_fn=os.setpgrp)
+                command, stdin=open(os.devnull), stdout=PIPE, stderr=STDOUT,
+                preexec_fn=os.setpgrp)
         except OSError as exc:
             # E.g. ssh command not found
             dialog = warning_dialog("%s: %s" % (

--- a/lib/cylc/gui/updater_dot.py
+++ b/lib/cylc/gui/updater_dot.py
@@ -84,7 +84,8 @@ class DotUpdater(threading.Thread):
         dotm = DotMaker(theme, size=dot_size)
         self.dots = dotm.get_dots()
 
-    def _set_tooltip(self, widget, tip_text):
+    @staticmethod
+    def _set_tooltip(widget, tip_text):
         tip = gtk.Tooltips()
         tip.enable()
         tip.set_tip(widget, tip_text)

--- a/lib/cylc/gui/updater_graph.py
+++ b/lib/cylc/gui/updater_graph.py
@@ -22,6 +22,7 @@ import os
 import re
 import threading
 from time import sleep
+import traceback
 
 from cylc.cfgspec.globalcfg import GLOBAL_CFG
 import cylc.flags

--- a/lib/cylc/gui/updater_tree.py
+++ b/lib/cylc/gui/updater_tree.py
@@ -108,7 +108,8 @@ class TreeUpdater(threading.Thread):
         self.updater.no_update_event.clear()
         return True
 
-    def search_level(self, model, iter_, func, data):
+    @staticmethod
+    def search_level(model, iter_, func, data):
         while iter_:
             if func(model, iter_, data):
                 return iter_
@@ -126,7 +127,8 @@ class TreeUpdater(threading.Thread):
             iter_ = model.iter_next(iter_)
         return None
 
-    def match_func(self, model, iter_, data):
+    @staticmethod
+    def match_func(model, iter_, data):
         column, key = data
         value = model.get_value(iter_, column)
         return value == key
@@ -589,7 +591,8 @@ class TreeUpdater(threading.Thread):
         iter_ = model.append(parent_iter, data)
         return iter_
 
-    def _get_row_id(self, model, rpath):
+    @staticmethod
+    def _get_row_id(model, rpath):
         """Record a row's first two values."""
         riter = model.get_iter(rpath)
         point_string = model.get_value(riter, 0)

--- a/lib/cylc/gui/updater_tree.py
+++ b/lib/cylc/gui/updater_tree.py
@@ -50,6 +50,7 @@ class TreeUpdater(threading.Thread):
         self.ancestors = {}
         self.descendants = []
         self.fam_state_summary = {}
+        self.state_summary = {}
         self._prev_id_named_paths = {}
         self._prev_data = {}
         self._prev_fam_data = {}

--- a/lib/cylc/gui/util.py
+++ b/lib/cylc/gui/util.py
@@ -199,7 +199,7 @@ def set_exception_hook_dialog(program_name=None):
     old_hook = sys.excepthook
     sys.excepthook = lambda e_type, e_value, e_traceback: (
         _launch_exception_hook_dialog(
-            e_type, e_value, e_traceback, sys.excepthook, program_name)
+            e_type, e_value, e_traceback, sys.excepthook, program_name))
 
 
 def setup_icons():

--- a/lib/cylc/gui/util.py
+++ b/lib/cylc/gui/util.py
@@ -178,7 +178,7 @@ def get_logo():
 
 
 def _launch_exception_hook_dialog(e_type, e_value, e_traceback,
-                                  old_hook=None, program_name=None):
+                                  old_hook, program_name):
     if program_name is None:
         program_name = "This program"
     exc_lines = traceback.format_exception(e_type, e_value, e_traceback)
@@ -197,8 +197,9 @@ def _launch_exception_hook_dialog(e_type, e_value, e_traceback,
 def set_exception_hook_dialog(program_name=None):
     """Set a custom uncaught exception hook for launching an error dialog."""
     old_hook = sys.excepthook
-    sys.excepthook = lambda *a: _launch_exception_hook_dialog(
-        *a, old_hook=old_hook, program_name=program_name)
+    sys.excepthook = lambda e_type, e_value, e_traceback: (
+        _launch_exception_hook_dialog(
+            e_type, e_value, e_traceback, sys.excepthook, program_name)
 
 
 def setup_icons():

--- a/lib/cylc/gui/view_dot.py
+++ b/lib/cylc/gui/view_dot.py
@@ -38,6 +38,13 @@ LED suite control interface.
         self.log_colors = log_colors
         self.insert_task_popup = insert_task_popup
 
+        self.t = None
+        self.defn_order_menu_item = None
+        self.headings_menu_item = None
+        self.transpose_menu_item = None
+        self.transpose_toolbutton = None
+        self.group_menu_item = None
+        self.group_toolbutton = None
         self.gcapture_windows = []
 
     def get_control_widgets(self):
@@ -209,7 +216,6 @@ LED suite control interface.
 
     def on_popup_quit(self, b, lv, w):
         lv.quit()
-        self.quitters.remove(lv)
         w.destroy()
 
     def refresh(self):

--- a/lib/cylc/gui/view_dot.py
+++ b/lib/cylc/gui/view_dot.py
@@ -216,8 +216,9 @@ LED suite control interface.
         self.t.update()
         self.t.action_required = True
 
-    def _set_tooltip(self, widget, tip_text):
-        # Convenience function to add hover over text to a widget.
+    @staticmethod
+    def _set_tooltip(widget, tip_text):
+        """Convenience function to add hover over text to a widget."""
         tip = gtk.Tooltips()
         tip.enable()
         tip.set_tip(widget, tip_text)

--- a/lib/cylc/gui/view_graph.py
+++ b/lib/cylc/gui/view_graph.py
@@ -228,11 +228,11 @@ Dependency graph suite control interface.
 
     def rearrange(self, col, n):
         cols = self.ttreeview.get_columns()
-        for i_n in range(len(cols)):
+        for i_n, col in enumerate(cols):
             if i_n == n:
-                cols[i_n].set_sort_indicator(True)
+                col.set_sort_indicator(True)
             else:
-                cols[i_n].set_sort_indicator(False)
+                col.set_sort_indicator(False)
         # col is cols[n]
         if col.get_sort_order() == gtk.SORT_ASCENDING:
             col.set_sort_order(gtk.SORT_DESCENDING)
@@ -295,7 +295,8 @@ Dependency graph suite control interface.
 
         return items
 
-    def _set_tooltip(self, widget, tip_text):
+    @staticmethod
+    def _set_tooltip(widget, tip_text):
         tip = gtk.Tooltips()
         tip.enable()
         tip.set_tip(widget, tip_text)

--- a/lib/cylc/gui/view_graph.py
+++ b/lib/cylc/gui/view_graph.py
@@ -19,8 +19,8 @@
 import re
 import gtk
 import gobject
-from updater_graph import GraphUpdater
 
+from cylc.gui.updater_graph import GraphUpdater
 from cylc.cylc_xdot import xdot_widgets
 from cylc.task_id import TaskID
 
@@ -45,6 +45,9 @@ Dependency graph suite control interface.
         self.get_right_click_menu = get_right_click_menu
         self.log_colors = log_colors
         self.insert_task_popup = insert_task_popup
+
+        self.t = None
+        self.menu_subgraphs_item = None
 
         self.gcapture_windows = []
 
@@ -225,20 +228,6 @@ Dependency graph suite control interface.
             self.t.group = []
         self.t.action_required = True
         self.t.best_fit = True
-
-    def rearrange(self, col, n):
-        cols = self.ttreeview.get_columns()
-        for i_n, col in enumerate(cols):
-            if i_n == n:
-                col.set_sort_indicator(True)
-            else:
-                col.set_sort_indicator(False)
-        # col is cols[n]
-        if col.get_sort_order() == gtk.SORT_ASCENDING:
-            col.set_sort_order(gtk.SORT_DESCENDING)
-        else:
-            col.set_sort_order(gtk.SORT_ASCENDING)
-        self.ttreestore.set_sort_column_id(n, col.get_sort_order())
 
     def refresh(self):
         self.t.update()
@@ -568,28 +557,3 @@ Dependency graph suite control interface.
 #        return
 #        self.t.best_fit = True
 #        self.t.action_required = True
-
-
-class StandaloneControlGraphApp(ControlGraph):
-    # For a ControlApp not launched by the gcylc main app:
-    # 1/ call gobject.threads_init() on startup
-    # 2/ call gtk.main_quit() on exit
-
-    def __init__(self, suite, owner, host, port):
-        gobject.threads_init()
-        ControlGraph.__init__(self, suite, owner, host, port)
-
-    def quit_gcapture(self):
-        for gwindow in self.gcapture_windows:
-            if not gwindow.quit_already:
-                gwindow.quit(None, None)
-
-    def delete_event(self, widget, event, data=None):
-        self.quit_gcapture()
-        ControlGraph.delete_event(self, widget, event, data)
-        gtk.main_quit()
-
-    def click_exit(self, foo):
-        self.quit_gcapture()
-        ControlGraph.click_exit(self, foo)
-        gtk.main_quit()

--- a/lib/cylc/gui/view_tree.py
+++ b/lib/cylc/gui/view_tree.py
@@ -18,9 +18,11 @@
 
 import gtk
 import gobject
-from updater_tree import TreeUpdater
-from cylc.task_id import TaskID
+
 from isodatetime.parsers import DurationParser
+
+from cylc.gui.updater_tree import TreeUpdater
+from cylc.task_id import TaskID
 
 
 class ControlTree(object):
@@ -46,6 +48,14 @@ class ControlTree(object):
         self.gcapture_windows = []
 
         self.ttree_paths = {}  # Cache dict of tree paths & states, names.
+        self.group_toolbutton = None
+        self.group_menu_item = None
+        self.tmodelfilter = None
+        self.t = None
+        self.sort_col_num = None
+        self.tmodelsort = None
+        self.ttreeview = None
+        self.ttreestore = None
 
     def get_control_widgets(self):
         main_box = gtk.VBox()
@@ -266,7 +276,6 @@ class ControlTree(object):
 
     def on_popup_quit(self, b, lv, w):
         lv.quit()
-        self.quitters.remove(lv)
         w.destroy()
 
     def refresh(self):
@@ -361,27 +370,6 @@ class ControlTree(object):
         items.append(self.group_toolbutton)
 
         return items
-
-
-class StandaloneControlTreeApp(ControlTree):
-    def __init__(self, suite, owner, host, port):
-        gobject.threads_init()
-        ControlTree.__init__(self, suite, owner, host, port)
-
-    def quit_gcapture(self):
-        for gwindow in self.gcapture_windows:
-            if not gwindow.quit_already:
-                gwindow.quit(None, None)
-
-    def delete_event(self, widget, event, data=None):
-        self.quit_gcapture()
-        ControlTree.delete_event(self, widget, event, data)
-        gtk.main_quit()
-
-    def click_exit(self, foo):
-        self.quit_gcapture()
-        ControlTree.click_exit(self, foo)
-        gtk.main_quit()
 
 
 class TreeViewTaskExtractor(object):

--- a/lib/cylc/gui/view_tree.py
+++ b/lib/cylc/gui/view_tree.py
@@ -287,7 +287,8 @@ class ControlTree(object):
         self.group_menu_item.connect('toggled', self.toggle_grouping)
         return items
 
-    def _set_tooltip(self, widget, tip_text):
+    @staticmethod
+    def _set_tooltip(widget, tip_text):
         """Convenience function to add hover over text to a widget."""
         tip = gtk.Tooltips()
         tip.enable()
@@ -412,7 +413,8 @@ class TreeViewTaskExtractor(object):
                     model.get_value(_iter, 1)))
         return ret
 
-    def _make_tree_from_rows(self, rows):
+    @staticmethod
+    def _make_tree_from_rows(rows):
         """Convert list of rows to a tree.
         Rows are denoted with the entry 'node' which holds the value
         (row1, row2)."""
@@ -443,7 +445,7 @@ class TreeViewTaskExtractor(object):
         its items."""
         ret = []
         for item in tree_list:
-            if type(item) is list:
+            if isinstance(item, list):
                 ret.extend(self._flatten_list(item))
             else:
                 ret.append(item)

--- a/lib/cylc/gui/warning_dialog.py
+++ b/lib/cylc/gui/warning_dialog.py
@@ -17,7 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import gtk
-from util import get_icon
+
+from cylc.gui.util import get_icon
 
 
 class warning_dialog(object):

--- a/lib/cylc/job_file.py
+++ b/lib/cylc/job_file.py
@@ -77,7 +77,9 @@ class JobFileWriter(object):
             raise exc
         # check syntax
         try:
-            proc = Popen([job_conf['shell'], '-n', tmp_name], stderr=PIPE)
+            proc = Popen(
+                [job_conf['shell'], '-n', tmp_name],
+                stderr=PIPE, stdin=open(os.devnull))
         except OSError as exc:
             # Popen has a bad habit of not telling you anything if it fails
             # to run the executable.

--- a/lib/cylc/log_diagnosis.py
+++ b/lib/cylc/log_diagnosis.py
@@ -7,6 +7,7 @@ from difflib import unified_diff
 
 class LogAnalyserError(Exception):
     def __init__(self, msg):
+        Exception.__init__(self, msg)
         self.msg = msg
 
     def __str__(self):

--- a/lib/cylc/log_diagnosis.py
+++ b/lib/cylc/log_diagnosis.py
@@ -106,7 +106,7 @@ class LogAnalyser(object):
 
         if new != ref:
             diff = unified_diff(new, ref)
-            print >> sys.stderr, '\n'.join(diff)
+            sys.stderr.write('\n'.join(diff) + '\n')
             raise LogAnalyserError(
                 "ERROR: triggering is NOT consistent with the reference log")
         else:

--- a/lib/cylc/mp_pool.py
+++ b/lib/cylc/mp_pool.py
@@ -58,7 +58,6 @@ def _run_command(ctx):
         return ctx
 
     try:
-        stdin_file = open(os.devnull)
         if ctx.cmd_kwargs.get('stdin_file_paths'):
             stdin_file = TemporaryFile()
             for file_path in ctx.cmd_kwargs['stdin_file_paths']:
@@ -67,6 +66,8 @@ def _run_command(ctx):
             stdin_file.seek(0)
         elif ctx.cmd_kwargs.get('stdin_str'):
             stdin_file = PIPE
+        else:
+            stdin_file = open(os.devnull)
         proc = Popen(
             ctx.cmd, stdin=stdin_file, stdout=PIPE, stderr=PIPE,
             env=ctx.cmd_kwargs.get('env'), shell=ctx.cmd_kwargs.get('shell'))

--- a/lib/cylc/mp_pool.py
+++ b/lib/cylc/mp_pool.py
@@ -31,6 +31,7 @@ Some notes:
 
 import logging
 import multiprocessing
+import os
 from pipes import quote
 from subprocess import Popen, PIPE
 import sys
@@ -57,7 +58,7 @@ def _run_command(ctx):
         return ctx
 
     try:
-        stdin_file = None
+        stdin_file = open(os.devnull)
         if ctx.cmd_kwargs.get('stdin_file_paths'):
             stdin_file = TemporaryFile()
             for file_path in ctx.cmd_kwargs['stdin_file_paths']:

--- a/lib/cylc/network/httpclient.py
+++ b/lib/cylc/network/httpclient.py
@@ -143,7 +143,7 @@ class SuiteRuntimeServiceClient(object):
         self.timeout = timeout
         self.my_uuid = my_uuid or uuid4()
         if print_uuid:
-            print >> sys.stderr, '%s' % self.my_uuid
+            sys.stderr.write('%s\n' % self.my_uuid)
 
         self.prog_name = os.path.basename(sys.argv[0])
         self.auth = auth

--- a/lib/cylc/network/httpclient.py
+++ b/lib/cylc/network/httpclient.py
@@ -384,8 +384,9 @@ class SuiteRuntimeServiceClient(object):
         import json
         import urllib2
         import ssl
-        if hasattr(ssl, '_create_unverified_context'):
-            ssl._create_default_https_context = ssl._create_unverified_context
+        unverified_context = getattr(ssl, '_create_unverified_context', None)
+        if unverified_context is not None:
+            ssl._create_default_https_context = unverified_context
 
         comms_protocol = url.split(':', 1)[0]  # Can use urlparse?
         username, password = self._get_auth(comms_protocol)[0:2]

--- a/lib/cylc/network/httpserver.py
+++ b/lib/cylc/network/httpserver.py
@@ -35,7 +35,7 @@ from cylc.exceptions import CylcError
 import cylc.flags
 from cylc.network import (
     NO_PASSPHRASE, PRIVILEGE_LEVELS, PRIV_IDENTITY, PRIV_DESCRIPTION,
-    PRIV_STATE_TOTALS, PRIV_FULL_READ, PRIV_SHUTDOWN, PRIV_FULL_CONTROL)
+    PRIV_FULL_READ, PRIV_SHUTDOWN, PRIV_FULL_CONTROL)
 from cylc.hostuserutil import get_host
 from cylc.suite_logging import ERR, LOG
 from cylc.suite_srv_files_mgr import (

--- a/lib/cylc/network/httpserver.py
+++ b/lib/cylc/network/httpserver.py
@@ -53,6 +53,8 @@ class HTTPServer(object):
     def __init__(self, suite):
         # Suite only needed for back-compat with old clients (see below):
         self.suite = suite
+        self.engine = None
+        self.port = None
 
         # Figure out the ports we are allowed to use.
         base_port = GLOBAL_CFG.get(['communication', 'base port'])

--- a/lib/cylc/option_parsers.py
+++ b/lib/cylc/option_parsers.py
@@ -247,17 +247,18 @@ Arguments:"""
                     "Set initial cycle point. "
                     "Required if not defined in suite.rc."))
 
-    def parse_args(self, remove_opts=[]):
+    def parse_args(self, remove_opts=None):
         """Parse options and arguments, overrides OptionParser.parse_args."""
         if self.auto_add:
             # Add common options after command-specific options.
             self.add_std_options()
 
-        for opt in remove_opts:
-            try:
-                self.remove_option(opt)
-            except ValueError:
-                pass
+        if remove_opts:
+            for opt in remove_opts:
+                try:
+                    self.remove_option(opt)
+                except ValueError:
+                    pass
 
         (options, args) = OptionParser.parse_args(self)
 

--- a/lib/cylc/prerequisite.py
+++ b/lib/cylc/prerequisite.py
@@ -18,7 +18,6 @@
 
 """Functionality for expressing and evaluating logical triggers."""
 
-from ast import literal_eval
 import math
 
 from cylc.conditional_simplifier import ConditionalSimplifier
@@ -184,7 +183,7 @@ class Prerequisite(object):
 
         """
         try:
-            res = literal_eval(self.conditional_expression)
+            res = eval(self.conditional_expression)
         except (SyntaxError, ValueError) as exc:
             err_msg = str(exc)
             if str(exc).find("unexpected EOF") != -1:

--- a/lib/cylc/prerequisite.py
+++ b/lib/cylc/prerequisite.py
@@ -18,6 +18,7 @@
 
 """Functionality for expressing and evaluating logical triggers."""
 
+from ast import literal_eval
 import math
 
 from cylc.conditional_simplifier import ConditionalSimplifier
@@ -183,8 +184,8 @@ class Prerequisite(object):
 
         """
         try:
-            res = eval(self.conditional_expression)
-        except Exception, exc:
+            res = literal_eval(self.conditional_expression)
+        except (SyntaxError, ValueError) as exc:
             err_msg = str(exc)
             if str(exc).find("unexpected EOF") != -1:
                 err_msg += ("\n(?could be unmatched parentheses in the graph "

--- a/lib/cylc/profiler.py
+++ b/lib/cylc/profiler.py
@@ -56,6 +56,8 @@ class Profiler(object):
         """Print a message to standard out with the current memory usage."""
         if not self.enabled:
             return
-        proc = Popen(["ps", "h", "-orss", str(os.getpid())], stdout=PIPE)
+        proc = Popen(
+            ["ps", "h", "-orss", str(os.getpid())],
+            stdin=open(os.devnull), stdout=PIPE)
         memory = int(proc.communicate()[0])
         print "PROFILE: Memory: %d KiB: %s" % (memory, message)

--- a/lib/cylc/profiling/__init__.py
+++ b/lib/cylc/profiling/__init__.py
@@ -25,8 +25,9 @@ from .git import is_git_repo
 
 def get_cylc_directory():
     """Returns the location of cylc's working copy."""
-    ver_str, _ = Popen(['cylc', 'version', '--long'], stdout=PIPE
-                       ).communicate()
+    ver_str, _ = Popen(
+        ['cylc', 'version', '--long'],
+        stdout=PIPE, stdin=open(os.devnull)).communicate()
     try:
         return os.path.realpath(re.search('\((.*)\)', ver_str).groups()[0])
     except IndexError:

--- a/lib/cylc/profiling/analysis.py
+++ b/lib/cylc/profiling/analysis.py
@@ -334,7 +334,7 @@ def print_table(table, transpose=False):
             if col_no != 0:
                 sys.stdout.write('  ')
             cell = table[row_no][col_no]
-            if type(cell) is list:
+            if isinstance(cell, list):
                 sys.stdout.write('-' * col_widths[col_no])
             else:
                 sys.stdout.write(cell + ' ' * (col_widths[col_no] - len(cell)))

--- a/lib/cylc/profiling/git.py
+++ b/lib/cylc/profiling/git.py
@@ -16,7 +16,7 @@
 """Provides python wrappers to certain git commands."""
 
 import os
-from subprocess import (Popen, PIPE, CalledProcessError, check_call)
+from subprocess import Popen, PIPE, CalledProcessError, check_call
 
 
 class GitCheckoutError(Exception):
@@ -30,7 +30,9 @@ def describe(ref=None):
         cmd = ['git', 'describe']
         if ref:
             cmd.append(ref)
-        return Popen(cmd, stdout=PIPE).communicate()[0].strip()
+        return Popen(
+            cmd,
+            stdin=open(os.devnull), stdout=PIPE).communicate()[0].strip()
     except CalledProcessError:
         return None
 
@@ -38,8 +40,9 @@ def describe(ref=None):
 def is_ancestor_commit(commit1, commit2):
     """Returns True if commit1 is an ancestor of commit2."""
     try:
-        ancestor = Popen(['git', 'merge-base', commit1, commit2],
-                         stdout=PIPE).communicate()[0].strip()
+        ancestor = Popen(
+            ['git', 'merge-base', commit1, commit2],
+            stdin=open(os.devnull), stdout=PIPE).communicate()[0].strip()
         return ancestor == commit1
     except CalledProcessError:
         return False
@@ -50,14 +53,15 @@ def checkout(branch, delete_pyc=False):
     try:
         cmd = ['git', 'checkout', '-q', branch]
         print '$ ' + ' '.join(cmd)
-        check_call(cmd)
+        check_call(cmd, stdin=open(os.devnull))
     except CalledProcessError:
         raise GitCheckoutError()
     try:
         if delete_pyc:
             cmd = ['find', 'lib', '-name', r'\*.pyc', '-delete']
             print '$ ' + ' '.join(cmd)
-            check_call(cmd, stdout=open(os.devnull, 'wb'))
+            check_call(
+                cmd, stdin=open(os.devnull), stdout=open(os.devnull, 'wb'))
     except CalledProcessError:
         pass
 

--- a/lib/cylc/profiling/profile.py
+++ b/lib/cylc/profiling/profile.py
@@ -35,9 +35,9 @@ from .git import (checkout, describe, GitCheckoutError,)
 
 def cylc_env(cylc_conf_path=''):
     """Provide an environment for executing cylc commands in."""
-    cylc_env = os.environ.copy()
-    cylc_env['CYLC_CONF_PATH'] = cylc_conf_path
-    return cylc_env
+    env = os.environ.copy()
+    env['CYLC_CONF_PATH'] = cylc_conf_path
+    return env
 
 
 CLEAN_ENV = cylc_env()

--- a/lib/cylc/remote.py
+++ b/lib/cylc/remote.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""Run command on a remote host."""
+"""Run command on a remote, (i.e. a remote [user@]host)."""
 
 import os
 from posix import WIFSIGNALED
@@ -28,7 +28,12 @@ from textwrap import TextWrapper
 import cylc.flags
 
 
-class remrun(object):
+def remrun(env=None, path=None, dry_run=False, forward_x11=False):
+    """Short for RemoteRunner().execute(...)"""
+    return RemoteRunner().execute(env, path, dry_run, forward_x11)
+
+
+class RemoteRunner(object):
     """Run current command on a remote host.
 
     If owner or host differ from username and localhost, strip the
@@ -70,8 +75,7 @@ class remrun(object):
             from cylc.hostuserutil import is_remote
             self.is_remote = is_remote(self.host, self.owner)
 
-    def execute(self, force_required=False, env=None, path=None,
-                dry_run=False, forward_x11=False):
+    def execute(self, env=None, path=None, dry_run=False, forward_x11=False):
         """Execute command on remote host.
 
         Returns False if remote re-invocation is not needed, True if it is

--- a/lib/cylc/remote.py
+++ b/lib/cylc/remote.py
@@ -21,7 +21,7 @@ import os
 from posix import WIFSIGNALED
 from pipes import quote
 import shlex
-import subprocess
+from subprocess import Popen
 import sys
 from textwrap import TextWrapper
 
@@ -146,7 +146,7 @@ class remrun(object):
             return command
 
         try:
-            popen = subprocess.Popen(command)
+            popen = Popen(command)
         except OSError as exc:
             sys.exit("ERROR: remote command invocation failed %s" % str(exc))
 

--- a/lib/cylc/run_get_stdout.py
+++ b/lib/cylc/run_get_stdout.py
@@ -18,7 +18,7 @@
 """Provide a utility function to get STDOUT from a shell command."""
 
 
-from os import killpg, setpgrp
+from os import devnull, killpg, setpgrp
 from signal import SIGTERM
 from subprocess import Popen, PIPE
 from time import sleep, time
@@ -45,7 +45,8 @@ def run_get_stdout(command, timeout=None, poll_delay=None):
     """
     try:
         popen = Popen(
-            command, shell=True, preexec_fn=setpgrp, stderr=PIPE, stdout=PIPE)
+            command, shell=True, preexec_fn=setpgrp, stdin=open(devnull),
+            stderr=PIPE, stdout=PIPE)
         is_killed_after_timeout = False
         if timeout:
             if poll_delay is None:

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -201,6 +201,11 @@ class Scheduler(object):
         # Last 10 durations (in seconds) of the main loop
         self.main_loop_intervals = deque(maxlen=10)
 
+        self.can_auto_stop = True
+        self.previous_profile_point = 0
+        self.count = 0
+        self.time_next_fs_check = None
+
     def start(self):
         """Start the server."""
         self._start_print_blurb()

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -908,7 +908,8 @@ conditions; see `cylc conditions`.
         # Get "pid,args" process string with "ps"
         pid_str = str(os.getpid())
         proc = Popen(
-            ["ps", "h", "-opid,args", pid_str], stdout=PIPE, stderr=PIPE)
+            ["ps", "h", "-opid,args", pid_str],
+            stdin=open(os.devnull), stdout=PIPE, stderr=PIPE)
         out, err = proc.communicate()
         ret_code = proc.wait()
         process_str = None
@@ -1289,7 +1290,8 @@ conditions; see `cylc conditions`.
             try:
                 contact_data = self.suite_srv_files_mgr.load_contact_file(
                     self.suite)
-                assert contact_data == self.contact_data
+                if contact_data != self.contact_data:
+                    raise AssertionError()
             except (AssertionError, IOError, ValueError,
                     SuiteServiceFileError):
                 ERR.critical(traceback.format_exc())
@@ -1684,7 +1686,9 @@ conditions; see `cylc conditions`.
 
     def _update_cpu_usage(self):
         """Obtain CPU usage statistics."""
-        proc = Popen(["ps", "-o%cpu= ", str(os.getpid())], stdout=PIPE)
+        proc = Popen(
+            ["ps", "-o%cpu= ", str(os.getpid())],
+            stdin=open(os.devnull), stdout=PIPE)
         try:
             cpu_frac = float(proc.communicate()[0])
         except (TypeError, OSError, IOError, ValueError) as exc:

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -286,8 +286,8 @@ conditions; see `cylc conditions`.
         logo_lines = logo.splitlines()
         license_lines = cylc_license.splitlines()
         lmax = max(len(line) for line in license_lines)
-        for i in range(len(logo_lines)):
-            print logo_lines[i], ('{0: ^%s}' % lmax).format(license_lines[i])
+        for i, logo_line in enumerate(logo_lines):
+            print logo_line, ('{0: ^%s}' % lmax).format(license_lines[i])
 
     def configure(self):
         """Configure suite daemon."""

--- a/lib/cylc/suite_db_mgr.py
+++ b/lib/cylc/suite_db_mgr.py
@@ -426,7 +426,7 @@ class SuiteDatabaseManager(object):
             pri_dao.upgrade_with_state_file(old_state_file_path)
             target = os.path.join(suite_run_d, "state.tar.gz")
             cmd = ["tar", "-C", suite_run_d, "-czf", target, "state"]
-            if call(cmd) == 0:
+            if call(cmd, stdin=open(os.devnull)) == 0:
                 rmtree(os.path.join(suite_run_d, "state"), ignore_errors=True)
             else:
                 try:

--- a/lib/cylc/suite_events.py
+++ b/lib/cylc/suite_events.py
@@ -172,7 +172,8 @@ class SuiteEventHandler(object):
                 self.proc_pool.put_command(
                     proc_ctx, self._run_event_handlers_callback)
 
-    def _run_event_handlers_callback(self, proc_ctx, abort_on_error=False):
+    @staticmethod
+    def _run_event_handlers_callback(proc_ctx, abort_on_error=False):
         """Callback on completion of a suite event handler."""
         if proc_ctx.ret_code:
             msg = '%s EVENT HANDLER FAILED' % proc_ctx.cmd_key[1]

--- a/lib/cylc/suite_logging.py
+++ b/lib/cylc/suite_logging.py
@@ -383,7 +383,7 @@ class SuiteLog(object):
             if cylc.flags.debug:
                 log_logger_level = logging.DEBUG
             elif cylc.flags.verbose:
-                log_logger_level = logging.VERBOSE
+                log_logger_level = logging.DEBUG
             else:
                 log_logger_level = logging.INFO
         # --- Create the 'log' logger. ---

--- a/lib/cylc/suite_srv_files_mgr.py
+++ b/lib/cylc/suite_srv_files_mgr.py
@@ -142,7 +142,7 @@ class SuiteSrvFilesManager(object):
             cmd = shlex.split(ssh_str) + ["-n", old_host] + cmd
         from subprocess import Popen, PIPE
         from time import sleep, time
-        proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
+        proc = Popen(cmd, stdin=open(os.devnull), stdout=PIPE, stderr=PIPE)
         # Terminate command after 10 seconds to prevent hanging SSH, etc.
         timeout = time() + 10.0
         while proc.poll() is None:
@@ -650,7 +650,8 @@ To start a new run, stop the old one first with one or more of these:
         command += ['-n', owner + '@' + host, script]
         from subprocess import Popen, PIPE
         try:
-            proc = Popen(command, stdout=PIPE, stderr=PIPE)
+            proc = Popen(
+                command, stdin=open(os.devnull), stdout=PIPE, stderr=PIPE)
         except OSError:
             if cylc.flags.debug:
                 import traceback

--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -108,7 +108,7 @@ class TaskEventsManager(object):
     def __init__(self, suite, proc_pool, suite_db_mgr, broadcast_mgr=None):
         self.suite = suite
         self.suite_url = None
-        self.suite_cfg = []
+        self.suite_cfg = {}
         self.proc_pool = proc_pool
         self.suite_db_mgr = suite_db_mgr
         if broadcast_mgr is None:

--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -54,9 +54,7 @@ from cylc.task_outputs import (
     TASK_OUTPUT_SUBMITTED, TASK_OUTPUT_STARTED, TASK_OUTPUT_SUCCEEDED,
     TASK_OUTPUT_FAILED)
 from cylc.wallclock import (
-    get_current_time_string,
-    get_unix_time_from_time_string,
-    RE_DATE_TIME_FORMAT_EXTENDED)
+    get_current_time_string, RE_DATE_TIME_FORMAT_EXTENDED)
 
 
 CustomTaskEventHandlerContext = namedtuple(

--- a/lib/cylc/task_job_mgr.py
+++ b/lib/cylc/task_job_mgr.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from cylc.suite_srv_files_mgr import SuiteServiceFileError
 
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
 # Copyright (C) 2008-2017 NIWA
@@ -49,6 +48,7 @@ from cylc.mkdir_p import mkdir_p
 from cylc.mp_pool import SuiteProcPool, SuiteProcContext
 from cylc.hostuserutil import is_remote, is_remote_host, is_remote_user
 from cylc.suite_logging import LOG
+from cylc.suite_srv_files_mgr import SuiteServiceFileError
 from cylc.task_events_mgr import TaskEventsManager
 from cylc.task_message import TaskMessage
 from cylc.task_outputs import (

--- a/lib/cylc/task_message.py
+++ b/lib/cylc/task_message.py
@@ -202,7 +202,7 @@ class TaskMessage(object):
         # otherwise drop through to local messaging.
         # Note: do not sys.exit(0) here as the commands do, it
         # will cause messaging failures on the remote host.
-        remrun().execute(env=env, path=[path])
+        remrun(env=env, path=[path])
 
     def _update_job_status_file(self, messages):
         """Write messages to job status file."""

--- a/lib/cylc/task_outputs.py
+++ b/lib/cylc/task_outputs.py
@@ -57,7 +57,7 @@ class TaskOutputs(object):
     # Memory optimization - constrain possible attributes to this list.
     __slots__ = ["_by_message", "_by_trigger"]
 
-    def __init__(self, tdef, point):
+    def __init__(self, tdef):
         self._by_message = {}
         self._by_trigger = {}
         for trigger, message in tdef.outputs:

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -37,9 +37,7 @@ from time import time
 import traceback
 
 from cylc.config import SuiteConfigError
-from cylc.cycling.loader import (
-    get_interval, get_interval_cls, get_point, ISO8601_CYCLING_TYPE,
-    standardise_point_string)
+from cylc.cycling.loader import get_point, standardise_point_string
 import cylc.flags
 from cylc.suite_logging import ERR, LOG
 from cylc.task_action_timer import TaskActionTimer

--- a/lib/cylc/task_state.py
+++ b/lib/cylc/task_state.py
@@ -189,7 +189,7 @@ class TaskState(object):
             self.external_triggers[ext] = False
 
         # Message outputs.
-        self.outputs = TaskOutputs(tdef, point)
+        self.outputs = TaskOutputs(tdef)
 
         # Standard outputs.
         self.outputs.add(TASK_OUTPUT_SUBMITTED)

--- a/lib/cylc/task_trigger.py
+++ b/lib/cylc/task_trigger.py
@@ -190,7 +190,7 @@ class Dependency(object):
             if isinstance(item, TaskTrigger):
                 ret.append(Prerequisite.MESSAGE_TEMPLATE % (
                     item.task_name, item.get_point(point), item.output))
-            elif type(item) is list:
+            elif isinstance(item, list):
                 ret.extend(['('] + cls._stringify_list(item, point) + [')'])
             else:
                 ret.append(item)

--- a/lib/isodatetime/data.py
+++ b/lib/isodatetime/data.py
@@ -205,7 +205,7 @@ class TimeRecurrence(object):
             self.format_number = 3
             if self.repetitions is not None:
                 point = self.start_point
-                for i in range(self.repetitions - 1):
+                for _ in range(self.repetitions - 1):
                     point += self.duration
                 self.end_point = point
         elif self.start_point is None:
@@ -213,7 +213,7 @@ class TimeRecurrence(object):
             self.format_number = 4
             if self.repetitions is not None:
                 point = self.end_point
-                for i in range(self.repetitions - 1):
+                for _ in range(self.repetitions - 1):
                     point -= self.duration
                 self.start_point = point
         else:
@@ -1343,7 +1343,6 @@ class TimePoint(object):
             other.set_time_zone(self.get_time_zone())
             my_year, my_day_of_year = self.get_ordinal_date()
             other_year, other_day_of_year = other.get_ordinal_date()
-            diff_year = my_year - other_year
             diff_day = my_day_of_year - other_day_of_year
             if my_year > other_year:
                 diff_day += get_days_in_year_range(other_year, my_year - 1)
@@ -1390,7 +1389,7 @@ class TimePoint(object):
             if self.get_is_week_date():
                 was_week_date = True
             self.to_calendar_date()
-        for i in range(abs(num_months)):
+        for _ in range(abs(num_months)):
             if num_months > 0:
                 self.month_of_year += 1
                 if self.month_of_year > CALENDAR.MONTHS_IN_YEAR:

--- a/lib/isodatetime/dumpers.py
+++ b/lib/isodatetime/dumpers.py
@@ -78,7 +78,7 @@ class TimePointDumper(object):
                  "date"),
                 (parser_spec.get_time_translate_info(), "time"),
                 (parser_spec.get_time_zone_translate_info(), "time_zone")]:
-            for regex, regex_sub, format_sub, prop_name in info:
+            for regex, _, format_sub, prop_name in info:
                 rec = re.compile(regex)
                 self._rec_formats[key].append((rec, format_sub, prop_name))
 
@@ -218,9 +218,9 @@ class TimePointDumper(object):
         if not hasattr(self, "_timepoint_parser"):
             self._timepoint_parser = parsers.TimePointParser()
         try:
-            (expr, info) = (
-                self._timepoint_parser.get_time_zone_info(time_zone_string))
-        except parsers.ISO8601SyntaxError as e:
+            info = self._timepoint_parser.get_time_zone_info(
+                time_zone_string)[1]
+        except parsers.ISO8601SyntaxError:
             return None
         info = self._timepoint_parser.process_time_zone_info(info)
         if info.get('time_zone_utc'):

--- a/lib/isodatetime/parsers.py
+++ b/lib/isodatetime/parsers.py
@@ -194,7 +194,8 @@ class TimePointParser(object):
                 self._time_zone_regex_map[format_type].append(
                     [re.compile(time_zone_regex), time_zone_expr])
 
-    def get_expressions(self, text):
+    @staticmethod
+    def get_expressions(text):
         """Yield valid expressions from text."""
         for line in text.splitlines():
             line_text = line.strip()
@@ -221,7 +222,8 @@ class TimePointParser(object):
         expression = "^" + expression + "$"
         return expression
 
-    def parse_time_zone_expression_to_regex(self, expression):
+    @staticmethod
+    def parse_time_zone_expression_to_regex(expression):
         """Construct regular expressions for the time zone."""
         for expr_regex, substitute, _, name in (
                 parser_spec.get_time_zone_translate_info()):

--- a/lib/isodatetime/parsers.py
+++ b/lib/isodatetime/parsers.py
@@ -21,7 +21,6 @@
 import re
 
 from . import data
-from . import dumpers
 from . import parser_spec
 from . import timezone
 
@@ -206,7 +205,7 @@ class TimePointParser(object):
 
     def parse_date_expression_to_regex(self, expression):
         """Construct regular expressions for the date."""
-        for expr_regex, substitute, format_, name in (
+        for expr_regex, substitute, _, name in (
                 parser_spec.get_date_translate_info(
                     self.expanded_year_digits)):
             expression = re.sub(expr_regex, substitute, expression)
@@ -216,7 +215,7 @@ class TimePointParser(object):
     @staticmethod
     def parse_time_expression_to_regex(expression):
         """Construct regular expressions for the time."""
-        for expr_regex, substitute, format_, name in (
+        for expr_regex, substitute, _, name in (
                 parser_spec.get_time_translate_info()):
             expression = re.sub(expr_regex, substitute, expression)
         expression = "^" + expression + "$"
@@ -224,7 +223,7 @@ class TimePointParser(object):
 
     def parse_time_zone_expression_to_regex(self, expression):
         """Construct regular expressions for the time zone."""
-        for expr_regex, substitute, format_, name in (
+        for expr_regex, substitute, _, name in (
                 parser_spec.get_time_zone_translate_info()):
             expression = re.sub(expr_regex, substitute, expression)
         expression = "^" + expression + "$"
@@ -323,8 +322,7 @@ class TimePointParser(object):
         regex = "^"
         for item in split_format:
             if parser_spec.REC_STRFTIME_DIRECTIVE_TOKEN.search(item):
-                item_regex, item_properties = (
-                    parser_spec.translate_strptime_token(item))
+                item_regex = parser_spec.translate_strptime_token(item)[0]
                 regex += item_regex
             else:
                 regex += re.escape(item)
@@ -350,12 +348,12 @@ class TimePointParser(object):
                 translator = data.PARSE_PROPERTY_TRANSLATORS[property_]
                 info.update(translator(value))
         date_info_keys = []
-        for expr_regex, substitute, format_, name in (
+        for expr_regex, substitute, _, name in (
                 parser_spec.get_date_translate_info(
                     self.expanded_year_digits)):
             date_info_keys.append(name)
         time_info_keys = []
-        for expr_regex, substitute, format_, name in (
+        for expr_regex, substitute, _, name in (
                 parser_spec.get_time_translate_info()):
             time_info_keys.append(name)
         date_info = {}

--- a/lib/isodatetime/tests.py
+++ b/lib/isodatetime/tests.py
@@ -975,7 +975,8 @@ class TestSuite(unittest.TestCase):
             str(data.Duration(days=7) + data.Duration(weeks=1)),
             "P14D")
 
-    def test_timepoint(self):
+    @staticmethod
+    def test_timepoint():
         """Test the time point data model (takes a while)."""
         pool = multiprocessing.Pool(processes=4)
         pool.map_async(test_timepoint_at_year, range(1801, 2403)).get()
@@ -1033,34 +1034,34 @@ class TestSuite(unittest.TestCase):
 
                 test_dates[3].set_time_zone(
                     data.TimeZone(hours=8, minutes=30))
-                for i in range(len(test_dates)):
-                    i_date_str = str(test_dates[i])
-                    date_no_tz = test_dates[i].copy()
+                for date1 in list(test_dates):
+                    date1_str = str(date1)
+                    date_no_tz = date1.copy()
                     date_no_tz.time_zone = data.TimeZone(hours=0, minutes=0)
 
                     # TODO: https://github.com/metomi/isodatetime/issues/34.
-                    if (test_dates[i].time_zone.hours >= 0 or
-                            test_dates[i].time_zone.minutes >= 0):
-                        utc_offset = date_no_tz - test_dates[i]
+                    if (date1.time_zone.hours >= 0 or
+                            date1.time_zone.minutes >= 0):
+                        utc_offset = date_no_tz - date1
                     else:
-                        utc_offset = (test_dates[i] - date_no_tz) * -1
+                        utc_offset = (date1 - date_no_tz) * -1
 
                     self.assertEqual(utc_offset.hours,
-                                     test_dates[i].time_zone.hours,
-                                     i_date_str + " utc offset (hrs)")
+                                     date1.time_zone.hours,
+                                     date1_str + " utc offset (hrs)")
                     self.assertEqual(utc_offset.minutes,
-                                     test_dates[i].time_zone.minutes,
-                                     i_date_str + " utc offset (mins)")
-                    for j in range(len(test_dates)):
-                        j_date_str = str(test_dates[j])
+                                     date1.time_zone.minutes,
+                                     date1_str + " utc offset (mins)")
+                    for date2 in list(test_dates):
+                        date2_str = str(date2)
                         self.assertEqual(
-                            test_dates[i], test_dates[j],
-                            i_date_str + " == " + j_date_str
+                            date1, date2,
+                            date1_str + " == " + date2_str
                         )
-                        duration = test_dates[j] - test_dates[i]
+                        duration = date2 - date1
                         self.assertEqual(
                             duration, data.Duration(days=0),
-                            i_date_str + " - " + j_date_str
+                            date1_str + " - " + date2_str
                         )
 
     def test_timepoint_dumper(self):

--- a/lib/isodatetime/tests.py
+++ b/lib/isodatetime/tests.py
@@ -1369,7 +1369,8 @@ class TestSuite(unittest.TestCase):
 
 def assert_equal(data1, data2):
     """A function-level equivalent of the unittest method."""
-    assert data1 == data2
+    if data1 != data2:
+        raise AssertionError()
 
 
 def test_timepoint_at_year(test_year):

--- a/lib/isodatetime/tests.py
+++ b/lib/isodatetime/tests.py
@@ -872,7 +872,7 @@ def get_timerecurrenceparser_tests():
         for point_expr in test_points:
             duration_tests = get_timedurationparser_tests()
             start_point = point_parser.parse(point_expr)
-            for duration_expr, duration_result in duration_tests:
+            for duration_expr, _ in duration_tests:
                 if duration_expr.startswith("-P"):
                     # Our negative durations are not supported in recurrences.
                     continue
@@ -1293,7 +1293,7 @@ class TestSuite(unittest.TestCase):
                         expression
                     )
                 test_results = []
-                for i, time_point in enumerate(test_recurrence):
+                for time_point in test_recurrence:
                     test_results.append(str(time_point))
                 self.assertEqual(test_results, ctrl_results,
                                  expression + "(%s)" % calendar_mode)

--- a/lib/parsec/example/cfgspec.py
+++ b/lib/parsec/example/cfgspec.py
@@ -15,12 +15,10 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Legal items and validators for the parsec test config file."""
 
 from parsec.validate import validator as vdr
 
-"""
-Legal items and validators for the parsec test config file.
-"""
 
 SPEC = {
         'title' : vdr( vtype="string" ),

--- a/lib/parsec/include.py
+++ b/lib/parsec/include.py
@@ -53,7 +53,7 @@ flist = []
 include_re = re.compile('\s*%include\s+([\'"]?)(.*?)([\'"]?)\s*$')
 
 
-def inline(lines, dir_, filename, for_grep=False, for_edit=False, viewcfg={},
+def inline(lines, dir_, filename, for_grep=False, for_edit=False, viewcfg=None,
            level=None):
     """Recursive inlining of parsec include-files"""
 
@@ -70,6 +70,8 @@ def inline(lines, dir_, filename, for_grep=False, for_edit=False, viewcfg={},
         mark = viewcfg['mark']
         single = viewcfg['single']
         label = viewcfg['label']
+    else:
+        viewcfg = {}
 
     global done
     global modtimes

--- a/lib/parsec/jinja2support.py
+++ b/lib/parsec/jinja2support.py
@@ -44,6 +44,7 @@ def assert_helper(logical, message):
 def jinja2process(flines, dir_, template_vars=None):
     """Pass configure file through Jinja2 processor."""
     env = Environment(
+        autoescape=True,
         loader=FileSystemLoader(dir_),
         undefined=StrictUndefined,
         extensions=['jinja2.ext.do'])

--- a/lib/parsec/jinja2support.py
+++ b/lib/parsec/jinja2support.py
@@ -44,7 +44,6 @@ def assert_helper(logical, message):
 def jinja2process(flines, dir_, template_vars=None):
     """Pass configure file through Jinja2 processor."""
     env = Environment(
-        autoescape=True,
         loader=FileSystemLoader(dir_),
         undefined=StrictUndefined,
         extensions=['jinja2.ext.do'])

--- a/lib/parsec/tests/getcfg/bin/one-line.py
+++ b/lib/parsec/tests/getcfg/bin/one-line.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Check that single-line config print works""" 
+"""Check that single-line config print works"""
 
 import os, sys
 

--- a/lib/parsec/tests/getcfg/bin/one-line.py
+++ b/lib/parsec/tests/getcfg/bin/one-line.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+"""Check that single-line config print works""" 
 
 import os, sys
 
@@ -6,9 +7,6 @@ fpath = os.path.dirname(os.path.abspath(__file__))
 # parsec
 sys.path.append( fpath + '/../../..' )
 
-"""
-Check that single-line config print works
-""" 
 
 from parsec.config import config
 from parsec.validate import validator as vdr

--- a/lib/parsec/tests/nullcfg/bin/empty.py
+++ b/lib/parsec/tests/nullcfg/bin/empty.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+"""
+An empty config file should successfully yield an empty sparse config dict.
+"""
+
 
 import os, sys
 
@@ -6,9 +10,6 @@ fpath = os.path.dirname(os.path.abspath(__file__))
 # parsec
 sys.path.append(fpath + '/../../..')
 
-"""
-An empty config file should successfully yield an empty sparse config dict.
-"""
 
 from parsec.config import config
 from parsec.validate import validator as vdr

--- a/lib/parsec/tests/synonyms/lib/python/cfgspec.py
+++ b/lib/parsec/tests/synonyms/lib/python/cfgspec.py
@@ -21,11 +21,11 @@ from parsec.validate import validator as vdr
 SPEC = {
         'boolean' : {
             '__MANY__' : { '__MANY__' : vdr( vtype="boolean" ) },
-            }, 
-        'integer' : { 
+            },
+        'integer' : {
             '__MANY__' : { '__MANY__' : vdr( vtype="integer" ) },
             },
-        'float'   : { 
+        'float'   : {
             '__MANY__' : { '__MANY__' : vdr( vtype="float"   ) },
             },
         'string'  : {

--- a/lib/parsec/upgrade.py
+++ b/lib/parsec/upgrade.py
@@ -99,7 +99,7 @@ class upgrader(object):
         if '__MANY__' not in upg['old']:
             return [upg]
         if upg['old'].count('__MANY__') > 1:
-            print >> sys.stderr, upg['old']
+            sys.stderr.write('%s\n' % upg['old'])
             raise UpgradeError("Multiple simultaneous __MANY__ not supported")
         exp_upgs = []
         pre = []
@@ -181,12 +181,12 @@ class upgrader(object):
                         if upg['cvt'].describe() != "DELETED (OBSOLETE)":
                             self.put_item(upg['new'], upg['cvt'].convert(old))
         if do_warn and cylc.flags.verbose:
-            print >> sys.stderr, (
-                "WARNING: deprecated items were automatically upgraded in '" +
-                self.descr + "':")
+            sys.stderr.write(
+                'WARNING: deprecated items were automatically upgraded in' +
+                " '%s':\n" % self.descr)
             for vn, msgs in warnings.items():
                 for m in msgs:
-                    print >> sys.stderr, " * (" + vn + ")", m
+                    sys.stderr.write(' * (%s) %s\n' % (vn, m))
 
 
 if __name__ == "__main__":
@@ -214,7 +214,7 @@ if __name__ == "__main__":
     x2 = converter(lambda x: 2 * x, 'value x 2')
 
     printcfg(cfg)
-    print
+    sys.stdout.write('\n')
 
     upg = upgrader(cfg, 'test file')
     # successive upgrades are incremental - at least until I think of a
@@ -233,5 +233,5 @@ if __name__ == "__main__":
 
     upg.upgrade()
 
-    print
+    sys.stdout.write('\n')
     printcfg(cfg)

--- a/lib/parsec/validate.py
+++ b/lib/parsec/validate.py
@@ -78,8 +78,10 @@ class IllegalItemError(ValidationError):
             self.msg = 'Illegal item: %s' % itemstr(keys, key)
 
 
-def validate(cfig, spec, keys=[]):
+def validate(cfig, spec, keys=None):
     """Validate and coerce a nested dict against a parsec spec."""
+    if not keys:
+        keys = []
     for key, val in cfig.items():
         if key not in spec:
             if '__MANY__' not in spec:
@@ -113,8 +115,10 @@ def validate(cfig, spec, keys=[]):
             pass
 
 
-def check_compulsory(cfig, spec, keys=[]):
+def check_compulsory(cfig, spec, keys=None):
     """Check compulsory items are defined in cfig."""
+    if not keys:
+        keys = []
     for key, val in spec.items():
         if isinstance(val, dict):
             check_compulsory(cfig, spec[key], keys + [key])
@@ -126,8 +130,8 @@ def check_compulsory(cfig, spec, keys=[]):
                         cfg = cfg[k]
                 except KeyError:
                     # TODO - raise an exception
-                    print >> sys.stderr, (
-                        "COMPULSORY ITEM MISSING", keys + [key])
+                    sys.stderr.write(
+                        "COMPULSORY ITEM MISSING %s\n" % (keys + [key]))
 
 
 def _populate_spec_defaults(defs, spec):
@@ -357,8 +361,10 @@ class validator(object):
 
     __slots__ = ['coercer', 'args']
 
-    def __init__(self, vtype='string', default=None, options=[],
+    def __init__(self, vtype='string', default=None, options=None,
                  allow_zeroes=True, compulsory=False):
+        if not options:
+            options = []
         self.coercer = coercers[vtype]
         self.args = {
             'options': options,


### PR DESCRIPTION
For most external commands, redirect the null device to STDIN to prevent them from inheriting the parent's STDIN.

Remove unused code. Remove usage of `[]` and `{}` in function signatures. Improve some error handling. Improve some print statements. Improve some overridden method interfaces.

Fix various style complaints. Fix various scoping issues. Fix various attribute issues. Fix various abstract class issues.

Simply interface to `remrun`. Fix unused argument issue. Use a function to wrap an object to simplify interface as well as getting the naming convention correct.