### PR TITLE
Action on custom outputs immediately.

### DIFF
--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -361,12 +361,12 @@ class TaskEventsManager(object):
             except (TypeError, ValueError):
                 itask.timeout_timers[TASK_STATUS_SUBMITTED] = None
             # Believe this and change state without polling (could poll?).
-            cylc.flags.pflag = True
+            self.pflag = True
             itask.state.reset_state(TASK_STATUS_SUBMITTED)
         elif an_output_was_satisfied:
             # Message of an as-yet unreported custom task output.
             # No state change.
-            cylc.flags.pflag = True
+            self.pflag = True
             self.suite_db_mgr.put_update_task_outputs(itask)
         else:
             # Unhandled messages. These include:

--- a/tests/message-triggers/02-action.t
+++ b/tests/message-triggers/02-action.t
@@ -1,0 +1,48 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test that message triggers (custom outputs) are actioned immediately even if
+# nothing else is happening at the time - GitHub #2548.
+
+. $(dirname $0)/test_header
+
+set_test_number 4
+
+install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+
+TEST_NAME=$TEST_NAME_BASE-validate
+run_ok $TEST_NAME cylc validate $SUITE_NAME
+
+# The suite tests that two tasks suicide immediately on message triggers.
+TEST_NAME=$TEST_NAME_BASE-run
+suite_run_ok $TEST_NAME cylc run --no-detach $SUITE_NAME
+
+# Check that bar does nothing but suicide. 
+TEST_NAME=$TEST_NAME_BASE-cmp-bar
+cylc cat-log $SUITE_NAME | grep bar.1 | awk '{$1=""; print $0}' > bar.log
+cmp_ok bar.log - << __END__
+ INFO - [bar.1] -suiciding
+__END__
+
+# Check that baz does nothing but suicide. 
+TEST_NAME=$TEST_NAME_BASE-cmp-baz
+cylc cat-log $SUITE_NAME | grep baz.1 | awk '{$1=""; print $0}' > baz.log
+cmp_ok baz.log - << __END__
+ INFO - [baz.1] -suiciding
+__END__
+
+purge_suite $SUITE_NAME

--- a/tests/message-triggers/02-action/suite.rc
+++ b/tests/message-triggers/02-action/suite.rc
@@ -1,0 +1,45 @@
+[cylc]
+    abort if any task fails = True
+    [[events]]
+        timeout = PT30S
+        abort on timeout = True
+[scheduling]
+    [[dependencies]]
+         graph = """
+            foo:fail => bar & baz
+            foo:a => !bar
+            foo:b => !baz"""
+[runtime]
+    [[foo]]
+        # Abort if messages don't result in the expected suite state change.
+        script = """
+sleep 5
+# There should be 3 task proxies in the suite state.
+cylc dump -t $CYLC_SUITE_NAME | sort > log.1
+diff log.1 - << __EOF__
+bar, 1, waiting, unspawned
+baz, 1, waiting, unspawned
+foo, 1, running, spawned
+__EOF__
+
+cylc message "the quick brown fox"
+sleep 5
+# There should now be 2 task proxies in the suite state.
+cylc dump -t $CYLC_SUITE_NAME | sort > log.2
+diff log.2 - << __EOF__
+baz, 1, waiting, unspawned
+foo, 1, running, spawned
+__EOF__
+
+cylc message "jumped over the lazy dog"
+sleep 5
+# There should now be only 1 task proxy in the suite state.
+cylc dump -t $CYLC_SUITE_NAME | sort > log.3
+diff log.3 - << __EOF__
+foo, 1, running, spawned
+__EOF__
+"""
+        [[[outputs]]]
+            a = "the quick brown fox"
+            b = "jumped over the lazy dog"
+    [[bar, baz]]


### PR DESCRIPTION
A recent change has stopped ~~suicide triggers~~  [custom outputs] getting actioned immediately if nothing else is happening at the time.

Still needs a closer look and a test.