### PR TITLE
deprecate conf/ syntax files

### DIFF
--- a/conf/DEPRECATED.md
+++ b/conf/DEPRECATED.md
@@ -1,0 +1,2 @@
+The `conf/` directory was deprecated at cylc-7.7.0, symlinks to the syntax
+file (which now reside in `etc/syntax`) will be removed at cylc-8.0.0.

--- a/conf/cylc-bash-completion
+++ b/conf/cylc-bash-completion
@@ -1,0 +1,1 @@
+../etc/cylc-bash-completion

--- a/conf/cylc-mode.el
+++ b/conf/cylc-mode.el
@@ -1,0 +1,1 @@
+../etc/syntax/cylc-mode.el

--- a/conf/cylc.lang
+++ b/conf/cylc.lang
@@ -1,0 +1,1 @@
+../etc/syntax/cylc.lang

--- a/conf/cylc.vim
+++ b/conf/cylc.vim
@@ -1,0 +1,1 @@
+../etc/syntax/cylc.vim

--- a/conf/cylc.xml
+++ b/conf/cylc.xml
@@ -1,0 +1,1 @@
+../etc/syntax/cylc.xml


### PR DESCRIPTION
Ideally we would deprecate configurations, paths etc in the current version and obsolete them at the next major version.

As many people have symlinked these files in their editors configuration we could maintain symlinks until cylc 8.

@hjoliver I'll leave the choice to you