### PR TITLE
Fix gscan exception hook dialog closure incapacity

### DIFF
--- a/lib/cylc/gui/util.py
+++ b/lib/cylc/gui/util.py
@@ -199,7 +199,7 @@ def set_exception_hook_dialog(program_name=None):
     old_hook = sys.excepthook
     sys.excepthook = lambda e_type, e_value, e_traceback: (
         _launch_exception_hook_dialog(
-            e_type, e_value, e_traceback, sys.excepthook, program_name))
+            e_type, e_value, e_traceback, old_hook, program_name))
 
 
 def setup_icons():


### PR DESCRIPTION
Whilst reviewing #2574 I noticed that when I obtained a exception traceback in `gscan` in a pop-up dialog window, the window would immediately re-open after being prompted to close via clicking of the 'OK' button or the 'Close Window' cross corner iron (ad infinitum with further attempts to close it).

_To recreate_: open gscan so it provides any 'entry' traceback e.g. by providing invalid arguments to it such as `cylc gscan -o '*' -n '*'` or by editing the code in `lib/cylc/gui/gscan.py` to create an error there.

I have resolved this by changing an argument so that (as I understand the logic) the `set_exception_hook_dialog` function will only launch an exception dialog if it has not already been launched. The variable `old_hook` was in fact already initialised within the function but not implemented in this way; it seems (?) the original writer intended to include it as an argument to `_launch_exception_hook_dialog` function but mistakenly put `sys.excepthook` instead.