### PR TITLE
gui: fix traceback on suite stop form

### DIFF
--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -1028,6 +1028,7 @@ Main Control GUI that displays one or more views or interfaces to the suite.
         stopclock = False
         stoptask = False
         stopkill = False
+        stopnownow = False
 
         if stop_rb.get_active():
             stop = True


### PR DESCRIPTION
The `control -> stop suite` form could generate traceback due to an unset variable.

@matthewrmshin, @hjoliver - whoever gets back first please review.