### PR TITLE
Add filter for security warnings from urllib3

### DIFF
--- a/doc/src/cylc-user-guide/cug.tex
+++ b/doc/src/cylc-user-guide/cug.tex
@@ -383,7 +383,7 @@ previous section, emerges naturally at run time.
 
 Cylc runs on Linux. It is tested quite thoroughly on modern RHEL and Ubuntu
 distros. Some users have also managed to make it work on other Unix variants
-including Apple OS X.
+including Apple OS X, but they are not officially tested and supported.
 
 \subsection{Third-Party Software Packages}
 

--- a/doc/src/cylc-user-guide/cug.tex
+++ b/doc/src/cylc-user-guide/cug.tex
@@ -387,8 +387,10 @@ including Apple OS X.
 
 \subsection{Third-Party Software Packages}
 
-{\bf Python \lstinline@>=@ 2.6} is required (but not yet Python 3). Python
-should already be installed in your Linux system. \url{https://python.org}.
+{\bf Python 2 \lstinline@>=@ 2.6} is required.
+{\bf Python 2 \lstinline@>=@ 2.7.9} is recommended for the best security.
+Python 2 should already be installed in your Linux system.
+\url{https://python.org/}.
 
 For Cylc's HTTPS communications layer:
 \begin{myitemize}
@@ -396,8 +398,6 @@ For Cylc's HTTPS communications layer:
   \item {\bf pyOpenSSL} - \url{http://www.pyopenssl.org/}
   \item {\bf python-requests} - \url{http://docs.python-requests.org/}
   \item ({\bf python-urllib3} - should be bundled with python-requests)
-  \item ({\bf Python \lstinline@>=@ 2.7.9} (but not yet Python 3) is
-        recommended for the best security.)
 \end{myitemize}
 
 The following packages are highly recommended, but are technically optional as

--- a/doc/src/cylc-user-guide/cug.tex
+++ b/doc/src/cylc-user-guide/cug.tex
@@ -381,7 +381,9 @@ previous section, emerges naturally at run time.
 \section{Installation}
 \label{Requirements}
 
-Cylc runs on Unix variants, usually Linux, and including Apple OS X.
+Cylc runs on Linux. It is tested quite thoroughly on modern RHEL and Ubuntu
+distros. Some users have also managed to make it work on other Unix variants
+including Apple OS X.
 
 \subsection{Third-Party Software Packages}
 
@@ -394,6 +396,8 @@ For Cylc's HTTPS communications layer:
   \item {\bf pyOpenSSL} - \url{http://www.pyopenssl.org/}
   \item {\bf python-requests} - \url{http://docs.python-requests.org/}
   \item ({\bf python-urllib3} - should be bundled with python-requests)
+  \item ({\bf Python \lstinline@>=@ 2.7.9} (but not yet Python 3) is
+        recommended for the best security.)
 \end{myitemize}
 
 The following packages are highly recommended, but are technically optional as

--- a/lib/cylc/network/httpclient.py
+++ b/lib/cylc/network/httpclient.py
@@ -385,8 +385,14 @@ class SuiteRuntimeServiceClient(object):
     def _call_server_impl_requests(self, url, method, payload):
         """Call server with "requests" library."""
         import requests
-        from requests.packages.urllib3.exceptions import InsecureRequestWarning
-        warnings.simplefilter("ignore", InsecureRequestWarning)
+        # Filter security warnings from urllib3 on python2.6. Obviously, we
+        # want to upgrade, but some sites have to run cylc on platforms with
+        # python2.6. On those platforms, these warnings serve no purpose except
+        # to annoy or confuse users.
+        from requests.packages.urllib3.exceptions import (
+            SecurityWarning, SNIMissingWarning)
+        warnings.simplefilter("ignore", SecurityWarning)
+        warnings.simplefilter("ignore", SNIMissingWarning)
         if self.session is None:
             self.session = requests.Session()
 

--- a/lib/cylc/network/httpclient.py
+++ b/lib/cylc/network/httpclient.py
@@ -385,14 +385,15 @@ class SuiteRuntimeServiceClient(object):
     def _call_server_impl_requests(self, url, method, payload):
         """Call server with "requests" library."""
         import requests
-        # Filter security warnings from urllib3 on python2.6. Obviously, we
+        # Filter security warnings from urllib3 on python <2.7.9. Obviously, we
         # want to upgrade, but some sites have to run cylc on platforms with
-        # python2.6. On those platforms, these warnings serve no purpose except
-        # to annoy or confuse users.
-        from requests.packages.urllib3.exceptions import (
-            SecurityWarning, SNIMissingWarning)
-        warnings.simplefilter("ignore", SecurityWarning)
-        warnings.simplefilter("ignore", SNIMissingWarning)
+        # python <2.7.9. On those platforms, these warnings serve no purpose
+        # except to annoy or confuse users.
+        if sys.version_info < (2, 7, 9):
+            from requests.packages.urllib3.exceptions import (
+                SecurityWarning, SNIMissingWarning)
+            warnings.simplefilter("ignore", SecurityWarning)
+            warnings.simplefilter("ignore", SNIMissingWarning)
         if self.session is None:
             self.session = requests.Session()
 


### PR DESCRIPTION
Obviously, we are aware of the security issues on the affected
platforms, but these warnings serve no purpose on those platforms except
to confuse or annoy users.

Sufficient to close #2686. (Real fix will require #1874.)