### PR TITLE
gui: switch suite, switch logs.

### DIFF
--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -175,7 +175,7 @@ Class to hold initialisation data.
             else:
                 self.host = auth
                 self.port = None
-        self.logdir = SuiteLog.get_inst(suite).get_dir()
+        self.logdir = SuiteLog.get_dir_for_suite(suite)
 
 
 class InfoBar(gtk.VBox):


### PR DESCRIPTION
Close #2559 

 `SuiteLog` is a singleton - which I guess it should not be! - and so it didn't switch to the new suite.  My fix is a bit unpleasant, but I think it'll do for this rather trivial problem.