### PR TITLE
gui --host=HOST edit job log requires X11 forward

### DIFF
--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -45,7 +45,7 @@ messaging."""
 import sys
 from cylc.remote import remrun, remote_cylc_cmd, watch_and_kill
 # Disallow remote re-invocation of edit mode (result: "ssh HOST vim <file>").
-if remrun(abort_if='edit'):
+if remrun(abort_if='edit', forward_x11=True):
     sys.exit(0)
 
 import os


### PR DESCRIPTION
Currently, we get orphaned processes.