### PR TITLE
Kill proc pool commands that take too long.

### DIFF
--- a/doc/src/cylc-user-guide/cug.tex
+++ b/doc/src/cylc-user-guide/cug.tex
@@ -6961,11 +6961,7 @@ See ~\ref{task-event-mail-interval} for details.
 Event handlers can be located in the suite \lstinline=bin/= directory;
 otherwise it is up to you to ensure their location is in \lstinline=$PATH= (in
 the shell in which the suite server program runs). They should require little
-resource and return quickly - as each event handler is invoked by a child
-process in a finite process pool that is also used to submit, poll and kill
-jobs. The child process will wait for the event handler to complete before
-moving on to the next item in the queue. If the process pool is saturated with
-long running event handlers, the suite will appear to hang.
+resource and return quickly - see~\ref{Managing External Command Execution}.
 
 Task event handlers can be specified using the
 \lstinline=[[[events]]]<event> handler= settings, where
@@ -7090,6 +7086,21 @@ of. If a suite gets delayed over many cycles the next tasks coming up can be
 identified as late immediately, and subsequent tasks can be identified as late
 as the suite progresses to subsequent cycle points, until it catches up to the
 clock.
+
+\subsection{Managing External Command Execution}
+\label{Managing External Command Execution}
+
+Job submission commands, event handlers, and job poll and kill commands, are
+executed by the suite server program in a ``pool'' of asynchronous
+subprocesses, in order to avoid holding the suite up. The process pool is
+actively managed to limit it to a configurable size (\ref{process pool size}).
+Custom event handlers should be light-weight and quick-running because they
+will tie up a process pool member until they complete, and the suite will
+appear to stall if the pool is saturated with long-running processes. Processes
+are killed after a configurable timeout (\ref{process pool timeout}) however,
+to guard against rogue commands that hang indefinitely. All process kills are
+logged by the suite server program. For killed job submissions the associated
+tasks also go to the {\em submit-failed} state.
 
 \subsection{Handling Job Preemption}
 \label{PreemptionHPC}

--- a/doc/src/cylc-user-guide/siterc.tex
+++ b/doc/src/cylc-user-guide/siterc.tex
@@ -29,13 +29,28 @@ automatically on exit. Leave unset for the default (usually
 \end{myitemize}
 
 \subsubsection{process pool size}
+\label{process pool size}
 
-Number of process pool worker processes used to execute shell commands
-(job submission, event handlers, job poll and kill commands).
+Maximum number of concurrent processes used to execute external job submission,
+event handlers, and job poll and kill commands - see~\ref{Managing External
+Command Execution}.
 
 \begin{myitemize}
 \item {\em type:} integer
-\item {\em default:} None (number of processor cores on the suite host)
+\item {\em default:} 4
+\end{myitemize}
+
+\subsubsection{process pool timeout}
+\label{process pool timeout}
+
+Interval after which long-running commands in the process pool will be killed -
+see~\ref{Managing External Command Execution}.
+
+\begin{myitemize}
+\item {\em type:} ISO 8601 duration/interval representation (e.g.\ 
+\lstinline=PT10S=, 10 seconds, or \lstinline=PT1M=, 1 minute).
+\item {\em default:} PT10M -  note this is set quite high to avoid killing
+  important processes when the system is under load.
 \end{myitemize}
 
 \subsubsection{disable interactive command prompts}

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -41,6 +41,7 @@ coercers['interval_list'] = coerce_interval_list
 
 SPEC = {
     'process pool size': vdr(vtype='integer', default=4),
+    'process pool timeout': vdr(vtype='interval', default=DurationFloat(600)),
     'temporary directory': vdr(vtype='string'),
     'state dump rolling archive length': vdr(
         vtype='integer', default=10),

--- a/lib/cylc/mp_pool.py
+++ b/lib/cylc/mp_pool.py
@@ -64,7 +64,7 @@ class SuiteProcContext(object):
             Return code of the command.
         .timestamp (str):
             Time string of latest update.
-        .proc_pool_timeout (int):
+        .proc_pool_timeout (float):
             command execution timeout.
     """
 

--- a/lib/cylc/mp_pool.py
+++ b/lib/cylc/mp_pool.py
@@ -64,8 +64,8 @@ class SuiteProcContext(object):
             Return code of the command.
         .timestamp (str):
             Time string of latest update.
-        .init_time (int):
-            Time command execution commenced.
+        .proc_pool_timeout (int):
+            command execution timeout.
     """
 
     # Format string for single line output
@@ -132,7 +132,7 @@ class SuiteProcPool(object):
         if not size:
             size = glbl_cfg().get(['process pool size'], size)
         self.size = size
-        self.cmd_timeout = glbl_cfg().get(['process pool timeout'])
+        self.proc_pool_timeout = glbl_cfg().get(['process pool timeout'])
         self.closed = False  # Close queue
         self.stopping = False  # No more job submit if True
         # .stopping may be set by an API command in a different thread
@@ -156,25 +156,34 @@ class SuiteProcPool(object):
             stopping = self.stopping
         return stopping
 
+    def _proc_exit(self, proc, err_xtra, ctx, callback, callback_args):
+        """Get ret_code, out, err of exited command, and call its callback."""
+        ctx.ret_code = proc.wait()
+        ctx.out, err = proc.communicate()
+        ctx.err = err + err_xtra
+        self._run_command_exit(ctx, callback, callback_args)
+
     def process(self):
         """Process done child processes and submit more."""
         # Handle child processes that are done
         runnings = []
         for proc, ctx, callback, callback_args in self.runnings:
-            ret_code = proc.poll()
-            if ret_code is None:
-                if time.time() > ctx.init_time + self.cmd_timeout:
-                    os.killpg(proc.pid, SIGKILL)
-                    ctx.ret_code = 1
-                    ctx.err = "killed on timeout (%s)" % self.cmd_timeout
-                    self._run_command_exit(ctx, callback, callback_args)
-                    proc.wait()
-                else:
-                    runnings.append([proc, ctx, callback, callback_args])
+            if proc.poll() is not None:
+                self._proc_exit(proc, "", ctx, callback, callback_args)
+            elif time.time() < ctx.timeout:
+                runnings.append([proc, ctx, callback, callback_args])
             else:
-                ctx.out, ctx.err = proc.communicate()
-                ctx.ret_code = ret_code
-                self._run_command_exit(ctx, callback, callback_args)
+                # Timed out, kill it.
+                try:
+                    os.killpg(proc.pid, SIGKILL)
+                except OSError:
+                    # must have just exited, since poll.
+                    err_xtra = ""
+                else:
+                    err_xtra = "\nkilled on timeout (%s)" % (
+                        self.proc_pool_timeout)
+                self._proc_exit(proc, err_xtra, ctx, callback, callback_args)
+
         # Update list of running items
         self.runnings[:] = runnings
         # Create more child processes, if items in queue and space in pool
@@ -188,7 +197,7 @@ class SuiteProcPool(object):
             else:
                 proc = self._run_command_init(ctx, callback, callback_args)
                 if proc is not None:
-                    ctx.init_time = time.time()
+                    ctx.timeout = time.time() + self.proc_pool_timeout
                     self.runnings.append([proc, ctx, callback, callback_args])
 
     def put_command(self, ctx, callback=None, callback_args=None):

--- a/lib/cylc/mp_pool.py
+++ b/lib/cylc/mp_pool.py
@@ -131,8 +131,8 @@ class SuiteProcPool(object):
     def __init__(self, size=None):
         if not size:
             size = glbl_cfg().get(['process pool size'], size)
-        self.cmd_timeout = glbl_cfg().get(['process pool timeout'])
         self.size = size
+        self.cmd_timeout = glbl_cfg().get(['process pool timeout'])
         self.closed = False  # Close queue
         self.stopping = False  # No more job submit if True
         # .stopping may be set by an API command in a different thread
@@ -166,7 +166,7 @@ class SuiteProcPool(object):
                 if time.time() > ctx.init_time + self.cmd_timeout:
                     os.killpg(proc.pid, SIGKILL)
                     ctx.ret_code = 1
-                    ctx.err = "killed on timeout"
+                    ctx.err = "killed on timeout (%s)" % self.cmd_timeout
                     self._run_command_exit(ctx, callback, callback_args)
                     proc.wait()
                 else:

--- a/tests/events/44-timeout.t
+++ b/tests/events/44-timeout.t
@@ -37,7 +37,7 @@ cylc cat-log "${SUITE_NAME}" | \
 
 cmp_ok log <<__END__
 ERROR - [(('event-handler-00', 'started'), 1) cmd] sleeper.sh foo.1
-	[(('event-handler-00', 'started'), 1) ret_code] 1
+	[(('event-handler-00', 'started'), 1) ret_code] -9
 	[(('event-handler-00', 'started'), 1) err] killed on timeout (PT10S)
 WARNING - 1/foo/01 ('event-handler-00', 'started') failed
 __END__

--- a/tests/events/44-timeout.t
+++ b/tests/events/44-timeout.t
@@ -1,0 +1,52 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+
+# Test that timed out event handlers get killed and recorded as failed.
+
+. "$(dirname "$0")/test_header"
+
+set_test_number 4
+
+create_test_globalrc "
+process pool timeout = PT10S" ""
+
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+
+suite_run_ok "${TEST_NAME_BASE}-run" \
+    cylc run --debug --no-detach "${SUITE_NAME}"
+
+cylc cat-log "${SUITE_NAME}" | \
+    grep -A 3 ERROR | sed -e 's/^.* \([EW]\)/\1/' > log
+
+cmp_ok log <<__END__
+ERROR - [(('event-handler-00', 'started'), 1) cmd] sleeper.sh foo.1
+	[(('event-handler-00', 'started'), 1) ret_code] 1
+	[(('event-handler-00', 'started'), 1) err] killed on timeout (PT10S)
+WARNING - 1/foo/01 ('event-handler-00', 'started') failed
+__END__
+
+cylc suite-state "${SUITE_NAME}" > suite-state.log
+
+contains_ok suite-state.log << __END__
+stopper, 1, succeeded
+foo, 1, succeeded
+__END__
+
+purge_suite "${SUITE_NAME}"

--- a/tests/events/44-timeout/bin/sleeper.sh
+++ b/tests/events/44-timeout/bin/sleeper.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sleep 300

--- a/tests/events/44-timeout/suite.rc
+++ b/tests/events/44-timeout/suite.rc
@@ -1,0 +1,13 @@
+[cylc]
+   [[events]]
+      abort on timeout = True
+      timeout = PT20S
+[scheduling]
+    [[dependencies]]
+        graph = "foo => stopper"
+[runtime]
+    [[foo]]
+        [[[events]]]
+            started handler = sleeper.sh %(id)s
+    [[stopper]]
+        script = cylc stop "${CYLC_SUITE_NAME}"

--- a/tests/job-submission/16-timeout.t
+++ b/tests/job-submission/16-timeout.t
@@ -1,0 +1,54 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+
+# Test that job submission kill on timeout results in a failed job submission.
+
+. "$(dirname "$0")/test_header"
+
+set_test_number 4
+
+create_test_globalrc "
+process pool timeout = PT10S" ""
+
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+
+suite_run_ok "${TEST_NAME_BASE}-suite-run" \
+    cylc run --debug --no-detach "${SUITE_NAME}"
+
+cylc cat-log "${SUITE_NAME}" \
+    | egrep -m 1 -A 3 "ERROR - \[jobs-submit cmd\]" \
+       | sed -e 's/^.* \(ERROR\)/\1/' > log
+
+SUITE_LOG_DIR=$(cylc cat-log -m p "${SUITE_NAME}")
+
+cmp_ok log <<__END__
+ERROR - [jobs-submit cmd] cylc jobs-submit --debug -- ${SUITE_LOG_DIR%suite/log}job 1/foo/01
+	[jobs-submit ret_code] 1
+	[jobs-submit err] killed on timeout (PT10S)
+__END__
+
+cylc suite-state "${SUITE_NAME}" > suite-state.log
+
+contains_ok suite-state.log << __END__
+stopper, 1, succeeded
+foo, 1, submit-failed
+__END__
+
+purge_suite "${SUITE_NAME}"

--- a/tests/job-submission/16-timeout.t
+++ b/tests/job-submission/16-timeout.t
@@ -40,7 +40,7 @@ SUITE_LOG_DIR=$(cylc cat-log -m p "${SUITE_NAME}")
 
 cmp_ok log <<__END__
 ERROR - [jobs-submit cmd] cylc jobs-submit --debug -- ${SUITE_LOG_DIR%suite/log}job 1/foo/01
-	[jobs-submit ret_code] 1
+	[jobs-submit ret_code] -9
 	[jobs-submit err] killed on timeout (PT10S)
 __END__
 

--- a/tests/job-submission/16-timeout/suite.rc
+++ b/tests/job-submission/16-timeout/suite.rc
@@ -1,0 +1,14 @@
+[cylc]
+   [[events]]
+      abort on timeout = True
+      timeout = PT20S
+[scheduling]
+    [[dependencies]]
+        graph = "foo:submit-fail => stopper"
+[runtime]
+    [[foo]]
+        [[[job]]]
+            batch system = at
+            batch submit command template = sleep 30
+    [[stopper]]
+        script = cylc stop "${CYLC_SUITE_NAME}"


### PR DESCRIPTION
Hung or long-running event handlers (etc.) can cause a suite to stall with tasks in the 'ready' state (i.e. with job submit commands queued but unable to execute because the max number of subprocesses is used up).
(I have some evidence that this has happened at BoM: a suite stalled with 'ready' tasks after reportedly spawning job polling commands that hung for some reason).

This kills subprocesses that are still running after 10 seconds.  Easier to do than I expected.  @cylc/core - thoughts? (should we do this; should it be configurable; is this approach OK?)

