### PR TITLE
Fix graph_parser validation for incorrect syntax order in a node

### DIFF
--- a/lib/cylc/graph_parser.py
+++ b/lib/cylc/graph_parser.py
@@ -674,7 +674,9 @@ class TestGraphParser(unittest.TestCase):
         The correct format is:
           NAME(<PARAMS>)([CYCLE-POINT-OFFSET])(:TRIGGER-TYPE)")
         """
-        gp = GraphParser()
+        params = {'m': ['0', '1'], 'n': ['0', '1']}
+        templates = {'m': '_m%(m)s', 'n': '_n%(n)s'}
+        gp = GraphParser(parameters=(params, templates))
         self.assertRaises(
             GraphParseError, gp.parse_graph, "foo[-P1Y]<m,n> => bar")
         self.assertRaises(

--- a/lib/cylc/graph_parser.py
+++ b/lib/cylc/graph_parser.py
@@ -680,6 +680,8 @@ class TestGraphParser(unittest.TestCase):
         self.assertRaises(
             GraphParseError, gp.parse_graph, "foo[-P1Y]<m,n> => bar")
         self.assertRaises(
+            GraphParseError, gp.parse_graph, "foo:fail<m,n> => bar")
+        self.assertRaises(
             GraphParseError, gp.parse_graph, "foo:fail[-P1Y] => bar")
         self.assertRaises(
             GraphParseError, gp.parse_graph, "foo[-P1Y]:fail<m,n> => bar")
@@ -689,6 +691,14 @@ class TestGraphParser(unittest.TestCase):
             GraphParseError, gp.parse_graph, "foo<m,n>:fail[-P1Y] => bar")
         self.assertRaises(
             GraphParseError, gp.parse_graph, "foo:fail<m,n>[-P1Y] => bar")
+        self.assertRaises(
+            GraphParseError, gp.parse_graph, "<m,n>:fail[-P1Y] => bar")
+        self.assertRaises(
+            GraphParseError, gp.parse_graph, "[-P1Y]<m,n> => bar")
+        self.assertRaises(
+            GraphParseError, gp.parse_graph, "[-P1Y]<m,n>:fail => bar")
+        self.assertRaises(
+            GraphParseError, gp.parse_graph, "bar => foo:fail<m,n>[-P1Y]")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fixes the tests for https://github.com/cylc/cylc/issues/2645 and now also the root cause of the problem.

The tests for order of trigger and parameter were correctly raising a
GraphParseError, but, not for the reason thought. They were raising
the error because parameters were not defined, not because the order
was being correctly identified. I have now added in the parameters,
and they do not pass anymore.

Originally, the exception message thrown said:
```python
Traceback (most recent call last):
  File "lib/cylc/graph_parser.py", line 681, in test_bad_node_syntax
    gp.parse_graph("foo[-P1Y]<m,n> => bar")
  File "lib/cylc/graph_parser.py", line 252, in parse_graph
    raise GraphParseError(str(exc))
GraphParseError: ERROR, parameter m is not defined in <m,n>: foo[-P1Y]<m,n> => bar
```

With just the test update, the tests fail correctly:
```python
$ python lib/cylc/graph_parser.py
F................
======================================================================
FAIL: test_bad_node_syntax (__main__.TestGraphParser)
Test that badly formatted graph nodes are detected.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "lib/cylc/graph_parser.py", line 681, in test_bad_node_syntax
    GraphParseError, gp.parse_graph, "foo[-P1Y]<m,n> => bar")
AssertionError: GraphParseError not raised

----------------------------------------------------------------------
Ran 17 tests in 0.007s
```
The root cause appears to have been findall splitting out each potential node, ignoring that they could have been adjacent. Instead we now look at each node as a whole.