### PR TITLE
Add parameters to suite DB, fix test error

### DIFF
--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -146,8 +146,6 @@ class Scheduler(object):
             self.options.templatevars, self.options.templatevars_file)
 
         self.run_mode = self.options.run_mode
-        self.cylc_version = CYLC_VERSION
-        self.UTC_mode = str(cylc.flags.utc)
 
         self.owner = get_user()
         self.host = get_host()
@@ -381,8 +379,8 @@ conditions; see `cylc conditions`.
 
         self.suite_db_mgr.put_suite_params(
             self.run_mode,
-            self.cylc_version,
-            self.UTC_mode,
+            CYLC_VERSION,
+            str(GLOBAL_CFG.get(['cylc', 'UTC mode'])),
             self.initial_point,
             self.final_point,
             self.pool.is_held,
@@ -887,8 +885,8 @@ conditions; see `cylc conditions`.
             self.configure_reftest(recon=True)
         self.suite_db_mgr.put_suite_params(
             self.run_mode,
-            self.cylc_version,
-            self.UTC_mode,
+            CYLC_VERSION,
+            str(GLOBAL_CFG.get(['cylc', 'UTC mode'])),
             self.initial_point,
             self.final_point,
             self.pool.is_held,

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -146,6 +146,8 @@ class Scheduler(object):
             self.options.templatevars, self.options.templatevars_file)
 
         self.run_mode = self.options.run_mode
+        self.cylc_version = CYLC_VERSION
+        self.UTC_mode = str(cylc.flags.utc)
 
         self.owner = get_user()
         self.host = get_host()
@@ -379,6 +381,8 @@ conditions; see `cylc conditions`.
 
         self.suite_db_mgr.put_suite_params(
             self.run_mode,
+            self.cylc_version,
+            self.UTC_mode,
             self.initial_point,
             self.final_point,
             self.pool.is_held,
@@ -883,6 +887,8 @@ conditions; see `cylc conditions`.
             self.configure_reftest(recon=True)
         self.suite_db_mgr.put_suite_params(
             self.run_mode,
+            self.cylc_version,
+            self.UTC_mode,
             self.initial_point,
             self.final_point,
             self.pool.is_held,

--- a/lib/cylc/suite_db_mgr.py
+++ b/lib/cylc/suite_db_mgr.py
@@ -237,14 +237,17 @@ class SuiteDatabaseManager(object):
                 "inheritance": value})
 
     def put_suite_params(
-            self, run_mode, initial_point, final_point, is_held,
-            cycle_point_format=None, warm_point=None):
-        """Put run mode, initial/final cycle point in runtime database.
+            self, run_mode, cylc_version, UTC_mode, initial_point,
+            final_point, is_held, cycle_point_format=None, warm_point=None):
+        """Put run mode, cylc version, UTC mode & initial & final cycle
+        points in runtime database.
 
         This method queues the relevant insert statements.
         """
         self.db_inserts_map[self.TABLE_SUITE_PARAMS].extend([
             {"key": "run_mode", "value": run_mode},
+            {"key": "cylc_version", "value": cylc_version},
+            {"key": "UTC_mode", "value": UTC_mode},
             {"key": "initial_point", "value": str(initial_point)},
             {"key": "final_point", "value": str(final_point)},
         ])

--- a/tests/database/00-simple.t
+++ b/tests/database/00-simple.t
@@ -41,6 +41,7 @@ cmp_ok "${SORTED_ORIG}" "${NAME}"
 NAME='select-suite-params.out'
 sqlite3 "${DB_FILE}" 'SELECT key,value FROM suite_params ORDER BY key' \
     >"${NAME}"
+sed -i "s/$(cylc --version)/<SOME-VERSION>/g" "${NAME}"
 cmp_ok "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/${NAME}" "${NAME}"
 
 NAME='select-task-events.out'

--- a/tests/database/00-simple/select-suite-params.out
+++ b/tests/database/00-simple/select-suite-params.out
@@ -1,3 +1,5 @@
+UTC_mode|False
+cylc_version|<SOME-VERSION>
 final_point|1
 initial_point|1
 run_mode|live

--- a/tests/restart/15-state-to-db.t
+++ b/tests/restart/15-state-to-db.t
@@ -55,7 +55,11 @@ __OUT__
 run_ok "${TEST_NAME_BASE}-suite_params" \
     sqlite3 "${SUITE_RUN_DIR}/log/db" \
     'SELECT key,value FROM suite_params ORDER BY key'
+sed -i "s/$(cylc --version)/<SOME-VERSION>/g" \
+    "${TEST_NAME_BASE}-suite_params.stdout"
 cmp_ok "${TEST_NAME_BASE}-suite_params.stdout" <<__OUT__
+UTC_mode|False
+cylc_version|<SOME-VERSION>
 final_point|20050101T0000Z
 initial_point|20000101T0000Z
 run_mode|live
@@ -63,8 +67,8 @@ __OUT__
 run_ok "${TEST_NAME_BASE}-suite_params_checkpoints" \
     sqlite3 "${SUITE_RUN_DIR}/log/db" \
     'SELECT key,value FROM suite_params_checkpoints WHERE id==1 ORDER BY key'
-cmp_ok "${TEST_NAME_BASE}-suite_params.stdout" <<__OUT__
-final_point|20050101T0000Z
+cmp_ok "${TEST_NAME_BASE}-suite_params_checkpoints.stdout" <<__OUT__
+final_point|20030101T0000Z
 initial_point|20000101T0000Z
 run_mode|live
 __OUT__


### PR DESCRIPTION
Address the remaining two items on the 'parameters' checklist of #1032 and amend affected tests. Additionally (as spotted while in local testing phase) fix error in ``tests/restart/15-state-to-db.t`` whereby sub-test 12 was a duplicate of 10 (``15-state-to-db-suite_params.stdout-cmp-ok``) presumably due to omission of alteration to the filename for comparison after lifting and pasting the equivalent code line.