### PR TITLE
pycodestyle: fixes

### DIFF
--- a/bin/cylc-edit
+++ b/bin/cylc-edit
@@ -199,7 +199,7 @@ def main():
     print 'INCLUDE-FILES WRITTEN:'
     for file in newfiles:
         f = re.sub(suitedir + '/', '', file)
-        if re.search('\.EDIT\.NEW\.', f):
+        if re.search(r'\.EDIT\.NEW\.', f):
             print ' + ' + f + ' (!!! WARNING: original changed on disk !!!)'
         else:
             print ' + ' + f

--- a/bin/cylc-gui
+++ b/bin/cylc-gui
@@ -36,7 +36,7 @@ To see current configuration settings use "cylc get-gui-config".
 
 In the graph view, View -> Options -> "Write Graph Frames" writes .dot graph
 files to the suite share directory (locally, for a remote suite). These can
-be processed into a movie by \$CYLC_DIR/dev/bin/live-graph-movie.sh=."""
+be processed into a movie by $CYLC_DIR/dev/bin/live-graph-movie.sh=."""
 
 import sys
 if '--use-ssh' in sys.argv[1:]:

--- a/bin/cylc-profile-battery
+++ b/bin/cylc-profile-battery
@@ -389,7 +389,7 @@ def install_experiments(experiment_ids, experiments, install_dir,
                 string = ''
                 for setting in run['globalrc']:
                     indent = 0
-                    setting = re.split('[\[\]]+', setting.strip())
+                    setting = re.split(r'[\[\]]+', setting.strip())
                     for part in setting[:-1]:  # Key hierarchy.
                         if not part:
                             continue

--- a/bin/cylc-search
+++ b/bin/cylc-search
@@ -48,7 +48,7 @@ def section_level(heading):
     # e.g. foo => 0
     #     [foo] => 1
     #    [[foo]] => 2
-    m = re.match('^(\[+)', heading)
+    m = re.match(r'^(\[+)', heading)
     if m:
         level = len(m.groups()[0])
     else:
@@ -97,7 +97,7 @@ prev_file = None
 
 for line in lines:
 
-    m = re.match('^#\+\+\+\+ START INLINED INCLUDE FILE ([\w/\.\-]+)', line)
+    m = re.match(r'^#\+\+\+\+ START INLINED INCLUDE FILE ([\w/\.\-]+)', line)
     if m:
         inc_file = m.groups()[0]
         in_include_file = True
@@ -108,18 +108,17 @@ for line in lines:
         line_count += 1
     else:
         inc_line_count += 1
-        m = re.match('^#\+\+\+\+ END INLINED INCLUDE FILE ' + inc_file, line)
+        m = re.match(r'^#\+\+\+\+ END INLINED INCLUDE FILE ' + inc_file, line)
         if m:
             in_include_file = False
             inc_file = None
             continue
 
-    m = re.match('\s*(\[+\s*(.+)\s*\]+)', line)
+    m = re.match(r'\s*(\[+\s*.+\s*\]+)', line)
     if m:
         # new section heading detected
         heading = m.groups()[0]
         level = section_level(heading)
-        name = m.groups()[1]
         # unwind to the current section level
         while len(sections) > level - 1:
             sections.pop()
@@ -154,22 +153,22 @@ if not options.search_bin:
     sys.exit(0)
 
 # search files in suite bin directory
-bin = os.path.join(suitedir, 'bin')
-if not os.path.isdir(bin):
+bin_ = os.path.join(suitedir, 'bin')
+if not os.path.isdir(bin_):
     print >> sys.stderr, "\nSuite " + suite + " has no bin directory"
     sys.exit(0)
 
-for file in os.listdir(bin):
-    if re.match('^\.', file):
+for name in os.listdir(bin_):
+    if name.startswith('.'):
         # skip hidden dot-files
         # (e.g. vim editor temporary files)
         continue
     new_file = True
     try:
-        h = open(os.path.join(bin, file), 'rb')
+        h = open(os.path.join(bin_, name), 'rb')
     except IOError, x:
         # e.g. there's a sub-directory under bin; ignore it.
-        print >> sys.stderr, 'Unable to open file ' + os.path.join(bin, file)
+        print >> sys.stderr, 'Unable to open file ' + os.path.join(bin_, name)
         print >> sys.stderr, x
         continue
     contents = h.readlines()
@@ -181,6 +180,6 @@ for file in os.listdir(bin):
         count += 1
         if re.search(pattern, line):
             if new_file:
-                print '\nFILE:', os.path.join(bin, file)
+                print '\nFILE:', os.path.join(bin_, name)
                 new_file = False
             print '   (' + str(count) + '): ' + line

--- a/bin/cylc-upgrade-run-dir
+++ b/bin/cylc-upgrade-run-dir
@@ -35,7 +35,7 @@ from cylc.mkdir_p import mkdir_p
 import cylc.flags
 
 OLD_LOGFILE_RE = re.compile(
-    """^
+    r"""^
     ([\w]+)  # task name
     \.
     ([^.]+)  # any cycle time format
@@ -49,7 +49,7 @@ OLD_LOGFILE_RE = re.compile(
 )
 
 OLD_WORKDIR_RE = re.compile(
-    """^
+    r"""^
     ([\w]+)  # task name
     \.
     ([^.]+)  # any cycle time format

--- a/lib/cylc/cycling/integer.py
+++ b/lib/cylc/cycling/integer.py
@@ -60,11 +60,11 @@ CYCLER_TYPE_SORT_KEY_INTEGER = "a"
 #         4: start at END, keep subtracting INTV (if n, only for n points)
 
 RE_COMPONENTS = {
-    "end": "(?P<end>[^PR/][^/]*)",
-    "intv": "(?P<intv>P[^/]*)",
-    "reps_1": "R(?P<reps>1)",
-    "reps": "R(?P<reps>\d+)",
-    "start": "(?P<start>[^PR/][^/]*)"
+    "end": r"(?P<end>[^PR/][^/]*)",
+    "intv": r"(?P<intv>P[^/]*)",
+    "reps_1": r"R(?P<reps>1)",
+    "reps": r"R(?P<reps>\d+)",
+    "start": r"(?P<start>[^PR/][^/]*)"
 }
 
 RECURRENCE_FORMAT_RECS = [
@@ -112,8 +112,8 @@ RECURRENCE_FORMAT_RECS = [
 del regex, format_num
 
 
-REC_RELATIVE_POINT = re.compile("^[-+]P\d+$")
-REC_INTERVAL = re.compile("^[-+]?P\d+$")
+REC_RELATIVE_POINT = re.compile(r"^[-+]P\d+$")
+REC_INTERVAL = re.compile(r"^[-+]?P\d+$")
 
 
 class IntegerPoint(PointBase):

--- a/lib/cylc/cylc_xdot.py
+++ b/lib/cylc/cylc_xdot.py
@@ -578,11 +578,11 @@ def get_reference_from_plain_format(plain_text):
     indexed_lines = []
     for line in plain_text.splitlines(True):
         # Remove spaces followed by numbers.
-        line = re.sub(r"\s+[+-]?\d+(?:\.\d+)?(?:e[+-][.\d]+)?\b", "", line)
+        line = re.sub(r"\s+[+-]?\d+(?:\.\d+)?(?:e[+-][.\d]+)?\b", r"", line)
         # Get rid of extra spaces.
-        line = re.sub("^((?:node|edge).*)\s+\w+", r"\1", line)
+        line = re.sub(r"^((?:node|edge).*)\s+\w+", r"\1", line)
         # Create a numeric content index.
-        line_items = re.split("(\d+)", line)
+        line_items = re.split(r"(\d+)", line)
         for i, item in enumerate(line_items):
             try:
                 line_items[i] = int(item)

--- a/lib/cylc/envvar.py
+++ b/lib/cylc/envvar.py
@@ -27,7 +27,7 @@ def check_varnames(env):
     returns a list of bad names (empty implies success)."""
     bad = []
     for varname in env:
-        if not re.match('^[a-zA-Z_][\w]*$', varname):
+        if not re.match(r'^[a-zA-Z_][\w]*$', varname):
             bad.append(varname)
     return bad
 

--- a/lib/cylc/graph_parser.py
+++ b/lib/cylc/graph_parser.py
@@ -129,8 +129,8 @@ class GraphParser(object):
 
     # Detect and extract suite state polling task info.
     REC_SUITE_STATE = re.compile(
-        r'(' + TaskID.NAME_RE + ')(<([\w\.\-/]+)::(' + TaskID.NAME_RE + ')(' +
-        _RE_TRIG + ')?>)')
+        r'(' + TaskID.NAME_RE + r')(<([\w\.\-/]+)::(' + TaskID.NAME_RE + r')('
+        + _RE_TRIG + r')?>)')
 
     def __init__(self, family_map=None, parameters=None):
         """Initializing the graph string parser.

--- a/lib/cylc/gui/cylc_logviewer.py
+++ b/lib/cylc/gui/cylc_logviewer.py
@@ -97,7 +97,8 @@ class cylc_logviewer(logviewer):
         if task == 'all':
             filter_ = None
         else:
-            filter_ = '\\[' + task + '%\d+\\]'
+            # Good enough to match "[task.CYCLE]"?
+            filter_ = r'\[' + task + r'\.[^\]]+\]'
 
         self.task_filter = filter_
         self.update_view()

--- a/lib/cylc/log_diagnosis.py
+++ b/lib/cylc/log_diagnosis.py
@@ -85,7 +85,7 @@ class LogAnalyser(object):
     def get_triggered(lines):
         res = []
         for line in lines:
-            m = re.search('INFO - (\[.* -triggered off .*)$', line)
+            m = re.search(r'INFO - (\[.* -triggered off .*)$', line)
             if m:
                 res.append(m.groups()[0])
         return res

--- a/lib/cylc/network/httpserver.py
+++ b/lib/cylc/network/httpserver.py
@@ -684,7 +684,7 @@ class SuiteRuntimeService(object):
         return (True, 'Command queued')
 
     def _access_priv_ok(self, required_privilege_level):
-        """Return True if a client is allowed access to info from server_obj.
+        """Return True if a client has enough privilege for given level.
 
         The required privilege level is compared to the level granted to the
         client by the connection validator (held in thread local storage).
@@ -696,7 +696,7 @@ class SuiteRuntimeService(object):
             return False
 
     def _check_access_priv(self, required_privilege_level):
-        """Raise an exception if client privilege is insufficient for server_obj.
+        """Raise an exception if client privilege is insufficient.
 
         (See the documentation above for the boolean version of this function).
 

--- a/lib/cylc/param_expand.py
+++ b/lib/cylc/param_expand.py
@@ -230,7 +230,7 @@ class NameExpander(object):
                     "ERROR, parameter offsets illegal here: '%s'" % origin)
             elif '=' in item:
                 # Specific value given.
-                pname, pval = re.split('\s*=\s*', item)
+                pname, pval = [val.strip() for val in item.split('=', 1)]
                 try:
                     pval = int(pval)
                 except ValueError:

--- a/lib/cylc/print_tree.py
+++ b/lib/cylc/print_tree.py
@@ -25,7 +25,7 @@ a_hbar = '-'
 a_vbar = '|'
 a_tee = a_vbar + a_hbar
 a_trm = '`' + a_hbar
-a_tee_re = '\|' + a_hbar
+a_tee_re = r'\|' + a_hbar
 
 # Unicode box-printing characters
 u_hbar = u'\u2500'

--- a/lib/cylc/profiling/__init__.py
+++ b/lib/cylc/profiling/__init__.py
@@ -29,7 +29,7 @@ def get_cylc_directory():
         ['cylc', 'version', '--long'],
         stdout=PIPE, stdin=open(os.devnull)).communicate()
     try:
-        return os.path.realpath(re.search('\((.*)\)', ver_str).groups()[0])
+        return os.path.realpath(re.search(r'\((.*)\)', ver_str).groups()[0])
     except IndexError:
         sys.exit('Could not locate local git repository for cylc.')
 
@@ -70,15 +70,17 @@ PROFILE_FILES = {
 
 # ------------- REGEXES ---------------
 # Matches the summary line from the cylc <cmd> --profile output.
-SUMMARY_LINE_REGEX = re.compile('([\d]+) function calls \(([\d]+) primitive'
-                                ' calls\) in ([\d.]+)(?: CPU)? seconds')
+SUMMARY_LINE_REGEX = re.compile(
+    r'([\d]+) function calls \(([\d]+) primitive'
+    r' calls\) in ([\d.]+)(?: CPU)? seconds')
 # Matches the memory checkpoints in the cylc <cmd> --profile output
-MEMORY_LINE_REGEX = re.compile('PROFILE: Memory: ([\d]+) KiB: ([\w.]+): (.*)')
+MEMORY_LINE_REGEX = re.compile(
+    r'PROFILE: Memory: ([\d]+) KiB: ([\w.]+): (.*)')
 # Matches main-loop memory checkpoints in cylc <cmd> --profile output.
-LOOP_MEMORY_LINE_REGEX = re.compile('(?:loop #|end main loop \(total loops )'
-                                    '([\d]+)(?:: |\): )(.*)')
+LOOP_MEMORY_LINE_REGEX = re.compile(
+    r'(?:loop #|end main loop \(total loops )([\d]+)(?:: |\): )(.*)')
 # Matches the sleep function line in cylc <cmd> --profile output.
-SLEEP_FUNCTION_REGEX = re.compile('([\d.]+)[\s]+[\d.]+[\s]+\{time.sleep\}')
+SLEEP_FUNCTION_REGEX = re.compile(r'([\d.]+)[\s]+[\d.]+[\s]+\{time.sleep\}')
 # The string prefixing the suite-startup timestamp (unix time).
 SUITE_STARTUP_STRING = 'SUITE STARTUP: '
 

--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -103,7 +103,7 @@ class TaskEventsManager(object):
     NN = "NN"
     POLLED_INDICATOR = "(polled)"
     RE_MESSAGE_TIME = re.compile(
-        '\A(.+) at (' + RE_DATE_TIME_FORMAT_EXTENDED + ')\Z', re.DOTALL)
+        r'\A(.+) at (' + RE_DATE_TIME_FORMAT_EXTENDED + r')\Z', re.DOTALL)
 
     def __init__(self, suite, proc_pool, suite_db_mgr, broadcast_mgr=None):
         self.suite = suite

--- a/lib/cylc/time_parser.py
+++ b/lib/cylc/time_parser.py
@@ -98,19 +98,23 @@ class CylcTimeParser(object):
         (re.compile(r"^R(?P<reps>1)//(?P<end>[^PR/][^/]*)$"), 4)
     ]
 
-    CHAIN_REGEX = re.compile('((?:[+-P]|[\dT])[\d\w]*)')
+    CHAIN_REGEX = re.compile(r'((?:[+-P]|[\dT])[\d\w]*)')
 
-    MIN_REGEX = re.compile('min\(([^\)]+)\)')
+    MIN_REGEX = re.compile(r'min\(([^\)]+)\)')
 
     OFFSET_REGEX = re.compile(r"(?P<sign>[+-])(?P<intv>P.+)$")
 
-    TRUNCATED_REC_MAP = {"---": [re.compile("^\d\dT")],
-                         "--": [re.compile("^\d\d\d\dT")],
-                         "-": [re.compile("^\d\d\dT"),
-                               re.compile("\dW\d\dT"),
-                               re.compile("W\d\d\d?T"),
-                               re.compile("W-\dT"),
-                               re.compile("W-\d")]}
+    TRUNCATED_REC_MAP = {
+        "---": [re.compile(r"^\d\dT")],
+        "--": [re.compile(r"^\d\d\d\dT")],
+        "-": [
+            re.compile(r"^\d\d\dT"),
+            re.compile(r"\dW\d\dT"),
+            re.compile(r"W\d\d\d?T"),
+            re.compile(r"W-\dT"),
+            re.compile(r"W-\d")
+        ]
+    }
 
     __slots__ = ('timepoint_parser', 'duration_parser', 'recurrence_parser',
                  'context_start_point', 'context_end_point')

--- a/lib/cylc/wallclock.py
+++ b/lib/cylc/wallclock.py
@@ -32,7 +32,7 @@ DATE_TIME_FORMAT_EXTENDED = "%Y-%m-%dT%H:%M:%S"
 DATE_TIME_FORMAT_EXTENDED_SUB_SECOND = "%Y-%m-%dT%H:%M:%S.%f"
 
 RE_DATE_TIME_FORMAT_EXTENDED = (
-    "\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:Z|[+-][\d:]+)?")
+    r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:Z|[+-][\d:]+)?")
 
 TIME_FORMAT_BASIC = "%H%M%S"
 TIME_FORMAT_BASIC_SUB_SECOND = "%H%M%S.%f"

--- a/lib/parsec/config.py
+++ b/lib/parsec/config.py
@@ -129,7 +129,7 @@ class config(object):
                 null = False
                 i = i.lstrip('[')
                 i = i.rstrip(']')
-                j = re.split('\]\[*', i)
+                j = re.split(r'\]\[*', i)
                 mkeys.append(j)
         if null:
             mkeys = [[]]

--- a/lib/parsec/fileparse.py
+++ b/lib/parsec/fileparse.py
@@ -76,8 +76,8 @@ _KEY_VALUE = re.compile(
 #       python-regex-to-match-text-in-single-quotes-
 #           ignoring-escaped-quotes-and-tabs-n
 
-_LINECOMMENT = re.compile('^\s*#')
-_BLANKLINE = re.compile('^\s*$')
+_LINECOMMENT = re.compile(r'^\s*#')
+_BLANKLINE = re.compile(r'^\s*$')
 
 # triple quoted values on one line
 _SINGLE_LINE_SINGLE = re.compile(r"^'''(.*?)'''\s*(#.*)?$")
@@ -261,7 +261,7 @@ def read_and_proc(fpath, template_vars=None, viewcfg=None, asedit=False):
 
     # process with Jinja2
     if do_jinja2:
-        if flines and re.match('^#![jJ]inja2\s*', flines[0]):
+        if flines and re.match(r'^#![jJ]inja2\s*', flines[0]):
             if cylc.flags.verbose:
                 print "Processing with Jinja2"
             try:
@@ -272,7 +272,7 @@ def read_and_proc(fpath, template_vars=None, viewcfg=None, asedit=False):
                 suffix = []
                 for line in reversed(exc_lines):
                     suffix.append(line)
-                    if re.match("\s*File", line):
+                    if re.match(r"\s*File", line):
                         break
                 msg = '\n'.join(reversed(suffix))
                 lines = None

--- a/lib/parsec/include.py
+++ b/lib/parsec/include.py
@@ -50,7 +50,7 @@ backups = {}
 newfiles = []
 flist = []
 
-include_re = re.compile('\s*%include\s+([\'"]?)(.*?)([\'"]?)\s*$')
+include_re = re.compile(r'\s*%include\s+([\'"]?)(.*?)([\'"]?)\s*$')
 
 
 def inline(lines, dir_, filename, for_grep=False, for_edit=False, viewcfg=None,
@@ -193,8 +193,8 @@ def split_file(dir_, lines, filename, recovery=False, level=None):
             continue
         if not match_on:
             m = re.match(
-                '^#\+\+\+\+ START INLINED INCLUDE FILE ' +
-                '([\w\/\.\-]+) \(DO NOT MODIFY THIS LINE!\)', line)
+                r'^#\+\+\+\+ START INLINED INCLUDE FILE ' +
+                r'([\w\/\.\-]+) \(DO NOT MODIFY THIS LINE!\)', line)
             if m:
                 match_on = True
                 inc_filename = m.groups()[0]
@@ -205,8 +205,8 @@ def split_file(dir_, lines, filename, recovery=False, level=None):
         elif match_on:
             # match on, go to end of the 'on' include-file
             m = re.match(
-                '^#\+\+\+\+ END INLINED INCLUDE FILE ' +
-                inc_filename + ' \(DO NOT MODIFY THIS LINE!\)', line)
+                r'^#\+\+\+\+ END INLINED INCLUDE FILE ' +
+                inc_filename + r' \(DO NOT MODIFY THIS LINE!\)', line)
             if m:
                 match_on = False
                 # now split this lot, in case of nested inclusions

--- a/tests/syntax/01-pycodestyle.t
+++ b/tests/syntax/01-pycodestyle.t
@@ -24,7 +24,14 @@ fi
 
 set_test_number 3
 
-run_ok "${TEST_NAME_BASE}" pycodestyle --ignore=E402 \
+# Ignores:
+# E402 module level import not at top of file:
+# - To allow import on demand for expensive modules.
+# W503 line break before binary operator
+# W504 line break after binary operator
+# - PEP8 allows both, line break before binary preferred for new code.
+run_ok "${TEST_NAME_BASE}" pycodestyle \
+    --ignore=E402,W503,W504 \
     "${CYLC_DIR}/lib/cylc" \
     "${CYLC_DIR}/lib/isodatetime" \
     "${CYLC_DIR}/lib/Jinja2Filters"/*.py \


### PR DESCRIPTION
W605 invalid escape sequence:
- In this PR, I have modified the code to raw quote regular expression strings with escape sequence.

W503 line break before binary operator and W504 line break after binary operator:
- PEP8 allows both style. For old code, line break after binary operator is OK (i.e. binary operator at end of first line). For new code, we should begin to adopt line break before binary operator style (i.e. binary operator at beginning of continuation line). In this PR, I have modify the test to ignore both.