### PR TITLE
job.sh: replace HERE document with echo commands

### DIFF
--- a/lib/cylc/job.sh
+++ b/lib/cylc/job.sh
@@ -78,12 +78,10 @@ cylc__job__main() {
             typeset host="$(hostname -f)"
         fi
     fi
-    cat <<__OUT__
-Suite    : ${CYLC_SUITE_NAME}
-Task Job : ${CYLC_TASK_JOB} (try ${CYLC_TASK_TRY_NUMBER})
-User@Host: ${USER}@${host}
-
-__OUT__
+    echo "Suite    : ${CYLC_SUITE_NAME}"
+    echo "Task Job : ${CYLC_TASK_JOB} (try ${CYLC_TASK_TRY_NUMBER})"
+    echo "User@Host: ${USER}@${host}"
+    echo
     # Derived environment variables
     export CYLC_SUITE_LOG_DIR="${CYLC_SUITE_RUN_DIR}/log/suite"
     CYLC_SUITE_WORK_DIR_ROOT="${CYLC_SUITE_WORK_DIR_ROOT:-${CYLC_SUITE_RUN_DIR}}"

--- a/lib/cylc/job.sh
+++ b/lib/cylc/job.sh
@@ -78,6 +78,9 @@ cylc__job__main() {
             typeset host="$(hostname -f)"
         fi
     fi
+    # Developer Note:
+    # We were using a HERE document for writing info here until we notice that
+    # Bash uses temporary files for HERE documents, which can be inefficient.
     echo "Suite    : ${CYLC_SUITE_NAME}"
     echo "Task Job : ${CYLC_TASK_JOB} (try ${CYLC_TASK_TRY_NUMBER})"
     echo "User@Host: ${USER}@${host}"


### PR DESCRIPTION
Bash may put HERE documents in a temporary file, which is not efficient.
On older versions of Bash, it may even create temporary files under
`/tmp` instead of using `mktemp`, which can be problematic on systems
with only a small amount of space in `/tmp`.

Problem first raised by @steoxley.