### PR TITLE
Fix submission failed handler on bad host select

### DIFF
--- a/lib/cylc/task_job_mgr.py
+++ b/lib/cylc/task_job_mgr.py
@@ -755,6 +755,7 @@ class TaskJobManager(object):
             # Submit number not yet incremented
             itask.submit_num += 1
             itask.summary['submit_num'] = itask.submit_num
+            itask.summary['job_hosts'][itask.submit_num] = ''
             # Retry delays, needed for the try_num
             self._set_retry_timers(itask, rtconfig)
             self._prep_submit_task_job_error(

--- a/tests/events/40-task-event-host-select-fail.t
+++ b/tests/events/40-task-event-host-select-fail.t
@@ -1,0 +1,47 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Ensure that submission failed handler on task host-select failure runs OK.
+
+. "$(dirname "$0")/test_header"
+set_test_number 3
+init_suite "${TEST_NAME_BASE}" <<'__SUITERC__'
+[cylc]
+    [[events]]
+        abort on stalled = True
+[scheduling]
+    [[dependencies]]
+        graph = foo
+[runtime]
+    [[foo]]
+        script = true
+        [[[events]]]
+            submission failed handler = echo empty [%(user@host)s]?
+        [[[remote]]]
+            host = $(false)
+__SUITERC__
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+
+suite_run_fail "${TEST_NAME_BASE}-run" cylc run --no-detach "${SUITE_NAME}"
+
+run_ok "log-handler-out" \
+    grep -qF '[(('"'"'event-handler-00'"'"', '"'"'submission failed'"'"'), 1) out] empty []?' \
+    "${SUITE_RUN_DIR}/log/suite/log"
+
+purge_suite "${SUITE_NAME}"
+exit


### PR DESCRIPTION
To reproduce.

```
[scheduling]
    [[dependencies]]
        graph = t1
[runtime]
    [[t1]]
        script = true
        [[[remote]]]
            host = $(false)
        [[[events]]]
            submission failed handler = echo %(id)s
```

On current master, the failed remote host select will cause a `KeyError` that will take down the suite with something like this:

```
2018-04-20T12:27:36+01 CRITICAL - Traceback (most recent call last):
	  File "/home/matt/cylc.git/lib/cylc/scheduler.py", line 231, in start
	    self.run()
	  File "/home/matt/cylc.git/lib/cylc/scheduler.py", line 1377, in run
	    self.process_task_pool()
	  File "/home/matt/cylc.git/lib/cylc/scheduler.py", line 1212, in process_task_pool
	    self.suite, itasks, self.run_mode == 'simulation')
	  File "/home/matt/cylc.git/lib/cylc/task_job_mgr.py", line 195, in submit_task_jobs
	    prepared_tasks, bad_tasks = self.prep_submit_task_jobs(suite, itasks)
	  File "/home/matt/cylc.git/lib/cylc/task_job_mgr.py", line 171, in prep_submit_task_jobs
	    check_syntax=check_syntax)
	  File "/home/matt/cylc.git/lib/cylc/task_job_mgr.py", line 727, in _prep_submit_task_job
	    suite, itask, dry_run, '(remote host select)', exc)
	  File "/home/matt/cylc.git/lib/cylc/task_job_mgr.py", line 780, in _prep_submit_task_job_error
	    self.poll_task_jobs)
	  File "/home/matt/cylc.git/lib/cylc/task_events_mgr.py", line 360, in process_message
	    self._process_message_submit_failed(itask, event_time)
	  File "/home/matt/cylc.git/lib/cylc/task_events_mgr.py", line 687, in _process_message_submit_failed
	    'job %s' % self.EVENT_SUBMIT_FAILED)
	  File "/home/matt/cylc.git/lib/cylc/task_events_mgr.py", line 425, in setup_event_handlers
	    self._setup_custom_event_handlers(itask, event, message)
	  File "/home/matt/cylc.git/lib/cylc/task_events_mgr.py", line 821, in _setup_custom_event_handlers
	    user_at_host = itask.summary['job_hosts'][itask.submit_num]
	KeyError: 1
```