### PR TITLE
Lowercase for shell bool vars.

### DIFF
--- a/bin/cylc-message
+++ b/bin/cylc-message
@@ -61,11 +61,11 @@ def main():
         key, value = item.split('=', 1)
         os.environ[key] = value
     task_message = TaskMessage(severity=options.severity)
-    if (task_message.env_map.get('CYLC_VERBOSE') in ["True", "true"] or
+    if (task_message.env_map.get('CYLC_VERBOSE') == "true" or
             options.verbose):
         cylc.flags.verbose = True
 
-    if task_message.env_map.get('CYLC_DEBUG') in ["True", "true"]:
+    if task_message.env_map.get('CYLC_DEBUG') == "true":
         cylc.flags.debug = True
 
     try:

--- a/bin/cylc-submit
+++ b/bin/cylc-submit
@@ -106,8 +106,8 @@ def main():
     task_job_mgr.task_remote_mgr.single_task_mode = True
     task_job_mgr.job_file_writer.set_suite_env({
         'CYLC_UTC': str(config.cfg['cylc']['UTC mode']),
-        'CYLC_DEBUG': str(cylc.flags.debug),
-        'CYLC_VERBOSE': str(cylc.flags.verbose),
+        'CYLC_DEBUG': str(cylc.flags.debug).lower(),
+        'CYLC_VERBOSE': str(cylc.flags.verbose).lower(),
         'CYLC_SUITE_NAME': suite,
         'CYLC_CYCLING_MODE': str(cylc.flags.cycling_mode),
         'CYLC_SUITE_INITIAL_CYCLE_POINT': str(

--- a/lib/cylc/job_file.py
+++ b/lib/cylc/job_file.py
@@ -156,7 +156,7 @@ class JobFileWriter(object):
         # Environment variables for prelude
         handle.write("\nexport CYLC_DIR='%s'" % (os.environ['CYLC_DIR']))
         if cylc.flags.debug:
-            handle.write("\nexport CYLC_DEBUG='true'")
+            handle.write("\nexport CYLC_DEBUG=true")
         for key in ['CYLC_VERSION'] + self._get_host_item(
                 job_conf, 'copyable environment variables'):
             if key in os.environ:

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -1054,8 +1054,8 @@ conditions; see `cylc conditions`.
         # Pass static cylc and suite variables to job script generation code
         self.task_job_mgr.job_file_writer.set_suite_env({
             'CYLC_UTC': str(cylc.flags.utc),
-            'CYLC_DEBUG': str(cylc.flags.debug),
-            'CYLC_VERBOSE': str(cylc.flags.verbose),
+            'CYLC_DEBUG': str(cylc.flags.debug).lower(),
+            'CYLC_VERBOSE': str(cylc.flags.verbose).lower(),
             'CYLC_SUITE_NAME': self.suite,
             'CYLC_CYCLING_MODE': str(cylc.flags.cycling_mode),
             'CYLC_SUITE_INITIAL_CYCLE_POINT': str(self.initial_point),

--- a/tests/jobscript/18-no-err.t
+++ b/tests/jobscript/18-no-err.t
@@ -1,0 +1,30 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+
+# Test that job.err is empty if nothing fails; see GitHub #2604
+
+. "$(dirname "${0}")/test_header"
+set_test_number 3
+
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+run_ok "${TEST_NAME_BASE}-run" cylc run "${SUITE_NAME}" --no-detach 
+JOB_ERR=$(cylc cat-log -l -e ${SUITE_NAME} foo.1)
+cmp_ok $JOB_ERR << __END__
+__END__
+purge_suite "${SUITE_NAME}"

--- a/tests/jobscript/18-no-err/suite.rc
+++ b/tests/jobscript/18-no-err/suite.rc
@@ -1,0 +1,10 @@
+[cylc]
+    [[events]]
+        inactivity = PT20S
+        abort on inactivity = True
+[scheduling]
+    [[dependencies]]
+        graph = foo
+[runtime]
+    [[foo]]
+        script = echo "hello"


### PR DESCRIPTION
Just noticed in job.err files:
```
$ cylc cat-log -e foo foo.1
/home/vagrant/cylc.git/lib/cylc/job.sh: line 29: False: command not found
```
Due to use of Python `str(bool)` as a shell boolean, or testing of  such a value in the job script - broken sometime since last release.
