### PR TITLE
Fix gcylc zero division error from task mean elapsed time

### DIFF
--- a/lib/cylc/gui/updater_tree.py
+++ b/lib/cylc/gui/updater_tree.py
@@ -245,6 +245,7 @@ class TreeUpdater(threading.Thread):
                         t_info[dt] = summary[id_][dt]
 
                     # Compute percent progress.
+                    t_info['progress'] = 0
                     if (isinstance(tstart, float) and (
                             isinstance(meant, float) or
                             isinstance(meant, int))):
@@ -252,11 +253,9 @@ class TreeUpdater(threading.Thread):
                         tnow = time()
                         if tnow > tetc_unix:
                             t_info['progress'] = 100
-                        else:
+                        elif meant != 0:
                             t_info['progress'] = int(
                                 100 * (tnow - tstart) / (tetc_unix - tstart))
-                    else:
-                        t_info['progress'] = 0
 
                     if (t_info['finished_time_string'] is None and
                             isinstance(tstart, float) and


### PR DESCRIPTION
An (internal Met Office operational) user has noticed a traceback dialog in the GUI:
```
Traceback (most recent call last):
  File "<HOME>/cylc.git/lib/cylc/gui/updater_tree.py", line 257, in update_gui
    100 * (tnow - tstart) / (tetc_unix - tstart))
ZeroDivisionError: float division
```
A brief look at the code reveals this is due to tasks which have a mean elapsed time value of zero - quite how this has occurred in a real suite is still a bit of a mystery to me and while the fix was trivial and the logic easy to follow, the difficultly here was reproducing the error (for self-review purposes) i.e. setting up a suite so that at least one task would have mean elapsed time of zero.

Eventually I just did a bodge job, so (unless you can easily come up with a more clever idea!) to recreate, just change line 240 to `meant = 0.0` and the `if tnow > tetc_unix` statement on line 253 to `if False` to automatically proceed to read the line in question, then run some suite with at least one task with script `sleep 10` or similar that cycles at least once (so `meant` gets re-computed).

N.B. there is some logic on 280:283 which does change `meant` to `1` if it is in fact `0` and I initially tried essentially moving that above the conditionals in question so the zero division error would not ever get raised, but it does influence the conditional on 261:264 so this simple change seemed more appropriate.