### PR TITLE
Make T-submit respect suite UTC mode.

### DIFF
--- a/bin/cylc-jobs-submit
+++ b/bin/cylc-jobs-submit
@@ -36,9 +36,15 @@ def main():
         "--remote-mode",
         help="Is this being run on a remote job host?",
         action="store_true", dest="remote_mode", default=False)
+    parser.add_option(
+        "--utc-mode",
+        help="(for remote mode) is the suite running in UTC mode?",
+        action="store_true", dest="utc_mode", default=False)
+
     opts, args = parser.parse_args()
     BatchSysManager().jobs_submit(
-        args[0], args[1:], remote_mode=opts.remote_mode)
+        args[0], args[1:], remote_mode=opts.remote_mode,
+        utc_mode=opts.utc_mode)
 
 
 if __name__ == "__main__" and not remrun():

--- a/lib/cylc/batch_sys_manager.py
+++ b/lib/cylc/batch_sys_manager.py
@@ -320,11 +320,14 @@ class BatchSysManager(object):
                 cur_time_str,
                 ctx.get_summary_str()))
 
-    def jobs_submit(self, job_log_root, job_log_dirs, remote_mode=False):
+    def jobs_submit(self, job_log_root, job_log_dirs, remote_mode=False,
+                    utc_mode=False):
         """Submit multiple jobs.
 
         job_log_root -- The log/job/ sub-directory of the suite.
         job_log_dirs -- A list containing point/name/submit_num for task jobs.
+        remote_mode -- am I running on the remote job host?
+        utc_mode -- is the suite running in UTC mode?
 
         """
         if "$" in job_log_root:
@@ -335,7 +338,7 @@ class BatchSysManager(object):
             items = self._jobs_submit_prep_by_stdin(job_log_root, job_log_dirs)
         else:
             items = self._jobs_submit_prep_by_args(job_log_root, job_log_dirs)
-        now = get_current_time_string()
+        now = get_current_time_string(override_use_utc=utc_mode)
         for job_log_dir, batch_sys_name, submit_opts in items:
             job_file_path = os.path.join(
                 job_log_root, job_log_dir, JOB_LOG_JOB)

--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -259,7 +259,6 @@ class TaskEventsManager(object):
         each poll with its result message.
 
         """
-
         # Log incoming messages with '>' to distinguish non-message log entries
         if incoming_event_time:
             if submit_num is None or submit_num == itask.submit_num:

--- a/lib/cylc/task_job_mgr.py
+++ b/lib/cylc/task_job_mgr.py
@@ -253,6 +253,8 @@ class TaskJobManager(object):
             cmd = ['cylc', self.JOBS_SUBMIT]
             if cylc.flags.debug:
                 cmd.append('--debug')
+            if cylc.flags.utc:
+                cmd.append('--utc-mode')
             remote_mode = False
             kwargs = {}
             for key, value, test_func in [

--- a/tests/job-submission/07-multi.t
+++ b/tests/job-submission/07-multi.t
@@ -34,18 +34,18 @@ LOG="${RUN_DIR}/log/suite/log"
 sed -n 's/^.*\(cylc jobs-submit\)/\1/p' "${LOG}" | sort -u >'edited-suite-log'
 
 sort >'edited-suite-log-ref' <<__LOG__
-cylc jobs-submit --debug -- ${RUN_DIR}/log/job 20200101T0000Z/t0/01 20200101T0000Z/t1/01 20200101T0000Z/t2/01 20200101T0000Z/t3/01
-cylc jobs-submit --debug -- ${RUN_DIR}/log/job 20210101T0000Z/t0/01 20210101T0000Z/t1/01 20210101T0000Z/t2/01 20210101T0000Z/t3/01
-cylc jobs-submit --debug -- ${RUN_DIR}/log/job 20220101T0000Z/t0/01 20220101T0000Z/t1/01 20220101T0000Z/t2/01 20220101T0000Z/t3/01
-cylc jobs-submit --debug -- ${RUN_DIR}/log/job 20230101T0000Z/t0/01 20230101T0000Z/t1/01 20230101T0000Z/t2/01 20230101T0000Z/t3/01
-cylc jobs-submit --debug -- ${RUN_DIR}/log/job 20240101T0000Z/t0/01 20240101T0000Z/t1/01 20240101T0000Z/t2/01 20240101T0000Z/t3/01
-cylc jobs-submit --debug -- ${RUN_DIR}/log/job 20250101T0000Z/t0/01 20250101T0000Z/t1/01 20250101T0000Z/t2/01 20250101T0000Z/t3/01
-cylc jobs-submit --debug --host=${CYLC_TEST_HOST} --remote-mode -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20200101T0000Z/t4/01 20200101T0000Z/t5/01 20200101T0000Z/t6/01
-cylc jobs-submit --debug --host=${CYLC_TEST_HOST} --remote-mode -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20210101T0000Z/t4/01 20210101T0000Z/t5/01 20210101T0000Z/t6/01
-cylc jobs-submit --debug --host=${CYLC_TEST_HOST} --remote-mode -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20220101T0000Z/t4/01 20220101T0000Z/t5/01 20220101T0000Z/t6/01
-cylc jobs-submit --debug --host=${CYLC_TEST_HOST} --remote-mode -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20230101T0000Z/t4/01 20230101T0000Z/t5/01 20230101T0000Z/t6/01
-cylc jobs-submit --debug --host=${CYLC_TEST_HOST} --remote-mode -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20240101T0000Z/t4/01 20240101T0000Z/t5/01 20240101T0000Z/t6/01
-cylc jobs-submit --debug --host=${CYLC_TEST_HOST} --remote-mode -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20250101T0000Z/t4/01 20250101T0000Z/t5/01 20250101T0000Z/t6/01
+cylc jobs-submit --debug --utc-mode -- ${RUN_DIR}/log/job 20200101T0000Z/t0/01 20200101T0000Z/t1/01 20200101T0000Z/t2/01 20200101T0000Z/t3/01
+cylc jobs-submit --debug --utc-mode -- ${RUN_DIR}/log/job 20210101T0000Z/t0/01 20210101T0000Z/t1/01 20210101T0000Z/t2/01 20210101T0000Z/t3/01
+cylc jobs-submit --debug --utc-mode -- ${RUN_DIR}/log/job 20220101T0000Z/t0/01 20220101T0000Z/t1/01 20220101T0000Z/t2/01 20220101T0000Z/t3/01
+cylc jobs-submit --debug --utc-mode -- ${RUN_DIR}/log/job 20230101T0000Z/t0/01 20230101T0000Z/t1/01 20230101T0000Z/t2/01 20230101T0000Z/t3/01
+cylc jobs-submit --debug --utc-mode -- ${RUN_DIR}/log/job 20240101T0000Z/t0/01 20240101T0000Z/t1/01 20240101T0000Z/t2/01 20240101T0000Z/t3/01
+cylc jobs-submit --debug --utc-mode -- ${RUN_DIR}/log/job 20250101T0000Z/t0/01 20250101T0000Z/t1/01 20250101T0000Z/t2/01 20250101T0000Z/t3/01
+cylc jobs-submit --debug --utc-mode --host=${CYLC_TEST_HOST} --remote-mode -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20200101T0000Z/t4/01 20200101T0000Z/t5/01 20200101T0000Z/t6/01
+cylc jobs-submit --debug --utc-mode --host=${CYLC_TEST_HOST} --remote-mode -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20210101T0000Z/t4/01 20210101T0000Z/t5/01 20210101T0000Z/t6/01
+cylc jobs-submit --debug --utc-mode --host=${CYLC_TEST_HOST} --remote-mode -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20220101T0000Z/t4/01 20220101T0000Z/t5/01 20220101T0000Z/t6/01
+cylc jobs-submit --debug --utc-mode --host=${CYLC_TEST_HOST} --remote-mode -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20230101T0000Z/t4/01 20230101T0000Z/t5/01 20230101T0000Z/t6/01
+cylc jobs-submit --debug --utc-mode --host=${CYLC_TEST_HOST} --remote-mode -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20240101T0000Z/t4/01 20240101T0000Z/t5/01 20240101T0000Z/t6/01
+cylc jobs-submit --debug --utc-mode --host=${CYLC_TEST_HOST} --remote-mode -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20250101T0000Z/t4/01 20250101T0000Z/t5/01 20250101T0000Z/t6/01
 __LOG__
 cmp_ok 'edited-suite-log' 'edited-suite-log-ref'
 


### PR DESCRIPTION
Close #2642 

@matthewrmshin @sadielbartholomew - apologies, I didn't notice you were assigned to the issue before I did this.  I won't bother adding a test in case you've already done so.  We can close this PR if you have a better way of doing it.

I found that T-submit was in the wrong time zone in the DB as well in the GUI.  The reason is, T-submit comes from inside `cylc jobs-submit` executing on the job host, and that does not currently know about the suite's UTC mode.  So I've added a `--utc-mode` option to the job submit command.

I've checked this works in UTC mode and not, when the system clock is in local time.  I haven't checked what happens when the system clock is UTC.

It might be sufficient to make a test that checks for consistent appearance of `Z` or `+12` (e.g.) on all times in the `task_jobs` DB table?