### PR TITLE
New task event for alerting of post-start 'late' clock-triggers

### DIFF
--- a/lib/cylc/cfgspec/suite.py
+++ b/lib/cylc/cfgspec/suite.py
@@ -402,6 +402,7 @@ SPEC = {
                 'succeeded handler': vdr(vtype='string_list'),
                 'failed handler': vdr(vtype='string_list'),
                 'submission failed handler': vdr(vtype='string_list'),
+                'late handler': vdr(vtype='string_list'),
                 'warning handler': vdr(vtype='string_list'),
                 'critical handler': vdr(vtype='string_list'),
                 'retry handler': vdr(vtype='string_list'),

--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -25,7 +25,6 @@ from cylc.task_id import TaskID
 from cylc.task_state import (
     TaskState, TASK_STATUS_WAITING, TASK_STATUS_RETRYING)
 from cylc.wallclock import get_unix_time_from_time_string
-from cylc.task_events_mgr import TaskEventsManager
 
 
 class TaskProxySequenceBoundsError(ValueError):
@@ -45,7 +44,7 @@ class TaskProxy(object):
                  "is_manual_submit", "summary", "local_job_file_path",
                  "try_timers", "task_host", "task_owner",
                  "job_vacated", "poll_timers", "timeout_timers",
-                 "delayed_start", "expire_time", "state", "task_is_late"]
+                 "delayed_start", "expire_time", "state"]
 
     def __init__(
             self, tdef, start_point, status=TASK_STATUS_WAITING,
@@ -111,7 +110,6 @@ class TaskProxy(object):
         self.timeout_timers = {}
         self.try_timers = {}
 
-        self.task_is_late = False
         self.delayed_start = None
         self.expire_time = None
 
@@ -210,26 +208,17 @@ class TaskProxy(object):
         Queued tasks are not counted as they've already been deemed ready.
 
         """
-        if self.start_time_reached(now):
-            if (not self.task_is_late and
-                self.tdef.clocktrigger_offset is not None and
-                not self.state.prerequisites_are_all_satisfied()):
-                #TaskEventsManager.setup_event_handlers(self.identity, 'late',
-                #                                       'Task late.')
-                self.task_is_late = True
-            return (
-                (
-                    self.state.status == TASK_STATUS_WAITING and
-                    self.state.prerequisites_are_all_satisfied() and
-                    all(self.state.external_triggers.values())
-                ) or
-                (
-                    self.state.status in self.try_timers and
-                    self.try_timers[self.state.status].is_delay_done(now)
-                )
+        return self.start_time_reached(now) and (
+            (
+                self.state.status == TASK_STATUS_WAITING and
+                self.state.prerequisites_are_all_satisfied() and
+                all(self.state.external_triggers.values())
+            ) or
+            (
+                self.state.status in self.try_timers and
+                self.try_timers[self.state.status].is_delay_done(now)
             )
-        else:
-            return False
+        )
 
     def reset_manual_trigger(self):
         """This is called immediately after manual trigger flag used."""

--- a/tests/cylc-get-config/00-simple/section2.stdout
+++ b/tests/cylc-get-config/00-simple/section2.stdout
@@ -26,6 +26,7 @@
         succeeded handler = 
         retry handler = 
         failed handler = 
+        late handler = 
         handler events = 
         mail smtp = 
         handlers = 
@@ -104,6 +105,7 @@
         succeeded handler = 
         retry handler = 
         failed handler = 
+        late handler = 
         handler events = 
         mail smtp = 
         handlers = 
@@ -181,6 +183,7 @@
         succeeded handler = 
         retry handler = 
         failed handler = 
+        late handler = 
         handler events = 
         mail smtp = 
         handlers = 
@@ -259,6 +262,7 @@
         succeeded handler = 
         retry handler = 
         failed handler = 
+        late handler = 
         handler events = 
         mail smtp = 
         handlers = 
@@ -337,6 +341,7 @@
         succeeded handler = 
         retry handler = 
         failed handler = 
+        late handler = 
         handler events = 
         mail smtp = 
         handlers = 
@@ -426,6 +431,7 @@
         succeeded handler = 
         retry handler = 
         failed handler = 
+        late handler = 
     [[[environment]]]
     [[[parameter environment templates]]]
     [[[directives]]]
@@ -504,6 +510,7 @@
         succeeded handler = 
         retry handler = 
         failed handler = 
+        late handler = 
     [[[environment]]]
     [[[parameter environment templates]]]
     [[[directives]]]
@@ -582,6 +589,7 @@
         succeeded handler = 
         retry handler = 
         failed handler = 
+        late handler = 
     [[[environment]]]
     [[[parameter environment templates]]]
     [[[directives]]]
@@ -659,6 +667,7 @@
         succeeded handler = 
         retry handler = 
         failed handler = 
+        late handler = 
     [[[environment]]]
     [[[parameter environment templates]]]
     [[[directives]]]
@@ -737,6 +746,7 @@
         succeeded handler = 
         retry handler = 
         failed handler = 
+        late handler = 
     [[[environment]]]
     [[[parameter environment templates]]]
     [[[directives]]]
@@ -815,6 +825,7 @@
         succeeded handler = 
         retry handler = 
         failed handler = 
+        late handler = 
     [[[environment]]]
     [[[parameter environment templates]]]
     [[[directives]]]
@@ -892,6 +903,7 @@
         succeeded handler = 
         retry handler = 
         failed handler = 
+        late handler = 
     [[[environment]]]
     [[[parameter environment templates]]]
     [[[directives]]]
@@ -970,6 +982,7 @@
         succeeded handler = 
         retry handler = 
         failed handler = 
+        late handler = 
     [[[environment]]]
     [[[parameter environment templates]]]
     [[[directives]]]


### PR DESCRIPTION
! **Reviewers: please ignore for the time being, I am not quite there with this (the 'late' event is not yet showing up in auto-emails, though no errors being raised in debug mode) but I am opening a PR to make it easier to discuss the difficulties I am having with the team ASAP next week** !

Closes #2207. As per the discussion within that issue (to summarise it), implemented so that an alert is _only_ raised _once_ and only for tasks with clock-triggers _subsequent_ to the suite start-time ('non-historical') so as to be potentially useful to users e.g. for operational forecasting, without being an annoyance. I went with `late` rather than `delayed` as the event name since a quick 'grep' of the codebase revealed 'delay' is used quite often as a scheduling keyword with 'late' largely unutilised, making it a bit more distinct as an event name.