### PR TITLE
Cat log remote tidy fix.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,12 +74,10 @@ task jobs on a FIFO (First In, First Out) basis, rather than randomly.
 [#2538](https://github.com/cylc/cylc/pull/2538) - remove leading whitespace
 from multi-line `script` items in task definitions, for cleaner job scripts.
 
-[#2624](https://github.com/cylc/cylc/pull/2624),
-[#2667](https://github.com/cylc/cylc/pull/2667),
-[#2669](https://github.com/cylc/cylc/pull/2669), 
-[#2672](https://github.com/cylc/cylc/pull/2672) - `cylc cat-log` (and GUI "View
-Jobs Logs") rewrite for enhanced functionality (and fix: should no longer leave
-orphaned `tail` processes on remote hosts).
+[#2503](https://github.com/cylc/cylc/pull/2503),
+[#2624](https://github.com/cylc/cylc/pull/2624) - `cylc cat-log`: all remote
+host actions now done by a `cylc` sub-command; and simpler command options (see
+`cylc cat-log --help`; **warning: the old command options are not supported**)
 
 ### Fixes
 
@@ -124,6 +122,10 @@ runs, so that the job file still gets written.
 
 [#2579](https://github.com/cylc/cylc/pull/2579) - `cylc gscan`: fix a
 re-spawning error dialog.
+
+[#2674](https://github.com/cylc/cylc/pull/2674) - `cylc cat-log`: avoid leaving
+orphaned tail-follow processes on job hosts.
+
 
 -------------------------------------------------------------------------------
 ## __cylc-7.6.1 (2018-03-28)__

--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -18,9 +18,9 @@
 
 """cylc [info] cat-log|log [OPTIONS] ARGS
 
-Print, edit, or tail-follow content, or print path or list directory, of local
-or remote task job logs and suite server logs. Batch-system view commands (e.g.
-'qcat') are used if defined in global config and the job is running.
+Print, view-in-editor, or tail-follow content, print path, or list directory,
+of local or remote task job and suite server logs. Batch-system view commands
+(e.g. 'qcat') are used if defined in global config and the job is running.
 
 For standard log types use the short-cut option argument or full filename (e.g.
 for job stdout "-f o" or "-f job.out" will do).
@@ -43,16 +43,14 @@ the general command reinvocation options for sites using ssh-based task
 messaging."""
 
 import sys
-from cylc.remote import remrun, remote_cylc_cmd
-if remrun(reveal=True):
+from cylc.remote import remrun, remote_cylc_cmd, watch_and_kill
+if remrun():
     sys.exit(0)
 
 import os
 import re
 import shlex
-import signal
 import traceback
-import threading
 from glob import glob
 from time import sleep
 from pipes import quote
@@ -72,6 +70,29 @@ from cylc.task_job_logs import (
 from parsec.fileparse import read_and_proc
 
 
+# Immortal tail-follow processes on job hosts can be cleaned up by killing
+# my subprocesses if my PPID or PPPID changes (due to parent ssh connection
+# dying). This works even if cat-log is invoked with '--host' from a third
+# host, and even if the sshd-invoked "$(SHELL) -c <remote-command>" does not
+# exec <remote-command> (affects whether my parent process or I get inherited
+# by init).
+#
+# Example: On host A: cylc cat-log --host=B <suite> <task-on-C>
+#    => on host A: cat-log spawns subprocess
+#                     ssh B "cylc cat-log <suite> <task-on-C>"
+#      => on host B: cat-log spawns subprocess
+#                     ssh C "cylc cat-log --remote <suite> <task-on-C>"
+#        => on host C: cat-log spawns subprocess
+#                       tail -f <task-on-C>.out
+#
+# Then Ctrl-C (or exit GUI log viewer) on host-A:
+#    => ssh from A to B dies
+#       => on B: cat-log detects the previous,
+#                  and kills its ssh subprocess to C
+#         => on C: cat-log detects the previous,
+#                  and kills its tail subprocess, then exits as finished
+
+
 MODES = {
     'p': 'print',
     'l': 'list-dir',
@@ -83,17 +104,6 @@ MODES = {
 
 
 BUFSIZE = 1024 * 1024
-
-
-def suicide():
-    """Kill myself if my parent PID changes."""
-    PPID = os.getppid()
-    PID = os.getpid()
-    while True:
-        sleep(1)
-        if os.getppid() != PPID:
-            os.killpg(PID, signal.SIGTERM)
-            break  # (technically unnecessary - I'll be dead here)
 
 
 def split_user_at_host(user_at_host):
@@ -162,26 +172,9 @@ def view_log(logpath, mode, tailer_tmpl, batchview_cmd=None, remote=False):
             cmd = batchview_cmd
         else:
             cmd = tailer_tmpl % {"filename": logpath}
-        # Ensure that the tail command dies if the parent process dies.
-        ppid = os.getppid()
-        if remote:
-            fn = os.setpgrp
-        else:
-            fn = None
-        proc = Popen(
-            shlex.split(cmd), stdin=open(os.devnull), preexec_fn=fn)
-        try:
-            while True:
-                sleep(0.5)
-                if proc.poll() is not None:
-                    break
-                if os.getppid() != ppid:
-                    os.killpg(proc.pid, signal.SIGTERM)
-                    break
-        except KeyboardInterrupt:
-            pass
-        proc.wait()
-        return 0
+        proc = Popen(shlex.split(cmd), stdin=open(os.devnull))
+        watch_and_kill(proc)
+        return proc.wait()
 
 
 def get_option_parser():
@@ -232,11 +225,6 @@ def get_option_parser():
         "--remote-arg",
         help="(for internal use: continue processing on job host)",
         action="append", dest="remote_args")
-
-    parser.add_option(
-        "--by-remrun",
-        help="(for internal use: was invoked by remrun)",
-        action="store_true", default=False, dest="by_remrun")
 
     return parser
 
@@ -321,12 +309,6 @@ def main():
             sys.exit(res)
         return
 
-    if options.by_remrun:
-        # If invoked remotely by ssh, start a watcher thread to kill me if the
-        # parent ssh connection dies.
-        t = threading.Thread(target=suicide)
-        t.start()
-
     suite_name = args[0]
     mode = MODES[options.mode]
 
@@ -354,7 +336,7 @@ def main():
         if out == 1:
             sys.exit(1)
         if mode == 'edit':
-            tmpfile_edit(out)
+            tmpfile_edit(out, options.geditor)
         return
 
     if len(args) == 2:
@@ -430,8 +412,10 @@ def main():
                 cmd.append('--remote-arg=%s' % quote(batchview_cmd))
             cmd.append(suite_name)
             capture = (mode == 'edit')
+            manage = (mode == 'tail')
             try:
-                proc = remote_cylc_cmd(cmd, user, host, capture)
+                proc = remote_cylc_cmd(cmd, user, host, capture=capture,
+                                       manage=manage)
             except KeyboardInterrupt:
                 # Ctrl-C while tailing.
                 pass
@@ -454,8 +438,8 @@ def main():
                 point, task, options.submit_num, options.filename))
             tail_tmpl = str(glbl_cfg().get_host_item("tail command template"))
             out = view_log(logpath, mode, tail_tmpl, batchview_cmd)
-            if out == 1:
-                sys.exit(1)
+            if mode != 'edit':
+                sys.exit(out)
         if mode == 'edit':
             tmpfile_edit(out, options.geditor)
 

--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -312,10 +312,10 @@ def main():
         return
 
     suite_name = args[0]
+    # Get long-format mode.
     try:
         mode = MODES[options.mode]
     except KeyError:
-        # User chose log form.
         mode = options.mode
 
     if len(args) == 1:
@@ -338,7 +338,7 @@ def main():
         else:
             logpath = os.path.join(logdir, basename)
         tail_tmpl = str(glbl_cfg().get_host_item("tail command template"))
-        out = view_log(logpath, MODES[options.mode], tail_tmpl)
+        out = view_log(logpath, mode, tail_tmpl)
         if out == 1:
             sys.exit(1)
         if mode == 'edit':
@@ -377,14 +377,14 @@ def main():
             # command (e.g. qcat) if one exists, and the log is out or err.
             conf_key = None
             if options.filename == JOB_LOG_OUT:
-                if options.mode == 'c':
+                if mode == 'cat':
                     conf_key = "out viewer"
-                elif options.mode == 't':
+                elif mode == 'tail':
                     conf_key = "out tailer"
             elif options.filename == JOB_LOG_ERR:
-                if options.mode == 'c':
+                if mode == 'cat':
                     conf_key = "err viewer"
-                elif options.mode == 't':
+                elif mode == 'tail':
                     conf_key = "err tailer"
             if conf_key is not None:
                 conf = glbl_cfg().get_host_item("batch systems", host, user)

--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -44,7 +44,8 @@ messaging."""
 
 import sys
 from cylc.remote import remrun, remote_cylc_cmd, watch_and_kill
-if remrun():
+# Disallow remote re-invocation of edit mode (result: "ssh HOST vim <file>").
+if remrun(abort_if='edit'):
     sys.exit(0)
 
 import os
@@ -314,7 +315,7 @@ def main():
     try:
         mode = MODES[options.mode]
     except KeyError:
-        # User chose log form. 
+        # User chose log form.
         mode = options.mode
 
     if len(args) == 1:

--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -197,7 +197,8 @@ def get_option_parser():
         "-m", "--mode",
         help="Mode: %s. Default c(cat)." % (
             ', '.join(['%s(%s)' % (i, j) for i, j in MODES.items()])),
-        action="store", choices=MODES.keys(), default='c', dest="mode")
+        action="store", choices=MODES.keys() + MODES.values(), default='c',
+        dest="mode")
 
     parser.add_option(
         "-r", "--rotation",
@@ -310,7 +311,11 @@ def main():
         return
 
     suite_name = args[0]
-    mode = MODES[options.mode]
+    try:
+        mode = MODES[options.mode]
+    except KeyError:
+        # User chose log form. 
+        mode = options.mode
 
     if len(args) == 1:
         # Cat suite logs, local only.

--- a/lib/cylc/remote.py
+++ b/lib/cylc/remote.py
@@ -149,9 +149,9 @@ def remote_cylc_cmd(cmd, user=None, host=None, capture=False, manage=False,
         return res
 
 
-def remrun(dry_run=False, forward_x11=False):
+def remrun(dry_run=False, forward_x11=False, abort_if=None):
     """Short for RemoteRunner().execute(...)"""
-    return RemoteRunner().execute(dry_run, forward_x11)
+    return RemoteRunner().execute(dry_run, forward_x11, abort_if)
 
 
 class RemoteRunner(object):
@@ -199,7 +199,7 @@ class RemoteRunner(object):
             from cylc.hostuserutil import is_remote
             self.is_remote = is_remote(self.host, self.owner)
 
-    def execute(self, dry_run=False, forward_x11=False):
+    def execute(self, dry_run=False, forward_x11=False, abort_if=None):
         """Execute command on remote host.
 
         Returns False if remote re-invocation is not needed, True if it is
@@ -208,6 +208,11 @@ class RemoteRunner(object):
         """
         if not self.is_remote:
             return False
+
+        if abort_if is not None and abort_if in sys.argv:
+            sys.stderr.write(
+                "ERROR: option '%s' not available for remote run\n" % abort_if)
+            return True
 
         # Build the remote command
         command = shlex.split(glbl_cfg().get_host_item(

--- a/tests/cylc-cat-log/05-remote-tail.t
+++ b/tests/cylc-cat-log/05-remote-tail.t
@@ -45,9 +45,13 @@ while ! grep -q -F '[foo.1] -(current:submitted)> started' \
 do
     sleep 1
 done
-TEST_NAME=$TEST_NAME_BASE-cat-log
-cylc cat-log $SUITE_NAME -f o -m t foo.1 > ${TEST_NAME}.out
-grep_ok "HELLO from foo 1" ${TEST_NAME}.out
+# cylc cat-log -m 't' tail-follows a file, so needs to be killed.
+# Send interrupt signal to tail command after 15 seconds.
+TEST_NAME="${TEST_NAME_BASE}-cat-log"
+timeout -s 'INT' 15 \
+    cylc cat-log "${SUITE_NAME}" -f 'o' -m 't' 'foo.1' \
+    >"${TEST_NAME}.out" 2>"${TEST_NAME}.err" || true
+grep_ok "HELLO from foo 1" "${TEST_NAME}.out"
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-stop
 run_ok $TEST_NAME cylc stop --kill --max-polls=20 --interval=1 $SUITE_NAME


### PR DESCRIPTION
Follow-up aborted #2672 and earlier attempts at avoiding orphaned tail processes on job hosts.

No need for watch-and kill threads or killing process groups.  Just kill invoked subprocesses (either ssh command reinvocation or tail-follow command) if main process's PPID or PPPID (etc) changes.

Example:  on host A: `cylc cat-log --host=B <suite> <task-on-C>`
 * => on host A: cat-log spawns subprocess `ssh B "cylc cat-log <suite> <task-on-C>"`
 * =>  on host B: cat-log spawns subprocess `ssh C "cylc cat-log --remote <suite> <task-on-C>"` 
 * => on host C: cat-log spawns subprocess `tail -f <task-on-C>.out`

Ctrl-C (or exit GUI viewer) on host-A:
 * ssh from A to B dies
 * => on B: cat-log detects the previous, and kills its ssh subprocess to C
 * => on C: cat-log detects the previous, and kills its tail subprocess, then exits normally as finished

