### PR TITLE
Prepend new broadcast items to config OrderedDict.

### DIFF
--- a/examples/satellite/ext-trigger/suite.rc
+++ b/examples/satellite/ext-trigger/suite.rc
@@ -73,8 +73,9 @@ datasets very quickly, to show parallel processing streams."""
         # Define a common cycle-point-specific work-directory for all
         # processing tasks so that they all work on the same dataset.
         work sub-directory = proc-$CYLC_TASK_CYCLE_POINT
-        pre-script = "DATASET=dataset-$CYLC_EXT_TRIGGER_ID"
         post-script = sleep 5
+        [[[environment]]]
+            DATASET = dataset-$CYLC_EXT_TRIGGER_ID
 
     [[get_data]]
         inherit = WORKDIR

--- a/lib/cylc/task_job_mgr.py
+++ b/lib/cylc/task_job_mgr.py
@@ -860,7 +860,7 @@ class TaskJobManager(object):
             itask.identity)
         if overrides:
             rtconfig = pdeepcopy(itask.tdef.rtconfig)
-            poverride(rtconfig, overrides)
+            poverride(rtconfig, overrides, prepend=True)
         else:
             rtconfig = itask.tdef.rtconfig
 

--- a/lib/parsec/OrderedDict.py
+++ b/lib/parsec/OrderedDict.py
@@ -99,3 +99,29 @@ class OrderedDictWithDefaults(OrderedDict):
     def __nonzero__(self):
         """Include any default keys in the nonzero calculation."""
         return bool(self.keys())
+
+    def prepend(self, key, value, dict_setitem=dict.__setitem__):
+        """Prepend new item in the ordered dict.
+
+        https://stackoverflow.com/questions/16664874/
+           how-can-i-add-an-element-at-the-top-of-an-ordereddict-in-python
+
+        Tested with Python 2.7 collections.OrderedDict and our bundled
+        ActiveState implementation for Python 2.6.
+
+        """
+        root = self._OrderedDict__root
+        first = root[1]
+
+        if key in self:
+            link = self._OrderedDict__map[key]
+            link_prev, link_next, _ = link
+            link_prev[1] = link_next
+            link_next[0] = link_prev
+            link[0] = root
+            link[1] = first
+            root[1] = first[0] = link
+        else:
+            root[1] = first[0] = self._OrderedDict__map[key] = [
+                root, first, key]
+            dict_setitem(self, key, value)

--- a/lib/parsec/OrderedDict.py
+++ b/lib/parsec/OrderedDict.py
@@ -124,4 +124,4 @@ class OrderedDictWithDefaults(OrderedDict):
         else:
             root[1] = first[0] = self._OrderedDict__map[key] = [
                 root, first, key]
-            dict_setitem(self, key, value)
+        dict_setitem(self, key, value)

--- a/lib/parsec/util.py
+++ b/lib/parsec/util.py
@@ -153,6 +153,7 @@ def poverride(target, sparse, prepend=False):
             else:
                 setitem(key, val)
 
+
 def m_override(target, sparse):
     """Override items in a target pdict.
 

--- a/tests/ext-trigger/00-satellite/suite.rc
+++ b/tests/ext-trigger/00-satellite/suite.rc
@@ -81,8 +81,8 @@ done"""
         # Define a common cycle-point-specific work-directory for all
         # processing tasks so that they all work on the same dataset.
         work sub-directory = proc-$CYLC_TASK_CYCLE_POINT
-        pre-command scripting = "DATASET=dataset-$CYLC_EXT_TRIGGER_ID"
-        ##post-command scripting = sleep 5
+        [[[environment]]]
+            DATASET = dataset-$CYLC_EXT_TRIGGER_ID
 
     [[get_data]]
         inherit = WORKDIR


### PR DESCRIPTION
Ensure that broadcasted environment variables, which target user environment sections, are defined before the other (truly user-defined) variables - which may need to reference the broadcasted ones.

Adds a prepend method to our customized OrderedDict to achieve this.  Existing test updated (fails on master, passes here).

Sort-of-Bug reported by @trwhitcomb 