### PR TITLE
Don't redirect stdin to /dev/null for editor.

### DIFF
--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -362,7 +362,7 @@ def main():
             sys.stderr.write(
                 " ".join(quote(item) for item in command) + "\n")
             stderr = None
-        proc = Popen(command, stdin=open(os.devnull), stderr=stderr)
+        proc = Popen(command, stderr=stderr)
         err = proc.communicate()[1]
         ret_code = proc.wait()
         if ret_code == 0:

--- a/bin/cylc-edit
+++ b/bin/cylc-edit
@@ -171,7 +171,7 @@ def main():
     command_list.append(suiterc)
     command = ' '.join(command_list)
     # THIS BLOCKS UNTIL THE COMMAND COMPLETES
-    retcode = call(command_list, stdin=open(os.devnull))
+    retcode = call(command_list)
     if retcode != 0:
         # the command returned non-zero exist status
         print >> sys.stderr, command, 'failed:', retcode


### PR DESCRIPTION
Another fix for recent stdin changes, like #2531 

`cylc cat-log -t` was broken, for editor vim (which I guess takes keyboard command from stdin).
  
(and another case in `cylc edit`)