### PR TITLE
test: triggering 20

### DIFF
--- a/tests/triggering/20-and-outputs-suicide/suite.rc
+++ b/tests/triggering/20-and-outputs-suicide/suite.rc
@@ -23,7 +23,7 @@
                 # showdown:good & showdown:ugly => ! bad
                 # showdown:bad & showdown:ugly => ! good
 
-                good | bad | ugly => fin
+                (good & bad) | (bad & ugly) | (ugly & good) => fin
             """
 [runtime]
     [[showdown]]


### PR DESCRIPTION
Minor follow up of #2656.

Adjust graphing for triggering final task to be more precise.
Otherwise, timing for a very busy test battery run may cause
inconsistency with the reference log.