### PR TITLE
modified a python.org and graphviz.org link to be clickable in tex files

### DIFF
--- a/doc/src/cylc-user-guide/cug.tex
+++ b/doc/src/cylc-user-guide/cug.tex
@@ -4079,7 +4079,7 @@ object oriented programming languages. The result of this should be
 fairly obvious for typical use of multiple inheritance in cylc suites,
 but for detailed documentation of how the algorithm works refer to the
 official Python documentation here:
-\lstinline=http://www.python.org/download/releases/2.3/mro/=.
+\url{http://www.python.org/download/releases/2.3/mro/}.
 
 The {\em inherit.multi.one} example suite, listed here, makes use of
 multiple inheritance:

--- a/doc/src/cylc-user-guide/suiterc.tex
+++ b/doc/src/cylc-user-guide/suiterc.tex
@@ -2126,7 +2126,7 @@ in simulation or dummy modes.
 Configuration of suite graphing for the \lstinline=cylc graph= command (graph
 extent, styling, and initial family-collapsed state) and the gcylc graph view
 (initial family-collapsed state). Graphviz documentation of node shapes
-and so on can be found at http://www.graphviz.org/Documentation.php.
+and so on can be found at \url{http://www.graphviz.org/documentation/}.
 
 \subsubsection[initial cycle point]{[visualization] \textrightarrow initial cycle point}
 


### PR DESCRIPTION
I thought it made sense for these two urls to be clickable like most are in the documentation. Also, fixed the url for graphviz documentation (no longer Documentation.php).