### PR TITLE
Fix docstring typo in #2582

### DIFF
--- a/lib/cylc/remote.py
+++ b/lib/cylc/remote.py
@@ -55,7 +55,7 @@ def remote_cylc_cmd(cmd, user=None, host=None, capture=False,
 
     Return:
         If capture=True, return the Popen object if created successfully.
-        Otherwise, return the return the exit code of the remote command.
+        Otherwise, return the exit code of the remote command.
     """
     if host is None:
         host = "localhost"


### PR DESCRIPTION
PR #2582 merged with urgency (as significant conflict resolution necessary for follow-on/dependent PRs), with typo outstanding. Trivial hence one reviewer sufficient.