### PR TITLE
Fix test 13-ready-restart.

### DIFF
--- a/tests/hold-release/13-ready-restart.t
+++ b/tests/hold-release/13-ready-restart.t
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test #958: task in ready state, stop now, restart hold, release
+# Test restart with a "ready" task. See GitHub #958 (update: and #2610).
 . "$(dirname "$0")/test_header"
 
 set_test_number 4

--- a/tests/hold-release/13-ready-restart/suite.rc
+++ b/tests/hold-release/13-ready-restart/suite.rc
@@ -1,11 +1,10 @@
 [meta]
-    title = Restart with hold, with a task in ready state
+    title = Restart with a task in the ready state.
 
 [cylc]
-    [[reference test]]
-        live mode suite timeout = PT1M
-        dummy mode suite timeout = PT1M
-        simulation mode suite timeout = PT1M
+    [[events]]
+        inactivity = PT30S
+        abort on inactivity = True
 
 [scheduling]
     [[dependencies]]
@@ -25,15 +24,21 @@ bar
             batch submit command template = sleep 10
     [[bar]]
         script = """
-# Stop the suite as soon as job file of "foo-1" is in the ready state
+# Stop the suite as soon as job file of "foo-1" is in the ready state.
 timeout 1m my-file-poll "${CYLC_SUITE_RUN_DIR}/log/job/1/foo-1/NN/job"
-cylc stop --now --now --max-polls=10 --interval=1 "${CYLC_SUITE_NAME}"
-# Restart the suite on hold
+# Kill the suite (cylc stop --now --now also kills the foo-1 job submit process
+# and may result in foo-1 going to the submit-failed state instead of ready).
+SUITE_PROC=$(cylc get-suite-contact $CYLC_SUITE_NAME | grep PROCESS)
+SUITE_PID=$(expr "$SUITE_PROC" : '.*=\([0-9].*\) python.*')
+kill -9 $SUITE_PID
+# Let the old job submit process finish.
+sleep 10
+# Restart the suite on hold.
 cylc restart --hold "${CYLC_SUITE_NAME}"
 timeout 1m my-log-grepper 'Held on start-up (no tasks will be submitted)'
-# Modify the job submission command template for "foo-1"
+# Modify the job submission command template for "foo-1".
 cylc broadcast "${CYLC_SUITE_NAME}" \
     -p '1' -n 'foo-1' -s '[job]batch submit command template=at now'
-# Release the suite to run to completion
+# Release the suite to run to completion.
 cylc release "${CYLC_SUITE_NAME}"
 """


### PR DESCRIPTION
Close #2610 

See https://github.com/cylc/cylc/issues/2610#issuecomment-376287090

This modified test, using kill instead of shutdown, seems to work reliably.  Watching the process table, the suite kill clearly leaves the job submit process running, so no chance of ending up with foo-1 submit-failed instead of ready.