### PR TITLE
Fix trigger --edit with host select

### DIFF
--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -1616,11 +1616,16 @@ conditions; see `cylc conditions`.
         if len(itasks) > 1:
             LOG.warning("Unique task match not found: %s" % items)
             return n_warnings + 1
-        if self.task_job_mgr.prep_submit_task_jobs(
-                self.suite, [itasks[0]], dry_run=True)[0]:
-            return n_warnings
-        else:
-            return n_warnings + 1
+        while self.stop_mode is None:
+            prep_tasks, bad_tasks = self.task_job_mgr.prep_submit_task_jobs(
+                self.suite, [itasks[0]], dry_run=True)
+            if itasks[0] in prep_tasks:
+                return n_warnings
+            elif itasks[0] in bad_tasks:
+                return n_warnings + 1
+            else:
+                self.task_job_mgr.proc_pool.handle_results_async()
+                sleep(1.0)
 
     def command_reset_task_states(self, items, state=None, outputs=None):
         """Reset the state of tasks."""

--- a/tests/cylc-trigger/08-edit-run-host-select.t
+++ b/tests/cylc-trigger/08-edit-run-host-select.t
@@ -1,0 +1,54 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test an edit-run (cylc trigger --edit) with host-select command.
+. "$(dirname "$0")/test_header"
+#-------------------------------------------------------------------------------
+set_test_number 3
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+#-------------------------------------------------------------------------------
+TEST_NAME="${TEST_NAME_BASE}-validate"
+run_ok "${TEST_NAME}" cylc validate "${SUITE_NAME}"
+#-------------------------------------------------------------------------------
+# Configure a fake editor and run a suite with a task that does an edit run.
+create_test_globalrc '' '
+[editors]
+    terminal = my-edit'
+TEST_NAME="${TEST_NAME_BASE}-run"
+run_ok "${TEST_NAME}" cylc run --no-detach "${SUITE_NAME}"
+#-------------------------------------------------------------------------------
+TEST_NAME="${TEST_NAME_BASE}-diff"
+DIFF_LOG="$(cylc cat-log -dl "${SUITE_NAME}" 'broken-task.1')"
+# Python 2.6 difflib adds an extra space after the filename,
+# but Python 2.7 does not. Remove it if it exists.
+sed -i 's/^--- original $/--- original/; s/^+++ edited $/+++ edited/' "${DIFF_LOG}"
+cmp_ok "${DIFF_LOG}" - <<'__END__'
+--- original
++++ edited
+@@ -30,7 +30,7 @@
+ 
+ cylc__job__inst__script() {
+ # SCRIPT:
+-/bin/false
++/bin/true
+ }
+ 
+ . "${CYLC_DIR}/lib/cylc/job.sh"
+__END__
+#-------------------------------------------------------------------------------
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/cylc-trigger/08-edit-run-host-select/bin/my-edit
+++ b/tests/cylc-trigger/08-edit-run-host-select/bin/my-edit
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sed -i 's@/bin/false@/bin/true@' "$@"

--- a/tests/cylc-trigger/08-edit-run-host-select/suite.rc
+++ b/tests/cylc-trigger/08-edit-run-host-select/suite.rc
@@ -1,0 +1,22 @@
+[meta]
+    title = A suite to test 'cylc trigger --edit' with host select command
+    description = """
+A broken task will fail and cause the suite to abort on timeout, unless a
+second task fixes and retriggers it with an edit-run."""
+[cylc]
+    [[events]]
+        abort on timeout = True
+        timeout = PT20S
+[scheduling]
+    [[dependencies]]
+        graph = broken-task:fail => fixer-task
+[runtime]
+    [[broken-task]]
+        script = /bin/false
+        [[[remote]]]
+            host = $(echo localhost)
+    [[fixer-task]]
+        script = """
+cylc trigger --edit $CYLC_SUITE_NAME broken-task 1 << __END__
+y
+__END__"""


### PR DESCRIPTION
`cylc trigger --edit` broken if task's remote host setting is a host select command. (Sorry.) This change fixes it.