### PR TITLE
Fix behaviour with multiple suicide triggers.

### DIFF
--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -963,7 +963,7 @@ class TaskPool(object):
         num_removed = 0
         for itask in self.get_tasks():
             if itask.state.suicide_prerequisites:
-                if itask.state.suicide_prerequisites_are_all_satisfied():
+                if itask.state.suicide_prerequisites_satisfied():
                     if itask.state.status in [TASK_STATUS_READY,
                                               TASK_STATUS_SUBMITTED,
                                               TASK_STATUS_RUNNING]:

--- a/lib/cylc/task_state.py
+++ b/lib/cylc/task_state.py
@@ -219,6 +219,12 @@ class TaskState(object):
         return (not self.prerequisites_are_all_satisfied() or
                 not self.suicide_prerequisites_are_all_satisfied())
 
+    def suicide_prerequisites_satisfied(self):
+        """Return True if any suicide prerequisites are satisfied."""
+        if self._suicide_is_satisfied is True:
+            return True
+        return any(preq.is_satisfied() for preq in self.suicide_prerequisites)
+
     def suicide_prerequisites_are_all_satisfied(self):
         """Return True if all suicide prerequisites are satisfied."""
         if self._suicide_is_satisfied is None:

--- a/lib/cylc/task_trigger.py
+++ b/lib/cylc/task_trigger.py
@@ -88,6 +88,16 @@ class TaskTrigger(object):
                 self.cycle_point_offset, point)
         return point
 
+    def __str__(self):
+        if self.abs_cycle_point:
+            return '%s[%s]:%s' % (self.task_name, self.abs_cycle_point,
+                                  self.output)
+        elif self.cycle_point_offset:
+            return '%s[%s]:%s' % (self.task_name, self.cycle_point_offset,
+                                  self.output)
+        else:
+            return '%s:%s' % (self.task_name, self.output)
+
     @staticmethod
     def get_trigger_name(trigger_name):
         """Standardise a trigger name.
@@ -181,6 +191,17 @@ class Dependency(object):
 
         """
         return ''.join(self._stringify_list(self._exp, point))
+
+    def __str__(self):
+        ret = []
+        if self.suicide:
+            ret.append('!')
+        for item in self._exp:
+            if isinstance(item, list):
+                ret.append(str(item))
+            else:
+                ret.append('( %s )' % str(item))
+        return ' '.join(ret)
 
     @classmethod
     def _stringify_list(cls, nested_expr, point):

--- a/tests/triggering/17-suicide-multi.t
+++ b/tests/triggering/17-suicide-multi.t
@@ -1,0 +1,33 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2017 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test suicide triggering
+# (this is currently just a copy of the tutorial suicide example, but I
+# anticipate making it more fiendish at some point).
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 2
+#-------------------------------------------------------------------------------
+install_suite $TEST_NAME_BASE suicide-multi
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-validate
+run_ok $TEST_NAME cylc validate $SUITE_NAME
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-run
+suite_run_ok $TEST_NAME cylc run --reference-test --debug --no-detach $SUITE_NAME
+#-------------------------------------------------------------------------------
+purge_suite $SUITE_NAME

--- a/tests/triggering/suicide-multi/reference.log
+++ b/tests/triggering/suicide-multi/reference.log
@@ -1,0 +1,11 @@
+2017-12-27T14:42:10Z INFO - Initial point: 1
+2017-12-27T14:42:10Z INFO - Final point: 3
+2017-12-27T14:42:10Z INFO - [showdown.1] -triggered off []
+2017-12-27T14:42:13Z INFO - [ugly.1] -triggered off ['showdown.1']
+2017-12-27T14:42:16Z INFO - [fin.1] -triggered off ['ugly.1']
+2017-12-27T14:42:19Z INFO - [showdown.2] -triggered off ['fin.1']
+2017-12-27T14:42:22Z INFO - [bad.2] -triggered off ['showdown.2']
+2017-12-27T14:42:25Z INFO - [fin.2] -triggered off ['bad.2']
+2017-12-27T14:42:28Z INFO - [showdown.3] -triggered off ['fin.2']
+2017-12-27T14:42:32Z INFO - [good.3] -triggered off ['showdown.3']
+2017-12-27T14:42:35Z INFO - [fin.3] -triggered off ['good.3']

--- a/tests/triggering/suicide-multi/suite.rc
+++ b/tests/triggering/suicide-multi/suite.rc
@@ -1,0 +1,36 @@
+[cylc]
+    [[events]]
+        timeout = PT1M
+
+[scheduling]
+    cycling mode = integer
+    initial cycle point = 1
+    final cycle point = 3
+    [[dependencies]]
+        [[[P1]]]
+            graph = """
+                fin[-P1] => showdown
+
+                showdown:good => good & ! bad & ! ugly
+                showdown:bad => bad & ! good & ! ugly
+                showdown:ugly => ugly & ! good & ! bad
+
+                good | bad | ugly => fin
+            """
+[runtime]
+    [[root]]
+        script = true
+    [[showdown]]
+        script = """
+            if ! (( ${CYLC_TASK_CYCLE_POINT} % 3 )); then
+                cylc message 'The-Good'
+            elif ! (( ( ${CYLC_TASK_CYCLE_POINT} + 1 ) % 3 )); then
+                cylc message 'The-Bad'
+            else
+                cylc message 'The-Ugly'
+            fi
+        """
+        [[[outputs]]]
+            good = 'The-Good'
+            bad = 'The-Bad'
+            ugly = 'The-Ugly'


### PR DESCRIPTION
When multiple suicide triggers are used tasks may go un-triggered.

See `tests/triggering/suicide-multi/suite.rc` for an example (removing the second suicide trigger in each case results in correct behaviour).

Also add `__str__` methods for the `task_trigger` classes for debugging.