### PR TITLE
trap error after cylc message success

### DIFF
--- a/lib/cylc/job.sh
+++ b/lib/cylc/job.sh
@@ -145,7 +145,9 @@ cylc__job__main() {
     # Send task succeeded message
     wait "${CYLC_TASK_MESSAGE_STARTED_PID}" 2>'/dev/null' || true
     cylc message -- "${CYLC_SUITE_NAME}" "${CYLC_TASK_JOB}" 'succeeded' || true
-    trap '' EXIT
+    for signal_name in ${CYLC_VACATION_SIGNALS:-} ${CYLC_FAIL_SIGNALS}; do
+        trap '' "${signal_name}"
+    done
     exit 0
 }
 

--- a/lib/cylc/job.sh
+++ b/lib/cylc/job.sh
@@ -145,9 +145,7 @@ cylc__job__main() {
     # Send task succeeded message
     wait "${CYLC_TASK_MESSAGE_STARTED_PID}" 2>'/dev/null' || true
     cylc message -- "${CYLC_SUITE_NAME}" "${CYLC_TASK_JOB}" 'succeeded' || true
-    for signal_name in ${CYLC_VACATION_SIGNALS:-} ${CYLC_FAIL_SIGNALS}; do
-        trap '' "${signal_name}"
-    done
+    trap '' ${CYLC_VACATION_SIGNALS:-} ${CYLC_FAIL_SIGNALS}
     exit 0
 }
 
@@ -184,9 +182,7 @@ cylc__job_finish() {
     typeset run_err_script="$2"
     shift 2
     typeset signal_name=
-    for signal_name in ${CYLC_VACATION_SIGNALS:-} ${CYLC_FAIL_SIGNALS}; do
-        trap '' "${signal_name}"
-    done
+    trap '' ${CYLC_VACATION_SIGNALS:-} ${CYLC_FAIL_SIGNALS}
     if [[ -n "${CYLC_TASK_MESSAGE_STARTED_PID:-}" ]]; then
         wait "${CYLC_TASK_MESSAGE_STARTED_PID}" 2>'/dev/null' || true
     fi


### PR DESCRIPTION
Address niche issue involving exit signals issued in the narrow gap between job success and exit.

We recently came across a user with a `.bash_logout` script containing the `clear` command. Since #2438 this can cause an exit `ERR` ("TERM environment variable not set.", we can't clean the terminal if there isn't a terminal to clean).

This results in two exit entries in the `job.status` file, in my tests cylc typically fails but sometimes succeeds tasks in this state.