### PR TITLE
Changes to allow grouped sub-graphs to be visible on GCylc startup.

### DIFF
--- a/doc/src/cylc-user-guide/gcylcrc.tex
+++ b/doc/src/cylc-user-guide/gcylcrc.tex
@@ -115,6 +115,16 @@ be sorted using ascending or descending order.
     \item {\em example:} \lstinline@sort column ascending = False@
 \end{myitemize}
 
+\subsubsection{sub-graphs on}
+
+Set the sub-graphs view to be enabled by default.
+This can be changed later using the toggle options for the graph view.
+
+\begin{myitemize}
+\item {\em type:} boolean (False or True)
+\item {\em default:} ``False''
+\end{myitemize}
+
 
 \subsubsection{task filter highlight color}
 

--- a/lib/cylc/cfgspec/gcylc.py
+++ b/lib/cylc/cfgspec/gcylc.py
@@ -83,7 +83,7 @@ SPEC = {
     'transpose dot': vdr(vtype='boolean', default=False),
     'transpose graph': vdr(vtype='boolean', default=False),
     'ungrouped views': vdr(vtype='string_list', default=[]),
-    'sub-graphs on': vdr(vtype='boolean', default=False), 
+    'sub-graphs on': vdr(vtype='boolean', default=False),
     'use theme': vdr(vtype='string', default="default"),
     'window size': vdr(vtype='integer_list', default=[800, 500]),
 }

--- a/lib/cylc/cfgspec/gcylc.py
+++ b/lib/cylc/cfgspec/gcylc.py
@@ -83,6 +83,7 @@ SPEC = {
     'transpose dot': vdr(vtype='boolean', default=False),
     'transpose graph': vdr(vtype='boolean', default=False),
     'ungrouped views': vdr(vtype='string_list', default=[]),
+    'sub-graphs on': vdr(vtype='boolean', default=False), 
     'use theme': vdr(vtype='string', default="default"),
     'window size': vdr(vtype='integer_list', default=[800, 500]),
 }

--- a/lib/cylc/gui/updater_graph.py
+++ b/lib/cylc/gui/updater_graph.py
@@ -33,6 +33,7 @@ from cylc.mkdir_p import mkdir_p
 from cylc.network.httpclient import ClientError
 from cylc.task_id import TaskID
 from cylc.task_state import TASK_STATUS_RUNAHEAD
+from cylc.cfgspec.gcylc import gcfg
 
 
 def compare_dict_of_dict(one, two):
@@ -81,7 +82,8 @@ class GraphUpdater(threading.Thread):
         self.best_fit = True  # zoom to page size
         self.normal_fit = False  # zoom to 1.0 scale
         self.crop = False
-        self.subgraphs_on = False   # organise by cycle point.
+        # organise by cycle point.
+        self.subgraphs_on = gcfg.get(["sub-graphs on"])
 
         self.descendants = {}
         self.all_families = []

--- a/lib/cylc/gui/view_graph.py
+++ b/lib/cylc/gui/view_graph.py
@@ -323,6 +323,7 @@ Dependency graph suite control interface.
                                          gtk.ICON_SIZE_SMALL_TOOLBAR)
         self.subgraphs_button.set_icon_widget(image)
         self.subgraphs_button.set_label("Subgraphs")
+        self.subgraphs_button.set_active(self.t.subgraphs_on)
         self.subgraphs_button.connect(
             'clicked', self.toggle_cycle_point_subgraphs)
         self._set_tooltip(self.subgraphs_button,


### PR DESCRIPTION
Hi there

As per [this](https://groups.google.com/forum/#!topic/cylc/RwE1q4Dxs3U) post on the Cylc Google group, here is a branch to allow GCylc to show subgraphs on start up.

Cheers

Jonny