### PR TITLE
Remove dev/null stdin pipes to editor commands.

### DIFF
--- a/bin/cylc-edit
+++ b/bin/cylc-edit
@@ -123,7 +123,7 @@ def main():
         command_list.append(suiterc)
         command = ' '.join(command_list)
         # THIS BLOCKS UNTIL THE COMMAND COMPLETES
-        retcode = call(command_list, stdin=open(os.devnull))
+        retcode = call(command_list)
         if retcode != 0:
             # the command returned non-zero exist status
             print >> sys.stderr, command, 'failed:', retcode

--- a/bin/cylc-view
+++ b/bin/cylc-view
@@ -154,7 +154,7 @@ def main():
     command_list.append(viewfile.name)
     command = ' '.join(command_list)
     # THIS BLOCKS UNTIL THE COMMAND COMPLETES
-    retcode = call(command_list, open(os.devnull))
+    retcode = call(command_list)
     if retcode != 0:
         # the command returned non-zero exist status
         print >> sys.stderr, command, 'failed:', retcode


### PR DESCRIPTION
Further to #2512, #2511.

For me `cylc view` fails and `cylc edit` causes the terminal to fail.