### PR TITLE
Fix stdin manip in edit-run.

### DIFF
--- a/bin/cylc-trigger
+++ b/bin/cylc-trigger
@@ -150,7 +150,7 @@ def main():
         command = ' '.join(command_list)
         try:
             # Block until the editor exits.
-            retcode = call(command_list, stdin=open(os.devnull))
+            retcode = call(command_list)
             if retcode != 0:
                 sys.exit(
                     'ERROR, command failed with %d:\n %s' % (retcode, command))


### PR DESCRIPTION
Close #2511 

I don't understand why `stdin=open(os.devnull)` inside the `call()` arg list has any effect on `raw_input()` later in the script, but it does!