### PR TITLE
WIP: Fix space in graph line string merge bug

### DIFF
--- a/lib/cylc/graph_parser.py
+++ b/lib/cylc/graph_parser.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Module for parsing cylc graph strings."""
 
+import os
 import re
 import unittest
 from cylc.param_expand import GraphExpander, ParamExpandError
@@ -74,6 +75,8 @@ class GraphParser(object):
         * A parameterized qualified node name looks like this:
             NODE(<PARAMS>)([CYCLE-POINT-OFFSET])(:TRIGGER-TYPE)
         * The default trigger type is ':succeed'.
+        * A remote suite qualified node name looks like this:
+            NODE(<REMOTE-SUITE-TRIGGER>)(:TRIGGER-TYPE)
         * Trigger qualifiers are ignored on the right to allow chaining:
                "foo => bar => baz & qux"
           Think of this as describing the graph structure first, then
@@ -95,10 +98,53 @@ class GraphParser(object):
     LEN_FAM_TRIG_EXT_ALL = len(FAM_TRIG_EXT_ALL)
     LEN_FAM_TRIG_EXT_ANY = len(FAM_TRIG_EXT_ANY)
 
+    _RE_ARROW_SPACES = r'\s*{arrow}\s*'.format(arrow=ARROW)
+
     _RE_NODE = r'(?:!)?' + TaskID.NAME_RE
-    _RE_PARAMS = r'<[\w,=\-+]+>'
-    _RE_OFFSET = r'\[[\w\-\+\^:]+\]'
-    _RE_TRIG = r':[\w\-]+'
+
+    _RE_PARAMS_CORE = r'\s*[\w\-+]+\s*(?:[=\-+]\s*[\w\-+]+\s*)?'
+    _RE_PARAMS_SPACES = r'<{core}(?:,{core})*>'.format(
+        core=_RE_PARAMS_CORE)
+    _RE_PARAMS = _RE_PARAMS_SPACES.replace(r'\s*', '')
+
+    _RE_OFFSET_SPACES = r'\[\s*[\w\-\+\^:]+\s*\]'
+    _RE_OFFSET = _RE_OFFSET_SPACES.replace(r'\s*', '')
+
+    _RE_TRIG_SPACES = r':(?:\w+[\w\-]*)+'
+    _RE_TRIG = _RE_TRIG_SPACES.replace(r'\s*', '')
+
+    _RE_TRIG_REMOTE = (r'<{taskname}::{taskname}'
+                       r'(?::[\w\-]*)?\s*>')
+    _RE_TRIG_REMOTE = _RE_TRIG_REMOTE.format(taskname=TaskID.NAME_RE)
+
+    _RE_TASK_PATTERN = (r'\s*(?:!)?'
+                        '(?:{task}(?:{param})?(?:{task})?(?:{offset})?'
+                        '|'
+                        '{param}(?:{task})?(?:{offset})?'
+                        '|'
+                        '{task}(?:{remote})?)'
+                        '(?:{trig})?')
+    _RE_TASK_PATTERN = _RE_TASK_PATTERN.format(param=_RE_PARAMS_SPACES,
+                                               offset=_RE_OFFSET_SPACES,
+                                               remote=_RE_TRIG_REMOTE,
+                                               trig=_RE_TRIG_SPACES,
+                                               task=TaskID.NAME_RE)
+
+    _RE_MULTI_PATTERN = (r'[\s(]*{pattern}'
+                         r'(?:\s*[&|][\s(]*{pattern}[\s)]*)*[\s)]*')
+    _RE_MULTI_TASK = _RE_MULTI_PATTERN.format(pattern=_RE_TASK_PATTERN)
+
+    REC_GRAPH_LINE = re.compile(
+        r'''\A
+        (?:{arrow})?                # allow arrow as leading string
+        (?:{multi_task}             # standard pattern for multiple tasks
+        (?:                         # python style atomic grouping
+        (?:{arrow}                  # graph in between task groups
+        {multi_task}                # standard pattern for multiple tasks
+        )*)                         # finish off the arrow/multi task combo
+        (?:{arrow})?
+        )?                          # close off the first multi_task group
+        \Z'''.format(arrow=_RE_ARROW_SPACES, multi_task=_RE_MULTI_TASK), re.X)
 
     # Match fully qualified parameterized single nodes.
     REC_NODE_FULL = re.compile(
@@ -161,13 +207,23 @@ class GraphParser(object):
         """
         # Strip comments, whitespace, and blank lines.
         non_blank_lines = []
+        bad_lines = []
         for line in graph_string.split('\n'):
             line = self.__class__.REC_COMMENT.sub('', line)
+
+            if not line or line.isspace():
+                continue
+            if not self.REC_GRAPH_LINE.match(line):
+                bad_lines.append(line)
+                continue
+
             # Apparently this is the fastest way to strip all whitespace!:
             line = "".join(line.split())
-            if not line:
-                continue
             non_blank_lines.append(line)
+
+        # Check if there were problem lines and abort
+        if bad_lines:
+            self._report_invalid_lines(bad_lines)
 
         # Join incomplete lines (beginning or ending with an arrow).
         full_lines = []
@@ -232,11 +288,7 @@ class GraphParser(object):
             if node_str.strip():
                 bad_lines.append(line.strip())
         if bad_lines:
-            raise GraphParseError(
-                "ERROR, bad graph node format:\n"
-                "  " + "\n  ".join(bad_lines) + "\n"
-                "Correct format is"
-                " NAME(<PARAMS>)([CYCLE-POINT-OFFSET])(:TRIGGER-TYPE)")
+            self._report_invalid_lines(bad_lines)
 
         # Expand parameterized lines (or detect undefined parameters).
         line_set = set()
@@ -269,6 +321,17 @@ class GraphParser(object):
 
         # If debugging, print the final result here:
         # self.print_triggers()
+
+    def _report_invalid_lines(self, lines):
+        raise GraphParseError(
+                "ERROR, bad graph node format:\n"
+                "  " + "\n  ".join(lines) + "\n"
+                "Correct format is:\n"
+                " NAME(<PARAMS>)([CYCLE-POINT-OFFSET])(:TRIGGER-TYPE)\n"
+                " {NAME(<PARAMS>) can also be: "
+                "<PARAMS>NAME or NAME<PARAMS>NAME_CONTINUED}\n"
+                " or\n"
+                " NAME(<REMOTE-SUITE-TRIGGER>)(:TRIGGER-TYPE)")
 
     def _proc_dep_pair(self, left, right):
         """Process a single dependency pair 'left => right'.

--- a/lib/cylc/graph_parser.py
+++ b/lib/cylc/graph_parser.py
@@ -503,11 +503,11 @@ class GraphParser(object):
                     title = "SUICIDE:"
                 else:
                     title = "TRIGGER:"
-                print '\nTASK:', right
-                print ' ', title, expr
+                print('\nTASK:', right)
+                print(' ', title, expr)
                 for t in triggers:
-                    print '    +', t
-                print '  from', self.original[right][expr]
+                    print('    +', t)
+                print('  from', self.original[right][expr])
 
 
 class TestGraphParser(unittest.TestCase):


### PR DESCRIPTION
I haven't finished writing formal tests for this change, but I thought I should actually show it and get feedback. Work on it has been very much in little steps as it isn't a high priority for me. It essentially puts in a more strict line regex pattern that the graph has to parse. It has run on a fake suite.rc and also some real ones from our suites here.

See my main commit (the first one) for a longer explanation of the change. I think I stumbled across some other things (other than the space issue) which according to docs should not have validated but appeared to - although that could have been on 7.5.0 and not the latest 7.6.1 build.

My main concern with my approach is that it puts more stuff in another regex area, such that if an update was done for example in https://github.com/cylc/cylc/pull/2596/files it would also require an update here (maybe). I wonder if there would be a way to pull regex for parameters, triggers, remote triggers, task/family status into a single spot?

From my speed comparisons against big and small suite graphs, there is negligible impact on speed (I can't comment on cpu/memory usage as I have not checked that).

In the dummy suite.rc, the results are below. The bad ones I've listed why they would have been rejected.

```shell
bad:    => =>  # two arrows with nothing in between
bad:    foo => !  # bad symbol on RHS
bad:    foo => @  # bad symbol on RHS
bad:    foo => +  # bad symbol on RHS
bad:    foo => %  # bad symbol on RHS
bad:    foo => @b  # bad symbol on RHS
bad:    foo => +b  # bad symbol on RHS
bad:    foo => %b  # bad symbol on RHS
bad:    foo => bar baz  # space in between two task nodes (i.e. this Issue)
bad:    get<run pets> => feed<run,pets>  # space between parameters on the LHS
bad:    get<run,pets> => feed<run pets>  # space between parameters on the RHS
bad:    OBS_PROC<>  # nothing in between <>
bad:    OBS_GET<run>: => OBS_PROC<run>  # nothing after :
bad:    OBS_GET<run>:succeed-all => OBS_PROC<>  # nothing within the <>
bad:    foo[] => foo  # nothing inside the []
bad:    OBS_GET<run>:succeed - all&foo => OBS_PROC<run> => hello => test | boo => hello<a,b,c-1> => a b  # spaces within the 'succeed-all' statement, spaces between task nodes at the end
bad:    FOO<cc:dd:fail>:hello  # remote trigger, but only one colon in between 'cc' and 'dd'
bad:    az =>=>  # two arrows with nothing in between
bad:    foo<other_suite :: task>  # spaces around the ::
bad:    foo<a,b><other_suite::task : fail>  # parameter and remote trigger on same task, spaces around colon in remote trigger
bad:    foo<a><bb::cc>  # parameter and remote trigger on same task
bad:    foo[PT6H]<cc::dd:fail>  # time offset and remote trigger on same task
bad:    foo<other_suite::task : fail>  # spaces around the :
bad:    foo<other_suite::task :succeed> => testing  # space after task
bad:    get <run,pets> => feed<run,pets>  # spce between 'get' and '<'
bad:    get < run = 1 , pets = dogs > => boo  # space between 'get' and '<'
bad:    OBS_GET<run> :succeed-all => OBS_PROC<run>  # space before :
bad:    OBS_GET<run>: succeed-all => OBS_PROC<run>  # space after :
bad:    OBS_GET<run> : succeed-all => OBS_PROC<run>  # spaces around :
bad:    OBS_GET<run>:succeed -all => OBS_PROC<run>  # space before -
bad:    OBS_GET<run>:succeed- all => OBS_PROC<run>  # space after -
bad:    OBS_GET<run> : succeed - all => OBS_PROC<run>  # spaces around : and -
bad:    model[- P1M] => model  # space between - and P1M
bad:    model [ -P1M ] => model  # space between 'model' and '['
bad:    Analysis[+ PT12H] => ObSensitivity  # space between + and PT12H
bad:    Analysis[ + PT12H ] => ObSensitivity  # space between + and PT12H
bad:    foo[ - P2M ] : out2 => baz  # space in between - and P2M, space around :
bad:    foo[- P2M]:out2 => baz  # space in between - and P2M
bad:    foo[-P2M] :out2 => baz  # space before :
bad:    foo[-P2M]: out2 => baz  # space after :
bad:    OBS_GET<run>:succeed - all&foo => OBS_PROC<run> => hello => test | boo  # spaces within the 'succeed-all' statement
```

```shell
good:     <lang=c++> => <lang = fortran-2008>
good:     <lang=c++>
good:     <lang = fortran-2008>
good:    <lang=c-1> => test
good:    OBS_GET<run>:succeed-all
good:    abc
good:    =>
good:    def
good:    az =>
good:    => hello => bar
good:    FOO<cc::dd:fail>:hello
good:    foo<other_suite::task>
good:    pre => init<run>
good:    pre => init< run>
good:    pre => init<run >
good:    get<run,pets> => feed<run,pets>
good:    get< run,pets> => feed<run,pets>
good:    get<run, pets> => feed<run,pets>
good:    get<run,pets > => feed<run,pets>
good:    get<run , pets> => feed<run,pets>
good:    get<run,pets-1> => get<run,pets>
good:    get<run,pets -1> => get<run,pets>
good:    get<run,pets- 1> => get<run,pets>
good:    get<run,pets - 1> => get<run,pets>
good:    get<run =1,pets=dogs> => boo
good:    get<run= 1,pets=dogs> => boo
good:    get<run = 1,pets=dogs> => boo
good:    get<run=1,pets=dogs>=>boo
good:    OBS_GET<run>:succeed-all => OBS_PROC<run>
good:    foo => bar
good:    foo => b-
good:    foo => b@
good:    foo => b+
good:    foo => b%
good:    foo => bar& baz
good:    foo => bar &baz
good:    foo => bar & baz
good:    foo => bar| baz
good:    foo => bar |baz
good:    foo => bar | baz
good:    model[-P1M] => model
good:    model[-P1M ] => model
good:    Analysis[+PT12H] => ObSensitivity
good:    Analysis[ +PT12H] => ObSensitivity
good:    copy:expired => !proc
good:    copy:expired => ! proc
good:    foo
good:    foo => bar => test
good:    foo => _
good:    foo => bar_baz
good:    foo[-P2M]:out2 => baz
good:    foo[ -P2M]:out2 => baz
good:    foo[ -P2M ]:out2 => baz
good:    sim<r,m,c=2>[-P1Y] => sim<r,m,c=0> | bar<g,h,i=3>
```