### PR TITLE
gcylc: Fix bug in pop-up for tasks (soon to be) removed

### DIFF
--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -1628,8 +1628,11 @@ been defined for this suite""").inform()
         try:
             results, bad_items = self.updater.client.get_info(
                 'get_task_requisites', items=[task_id])
+        except AttributeError:
+            pass
         except ClientError as exc:
             warning_dialog(str(exc), self.window).warn()
+            return
         if not results or task_id in bad_items:
             warning_dialog(
                 "Task proxy " + task_id +


### PR DESCRIPTION
I have observed a minor bug in the GUI. When attempting to view the ``prereq's & outputs`` file from the ``View`` menu for task that is completed (naturally I discovered this when trying to access this file for a task that was on the verge of completing & must have completed before I hit the button), one gets either of the following tracebacks on ``master``:
```
Traceback (most recent call last):
  File "${HOME}/cylc.git/lib/cylc/gui/app_gcylc.py", line 1633, in popup_requisites
    if not results or task_id in bad_items:
UnboundLocalError: local variable 'results' referenced before assignment
```
or:
```
Traceback (most recent call last):
  File "${HOME}/cylc.git/lib/cylc/gui/app_gcylc.py", line 1629, in popup_requisites
    results, bad_items = self.updater.client.get_info(
AttributeError: 'NoneType' object has no attribute 'get_info'
```
To recreate, right-click a task whilst running & keep the menu open until the task has completed & disappeared from the GUI (or is just about to), then click ``prereq's & outputs``.

Suggested change seems to be sufficient, but for safety we might want to catch all exceptions from the ``try`` statement or initialise ``results`` & ``bad_items`` to empty strings?