### PR TITLE
Permit syntax errors with trigger edits.

### DIFF
--- a/bin/cylc-trigger
+++ b/bin/cylc-trigger
@@ -113,7 +113,8 @@ def main():
             old_mtime = None
 
         # Tell the suite server program to generate the job file.
-        pclient.put_command('dry_run_tasks', items=[task_id])
+        pclient.put_command('dry_run_tasks', items=[task_id],
+                            check_syntax=False)
 
         # Wait for the new job file to be written. Use mtime because the same
         # file could potentially exist already, left from a previous run.

--- a/lib/cylc/network/httpserver.py
+++ b/lib/cylc/network/httpserver.py
@@ -251,7 +251,7 @@ class SuiteRuntimeService(object):
         self._check_access_priv_and_report(PRIV_FULL_CONTROL)
         if not isinstance(items, list):
             items = [items]
-        check_syntax = check_syntax in [True, 'True']
+        check_syntax = self._literal_eval('check_syntax', check_syntax)
         self.schd.command_queue.put(('dry_run_tasks', (items,),
                                     {'check_syntax': check_syntax}))
         return (True, 'Command queued')

--- a/lib/cylc/network/httpserver.py
+++ b/lib/cylc/network/httpserver.py
@@ -243,7 +243,7 @@ class SuiteRuntimeService(object):
 
     @cherrypy.expose
     @cherrypy.tools.json_out()
-    def dry_run_tasks(self, items):
+    def dry_run_tasks(self, items, check_syntax=True):
         """Prepare job file for a task.
 
         items[0] is an identifier for matching a task proxy.
@@ -251,7 +251,9 @@ class SuiteRuntimeService(object):
         self._check_access_priv_and_report(PRIV_FULL_CONTROL)
         if not isinstance(items, list):
             items = [items]
-        self.schd.command_queue.put(("dry_run_tasks", (items,), {}))
+        check_syntax = check_syntax in [True, 'True']
+        self.schd.command_queue.put(('dry_run_tasks', (items,),
+                                    {'check_syntax': check_syntax}))
         return (True, 'Command queued')
 
     @cherrypy.expose

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -1613,7 +1613,7 @@ conditions; see `cylc conditions`.
         """Trigger tasks."""
         return self.pool.trigger_tasks(items, back_out)
 
-    def command_dry_run_tasks(self, items):
+    def command_dry_run_tasks(self, items, check_syntax=True):
         """Dry-run tasks, e.g. edit run."""
         itasks, bad_items = self.pool.filter_task_proxies(items)
         n_warnings = len(bad_items)
@@ -1622,7 +1622,8 @@ conditions; see `cylc conditions`.
             return n_warnings + 1
         while self.stop_mode is None:
             prep_tasks, bad_tasks = self.task_job_mgr.prep_submit_task_jobs(
-                self.suite, [itasks[0]], dry_run=True)
+                self.suite, [itasks[0]], dry_run=True,
+                check_syntax=check_syntax)
             if itasks[0] in prep_tasks:
                 return n_warnings
             elif itasks[0] in bad_tasks:

--- a/lib/cylc/task_job_mgr.py
+++ b/lib/cylc/task_job_mgr.py
@@ -778,7 +778,7 @@ class TaskJobManager(object):
                 suite, itask.point, itask.tdef.name, itask.submit_num,
                 self.JOB_FILE_BASE)
             self.job_file_writer.write(local_job_file_path, job_conf,
-                check_syntax=check_syntax)
+                                       check_syntax=check_syntax)
         except StandardError as exc:
             # Could be a bad command template, IOError, etc
             self._prep_submit_task_job_error(

--- a/lib/cylc/task_job_mgr.py
+++ b/lib/cylc/task_job_mgr.py
@@ -149,7 +149,8 @@ class TaskJobManager(object):
             self._run_job_cmd(
                 self.JOBS_POLL, suite, poll_me, self._poll_task_jobs_callback)
 
-    def prep_submit_task_jobs(self, suite, itasks, dry_run=False):
+    def prep_submit_task_jobs(self, suite, itasks, dry_run=False,
+                              check_syntax=True):
         """Prepare task jobs for submit.
 
         Prepare tasks where possible. Ignore tasks that are waiting for host
@@ -161,7 +162,8 @@ class TaskJobManager(object):
         prepared_tasks = []
         bad_tasks = []
         for itask in itasks:
-            prep_task = self._prep_submit_task_job(suite, itask, dry_run)
+            prep_task = self._prep_submit_task_job(suite, itask, dry_run,
+                                                   check_syntax=check_syntax)
             if prep_task:
                 prepared_tasks.append(itask)
             elif prep_task is False:
@@ -727,7 +729,7 @@ class TaskJobManager(object):
                     self.task_events_mgr.EVENT_SUBMIT_FAILED, ctx.timestamp),
                 self.poll_task_jobs)
 
-    def _prep_submit_task_job(self, suite, itask, dry_run):
+    def _prep_submit_task_job(self, suite, itask, dry_run, check_syntax=True):
         """Prepare a task job submission.
 
         Return itask on a good preparation.
@@ -775,7 +777,8 @@ class TaskJobManager(object):
             local_job_file_path = self.task_events_mgr.get_task_job_log(
                 suite, itask.point, itask.tdef.name, itask.submit_num,
                 self.JOB_FILE_BASE)
-            self.job_file_writer.write(local_job_file_path, job_conf)
+            self.job_file_writer.write(local_job_file_path, job_conf,
+                check_syntax=check_syntax)
         except StandardError as exc:
             # Could be a bad command template, IOError, etc
             self._prep_submit_task_job_error(

--- a/tests/cylc-trigger/03-edit-run.t
+++ b/tests/cylc-trigger/03-edit-run.t
@@ -18,7 +18,7 @@
 # Test an edit-run (cylc trigger --edit).
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
-set_test_number 3
+set_test_number 4
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-validate"
@@ -44,6 +44,25 @@ cmp_ok "${DIFF_LOG}" - <<'__END__'
  cylc__job__inst__script() {
  # SCRIPT:
 -/bin/false
++/bin/true
+ }
+ 
+ . "${CYLC_DIR}/lib/cylc/job.sh"
+__END__
+#-------------------------------------------------------------------------------
+TEST_NAME="${TEST_NAME_BASE}-diff2"
+DIFF_LOG=$(cylc cat-log -dl $SUITE_NAME syntax_errored_task.1)
+# Python 2.6 difflib adds an extra space after the filename,
+# but Python 2.7 does not. Remove it if it exists.
+sed -i 's/^--- original $/--- original/; s/^+++ edited $/+++ edited/' $DIFF_LOG
+cmp_ok "${DIFF_LOG}" - <<'__END__'
+--- original
++++ edited
+@@ -30,7 +30,7 @@
+ 
+ cylc__job__inst__script() {
+ # SCRIPT:
+-$(
 +/bin/true
  }
  

--- a/tests/cylc-trigger/03-edit-run/bin/my-edit
+++ b/tests/cylc-trigger/03-edit-run/bin/my-edit
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sed -i 's@/bin/false@/bin/true@' "$@"
+sed -i 's@\(/bin/false\|$(\)@/bin/true@' "$@"

--- a/tests/cylc-trigger/03-edit-run/suite.rc
+++ b/tests/cylc-trigger/03-edit-run/suite.rc
@@ -9,12 +9,22 @@ second task fixes and retriggers it with an edit-run."""
         timeout = PT20S
 [scheduling]
     [[dependencies]]
-        graph = broken-task:fail => fixer-task
+        graph = """
+            broken-task:fail => fixer-task
+            syntax_errored_task:submit-fail => syntax_fixer_task
+        """
 [runtime]
     [[broken-task]]
         script = /bin/false
     [[fixer-task]]
         script = """
 cylc trigger --edit $CYLC_SUITE_NAME broken-task 1 << __END__
+y
+__END__"""
+    [[syntax_errored_task]]
+        script = $(
+    [[syntax_fixer_task]]
+        script = """
+cylc trigger --edit $CYLC_SUITE_NAME syntax_errored_task 1 << __END__
 y
 __END__"""


### PR DESCRIPTION
At present the cylc job file writer aborts on syntax error, this causes `cylc trigger` to hang as no job file is written. This PR skips the syntax check for dry runs so that users can attempt to fix their scripts at runtime via `cylc trigger --edit`.

Possibly related to reported intermittent hanging of `cylc trigger --edit`.