### PR TITLE
hell freezes over: cat-log self-tidy when re-invoked by ssh

### DIFF
--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -44,7 +44,7 @@ messaging."""
 
 import sys
 from cylc.remote import remrun, remote_cylc_cmd
-if remrun():
+if remrun(reveal=True):
     sys.exit(0)
 
 import os
@@ -86,6 +86,7 @@ BUFSIZE = 1024 * 1024
 
 
 def suicide():
+    """Kill myself if my parent PID changes."""
     PPID = os.getppid()
     PID = os.getpid()
     while True:
@@ -232,6 +233,11 @@ def get_option_parser():
         help="(for internal use: continue processing on job host)",
         action="append", dest="remote_args")
 
+    parser.add_option(
+        "--by-remrun",
+        help="(for internal use: was invoked by remrun)",
+        action="store_true", default=False, dest="by_remrun")
+
     return parser
 
 
@@ -315,8 +321,11 @@ def main():
             sys.exit(res)
         return
 
-    t = threading.Thread(target=suicide)
-    t.start()
+    if options.by_remrun:
+        # If invoked remotely by ssh, start a watcher thread to kill me if the
+        # parent ssh connection dies.
+        t = threading.Thread(target=suicide)
+        t.start()
 
     suite_name = args[0]
     mode = MODES[options.mode]

--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -52,6 +52,7 @@ import re
 import shlex
 import signal
 import traceback
+import threading
 from glob import glob
 from time import sleep
 from pipes import quote
@@ -82,6 +83,16 @@ MODES = {
 
 
 BUFSIZE = 1024 * 1024
+
+
+def suicide():
+    PPID = os.getppid()
+    PID = os.getpid()
+    while True:
+        sleep(1)
+        if os.getppid() != PPID:
+            os.killpg(PID, signal.SIGTERM)
+            break  # (technically unnecessary - I'll be dead here)
 
 
 def split_user_at_host(user_at_host):
@@ -152,8 +163,12 @@ def view_log(logpath, mode, tailer_tmpl, batchview_cmd=None, remote=False):
             cmd = tailer_tmpl % {"filename": logpath}
         # Ensure that the tail command dies if the parent process dies.
         ppid = os.getppid()
+        if remote:
+            fn = os.setpgrp
+        else:
+            fn = None
         proc = Popen(
-            shlex.split(cmd), stdin=open(os.devnull), preexec_fn=os.setpgrp)
+            shlex.split(cmd), stdin=open(os.devnull), preexec_fn=fn)
         try:
             while True:
                 sleep(0.5)
@@ -299,6 +314,9 @@ def main():
         if res == 1:
             sys.exit(res)
         return
+
+    t = threading.Thread(target=suicide)
+    t.start()
 
     suite_name = args[0]
     mode = MODES[options.mode]

--- a/lib/cylc/remote.py
+++ b/lib/cylc/remote.py
@@ -115,9 +115,9 @@ def remote_cylc_cmd(cmd, user=None, host=None, capture=False,
         return res
 
 
-def remrun(dry_run=False, forward_x11=False):
+def remrun(dry_run=False, forward_x11=False, reveal=False):
     """Short for RemoteRunner().execute(...)"""
-    return RemoteRunner().execute(dry_run, forward_x11)
+    return RemoteRunner().execute(dry_run, forward_x11, reveal)
 
 
 class RemoteRunner(object):
@@ -165,8 +165,10 @@ class RemoteRunner(object):
             from cylc.hostuserutil import is_remote
             self.is_remote = is_remote(self.host, self.owner)
 
-    def execute(self, dry_run=False, forward_x11=False):
+    def execute(self, dry_run=False, forward_x11=False, reveal=False):
         """Execute command on remote host.
+
+        reveal - if True, pass --by-remrun to the remote command.
 
         Returns False if remote re-invocation is not needed, True if it is
         needed and executes successfully otherwise aborts.
@@ -221,7 +223,8 @@ class RemoteRunner(object):
             command.append(r'--verbose')
         if cylc.flags.debug or os.getenv('CYLC_DEBUG') in ["True", "true"]:
             command.append(r'--debug')
-
+        if reveal:
+            command.append(r'--by-remrun')
         for arg in self.args:
             command.append(quote(arg))
             # above: args quoted to avoid interpretation by the shell,


### PR DESCRIPTION
ref: https://github.com/cylc/cylc/issues/2663#issuecomment-389480253

Hell freezing over is the only thing that trump "come hell or high water".

Explanation next...