### PR TITLE
Fix check-versions and other tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ install:
     - ssh-keyscan -t rsa localhost >> ~/.ssh/known_hosts
 
     # Install dependencies
-    - sudo apt-get install build-essential
+    - sudo apt-get install build-essential texlive-latex-base
     - sudo apt-get install at python-pip python-dev graphviz libgraphviz-dev python-gtk2-dev
       heirloom-mailx
     # Pygraphviz needs special treatment to avoid an error from "from . import release"
@@ -70,5 +70,5 @@ script:
 
 # Check output (more useful if you narrow down what tests get run)
 after_script:
-    - find $HOME/cylc-run -type f -name '*err' -exec echo '==== {} ====' \; -exec cat '{}' \;
+    - find $HOME/cylc-run -name '*.err' -type f -exec echo '==== {} ====' \; -exec cat '{}' \;
     - find /tmp/${USER}/cylctb-* -type f -exec echo '==== {} ====' \; -exec cat '{}' \;

--- a/admin/get-repo-version
+++ b/admin/get-repo-version
@@ -27,7 +27,7 @@ LF='
 
 # move to the repository
 cd $( dirname "$0" )/..
-VN=$(git describe --abbrev=4 --tags HEAD 2>/dev/null)
+VN=$(git describe --always --abbrev=4 --tags HEAD 2>/dev/null)
 case "$VN" in
     *$LF*) (exit 1) ;;
     [0-9]*)

--- a/bin/cylc
+++ b/bin/cylc
@@ -27,9 +27,7 @@ get_version() {
         CYLC_VERSION="$(cat ${CYLC_DIR}/VERSION)"
     # Otherwise, use git (if in a git repo) to determine version
     elif [[ -d "${CYLC_DIR}/.git" ]]; then
-        local DESC=
-        DESC="$(cd ${CYLC_DIR} && git describe --abbrev=4 2>/dev/null)"
-        CYLC_VERSION="${DESC}"
+        CYLC_VERSION="$(cd ${CYLC_DIR} && git describe --abbrev=4 --always)"
         # Append "-dirty" if there are uncommitted changes.
         if [[ -n "$(cd ${CYLC_DIR} && git status \
                 --untracked-files=no --porcelain)" ]]; then

--- a/bin/cylc-check-versions
+++ b/bin/cylc-check-versions
@@ -69,8 +69,6 @@ def main():
         load_template_vars(options.templatevars, options.templatevars_file))
     account_set = set()
     for name in config.get_namespace_list('all tasks'):
-        host_str = config.get_config(['runtime', name, 'remote', 'host'])
-        user = config.get_config(['runtime', name, 'remote', 'owner'])
         account_set.add((
             config.get_config(['runtime', name, 'remote', 'owner']),
             config.get_config(['runtime', name, 'remote', 'host'])))

--- a/bin/cylc-check-versions
+++ b/bin/cylc-check-versions
@@ -37,13 +37,15 @@ site dependent -- see cylc global config documentation."""
 import os
 import sys
 from subprocess import Popen, PIPE
+from time import sleep
 
 import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.version import CYLC_VERSION
 from cylc.config import SuiteConfig
-from cylc.host_select import get_task_host
+from cylc.mp_pool import SuiteProcPool
 from cylc.suite_srv_files_mgr import SuiteSrvFilesManager
+from cylc.task_remote_mgr import TaskRemoteMgr
 from cylc.templatevars import load_template_vars
 
 
@@ -58,21 +60,34 @@ def main():
     (options, args) = parser.parse_args(remove_opts=['--host', '--user'])
 
     # suite name or file path
-    suite, suiterc = SuiteSrvFilesManager().parse_suite_arg(options, args[0])
+    suite_srv_files_mgr = SuiteSrvFilesManager()
+    suite, suiterc = suite_srv_files_mgr.parse_suite_arg(options, args[0])
 
     # extract task host accounts from the suite
     config = SuiteConfig(
         suite, suiterc,
         load_template_vars(options.templatevars, options.templatevars_file))
-    result = config.get_namespace_list('all tasks')
-    namespaces = result.keys()
-    accounts = set()
-    for name in namespaces:
-        host = get_task_host(
-            config.get_config(['runtime', name, 'remote', 'host']))
-        owner = config.get_config(['runtime', name, 'remote', 'owner'])
-        accounts.add((owner, host))
-    accounts = list(accounts)
+    account_set = set()
+    for name in config.get_namespace_list('all tasks'):
+        host_str = config.get_config(['runtime', name, 'remote', 'host'])
+        user = config.get_config(['runtime', name, 'remote', 'owner'])
+        account_set.add((
+            config.get_config(['runtime', name, 'remote', 'owner']),
+            config.get_config(['runtime', name, 'remote', 'host'])))
+    task_remote_mgr = TaskRemoteMgr(
+        suite, SuiteProcPool(), suite_srv_files_mgr)
+    for _, host_str in account_set:
+        task_remote_mgr.remote_host_select(host_str)
+    accounts = []
+    while account_set:
+        for user, host_str in account_set.copy():
+            res = task_remote_mgr.remote_host_select(host_str)
+            if res:
+                account_set.remove((user, host_str))
+                accounts.append((user, res))
+        if account_set:
+            task_remote_mgr.proc_pool.handle_results_async()
+            sleep(1.0)
 
     # Interrogate the each remote account with CYLC_VERSION set to our version.
     # Post backward compatibility concerns to do this we can just run:
@@ -86,7 +101,7 @@ def main():
 
     warn = {}
     contacted = 0
-    for user, host in accounts:
+    for user, host in sorted(accounts):
         argv = ["cylc", "version"]
         if user and host:
             argv += ["--user=%s" % user, "--host=%s" % host]

--- a/lib/cylc/profiling/git.py
+++ b/lib/cylc/profiling/git.py
@@ -27,7 +27,7 @@ class GitCheckoutError(Exception):
 def describe(ref=None):
     """Returns stdout of the `git describe <COMMIT>` command."""
     try:
-        cmd = ['git', 'describe']
+        cmd = ['git', 'describe', '--tags', '--always']
         if ref:
             cmd.append(ref)
         return Popen(

--- a/tests/cylc-get-cylc-version/00-basic/suite.rc
+++ b/tests/cylc-get-cylc-version/00-basic/suite.rc
@@ -11,8 +11,5 @@ test suite (should be the same)."""
 [runtime]
     [[root]]
         script = """
-CYLC_VERSION_1=$(cylc --version)
-CYLC_VERSION_2=$(cylc get-cylc-version $CYLC_SUITE_NAME)
-if [[ $CYLC_VERSION_1 != $CYLC_VERSION_2 ]]; then
-   exit 1
-fi"""
+diff -u <(cylc --version) <(cylc get-cylc-version "${CYLC_SUITE_NAME}")
+"""

--- a/tests/documentation/00-make.t
+++ b/tests/documentation/00-make.t
@@ -25,6 +25,6 @@ fi
 set_test_number 1
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-make-docs
-run_ok $TEST_NAME make -C $CYLC_DIR/doc
+run_ok $TEST_NAME make -C $CYLC_DIR/doc <'/dev/null'
 #-------------------------------------------------------------------------------
 exit

--- a/tests/profile-battery/00-compatability.t
+++ b/tests/profile-battery/00-compatability.t
@@ -54,9 +54,8 @@ then
 else
     fail "${TEST_NAME}"
     # Move/rename profiling files so they will be cat'ed out by travis-ci.
-    PROF_FILES=($(sed 's/Profile files:\(.*\)/\1/' <<< \
-        $(cat "${LOG_DIR}.stderr" | grep 'Profile files:')))
-    for file_path in ${PROF_FILES[@]}; do
+    while read; do
+        file_path="${REPLY}"
         file_prefix=$(basename ${file_path})
         profile_dir=$(dirname ${file_path})
         profile_files=($(find "${profile_dir}" -type f -name "${file_prefix}*" \
@@ -64,6 +63,6 @@ else
         for profile_file in ${profile_files[@]}; do
             mv "${profile_file}" "${LOG_DIR}/$(basename ${profile_file})-err"
         done
-    done
+    done < <(sed -n 's/Profile files:\(.*\)/\1/p' "${LOG_DIR}.stderr")
     mv "${LOG_DIR}.log" "${LOG_DIR}.profile-battery-log-err"
 fi


### PR DESCRIPTION
Update to use `cylc.task_remote_mgr` instead of `cylc.host_select`.
Ensure we have the correct package to make documentation.
Use `git describe --always` to prevent it from failing.

Fix test broken by #2468. Fix tests due to recent change to Travis CI? (Package for LaTex and behaviour of `git describe`.)