### PR TITLE
Fix suite DB UTC mode parameter error

### DIFF
--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -380,7 +380,7 @@ conditions; see `cylc conditions`.
         self.suite_db_mgr.put_suite_params(
             self.run_mode,
             CYLC_VERSION,
-            str(GLOBAL_CFG.get(['cylc', 'UTC mode'])),
+            str(cylc.flags.utc),
             self.initial_point,
             self.final_point,
             self.pool.is_held,
@@ -886,7 +886,7 @@ conditions; see `cylc conditions`.
         self.suite_db_mgr.put_suite_params(
             self.run_mode,
             CYLC_VERSION,
-            str(GLOBAL_CFG.get(['cylc', 'UTC mode'])),
+            str(cylc.flags.utc),
             self.initial_point,
             self.final_point,
             self.pool.is_held,

--- a/tests/restart/15-state-to-db.t
+++ b/tests/restart/15-state-to-db.t
@@ -58,7 +58,7 @@ run_ok "${TEST_NAME_BASE}-suite_params" \
 sed -i "s/$(cylc --version)/<SOME-VERSION>/g" \
     "${TEST_NAME_BASE}-suite_params.stdout"
 cmp_ok "${TEST_NAME_BASE}-suite_params.stdout" <<__OUT__
-UTC_mode|False
+UTC_mode|True
 cylc_version|<SOME-VERSION>
 final_point|20050101T0000Z
 initial_point|20000101T0000Z


### PR DESCRIPTION
Amends an issue with the recently-merged PR #2575 (my own!), which occurred because I did not fully clarify what was required from verbal feedback response from @matthewrmshin who pointed out a newly-introduced issue after the feedback response commit but approved before I implemented it. Namely, `GLOBAL_CFG.get(['cylc', 'UTC mode'])` does not produce the correct UTC mode parameter (being the global and not suite-specific setting), unlike the original `cylc.flags.utc`. When looking at the `suite.rc` file for the `restart/15-state-to-db.t` test, one sees that `UTC mode = True` is in fact set, demonstrating this is the case, as the added test wrongly specified it should appear in the database as the default `False`.

My apologies for the muddle / need for a separate PR @hjoliver!