### PR TITLE
Place prompts above all windows.

### DIFF
--- a/lib/cylc/prompt.py
+++ b/lib/cylc/prompt.py
@@ -21,7 +21,8 @@ import sys
 from cylc.cfgspec.globalcfg import GLOBAL_CFG
 
 
-def prompt(question, force=False, gui=False, no_force=False, no_abort=False):
+def prompt(question, force=False, gui=False, no_force=False, no_abort=False,
+           keep_above=True):
     """Interactive Yes/No prompt for cylc CLI scripts.
 
     For convenience, on No we just exit rather than return.
@@ -38,6 +39,7 @@ def prompt(question, force=False, gui=False, no_force=False, no_abort=False):
             gtk.MESSAGE_QUESTION, gtk.BUTTONS_YES_NO,
             question
         )
+        dialog.set_keep_above(keep_above)
         gui_response = dialog.run()
         response_no = (gui_response != gtk.RESPONSE_YES)
     else:


### PR DESCRIPTION
User request for the "Trigger edited task..." prompt to appear on-top of the gcylc window as it does not appear in the task-bar so can become difficult to re-locate once lost.

As the gui calls trigger and other commands via subprocess the prompts displayed are not associated with any parent window and so fancy trickery is not possible, we can, however, place the prompts above all windows.

This change affects the following commands:

* hold
* insert
* kill
* poll
* release
* reload
* remove
* reset
* set
* spawn
* stop
* trigger