### PR TITLE
Ensure '.' can be used for inspection commands.

### DIFF
--- a/lib/cylc/suite_srv_files_mgr.py
+++ b/lib/cylc/suite_srv_files_mgr.py
@@ -385,6 +385,8 @@ To start a new run, stop the old one first with one or more of these:
         If arg is a file, suite name is the base name of its container
         directory.
         """
+        if arg == '.':
+            arg = os.getcwd()
         try:
             path = self.get_suite_rc(arg, options.suite_owner)
             name = arg


### PR DESCRIPTION
Using `.` as a suite path e.g:
```
cylc validate .
```
works intermittently in my environment.

PR adds a failsafe to ensure this behaviour is reliable in these circumstances (whatever they turn out to be).