### PR TITLE
Fix gscan and profile-battery --help display issue

### DIFF
--- a/bin/cylc-gscan
+++ b/bin/cylc-gscan
@@ -31,17 +31,6 @@ if "--use-ssh" in sys.argv[1:]:
     if remrun(forward_x11=True):
         sys.exit(0)
 
-import gtk
-import warnings
-warnings.filterwarnings('ignore', 'use the new', Warning)
-
-gtk.settings_get_default().set_long_property(
-    "gtk-button-images", True, "main")
-gtk.settings_get_default().set_long_property(
-    "gtk-menu-images", True, "main")
-
-from cylc.cfgspec.glbl_cfg import glbl_cfg
-from cylc.gui.gscan import ScanApp
 from cylc.option_parsers import CylcOptionParser as COP
 
 
@@ -79,6 +68,18 @@ def main():
         help="Time interval (in seconds) between full updates",
         type="int", metavar="SECONDS", dest="interval")
     options, args = parser.parse_args()
+
+    # Only import GTK, etc here, as the command may be called with "--help" in
+    # batch mode, which may be unable to import GTK.
+    import gtk
+    import warnings
+    warnings.filterwarnings('ignore', 'use the new', Warning)
+    gtk.settings_get_default().set_long_property(
+        "gtk-button-images", True, "main")
+    gtk.settings_get_default().set_long_property(
+        "gtk-menu-images", True, "main")
+    from cylc.cfgspec.glbl_cfg import glbl_cfg
+    from cylc.gui.gscan import ScanApp
 
     if options.all_ports:
         args.extend(glbl_cfg().get(["suite host scanning", "hosts"]))

--- a/lib/cylc/profiling/analysis.py
+++ b/lib/cylc/profiling/analysis.py
@@ -27,7 +27,7 @@ try:
     import matplotlib.cm as colour_map
     import matplotlib.pyplot as plt
     CAN_PLOT = True
-except ImportError:
+except (ImportError, RuntimeError):
     CAN_PLOT = False
 
 from . import (PROFILE_MODE_TIME, PROFILE_MODE_CYLC, SUMMARY_LINE_REGEX,

--- a/tests/cli/01-help.t
+++ b/tests/cli/01-help.t
@@ -18,7 +18,7 @@
 # cylc help and basic invocation.
 
 . "$(dirname "$0")/test_header"
-set_test_number 45
+set_test_number 136
 
 # Top help
 run_ok "${TEST_NAME_BASE}-0" cylc
@@ -108,5 +108,11 @@ run_ok "${TEST_NAME_BASE}-version.stdout" \
     test -n "${TEST_NAME_BASE}-version.stdout"
 cmp_ok "${TEST_NAME_BASE}-version.stdout" "${TEST_NAME_BASE}---version.stdout"
 cmp_ok "${TEST_NAME_BASE}-version.stdout" "${TEST_NAME_BASE}-V.stdout"
+
+# --help with no DISPLAY
+while read ITEM; do
+    run_ok "${TEST_NAME_BASE}-no-display-${ITEM}--help" \
+        env DISPLAY= cylc "${ITEM#cylc-}" --help
+done < <(cd "${CYLC_DIR}/bin" && ls 'cylc-'*)
 
 exit


### PR DESCRIPTION
Invoking the commands with `--help` should no longer require DISPLAY.

Fix #2681.