### PR TITLE
Fix recovery of a failed host select command

### DIFF
--- a/tests/job-submission/15-garbage-host-command-2.t
+++ b/tests/job-submission/15-garbage-host-command-2.t
@@ -1,0 +1,28 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test recovery of a failed host select command for a group of tasks.
+. "$(dirname "$0")/test_header"
+
+set_test_number 2
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+suite_run_ok "${TEST_NAME_BASE}-run" \
+    cylc run --debug --no-detach --reference-test "${SUITE_NAME}"
+#-------------------------------------------------------------------------------
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/job-submission/15-garbage-host-command-2/bin/my-host-select
+++ b/tests/job-submission/15-garbage-host-command-2/bin/my-host-select
@@ -1,0 +1,3 @@
+#!/bin/bash
+TXT="${CYLC_SUITE_RUN_DIR}/my-host-select.txt"
+cat "${TXT}" || echo 'localhost' >"${TXT}"

--- a/tests/job-submission/15-garbage-host-command-2/reference.log
+++ b/tests/job-submission/15-garbage-host-command-2/reference.log
@@ -1,0 +1,12 @@
+2018-02-23T15:03:50Z INFO - Initial point: 1
+2018-02-23T15:03:50Z INFO - Final point: 1
+2018-02-23T15:03:51Z INFO - [foo_i3.1] -triggered off []
+2018-02-23T15:03:51Z INFO - [foo_i1.1] -triggered off []
+2018-02-23T15:03:51Z INFO - [foo_i4.1] -triggered off []
+2018-02-23T15:03:51Z INFO - [foo_i2.1] -triggered off []
+2018-02-23T15:03:51Z INFO - [foo_i5.1] -triggered off []
+2018-02-23T15:04:53Z INFO - [foo_i3.1] -triggered off []
+2018-02-23T15:04:53Z INFO - [foo_i1.1] -triggered off []
+2018-02-23T15:04:53Z INFO - [foo_i4.1] -triggered off []
+2018-02-23T15:04:53Z INFO - [foo_i2.1] -triggered off []
+2018-02-23T15:04:53Z INFO - [foo_i5.1] -triggered off []

--- a/tests/job-submission/15-garbage-host-command-2/suite.rc
+++ b/tests/job-submission/15-garbage-host-command-2/suite.rc
@@ -1,0 +1,13 @@
+[cylc]
+    [[parameters]]
+        i = 1..5
+[scheduling]
+    [[dependencies]]
+        graph = foo<i>
+[runtime]
+    [[foo<i>]]
+        script = true
+        [[[job]]]
+            submission retry delays = PT10S
+        [[[remote]]]
+            host = $(my-host-select)


### PR DESCRIPTION
Recovery of a failed host select command was a bit broken. This change
ensures that the result is reset as soon as it is consumed.

This also ensures that the retry timer is set for submission retry on host select command failure.