### PR TITLE
gcylc: prevent negative job progress

### DIFF
--- a/lib/cylc/gui/updater_tree.py
+++ b/lib/cylc/gui/updater_tree.py
@@ -251,11 +251,15 @@ class TreeUpdater(threading.Thread):
                             isinstance(meant, int))):
                         tetc_unix = tstart + meant
                         tnow = time()
-                        if tnow > tetc_unix:
+                        if tstart > tnow:
+                            # Reportably possible via interraction with
+                            # cylc reset.
+                            t_info['progress'] = 0
+                        elif tnow > tetc_unix:
                             t_info['progress'] = 100
                         elif meant != 0:
                             t_info['progress'] = int(
-                                100 * (tnow - tstart) / (tetc_unix - tstart))
+                                100 * (tnow - tstart) / (meant))
 
                     if (t_info['finished_time_string'] is None and
                             isinstance(tstart, float) and


### PR DESCRIPTION
Fix unreproducible bug whereby the gui attempts to display a negative progress value when a task's status is juggled about via `cylc reset`, see traceback:

```
/data/local/fcm/cylc-7.5.0/lib/cylc/gui/view_tree.py:318: Warning: value "-43" of type `gint' is invalid or out of range for property `value' of type `gint'
  cell.set_property('value', percent)
```