### PR TITLE
gcylc: job log files

### DIFF
--- a/bin/cylc-jobscript
+++ b/bin/cylc-jobscript
@@ -57,7 +57,7 @@ elif sys.argv[1] in ['-e', '--edit']:
 " $1
 }
 
-PLAIN=0
+PLAIN=false
 EDITOR_CMD=
 SUBMIT_ARGS=
 for arg in "${@}"; do
@@ -68,7 +68,7 @@ for arg in "${@}"; do
          [[ "${arg}" == '-e' ]] || [[ "${arg}" == '-g' ]]; then
         EDITOR_CMD="$(editor ${arg})"
     elif [[ "${arg}" == '--plain' ]]; then
-        PLAIN=1
+        PLAIN=true
     else
         SUBMIT_ARGS="${SUBMIT_ARGS} ${arg}"
     fi
@@ -76,7 +76,7 @@ done
 
 if CYLC_SUBMIT_OUT="$(cylc submit --dry-run ${SUBMIT_ARGS})"; then
     JOBSCRIPT="$(sed -n 's/^JOB SCRIPT=//p' <<<"${CYLC_SUBMIT_OUT}")"
-    if [[ ${PLAIN} == 0 ]]; then
+    if ! "${PLAIN}"; then
         echo "Task Job Script Generated: ${JOBSCRIPT}" >&2
     fi
     if [[ -n ${EDITOR_CMD} ]]; then

--- a/bin/cylc-jobscript
+++ b/bin/cylc-jobscript
@@ -37,6 +37,7 @@ Options:
   -h, --help   Print this usage message.
   -e --edit    Open the jobscript in a CLI text editor.
   -g --gedit   Open the jobscript in a GUI text editor.
+  --plain      Don't print the "Task Job Script Generated message."
  (see also 'cylc submit --help')
 
 Arguments:
@@ -56,6 +57,7 @@ elif sys.argv[1] in ['-e', '--edit']:
 " $1
 }
 
+PLAIN=0
 EDITOR_CMD=
 SUBMIT_ARGS=
 for arg in "${@}"; do
@@ -65,6 +67,8 @@ for arg in "${@}"; do
     elif [[ "${arg}" == '--edit' ]] || [[ "${arg}" == '--gedit' ]] || \
          [[ "${arg}" == '-e' ]] || [[ "${arg}" == '-g' ]]; then
         EDITOR_CMD="$(editor ${arg})"
+    elif [[ "${arg}" == '--plain' ]]; then
+        PLAIN=1
     else
         SUBMIT_ARGS="${SUBMIT_ARGS} ${arg}"
     fi
@@ -72,9 +76,11 @@ done
 
 if CYLC_SUBMIT_OUT="$(cylc submit --dry-run ${SUBMIT_ARGS})"; then
     JOBSCRIPT="$(sed -n 's/^JOB SCRIPT=//p' <<<"${CYLC_SUBMIT_OUT}")"
-    echo "Task Job Script Generated: ${JOBSCRIPT}" >&2
+    if [[ ${PLAIN} == 0 ]]; then
+        echo "Task Job Script Generated: ${JOBSCRIPT}" >&2
+    fi
     if [[ -n ${EDITOR_CMD} ]]; then
-        $EDITOR_CMD "${JOBSCRIPT}"
+        exec $EDITOR_CMD "${JOBSCRIPT}"
     else
         exec less "${JOBSCRIPT}"
     fi

--- a/bin/cylc-jobscript
+++ b/bin/cylc-jobscript
@@ -34,26 +34,50 @@ Other options (e.g. for suite host and owner) are passed
 through to the submit command.
 
 Options:
-  -h,--help   - print this usage message.
+  -h, --help   Print this usage message.
+  -e --edit    Open the jobscript in a CLI text editor.
+  -g --gedit   Open the jobscript in a GUI text editor.
  (see also 'cylc submit --help')
 
 Arguments:
-  REG         - Registered suite name.
-  TASK        - Task ID (NAME.CYCLE_POINT)
+  REG          Registered suite name.
+  TASK         Task ID (NAME.CYCLE_POINT)
 __END__
 }
 
+editor () {
+    python -c "
+import sys
+from cylc.cfgspec.globalcfg import GLOBAL_CFG
+if sys.argv[1] in ['-g', '--gedit']:
+    print GLOBAL_CFG.get(['editors', 'gui'])
+elif sys.argv[1] in ['-e', '--edit']:
+    print GLOBAL_CFG.get(['editors', 'terminal'])
+" $1
+}
+
+EDITOR_CMD=
+SUBMIT_ARGS=
 for arg in "${@}"; do
     if [[ "${arg}" == '-h' ]] || [[ "${arg}" == '--help' ]]; then
         usage
         exit 0
+    elif [[ "${arg}" == '--edit' ]] || [[ "${arg}" == '--gedit' ]] || \
+         [[ "${arg}" == '-e' ]] || [[ "${arg}" == '-g' ]]; then
+        EDITOR_CMD="$(editor ${arg})"
+    else
+        SUBMIT_ARGS="${SUBMIT_ARGS} ${arg}"
     fi
 done
 
-if CYLC_SUBMIT_OUT="$(cylc submit --dry-run "${@}")"; then
+if CYLC_SUBMIT_OUT="$(cylc submit --dry-run ${SUBMIT_ARGS})"; then
     JOBSCRIPT="$(sed -n 's/^JOB SCRIPT=//p' <<<"${CYLC_SUBMIT_OUT}")"
     echo "Task Job Script Generated: ${JOBSCRIPT}" >&2
-    exec less "${JOBSCRIPT}"
+    if [[ -n ${EDITOR_CMD} ]]; then
+        $EDITOR_CMD "${JOBSCRIPT}"
+    else
+        exec less "${JOBSCRIPT}"
+    fi
 else
     echo "${CYLC_SUBMIT_OUT}" >&2
     echo "ERROR: no jobscript generated" >&2

--- a/doc/src/cylc-user-guide/suiterc.tex
+++ b/doc/src/cylc-user-guide/suiterc.tex
@@ -1113,6 +1113,20 @@ All namespaces inherit initially from {\em root}, which can be
 explicitly configured to provide or override default settings
 for all tasks in the suite.
 
+\paragraph[inherit]{[runtime] \textrightarrow [[\_\_NAME\_\_]] \textrightarrow
+extra log files}
+
+A list of user defined log files associated with a task. Files defined here
+will appear alongside the default log files in the cylc gui. Log files
+must reside in the job log directory and ideally should be named using the
+\lstinline=$CYLC_TASK_LOG_ROOT= prefix (see~\ref{TaskJobScriptVariables}).
+
+\begin{myitemize}
+\item {\em type:} Comma-separated list of strings (log file names).
+\item {\em default:} (none)
+\item {\em example:} (job.custom-log-name)
+\end{myitemize}
+
 \paragraph[inherit]{[runtime] \textrightarrow [[\_\_NAME\_\_]] \textrightarrow inherit}
 
 A list of the immediate parent(s) this namespace inherits from. If no


### PR DESCRIPTION
* Fix and document the `extra log files` setting (now takes a relative path).
* Add "view in editor" support for `extra log files` in `gcylc`.
* Add text-editor functionality to `cylc jobscript`.
* Add "preview jobscript" functionality to `gcylc`.