### PR TITLE
gui dbchooser: don't duplicate running suites

### DIFF
--- a/lib/cylc/gui/dbchooser.py
+++ b/lib/cylc/gui/dbchooser.py
@@ -63,12 +63,7 @@ class db_updater(threading.Thread):
 
         for suite, auth in self.running_choices:
             if suite in regd_choices:
-                if is_remote_host(auth.split(':', 1)[0]):
-                    descr, suite_dir = (None, None)
-                else:
-                    # local suite
-                    suite_dir, descr = regd_choices[suite][1:3]
-                    del regd_choices[suite]
+                suite_dir, descr = regd_choices.pop(suite)[1:3]
             nest2 = self.newtree
             regp = suite.split(SuiteSrvFilesManager.DELIM)
             for key in regp[:-1]:


### PR DESCRIPTION
This change is due to #2430 and #2492, where listing of running suites
is now done via the local file system.

Fix bullet point 1 of #2544.