### PR TITLE
Incorporate suite host selection logic

### DIFF
--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -418,10 +418,10 @@ def main():
                 cmd.append('--remote-arg=%s' % quote(batchview_cmd))
             cmd.append(suite_name)
             capture = (mode == 'edit')
-            manage = (mode == 'tail')
             try:
-                proc = remote_cylc_cmd(cmd, user, host, capture=capture,
-                                       manage=manage)
+                proc = remote_cylc_cmd(
+                    cmd, user, host, capture_process=capture,
+                    manage=(mode == 'tail'))
             except KeyboardInterrupt:
                 # Ctrl-C while tailing.
                 pass

--- a/bin/cylc-get-host-metrics
+++ b/bin/cylc-get-host-metrics
@@ -1,0 +1,217 @@
+#!/usr/bin/env python
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""cylc get-host-metrics [OPTIONS]
+
+   Get metrics for localhost, in the form of a JSON structure with top-level
+   keys as requested via the OPTIONS:
+
+   1. --load
+          1, 5 and 15 minute load averages (as keys) from the 'uptime' command.
+   2. --memory
+          Total free RAM memory, in kilobytes, from the 'free -k' command.
+   3. --disk-space=PATH / --disk-space=PATH1,PATH2,PATH3 (etc)
+          Available disk space from the 'df -Pk' command, in kilobytes, for one
+          or more valid mount directory PATHs (as listed under 'Mounted on')
+          within the filesystem of localhost. Multiple PATH options can be
+          specified via a comma-delimited list, each becoming a key under the
+          top-level disk space key.
+
+   If no options are specified, --load and --memory are invoked by default."""
+
+
+import sys
+if '--use-ssh' in sys.argv[1:]:
+    sys.argv.remove('--use-ssh')
+    from cylc.remote import remrun
+    if remrun():
+        sys.exit(0)
+
+import os
+import re
+from subprocess import Popen, PIPE, CalledProcessError
+import json
+
+import cylc.flags
+from cylc.option_parsers import CylcOptionParser as COP
+
+
+"""Templates for extracting desired metric data via regular expression.
+
+   Example command outputs, with '*' enclosing data to extract with templates:
+
+   LOAD_TEMPLATES
+     $ uptime
+     17:52:58 up  8:08,  2 users,  load average: *0.13*, *0.09*, *0.07*
+
+   MEMORY_TEMPLATES
+     $ free -k
+                  total       used       free     shared    buffers     cached
+     Mem:       6116852    5017920    1098932    54964     130328    1837404
+     -/+ buffers/cache:    3050188  *3066664*
+     Swap:      4190204      14624    4175580
+
+   DISK_TEMPLATES, e.g. for mount directory path option '--disk-space=/boot'
+     $ df -Pk /boot
+     Filesystem            1024-blocks      Used Available Capacity Mounted on
+     /dev/md0                    96978     33904   *57856*      37% /boot."""
+LOAD_TEMPLATES = ['uptime', (1, 5, 15), re.compile(
+                  r'load average:\s([\d\.]+),\s([\d\.]+),\s([\d\.]+)')]
+MEMORY_TEMPLATES = ['free -k', re.compile(
+                    r'\-/\+ buffers/cache:\s+\d+\s+(\d+)')]
+DISK_TEMPLATES = ['df -Pk', re.compile(
+                  r'Mounted on\n\S+\s+\d+\s+\d+\s+(\d+)\s+')]
+
+
+def main():
+    parser = COP(__doc__, comms=True, noforce=True, argdoc=[])
+
+    parser.add_option(
+        "--load", "-l",
+        help="1, 5 and 15 minute load averages from the 'uptime' command",
+        action="store_true", default=False, dest="load")
+
+    parser.add_option(
+        "--memory", "-m",
+        help="Total free RAM memory, in KB, from the 'free -k' command.",
+        action="store_true", default=False, dest="memory")
+
+    parser.add_option(
+        "--disk-space",
+        help="Available disk space, in KB, from the 'df -Pk' command",
+        action="store", default=None, dest="disk")
+
+    options, args = parser.parse_args()
+    print get_host_metric(options.load, options.memory, options.disk)
+
+    sys.exit()
+
+
+def run_command_string(command_string):
+    """Return the result from running a command string in a local shell.
+
+       Return stdout if command successful, else raise CalledProcessError."""
+    command_sequence = command_string.split()
+    # Note: can replace function w/ 'subprocess.check_output()' when drop v2.6.
+    process = Popen(command_sequence, stdin=open(os.devnull), stdout=PIPE,
+                    stderr=PIPE)
+    stdoutput = process.communicate()[0]
+    process.wait()
+    return_code = process.returncode
+    if return_code:
+        raise CalledProcessError(return_code, command_sequence)
+    else:
+        return str(stdoutput)
+
+
+def extract_pattern(data_pattern, raw_string):
+    """Try to return first parenthesized subgroup of a regex string search."""
+    error_msg = "No 're.search' matches for:\n  %s\non the string:\n  %s" % (
+        data_pattern.pattern, raw_string)
+    try:
+        matches = re.search(data_pattern, raw_string)
+    except re.error:
+        sys.stderr.write(error_msg)
+    if matches:
+        return matches.groups()
+    else:
+        raise AttributeError(error_msg)
+
+
+def process_load():
+    """Return dictionary with load average float values from 'uptime' command.
+
+       String keys e.g. 'load:1' give minutes average was measured over."""
+    cmd, av_times, patt = LOAD_TEMPLATES
+    av_raw_tuple = extract_pattern(patt, run_command_string(cmd))
+    try:
+        av_floats_tuple = [float(av_raw) for av_raw in av_raw_tuple]
+    except ValueError:
+        raise
+    return dict(zip(
+        ["load:" + str(time) for time in av_times], av_floats_tuple))
+
+
+def process_memory():
+    """Return dict with integer value of free memory from 'free -k' command."""
+    cmd, patt = MEMORY_TEMPLATES
+    free_memory_str, = extract_pattern(patt, run_command_string(cmd))
+    try:
+        free_memory_int = int(free_memory_str)
+    except ValueError:
+        raise
+    return {"memory": free_memory_int}
+
+
+def process_disk(paths_list):
+    """Return dictionary with available disk space for given mount dir paths.
+
+       Disk space data, from 'df -Pk' command, stored as float values under
+       associated path string keys."""
+    partial_cmd, patt = DISK_TEMPLATES
+    path_dict = {}
+    for path in paths_list:
+        # Invoke 'df' for each path/file separately; safer for extracting the
+        # correct data; not as efficient but the command is not intensive.
+        cmd_output = run_command_string(partial_cmd + ' ' + path)
+        free_space_str, = extract_pattern(patt, cmd_output)
+        if free_space_str:
+            try:
+                free_space_int = int(free_space_str)
+            except ValueError:
+                raise
+            path_dict["disk-space:" + path] = free_space_int
+    return path_dict
+
+
+def get_host_metric(inc_load, inc_memory, disk_paths):
+    """Return JSON structure containing specified metric data for localhost.
+
+       Example:
+         {
+             "load:5": 0.059999999999999998,
+             "disk-space:/boot": 57856,
+             "load:1": 0.050000000000000003,
+             "memory": 3168296,
+             "load:15": 0.080000000000000002,
+             "disk-space:/": 9212088
+         }
+
+       The data included depends on the options specified to the command and
+       is one or more from: load average, free memory and available disk space
+       (for specified mount directory paths)."""
+
+    HOST_METRIC = {}
+
+    if disk_paths:
+        paths_list = disk_paths.split(',')
+        # Filter out empty string from possible option spec trailing comma.
+        paths_list = [path for path in paths_list if path]
+        HOST_METRIC.update(process_disk(paths_list))
+    # Load & memory provided as default, but disk space could be wanted
+    # singly so can't just do this via the option parser defaults.
+    if inc_load or all([not inc_load, not inc_memory, not disk_paths]):
+        HOST_METRIC.update(process_load())
+    if inc_memory or all([not inc_load, not inc_memory, not disk_paths]):
+        HOST_METRIC.update(process_memory())
+
+    return json.dumps(HOST_METRIC, indent=4)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/cylc-get-host-metrics
+++ b/bin/cylc-get-host-metrics
@@ -18,22 +18,22 @@
 
 """cylc get-host-metrics [OPTIONS]
 
-   Get metrics for localhost, in the form of a JSON structure with top-level
-   keys as requested via the OPTIONS:
+Get metrics for localhost, in the form of a JSON structure with top-level
+keys as requested via the OPTIONS:
 
-   1. --load
-          1, 5 and 15 minute load averages (as keys) from the 'uptime' command.
-   2. --memory
-          Total free RAM memory, in kilobytes, from the 'free -k' command.
-   3. --disk-space=PATH / --disk-space=PATH1,PATH2,PATH3 (etc)
-          Available disk space from the 'df -Pk' command, in kilobytes, for one
-          or more valid mount directory PATHs (as listed under 'Mounted on')
-          within the filesystem of localhost. Multiple PATH options can be
-          specified via a comma-delimited list, each becoming a key under the
-          top-level disk space key.
+1. --load
+       1, 5 and 15 minute load averages (as keys) from the 'uptime' command.
+2. --memory
+       Total free RAM memory, in kilobytes, from the 'free -k' command.
+3. --disk-space=PATH / --disk-space=PATH1,PATH2,PATH3 (etc)
+       Available disk space from the 'df -Pk' command, in kilobytes, for one
+       or more valid mount directory PATHs (as listed under 'Mounted on')
+       within the filesystem of localhost. Multiple PATH options can be
+       specified via a comma-delimited list, each becoming a key under the
+       top-level disk space key.
 
-   If no options are specified, --load and --memory are invoked by default."""
-
+If no options are specified, --load and --memory are invoked by default.
+"""
 
 import sys
 if '--use-ssh' in sys.argv[1:]:
@@ -48,55 +48,67 @@ from subprocess import Popen, PIPE, CalledProcessError
 import json
 
 import cylc.flags
-from cylc.option_parsers import CylcOptionParser as COP
+from cylc.option_parsers import OptionParser
 
 
 """Templates for extracting desired metric data via regular expression.
 
-   Example command outputs, with '*' enclosing data to extract with templates:
+Example command outputs, with '*' enclosing data to extract with templates:
 
-   LOAD_TEMPLATES
-     $ uptime
-     17:52:58 up  8:08,  2 users,  load average: *0.13*, *0.09*, *0.07*
+LOAD_TEMPLATES:
+    $ uptime
+    17:52:58 up  8:08,  2 users,  load average: *0.13*, *0.09*, *0.07*
 
-   MEMORY_TEMPLATES
-     $ free -k
-                  total       used       free     shared    buffers     cached
-     Mem:       6116852    5017920    1098932    54964     130328    1837404
-     -/+ buffers/cache:    3050188  *3066664*
-     Swap:      4190204      14624    4175580
+MEMORY_TEMPLATES
+    ('free -k' command inconsistent across Linux distros, see e.g.
+     'https://access.redhat.com/solutions/406773', so check '/proc' directly)
+    $ cat /proc/meminfo
+    MemTotal:        6116852 kB
+    MemFree:        *670856* kB
+    [MemAvailable:    3765092 kB]
+    Buffers:        *315808* kB
+    Cached:        *1497064* kB
+    SwapCached:            0 kB
+    Active:          3417432 kB
+    ...
+    ...
+    where [] encloses fields on RHEL7 only.
 
-   DISK_TEMPLATES, e.g. for mount directory path option '--disk-space=/boot'
-     $ df -Pk /boot
-     Filesystem            1024-blocks      Used Available Capacity Mounted on
-     /dev/md0                    96978     33904   *57856*      37% /boot."""
+DISK_TEMPLATES, e.g. for mount directory path option '--disk-space=/boot':
+    $ df -Pk /boot
+    Filesystem            1024-blocks      Used Available Capacity Mounted on
+    /dev/md0                    96978     33904   *57856*      37% /boot.
+"""
 LOAD_TEMPLATES = ['uptime', (1, 5, 15), re.compile(
                   r'load average:\s([\d\.]+),\s([\d\.]+),\s([\d\.]+)')]
-MEMORY_TEMPLATES = ['free -k', re.compile(
-                    r'\-/\+ buffers/cache:\s+\d+\s+(\d+)')]
+MEMORY_TEMPLATES = ['cat /proc/meminfo', re.compile(
+                    (r'MemFree:\s*(\d+)\skB\n.*\n*Buffers:\s*(\d+)\skB'
+                     r'\n.*\n*Cached:\s*(\d+)\skB'))]
 DISK_TEMPLATES = ['df -Pk', re.compile(
                   r'Mounted on\n\S+\s+\d+\s+\d+\s+(\d+)\s+')]
 
 
 def main():
-    parser = COP(__doc__, comms=True, noforce=True, argdoc=[])
+    parser = OptionParser(__doc__)
 
     parser.add_option(
         "--load", "-l",
-        help="1, 5 and 15 minute load averages from the 'uptime' command",
+        help="1, 5 and 15 minute load averages from the 'uptime' command.",
         action="store_true", default=False, dest="load")
 
     parser.add_option(
         "--memory", "-m",
-        help="Total free RAM memory, in KB, from the 'free -k' command.",
+        help="Total memory not in use by the system, buffer or cache, in " +
+             "KB, from '/proc/meminfo'.",
         action="store_true", default=False, dest="memory")
 
     parser.add_option(
         "--disk-space",
-        help="Available disk space, in KB, from the 'df -Pk' command",
+        help="Available disk space, in KB, from the 'df -Pk' command.",
         action="store", default=None, dest="disk")
 
     options, args = parser.parse_args()
+
     print get_host_metric(options.load, options.memory, options.disk)
 
     sys.exit()
@@ -105,7 +117,8 @@ def main():
 def run_command_string(command_string):
     """Return the result from running a command string in a local shell.
 
-       Return stdout if command successful, else raise CalledProcessError."""
+    Return stdout if command successful, else raise CalledProcessError.
+    """
     command_sequence = command_string.split()
     # Note: can replace function w/ 'subprocess.check_output()' when drop v2.6.
     process = Popen(command_sequence, stdin=open(os.devnull), stdout=PIPE,
@@ -136,33 +149,30 @@ def extract_pattern(data_pattern, raw_string):
 def process_load():
     """Return dictionary with load average float values from 'uptime' command.
 
-       String keys e.g. 'load:1' give minutes average was measured over."""
+    String keys e.g. 'load:1' give minutes average was measured over.
+    """
     cmd, av_times, patt = LOAD_TEMPLATES
     av_raw_tuple = extract_pattern(patt, run_command_string(cmd))
-    try:
-        av_floats_tuple = [float(av_raw) for av_raw in av_raw_tuple]
-    except ValueError:
-        raise
+    av_floats_tuple = [float(av_raw) for av_raw in av_raw_tuple]
     return dict(zip(
         ["load:" + str(time) for time in av_times], av_floats_tuple))
 
 
 def process_memory():
-    """Return dict with integer value of free memory from 'free -k' command."""
+    """Return dict with integer usable memory value from '/proc/meminfo'."""
     cmd, patt = MEMORY_TEMPLATES
-    free_memory_str, = extract_pattern(patt, run_command_string(cmd))
-    try:
-        free_memory_int = int(free_memory_str)
-    except ValueError:
-        raise
-    return {"memory": free_memory_int}
+    mem_tuple = extract_pattern(patt, run_command_string(cmd))
+    # Sum free, buffer and cache memory values (free plus/minus buffer/cache).
+    usable_memory = sum([int(mem_val) for mem_val in mem_tuple])
+    return {"memory": usable_memory}
 
 
 def process_disk(paths_list):
     """Return dictionary with available disk space for given mount dir paths.
 
-       Disk space data, from 'df -Pk' command, stored as float values under
-       associated path string keys."""
+    Disk space data, from 'df -Pk' command, stored as float values under
+    associated path string keys.
+    """
     partial_cmd, patt = DISK_TEMPLATES
     path_dict = {}
     for path in paths_list:
@@ -171,31 +181,27 @@ def process_disk(paths_list):
         cmd_output = run_command_string(partial_cmd + ' ' + path)
         free_space_str, = extract_pattern(patt, cmd_output)
         if free_space_str:
-            try:
-                free_space_int = int(free_space_str)
-            except ValueError:
-                raise
-            path_dict["disk-space:" + path] = free_space_int
+            path_dict["disk-space:" + path] = int(free_space_str)
     return path_dict
 
 
 def get_host_metric(inc_load, inc_memory, disk_paths):
     """Return JSON structure containing specified metric data for localhost.
 
-       Example:
-         {
-             "load:5": 0.059999999999999998,
-             "disk-space:/boot": 57856,
-             "load:1": 0.050000000000000003,
-             "memory": 3168296,
-             "load:15": 0.080000000000000002,
-             "disk-space:/": 9212088
-         }
+    Example:
+      {
+          "load:5": 0.059999999999999998,
+          "disk-space:/boot": 57856,
+          "load:1": 0.050000000000000003,
+          "memory": 3168296,
+          "load:15": 0.080000000000000002,
+          "disk-space:/": 9212088
+      }
 
-       The data included depends on the options specified to the command and
-       is one or more from: load average, free memory and available disk space
-       (for specified mount directory paths)."""
-
+    The data included depends on the options specified to the command and
+    is one or more from: load average, free memory and available disk space
+    (for specified mount directory paths).
+    """
     HOST_METRIC = {}
 
     if disk_paths:

--- a/bin/cylc-gpanel
+++ b/bin/cylc-gpanel
@@ -29,7 +29,7 @@ This applet can be tested using the --test option.
 To customize themes, copy $CYLC_DIR/etc/gcylc.rc.eg to $HOME/.cylc/gcylc.rc and
 follow the instructions in the file.
 
-To configure default suite hosts, edit "[suite host scanning]hosts" in your
+To configure default suite hosts, edit "[suite servers]scan hosts" in your
 global.rc file."""
 
 from optparse import OptionParser

--- a/bin/cylc-gscan
+++ b/bin/cylc-gscan
@@ -82,7 +82,8 @@ def main():
     from cylc.gui.gscan import ScanApp
 
     if options.all_ports:
-        args.extend(glbl_cfg().get(["suite host scanning", "hosts"]))
+        args.extend(glbl_cfg().get(
+            ["suite servers", "scan hosts"], ["localhost"]))
     scan_app = ScanApp(
         hosts=args,
         patterns_name=options.patterns_name,

--- a/bin/cylc-help
+++ b/bin/cylc-help
@@ -246,6 +246,7 @@ information_commands['get-suite-config'] = ['get-suite-config', 'get-config']
 information_commands['get-site-config'] = [
     'get-site-config', 'get-global-config']
 information_commands['get-gui-config'] = ['get-gui-config']
+information_commands['get-host-metrics'] = ['get-host-metrics']
 
 control_commands = {}
 control_commands['gui'] = ['gui']
@@ -389,6 +390,7 @@ comsum['monitor'] = 'An in-terminal suite monitor (see also gcylc)'
 comsum['get-suite-config'] = 'Print suite configuration items'
 comsum['get-site-config'] = 'Print site/user configuration items'
 comsum['get-gui-config'] = 'Print gcylc configuration items'
+comsum['get-host-metrics'] = 'Print localhost metric data'
 comsum['get-suite-contact'] = (
     'Print contact information of a suite server program')
 comsum['get-suite-version'] = 'Print cylc version of a suite server program'

--- a/bin/cylc-run
+++ b/bin/cylc-run
@@ -18,12 +18,6 @@
 
 """CLI of "cylc run". See cylc.scheduler_cli for detail."""
 
-import sys
-from cylc.remote import remrun
-if remrun():
-    sys.exit(0)
-
-
 from cylc.scheduler_cli import main
 
 

--- a/bin/cylc-scan
+++ b/bin/cylc-scan
@@ -28,8 +28,8 @@ users.
 If a list of HOSTS is specified, it will obtain a listing of running suites by
 scanning all ports in the relevant range for running suites on the specified
 hosts. If the -a/--all option is specified, it will use the global
-configuration "[suite host scanning]" setting to determine a list of hosts to
-scan.
+configuration "[suite servers]scan hosts" setting to determine a list of hosts
+to scan.
 
 Suite passphrases are not needed to get identity information (name and owner).
 Titles, descriptions, state totals, and cycle point state totals may also be
@@ -209,7 +209,8 @@ def main():
     except ValueError as exc:
         parser.error(str(exc))
     if options.all_ports:
-        args.extend(glbl_cfg().get(["suite host scanning", "hosts"]))
+        args.extend(
+            glbl_cfg().get(["suite servers", "scan hosts"], ["localhost"]))
     if not args:
         args = get_scan_items_from_fs(cre_owner)
     if not args:

--- a/bin/cylc-scan
+++ b/bin/cylc-scan
@@ -161,10 +161,8 @@ def main():
     options, args = parser.parse_args()
 
     if options.print_ports:
-        base = glbl_cfg().get(["communication", "base port"])
-        max_num_ports = glbl_cfg().get(
-            ["communication", "maximum number of ports"])
-        print base, "<= port <=", base + max_num_ports
+        run_ports_list = glbl_cfg().get(['suite servers', 'run ports'])
+        print run_ports_list[0], '<= port <=', run_ports_list[-1]
         sys.exit(0)
 
     indent = "   "

--- a/doc/src/cylc-user-guide/cug.tex
+++ b/doc/src/cylc-user-guide/cug.tex
@@ -1004,6 +1004,23 @@ to view its output logs. The relative merits of the three {\em suite
 views} - dot, text, and graph - will be more apparent later when we
 have more tasks. Closing the GUI does not affect the suite itself.
 
+\subsection{Remote Suites}
+\label{RemoteSuites}
+
+Suites can run on {\em localhost} or on a {\em remote} host.
+
+To start up a suite on a given host, specify it explicitly via the
+\lstinline@--host=@ option to a \lstinline=run= or \lstinline=restart=
+command.
+
+Otherwise, Cylc selects the best host to start up on from allowed
+\lstinline=run hosts= as specified in the global config under
+\lstinline=[suite servers]=, which defaults to localhost. Should there be
+more than one allowed host set, the {\em most suitable} is determined
+according to the settings specified under \lstinline=[[run host select]]=,
+namely exclusion of hosts not meeting suitability {\em thresholds}, if
+provided, then ranking according to the given {\em rank} method.
+
 \subsection{Discovering Running Suites}
 
 Suites that are currently running can be detected with command line or
@@ -1173,7 +1190,7 @@ $ cylc cat-log -e tut/oneoff/basic hello.1   # task stderr log
 \vspace{3mm}
 
 The \lstinline=hello= task in the first two tutorial suites defaults to
-running on the suite host. To make it run on a remote host instead
+running on the suite host~\ref{RemoteSuites}. To make it run on a different host instead
 change its runtime configuration as in \lstinline=tut/oneoff/remote=:
 \lstset{language=suiterc}
 \begin{lstlisting}
@@ -7061,8 +7078,8 @@ tracking (see these with \lstinline=cylc get-site-config=):
     maximum number of ports = 100
 
 [hosts]
-    # The default task host is the suite host, i.e. localhost:
-    # Add task host sections if local defaults are not sufficient.
+    # The default task host is the suite host:
+    # Add task host sections if defaults are not sufficient.
     [[HOST]]
        # Method of communication of task progress back to the suite:
         #   1) default - HTTPS via network ports

--- a/doc/src/cylc-user-guide/siterc.tex
+++ b/doc/src/cylc-user-guide/siterc.tex
@@ -943,21 +943,6 @@ if you have to use the {\em hardwired} self-identification method.
 \item {\em default:} (none)
 \end{myitemize}
 
-\subsection{[suite host scanning]}
-
-Utilities such as \lstinline=cylc gscan= need to scan hosts for
-running suites. Note this item is deprecated as detailed below.
-
-\subsubsection[hosts]{[suite host scanning] \textrightarrow hosts }
-
-A list of hosts to scan for running suites. This is deprecated in favour of
-scan hosts under suite servers.
-
-\begin{myitemize}
-\item {\em type:} comma-separated list of host names or IP addresses.
-\item {\em default:} localhost
-\end{myitemize}
-
 \subsection{[task events]}
 
 Global site/user defaults for~\ref{TaskEventHandling}.

--- a/doc/src/cylc-user-guide/siterc.tex
+++ b/doc/src/cylc-user-guide/siterc.tex
@@ -325,21 +325,26 @@ Cylc defaults to HTTPS if this setting is not explicitly configured.
 
 \subsubsection[base port]{[communication] \textrightarrow base port }
 
-The first port that cylc is allowed to use.
+The first port that Cylc is allowed to use. This config item is deprecated;
+instead specify this in combination with the also-deprecated
+\lstinline=maximum number of ports= using the \lstinline=run ports=
+setting under \lstinline=[suite servers]=.
 
 \begin{myitemize}
 \item {\em type:} integer
-\item {\em default:} 43001
+\item {\em default:} \lstinline=43001=
 \end{myitemize}
 
 \subsubsection[maximum number of ports]{[communication] \textrightarrow maximum number of ports}
 
 This determines the maximum number of suites that can run at once on the
-suite host.
+suite host. It is deprecated; instead specify this in combination with the
+also-deprecated \lstinline=base port= using the \lstinline=run ports=
+setting under \lstinline=[suite servers]=.
 
 \begin{myitemize}
 \item {\em type:} integer
-\item {\em default:} 100
+\item {\em default:} \lstinline=100=
 \end{myitemize}
 
 \subsubsection[proxies on]{[communication] \textrightarrow proxies on}
@@ -748,6 +753,141 @@ exceeds its execution time limit.
     \end{lstlisting}
 \end{myitemize}
 
+\subsection{[suite servers] }
+
+Configure allowed suite hosts and ports for starting up (running or
+restarting) suites and enabling them to be detected whilst running via
+utilities such as \lstinline=cylc gscan=. Additionally configure host
+selection settings specifying how to determine the most suitable run host at
+any given time from those configured.
+
+\subsubsection[run hosts]{[suite servers] \textrightarrow run hosts }
+
+A list of allowed suite run hosts. One of these hosts will be appointed for
+a suite to start up on if an explicit host is not provided as an option to
+a \lstinline=run= or \lstinline=restart= command.
+
+\begin{myitemize}
+\item {\em type:} comma-separated list of host names and/or IP addresses.
+\item {\em default:} \lstinline=localhost=
+\end{myitemize}
+
+\subsubsection[scan hosts]{[suite servers] \textrightarrow scan hosts }
+
+A list of hosts to scan for running suites.
+
+\begin{myitemize}
+\item {\em type:} comma-separated list of host names and/or IP addresses.
+\item {\em default:} \lstinline=localhost=
+\end{myitemize}
+
+\subsubsection[run ports]{[suite servers] \textrightarrow run ports }
+
+A list of allowed ports for Cylc to use to run suites. Note that only one
+suite can run per port for a given host, so the length of this list
+determines the maximum number of suites that can run at once per suite host.
+This config item supersedes the deprecated settings \lstinline=base port=
+and \lstinline=maximum number of ports=, where the base port is equivalent to
+the first port, and the maximum number of ports to the length, of this list.
+
+\begin{myitemize}
+\item {\em type:} string in the format \lstinline=X .. Y= for
+ \lstinline@X <= Y@ where \lstinline=X= and \lstinline=Y= are integers.
+\item {\em default:} \lstinline=43001 .. 43100= (equivalent to the list
+\lstinline=43001, 43002, ... , 43099, 43100=)
+\end{myitemize}
+
+\subsubsection[scan ports]{[suite servers] \textrightarrow scan ports }
+
+A list of ports to scan for running suites on each host set in scan hosts.
+
+\begin{myitemize}
+\item {\em type:} string in the format \lstinline=X .. Y= for
+ \lstinline@X <= Y@ where \lstinline=X= and \lstinline=Y= are integers.
+\item {\em default:} \lstinline=43001 .. 43100= (equivalent to the list
+\lstinline=43001, 43002, ... , 43099, 43100=)
+\end{myitemize}
+
+\subsubsection[run host select]{[suite servers] \textrightarrow [[run host select]]}
+
+Configure thresholds for excluding insufficient hosts and a method for
+ranking the remaining hosts to be applied in selection of the most suitable
+\lstinline=run host=, from those configured, at start-up whenever a set host
+is not specified on the command line via the \lstinline@--host=@ option.
+
+\paragraph[rank]{[suite servers] \textrightarrow [[run host select]] \textrightarrow rank}
+
+The method to use to rank the \lstinline=run host= list in order of
+suitability.
+
+\begin{myitemize}
+\item {\em type:} string (which must be one of the options outlined below)
+\item {\em default:} \lstinline=random=
+\item {\em options:}
+    \begin{myitemize}
+    \item {\bf random} - shuffle the hosts to select a host at random
+    \item {\bf load:1} - rank and select for the lowest load average over 1 minute (as given by the \lstinline=uptime= command)
+    \item {\bf load:5} - as for \lstinline=load:1= above, but over 5 minutes
+    \item {\bf load:15} - as for \lstinline=load:1= above, but over 15 minutes
+    \item {\bf memory} - rank and select for the highest usable memory i.e.
+      free memory plus memory in the buffer cache ('buffers') and in the
+      page cache ('cache'), as specified under \lstinline=/proc/meminfo=
+    \item {\bf disk-space:PATH} - rank and select for the highest free disk
+      space for a given mount directory path \lstinline=PATH= as given by
+      the \lstinline=df= command, where multiple paths may be specified
+      individually i.e. via \lstinline=disk-space:PATH_1= and
+      \lstinline=disk-space:PATH_2=, etc.
+    \end{myitemize}
+\item {\em default:} (none)
+\end{myitemize}
+
+\paragraph[thresholds]{[suite servers] \textrightarrow [[run host select]] \textrightarrow thresholds}
+
+A list of thresholds i.e. cutoff values which run hosts must meet in order
+to be considered as a possible run host. Each threshold is a minimum or a
+maximum requirement depending on the context of the measure; usable
+memory (\lstinline=memory=) and free disk space
+(\lstinline=disk-space:PATH=) threshold values set a {\em minimum} value,
+which must be exceeded, whereas load average (\lstinline=load:1=,
+\lstinline=load:5= and \lstinline=load:15=) threshold values set a
+{\em maximum}, which must not be. Failure to meet a threshold results in
+exclusion from the list of hosts that undergo ranking to
+determine the best host which becomes the run host.
+
+\begin{myitemize}
+\item {\em type:} string in format
+\lstinline=MEASURE_1 CUTOFF_1; ... ;MEASURE_n CUTOFF_n= (etc),
+where each \lstinline=MEASURE_N= is one of the options below (note
+these correspond to all the rank methods accepted under the rank setting
+except for \lstinline=random= which does not make sense as a threshold
+measure). Spaces delimit corresponding measures and their values, while
+semi-colons (optionally with subsequent spaces) delimit each measure-value
+pair.
+\item {\em options:}
+    \begin{myitemize}
+    \item {\bf load:1} - load average over 1 minute (as given by
+the \lstinline=uptime= command)
+    \item {\bf load:5} - as for \lstinline=load:1= above, but over 5 minutes
+    \item {\bf load:15} - as for \lstinline=load:1= above, but over 15 minutes
+    \item {\bf memory} - usable memory i.e. free memory plus memory in the
+      buffer cache ('buffers') and in the page cache ('cache'), in KB, as
+      specified under \lstinline=/proc/meminfo=
+    \item {\bf disk-space:PATH} - free disk space for a given mount
+directory path \lstinline=PATH=, in KB, as given by the \lstinline=df=
+command, where multiple paths may be specified individually i.e. via
+\lstinline=disk-space:PATH_1= and \lstinline=disk-space:PATH_2=, etc.
+    \end{myitemize}
+\item {\em default:} (none)
+\item {\em examples:}
+    \begin{myitemize}
+            \item \lstinline@thresholds = memory 2000@ (set a minimum of 2000 KB in usable memory for possible run hosts)
+            \item \lstinline@thresholds = load:5 0.5; load:15 1.0; disk-space:/ 5000@ (set a maximum of 0.5 and 1.0 for load averages over 5
+and 15 minutes respectively and a minimum of 5000 KB of free disk-space on
+the \lstinline=/= mount directory. If any of these thresholds are not met
+by a host, it will be excluded for running a suite on.)
+    \end{myitemize}
+\end{myitemize}
+
 \subsection{[suite host self-identification] }
 
 The suite host's identity must be determined locally by cylc and passed
@@ -806,11 +946,13 @@ if you have to use the {\em hardwired} self-identification method.
 \subsection{[suite host scanning]}
 
 Utilities such as \lstinline=cylc gscan= need to scan hosts for
-running suites.
+running suites. Note this item is deprecated as detailed below.
 
 \subsubsection[hosts]{[suite host scanning] \textrightarrow hosts }
 
-A list of hosts to scan for running suites.
+A list of hosts to scan for running suites. This is deprecated in favour of
+scan hosts under suite servers.
+
 \begin{myitemize}
 \item {\em type:} comma-separated list of host names or IP addresses.
 \item {\em default:} localhost

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -260,10 +260,6 @@ SPEC = {
         'host': vdr(vtype='string'),
     },
 
-    'suite host scanning': {
-        'hosts': vdr(vtype='string_list', default=["localhost"])
-    },
-
     'authentication': {
         # Allow owners to grant public shutdown rights at the most, not full
         # control.
@@ -275,9 +271,9 @@ SPEC = {
     },
 
     'suite servers': {
-        'run hosts': vdr(vtype='string_list', default=["localhost"]),
+        'run hosts': vdr(vtype='string_list'),
         'run ports': vdr(vtype='range_list', default=range(43001, 43101)),
-        'scan hosts': vdr(vtype='string_list', default=["localhost"]),
+        'scan hosts': vdr(vtype='string_list'),
         'scan ports': vdr(vtype='range_list', default=range(43001, 43101)),
         'run host select': {
             'rank': vdr(
@@ -285,7 +281,7 @@ SPEC = {
                 options=["random", "load:1", "load:5", "load:15", "memory",
                          "disk-space"],
                 default="random"),
-            'thresholds': vdr(vtype='string', default=None),
+            'thresholds': vdr(vtype='string'),
         },
     },
 }

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -33,12 +33,13 @@ from cylc.envvar import expandvars
 from cylc.mkdir_p import mkdir_p
 import cylc.flags
 from cylc.cfgspec.utils import (
-    coerce_interval, coerce_interval_list, DurationFloat)
+    coerce_interval, coerce_interval_list, coerce_range_list, DurationFloat)
 from cylc.network import PRIVILEGE_LEVELS, PRIV_STATE_TOTALS, PRIV_SHUTDOWN
 from cylc.version import CYLC_VERSION
 
 coercers['interval'] = coerce_interval
 coercers['interval_list'] = coerce_interval_list
+coercers['range_list'] = coerce_range_list
 
 SPEC = {
     'process pool size': vdr(vtype='integer', default=4),
@@ -272,6 +273,21 @@ SPEC = {
                 PRIVILEGE_LEVELS[:PRIVILEGE_LEVELS.index(PRIV_SHUTDOWN) + 1]),
             default=PRIV_STATE_TOTALS),
     },
+
+    'suite servers': {
+        'run hosts': vdr(vtype='string_list', default=["localhost"]),
+        'run ports': vdr(vtype='range_list', default=range(43001, 43101)),
+        'scan hosts': vdr(vtype='string_list', default=["localhost"]),
+        'scan ports': vdr(vtype='range_list', default=range(43001, 43101)),
+        'run host select': {
+            'rank': vdr(
+                vtype='string',
+                options=["random", "load:1", "load:5", "load:15", "memory",
+                         "disk-space"],
+                default="random"),
+            'thresholds': vdr(vtype='string', default=None),
+        },
+    },
 }
 
 
@@ -279,10 +295,20 @@ def upg(cfg, descr):
     """Upgrader."""
     add_bin_dir = converter(lambda x: x + '/bin', "Added + '/bin' to path")
     use_ssh = converter(lambda x: "ssh", "set to 'ssh'")
+
     u = upgrader(cfg, descr)
-    u.deprecate('5.1.1', ['editors', 'in-terminal'], ['editors', 'terminal'])
-    u.deprecate('5.1.1', ['task hosts'], ['hosts'])
-    u.deprecate('5.1.1', ['hosts', 'local'], ['hosts', 'localhost'])
+    u.deprecate(
+        '5.1.1',
+        ['editors', 'in-terminal'],
+        ['editors', 'terminal'])
+    u.deprecate(
+        '5.1.1',
+        ['task hosts'],
+        ['hosts'])
+    u.deprecate(
+        '5.1.1',
+        ['hosts', 'local'],
+        ['hosts', 'localhost'])
     u.deprecate(
         '5.1.1',
         ['hosts', '__MANY__', 'workspace directory'],
@@ -322,37 +348,40 @@ def upg(cfg, descr):
             '6.4.1',
             ['test battery', 'directives', batch_sys_name + ' directives'],
             ['test battery', 'batch systems', batch_sys_name, 'directives'])
-    u.obsolete('6.4.1', ['test battery', 'directives'])
-    u.obsolete('6.11.0', ['state dump rolling archive length'])
-    u.deprecate('6.11.0', ['cylc', 'event hooks'], ['cylc', 'events'])
+    u.obsolete(
+        '6.4.1',
+        ['test battery', 'directives'])
+    u.obsolete(
+        '6.11.0',
+        ['state dump rolling archive length'])
+    u.deprecate(
+        '6.11.0',
+        ['cylc', 'event hooks'],
+        ['cylc', 'events'])
     for key in SPEC['cylc']['events']:
         u.deprecate(
-            '6.11.0', ['cylc', 'event hooks', key], ['cylc', 'events', key])
+            '6.11.0',
+            ['cylc', 'event hooks', key],
+            ['cylc', 'events', key])
     u.obsolete(
         '7.0.0',
-        ['pyro', 'base port']
-    )
+        ['pyro', 'base port'])
     u.obsolete(
         '7.0.0',
         ['pyro', 'maximum number of ports'],
-        ['communication', 'maximum number of ports']
-    )
+        ['communication', 'maximum number of ports'])
     u.obsolete(
         '7.0.0',
-        ['pyro', 'ports directory'],
-    )
+        ['pyro', 'ports directory'])
     u.obsolete(
         '7.0.0',
-        ['pyro']
-    )
+        ['pyro'])
     u.obsolete(
         '7.0.0',
-        ['authentication', 'hashes']
-    )
+        ['authentication', 'hashes'])
     u.obsolete(
         '7.0.0',
-        ['authentication', 'scan hash']
-    )
+        ['authentication', 'scan hash'])
     u.deprecate(
         '7.0.0',
         ['execution polling intervals'],
@@ -373,13 +402,30 @@ def upg(cfg, descr):
     # use 'tail -pid' to kill 'tail' on ssh exit, but we do this in cylc now.
     u.obsolete(
         '7.6.0',
-        ['hosts', '__MANY__', 'remote tail command template']
-    )
+        ['hosts', '__MANY__', 'remote tail command template'])
     u.deprecate(
         '7.6.0',
         ['hosts', '__MANY__', 'local tail command template'],
-        ['hosts', '__MANY__', 'tail command template']
-    )
+        ['hosts', '__MANY__', 'tail command template'])
+    u.deprecate(
+        '7.8.0',
+        ['communication', 'base port'],
+        ['suite servers', 'run ports'],
+        converter(lambda x: '%s .. %s' % (
+            int(x),
+            int(x) + int(cfg['communication']['maximum number of ports'])),
+            "Format as range list"))
+    u.obsolete(
+        '7.8.0',
+        ['communication', 'maximum number of ports'])
+    u.deprecate(
+        '7.8.0',
+        ['suite host scanning'],
+        ['suite servers'])
+    u.deprecate(
+        '7.8.0',
+        ['suite servers', 'hosts'],
+        ['suite servers', 'scan hosts'])
     u.upgrade()
 
 

--- a/lib/cylc/cfgspec/utils.py
+++ b/lib/cylc/cfgspec/utils.py
@@ -76,27 +76,28 @@ def coerce_interval_list(value, keys, args):
 def convert_range_list(values, keys):
     """Convert valid 'X .. Y' string to list of integers from X to Y inclusive.
 
-    Return the list object or None if input is invalid 'X .. Y' format."""
-    list_format = r'\s*(\d+)\s\.\.\s(\d+)\s*$'
+    Return the list object, or None if input is invalid 'X .. Y' format.
+    """
+    list_format = r'\s*(\d+)\s*\.\.\s*(\d+)\s*$'
     matches = re.match(list_format, values)
+
     core_err_msg = "Cannot extract start and end integers from '%s'" % values
     if not matches:
         raise ValueError(core_err_msg)
+    list_start, list_end = matches.group(1, 2)
     try:
-        list_start, list_end = matches.group(1, 2)
         startpoint = int(list_start)
-        # Range function has non-inclusive end-point so must add 1.
-        endpoint = int(list_end) + 1
-        if startpoint >= endpoint:
-            raise ValueError("%s >= %s but 'X .. Y' format requires X < Y." %
-                             (startpoint, endpoint))
-    except (AttributeError, TypeError):
-        raise ValueError(core_err_msg)
+        endpoint = int(list_end) + 1  # range has non-inclusive end-point.
+    except ValueError:
+        ValueError(core_err_msg)
+    if startpoint >= endpoint:
+        raise ValueError("%s >= %s but 'X .. Y' format requires X <= Y." %
+                         (startpoint, endpoint - 1))
     return range(startpoint, endpoint)
 
 
 def coerce_range_list(value, keys, _):
-    """Coerce a valid 'X .. Y' string into a list of integers."""
+    """Coerce a string 'X .. Y' with integer X, Y into a list of integers."""
     return convert_range_list(value, keys)
 
 

--- a/lib/cylc/cfgspec/utils.py
+++ b/lib/cylc/cfgspec/utils.py
@@ -73,6 +73,33 @@ def coerce_interval_list(value, keys, args):
     )
 
 
+def convert_range_list(values, keys):
+    """Convert valid 'X .. Y' string to list of integers from X to Y inclusive.
+
+    Return the list object or None if input is invalid 'X .. Y' format."""
+    list_format = r'\s*(\d+)\s\.\.\s(\d+)\s*$'
+    matches = re.match(list_format, values)
+    core_err_msg = "Cannot extract start and end integers from '%s'" % values
+    if not matches:
+        raise ValueError(core_err_msg)
+    try:
+        list_start, list_end = matches.group(1, 2)
+        startpoint = int(list_start)
+        # Range function has non-inclusive end-point so must add 1.
+        endpoint = int(list_end) + 1
+        if startpoint >= endpoint:
+            raise ValueError("%s >= %s but 'X .. Y' format requires X < Y." %
+                             (startpoint, endpoint))
+    except (AttributeError, TypeError):
+        raise ValueError(core_err_msg)
+    return range(startpoint, endpoint)
+
+
+def coerce_range_list(value, keys, _):
+    """Coerce a valid 'X .. Y' string into a list of integers."""
+    return convert_range_list(value, keys)
+
+
 def coerce_xtrig(value, keys, _):
     """Coerce a string into an xtrigger function context object.
 

--- a/lib/cylc/network/httpclient.py
+++ b/lib/cylc/network/httpclient.py
@@ -576,7 +576,7 @@ class SuiteRuntimeServiceClient(object):
             # * Add `-n` to the SSH command
             stdin = None
         proc = remote_cylc_cmd(
-            command, self.owner, self.host, capture=True,
+            command, self.owner, self.host, capture_process=True,
             ssh_login_shell=(self.comms1.get(
                 self.srv_files_mgr.KEY_SSH_USE_LOGIN_SHELL
             ) in ['True', 'true']),

--- a/lib/cylc/network/httpserver.py
+++ b/lib/cylc/network/httpserver.py
@@ -59,10 +59,7 @@ class HTTPServer(object):
         self.port = None
 
         # Figure out the ports we are allowed to use.
-        base_port = glbl_cfg().get(['communication', 'base port'])
-        max_ports = glbl_cfg().get(
-            ['communication', 'maximum number of ports'])
-        self.ok_ports = range(int(base_port), int(base_port) + int(max_ports))
+        self.ok_ports = glbl_cfg().get(['suite servers', 'run ports'])
         random.shuffle(self.ok_ports)
 
         comms_options = glbl_cfg().get(['communication', 'options'])

--- a/lib/cylc/network/port_scan.py
+++ b/lib/cylc/network/port_scan.py
@@ -135,19 +135,16 @@ def scan_many(items, timeout=None, updater=None):
     todo_set = set()
     wait_set = set()
     # Determine ports to scan
-    base_port = None
-    max_ports = None
+    valid_ports = None
     for item in items:
         if isinstance(item, tuple):
             # Assume item is ("host", port)
             todo_set.add(item)
         else:
             # Full port range for a host
-            if base_port is None or max_ports is None:
-                base_port = glbl_cfg().get(['communication', 'base port'])
-                max_ports = glbl_cfg().get(
-                    ['communication', 'maximum number of ports'])
-            for port in range(base_port, base_port + max_ports):
+            if valid_ports is None:
+                valid_ports = glbl_cfg().get(['suite servers', 'run ports'])
+            for port in valid_ports:
                 todo_set.add((item, port))
     proc_items = []
     results = []

--- a/lib/cylc/remote.py
+++ b/lib/cylc/remote.py
@@ -18,28 +18,21 @@
 """Run command on a remote, (i.e. a remote [user@]host)."""
 
 import os
-import sys
-import shlex
-import signal
-import unittest
-import json
-import socket
-from time import sleep
 from pipes import quote
 from posix import WIFSIGNALED
-from random import shuffle, choice
-from multiprocessing import Pool
-
+import shlex
+import signal
 # CODACY ISSUE:
 #   Consider possible security implications associated with Popen module.
 # REASON IGNORED:
 #   Subprocess is needed, but we use it with security in mind.
-from subprocess import Popen, PIPE, CalledProcessError
+from subprocess import Popen, PIPE
+import sys
+from time import sleep
 
-import cylc.flags
 from cylc.cfgspec.glbl_cfg import glbl_cfg
+import cylc.flags
 from cylc.version import CYLC_VERSION
-from cylc.hostuserutil import get_fqdn_by_host
 
 
 def get_proc_ancestors():
@@ -56,7 +49,7 @@ def get_proc_ancestors():
 
 
 def watch_and_kill(proc):
-    """ Kill proc if my PPID (etc.) changed - e.g. ssh connection dropped."""
+    """Kill proc if my PPID (etc.) changed - e.g. ssh connection dropped."""
     gpa = get_proc_ancestors()
     while True:
         sleep(0.5)
@@ -91,8 +84,8 @@ def run_ssh_cmd(command, stdin=None, capture_process=False,
         * If capture_process=True, the Popen object if created successfully.
         * Else True if the remote command is executed successfully, or
           if unsuccessful and capture_status=True the remote command exit code.
-        * Otherwise exit with an error message."""
-
+        * Otherwise exit with an error message.
+    """
     # CODACY ISSUE:
     #   subprocess call - check for execution of untrusted input.
     # REASON IGNORED:
@@ -206,7 +199,8 @@ def construct_ssh_cmd(raw_cmd, user=None, host=None, forward_x11=False,
         if cylc.flags.debug or os.getenv('CYLC_DEBUG') in ["True", "true"]:
             command.append(r'--debug')
     if cylc.flags.debug:
-        sys.stderr.write(' '.join(quote(c) for c in command) + '\n')
+        sys.stderr.write("INFO: ran the command '%s' on host '%s'\n" % (
+            ' '.join(quote(c) for c in command), host))
 
     return command
 
@@ -232,7 +226,8 @@ def remote_cylc_cmd(
 
     Return:
         If capture=True, return the Popen object if created successfully.
-        Otherwise, return the exit code of the remote command."""
+        Otherwise, return the exit code of the remote command.
+    """
     command = construct_ssh_cmd(
         cmd, user=user, host=host, set_stdin=stdin,
         ssh_login_shell=ssh_login_shell, ssh_cylc=ssh_cylc)
@@ -255,15 +250,15 @@ class RemoteRunner(object):
 
     To ensure that users are aware of remote re-invocation info is always
     printed, but to stderr so as not to interfere with results.
-
     """
 
-    def __init__(self, argv=None):
+    def __init__(self, argv=None, set_rel_local=False):
         self.owner = None
         self.host = None
         self.ssh_login_shell = None
         self.ssh_cylc = None
         self.argv = argv or sys.argv
+        self.set_rel_local = set_rel_local  # state host as relative localhost
 
         cylc.flags.verbose = '-v' in self.argv or '--verbose' in self.argv
 
@@ -295,7 +290,8 @@ class RemoteRunner(object):
         """Execute command on remote host.
 
         Returns False if remote re-invocation is not needed, True if it is
-        needed and executes successfully otherwise aborts."""
+        needed and executes successfully otherwise aborts.
+        """
         if not self.is_remote:
             return False
 
@@ -310,582 +306,15 @@ class RemoteRunner(object):
             # above: args quoted to avoid interpretation by the shell,
             # e.g. for match patterns such as '.*' on the command line.
 
+        if self.set_rel_local:
+            # State as relative localhost to prevent recursive host selection.
+            cmd.append("--host=localhost")
         command = construct_ssh_cmd(
             cmd, user=self.owner, host=self.host, forward_x11=forward_x11,
             ssh_login_shell=self.ssh_login_shell, ssh_cylc=self.ssh_cylc,
-            set_UTC=True, allow_flag_opts=True)
+            set_UTC=True, allow_flag_opts=False)
 
         if dry_run:
             return command
         else:
             return run_ssh_cmd(command)
-
-
-class EmptyHostList(Exception):
-    """Exception to be raised if there are no valid run hosts.
-
-       Raise if, from the global configuration settings, no hosts are listed
-       for potential appointment to run suites (as 'run hosts') or none
-       satisfy requirements to pass 'run host select' specifications.
-
-       Print message with the current state of relevant settings for info."""
-
-    def __str__(self):
-        msg = "No hosts currently compatible with this global configuration:\n"
-        suite_server_cfg_items = (['run hosts'], ['run host select', 'rank'],
-                                  ['run host select', 'thresholds'])
-        for cfg_end_ref in suite_server_cfg_items:
-            cfg_full_ref = cfg_end_ref.insert(0, 'suite servers')
-            # Add 2-space indentation for clarity in distinction of items.
-            msg = '\n  '.join([msg, cfg_item[-1] + ':',
-                               '  ' + glbl_cfg().get(cfg_full_ref)])
-        return msg
-
-
-class HostAppointer(object):
-    """Appoint the most suitable host to run a suite on.
-
-       Determine the one host most suitable to (re-)run a suite on from all
-       'run hosts' given the 'run host selection' ranking & threshold options
-       as specified (else taken as default) in the global configuration.
-    """
-
-    CMD_BASE = "get-host-metrics"  # 'cylc' prepended by remote_cylc_cmd.
-
-    def __init__(self):
-        self.use_disk_path = "/"
-        self.max_processes = 5
-
-        try:
-            self.HOSTS = glbl_cfg().get(['suite servers', 'run hosts'])
-            self.RANK_METHOD = glbl_cfg().get(
-                ['suite servers', 'run host select', 'rank'])
-            self.THRESHOLDS = glbl_cfg().get(
-                ['suite servers', 'run host select', 'thresholds'])
-        except KeyError:  # Catch for unittest which updates these internally.
-            self.HOSTS = []
-            self.RANK_METHOD = 'random'
-            self.THRESHOLDS = None
-
-        self.PARSED_THRESHOLDS = self.parse_thresholds(self.THRESHOLDS)
-
-    @staticmethod
-    def parse_thresholds(raw_thresholds_spec):
-        """Parse raw 'thresholds' global configuration option to dict."""
-        if not raw_thresholds_spec:
-            return {}
-        valid_thresholds = {}
-        for threshold in raw_thresholds_spec.split(';'):
-            threshold = threshold.strip()
-            try:
-                measure, cutoff = threshold.split(' ')
-            except (AttributeError, ValueError):
-                raise AttributeError(
-                    "Invalid threshold component '%s'." % threshold)
-            try:
-                if measure.startswith("load"):
-                    cutoff = float(cutoff)
-                elif measure == "memory" or measure.startswith("disk-space"):
-                    cutoff = int(cutoff)
-                else:
-                    raise AttributeError("Invalid threshold measure '%s'." %
-                                         measure)
-            except ValueError:
-                raise ValueError(
-                    "Threshold value '%s' of wrong type." % cutoff)
-            else:
-                valid_thresholds[measure] = cutoff
-        return valid_thresholds
-
-    @staticmethod
-    def selection_complete(host_list):
-        """Check for and address a list (of hosts) with length zero or one.
-
-           Check length of a list (of hosts); for zero items raise an error,
-           for one return that item, else (for multiple items) return False."""
-        if len(host_list) == 0:
-            raise EmptyHostList()
-        elif len(host_list) == 1:
-            return host_list[0]
-        else:
-            return False
-
-    def _trivial_choice(self, host_list, ignore_if_thresholds_prov=False):
-        """Address run host configuration that can be dealt with trivially.
-
-           If thresholds are not provided or set to be ignored, test if
-           'host_list' has length zero or one, else if the ranking method is
-           random; if so return an exception or host selected appropriately."""
-        if ignore_if_thresholds_prov and self.PARSED_THRESHOLDS:
-            return False
-        if self.selection_complete(host_list):
-            return self.selection_complete(host_list)
-        elif self.RANK_METHOD == 'random':
-            return choice(host_list)
-        else:
-            return False
-
-    def _process_get_host_metrics_cmd(self):
-        """Return 'get_host_metrics' command to run with only required options.
-
-           Return the command string to run 'cylc get host metric' with only
-           the required options given rank method and thresholds specified."""
-
-        # Convert config keys to associated command options. Ignore 'random'.
-        considerations = [self.RANK_METHOD] + self.PARSED_THRESHOLDS.keys()
-        opts = set()
-        for spec in considerations:
-            if spec.startswith("load"):
-                opts.add("--load")
-            elif spec.startswith("disk-space"):
-                opts.add("--disk-space=" + self.use_disk_path)
-            elif spec == "memory":
-                opts.add("--memory")
-
-        cmd = [self.CMD_BASE] + list(opts)
-        return " ".join(cmd)
-
-    def _remove_bad_hosts(self, cmd_with_opts, mock_stats=False):
-        """Return dictionary of 'good' hosts with their metric stats.
-
-        Run 'get-host-metrics' on each run host in parallel & store
-        extracted stats for 'good' hosts only. Ignore 'bad' hosts whereby
-        either metric data cannot be accessed from the command or at least
-        one metric value does not pass a specified threshold.
-        """
-        cmd = cmd_with_opts.split()
-        if mock_stats:  # Create fake data for unittest purposes (only).
-            host_stats = dict(mock_stats)  # Prevent mutable object issues.
-        else:
-            if not self.HOSTS:
-                return {}
-            proc_pool = Pool(min(len(self.HOSTS), self.max_processes))
-            host_stats = dict(zip(
-                self.HOSTS,
-                proc_pool.map(get_host_metrics,
-                              zip(self.HOSTS, [cmd] * len(self.HOSTS)))
-            ))
-
-        for host, data in dict(host_stats).items():
-            if not data:
-                # No results for host (command failed) -> skip.
-                host_stats.pop(host)
-                continue
-            for measure, cutoff in self.PARSED_THRESHOLDS.items():
-                datum = data[measure]
-                # Cutoff is a minimum or maximum depending on measure context.
-                if ((datum > cutoff and measure.startswith("load")) or
-                    (datum < cutoff and (
-                        measure == "memory" or
-                        measure.startswith("disk-space")))):
-                    host_stats.pop(host)
-                    break
-        return host_stats
-
-    def _rank_good_hosts(self, all_host_stats):
-        """Rank, by specified method, 'good' hosts to return the most suitable.
-
-           Take a dictionary of hosts considered 'good' with the corresponding
-           metric data, and rank them via the method specified in the global
-           configuration, returning the lowest-ranked (taken as best) host."""
-
-        # Convert all dict values from full metrics structures to single
-        # metric data values corresponding to the rank method to rank with.
-        hosts_with_vals_to_rank = dict((host, metric[self.RANK_METHOD]) for
-                                       host, metric in all_host_stats.items())
-
-        # Rank new dict by value and return list of hosts (only) in rank order.
-        sort_asc_hosts = sorted(
-            hosts_with_vals_to_rank, key=hosts_with_vals_to_rank.get)
-        if self.RANK_METHOD in ("memory", "disk-space:" + self.use_disk_path):
-            # Want 'most free' i.e. highest => final host in asc. list.
-            return sort_asc_hosts[-1]
-        else:  # A load av. is only poss. left; 'random' dealt with earlier.
-            return sort_asc_hosts[0]  # Want lowest => first host in asc. list.
-
-    def appoint_host(self, override_stats=False):
-        """Appoint the most suitable host to (re-)run a suite on."""
-
-        # Check if immediately 'trivial': no thresholds and zero or one hosts.
-        initial_check = self._trivial_choice(
-            self.HOSTS, ignore_if_thresholds_prov=True)
-        if initial_check:
-            return initial_check
-
-        good_host_stats = self._remove_bad_hosts(
-            self._process_get_host_metrics_cmd(), mock_stats=override_stats)
-
-        # Re-check for triviality after bad host removal; otherwise must rank.
-        pre_rank_check = self._trivial_choice(good_host_stats.keys())
-        if pre_rank_check:
-            return pre_rank_check
-
-        return self._rank_good_hosts(good_host_stats)
-
-def get_host_metrics((host, cmd)):
-    """Wrapper for the `cylc get-host-metric` command.
-
-    NOTE: multiprocessing.Pool.map does not work
-    """
-    try:
-        host_fqdn = get_fqdn_by_host(host)
-        if host_fqdn == get_fqdn_by_host('localhost'):
-            host = None
-    except socket.gaierror:
-        # No such host.
-        sys.stderr.write("Invalid host '%s'." % host)
-        return
-
-    process = Popen(construct_ssh_cmd(cmd, host=host), stdin=open(os.devnull),
-                    stdout=PIPE, stderr=PIPE)
-    if process.wait():
-        # Command failed.
-        sys.stderr.write((
-            "Can't obtain metric data from host '%s'; return code '%s' "
-            "from '%s'\n" % (host, process.returncode, cmd)))
-        return
-
-    return json.loads(process.communicate()[0])
-
-
-class TestHostAppointer(unittest.TestCase):
-    """Unit tests for the HostAppointer class."""
-
-    def setUp(self):
-        """Create variables and templates to use in tests."""
-        self.app = HostAppointer()
-
-    def create_custom_metric(self, disk_int, mem_int, load_floats):
-        """Non-test method to create and return a dummy metric for testing.
-
-           Return a structure in the format of 'get_host_metric' output
-           containing fake data. 'disk_int' and 'mem_int' should be integers
-           and 'load_floats' a list of three floats. Use 'None' instead to not
-           add the associated top-level key to metric."""
-        metric = {}
-        if disk_int is not None:  # Distinguish None from '0', value to insert.
-            metric.update({'disk-space:' + self.app.use_disk_path: disk_int})
-        if mem_int is not None:
-            metric.update({"memory": mem_int})
-        if load_floats is not None:
-            load_1min, load_5min, load_15min = load_floats
-            load_data = {
-                "load:1": load_1min,
-                "load:5": load_5min,
-                "load:15": load_15min
-            }
-            metric.update(load_data)
-        return json.dumps(metric)
-
-    def create_mock_hosts(self, N_hosts, initial_values, increments, load_var):
-        """Non-test method to create list of tuples of mock hosts and metrics.
-
-           For mock hosts, 'N_hosts' in number, create associated metrics with
-           data values that are incremented to create known data variation. The
-           list is shuffled to remove ordering by sequence position; name label
-           numbers (lower for lower values) indicate the data ordering."""
-        mock_host_data = []
-        for label in range(1, N_hosts + 1):
-            val = []
-            # Indices {0,1,2} refer to {disk, memory, load} data respectively.
-            for index in range(3):
-                val.append(
-                    initial_values[index] + (label - 1) * increments[index])
-            # Load is special as it needs 3 values and they are floats not ints
-            val[2] = (val[2], float(val[2]) + load_var,
-                      float(val[2]) + 2 * load_var)
-            metric = self.create_custom_metric(val[0], val[1], val[2])
-            mock_host_data.append(('HOST_' + str(label), json.loads(metric)))
-        shuffle(mock_host_data)
-        return mock_host_data
-
-    def mock_global_config(self, set_hosts=None, set_rank_method='random',
-                           set_thresholds=None):
-        """Non-test method to edit global config input to HostAppointer()."""
-        if set_hosts is None:
-            set_hosts = []
-        self.app.HOSTS = set_hosts
-        self.app.RANK_METHOD = set_rank_method
-        self.app.PARSED_THRESHOLDS = self.app.parse_thresholds(set_thresholds)
-
-    def setup_test_rank_good_hosts(self, num, init, incr, var):
-        """Non-test method to setup routine tests for '_rank_good_hosts'.
-
-           Note:
-           * Host list input as arg so not reading from 'self.app.HOSTS' =>
-             only 'set_rank_method' arg to 'mock_global_config' is relevant.
-           * RANK_METHOD 'random' dealt with before this method is called;
-             '_rank_good_hosts' not written to cater for it, so not tested.
-           * Mock set {HOST_X} created so that lower X host has lower data
-             values (assuming positive 'incr') so for X = {1, ..., N} HOST_1
-             or HOST_N is always 'best', depending on rank method context.
-        """
-        self.mock_global_config(set_rank_method='memory')
-        self.assertEqual(
-            self.app._rank_good_hosts(dict(
-                self.create_mock_hosts(num, init, incr, var))),
-            'HOST_' + str(num)
-        )
-        self.mock_global_config(set_rank_method='disk-space:%s' %
-                                self.app.use_disk_path)
-        self.assertEqual(
-            self.app._rank_good_hosts(dict(
-                self.create_mock_hosts(num, init, incr, var))),
-            'HOST_' + str(num)
-        )
-        # Use 'load:5' as test case of load averages. No need to test all.
-        self.mock_global_config(set_rank_method='load:5')
-        self.assertEqual(
-            self.app._rank_good_hosts(dict(
-                self.create_mock_hosts(num, init, incr, var))),
-            'HOST_1'
-        )
-
-    def test_parse_thresholds(self):
-        """Test the 'parse_thresholds' method."""
-        self.mock_global_config()
-        self.assertEqual(
-            self.app.parse_thresholds(None),
-            {}
-        )
-        self.assertEqual(
-            self.app.parse_thresholds("load:5 0.5; load:15 1.0; memory" +
-                                      " 100000; disk-space:/ 9999999"),
-            {
-                "load:5": 0.5,
-                "load:15": 1.0,
-                "memory": 100000,
-                "disk-space:/": 9999999
-            }
-        )
-        self.assertRaises(
-            AttributeError,
-            self.app.parse_thresholds,
-            "memory 300000; gibberish 1.0"
-        )
-        self.assertRaises(
-            ValueError,
-            self.app.parse_thresholds,
-            "load:5 rogue_string"
-        )
-        # Note lack of semi-colon separator.
-        self.assertRaises(
-            AttributeError,
-            self.app.parse_thresholds,
-            "disk-space:/ 888 memory 300000"
-        )
-
-    def test_trivial_choice(self):
-        """Test '_trivial_choice' and by extension 'selection_complete'."""
-        self.mock_global_config()  # Case with defaults.
-        # assertIn not introduced until Python 2.7, so can't use.
-        self.assertTrue(
-            self.app._trivial_choice(['HOST_1', 'HOST_2', 'HOST_3'],
-                                     ignore_if_thresholds_prov=True) in
-            ('HOST_1', 'HOST_2', 'HOST_3')
-        )
-
-        # Case of defaults except with RANK_METHOD as anything but 'random';
-        # really tests 'selection_complete' method (via '_trivial_choice').
-        self.mock_global_config(set_rank_method='memory')
-        self.assertEqual(
-            self.app._trivial_choice(['HOST_1', 'HOST_2', 'HOST_3']),
-            False
-        )
-        self.assertEqual(
-            self.app._trivial_choice(['HOST_1']),
-            'HOST_1'
-        )
-        self.assertRaises(
-            EmptyHostList,
-            self.app._trivial_choice, []
-        )
-
-        # Case with (any) valid thresholds and ignore_if_thresholds_prov=True.
-        self.mock_global_config(set_thresholds='memory 10000')
-        self.assertEqual(
-            self.app._trivial_choice(['HOST_1', 'HOST_2', 'HOST_3'],
-                                     ignore_if_thresholds_prov=True),
-            False
-        )
-
-    def test_process_get_host_metric_cmd(self):
-        """Test the '_process_get_host_metrics_cmd' method."""
-        self.mock_global_config()
-        self.assertEqual(
-            self.app._process_get_host_metrics_cmd(),
-            'get-host-metrics'
-        )
-        self.mock_global_config(set_thresholds='memory 1000')
-        self.assertEqual(
-            self.app._process_get_host_metrics_cmd(),
-            'get-host-metrics --memory'
-        )
-        self.mock_global_config(set_rank_method='memory')
-        self.assertEqual(
-            self.app._process_get_host_metrics_cmd(),
-            'get-host-metrics --memory'
-        )
-        self.mock_global_config(
-            set_rank_method='disk-space:%s' % self.app.use_disk_path,
-            set_thresholds='load:1 1000')
-        self.assertEqual(
-            self.app._process_get_host_metrics_cmd(),
-            'get-host-metrics --disk-space=' + self.app.use_disk_path +
-            ' --load'
-        )
-        self.mock_global_config(
-            set_rank_method='memory',
-            set_thresholds='disk-space:/ 1000; memory 1000; load:15 1.0')
-        # self.PARSED_THRESHOLDS etc dict => unordered keys: opts order varies;
-        # instead of cataloging all combos or importing itertools, test split.
-        self.assertEqual(
-            set(self.app._process_get_host_metrics_cmd().split()),
-            set(['get-host-metrics', '--memory', '--disk-space=/', '--load'])
-        )
-
-    def test_remove_bad_hosts(self):
-        """Test the '_remove_bad_hosts' method.
-
-           Test using 'localhost' only since remote host functionality is
-           contained only inside remote_cylc_cmd() so is outside of the scope
-           of HostAppointer."""
-        self.mock_global_config(set_hosts=['localhost'])
-        self.failUnless(
-            self.app._remove_bad_hosts(
-                self.app.CMD_BASE).get('localhost', False)
-        )
-        # Test 'localhost' true identifier is treated properly too.
-        self.mock_global_config(set_hosts=[get_fqdn_by_host('localhost')])
-        self.failUnless(
-            self.app._remove_bad_hosts(
-                self.app.CMD_BASE).get(get_fqdn_by_host('localhost'), False)
-        )
-
-        self.mock_global_config(set_hosts=['localhost', 'FAKE_HOST'])
-        # Check for no exceptions and 'localhost' but not 'FAKE_HOST' data
-        # Difficult to unittest for specific stderr string; this is sufficient.
-        self.failUnless(
-            self.app._remove_bad_hosts(
-                self.app.CMD_BASE).get('localhost', False)
-        )
-        self.failUnless(
-            not self.app._remove_bad_hosts(
-                self.app.CMD_BASE).get('FAKE_HOST', False)
-        )
-        self.mock_global_config(set_hosts=['localhost'])  # see above RE stderr
-        self.assertEqual(
-            self.app._remove_bad_hosts(self.app.CMD_BASE + ' --nonsense'),
-            {}
-        )
-
-        # Apply thresholds impossible to pass; check results in host removal.
-        self.mock_global_config(
-            set_hosts=['localhost'], set_thresholds='load:15 0.0')
-        self.assertEqual(
-            self.app._remove_bad_hosts(self.app.CMD_BASE + " --load"),
-            {}
-        )
-        self.mock_global_config(
-            set_hosts=['localhost'], set_thresholds='memory 1000000000')
-        self.assertEqual(
-            self.app._remove_bad_hosts(self.app.CMD_BASE + " --memory"),
-            {}
-        )
-
-    def test_rank_good_hosts(self):
-        """Test the '_rank_good_hosts' method."""
-
-        # Considering special cases:
-        # Case with 0 or 1 hosts filtered out before method called, so ignore.
-        # Variation in load averages is irrelevant; no need to test lack of.
-
-        # Case with no increments => same stats for all hosts. Random result.
-        self.mock_global_config(set_rank_method='memory')  # Any except random.
-        self.assertTrue(
-            self.app._rank_good_hosts(dict(
-                self.create_mock_hosts(
-                    5, [100, 100, 1.0], [0, 0, 0.0], 0.1))) in
-            ('HOST_1', 'HOST_2', 'HOST_3', 'HOST_4', 'HOST_5')
-        )
-
-        # Test a selection of routine cases; only requirements are for types:
-        # init and incr in form [int, int, float] and int var, and for size:
-        # num > 1, all elements of init > 0(.0) and incr >= 0(.0), var >= 0.0.
-        self.setup_test_rank_good_hosts(
-            2, [100, 100, 1.0], [100, 100, 1.0], 0.2)
-        self.setup_test_rank_good_hosts(
-            10, [500, 200, 0.1], [100, 10, 10.0], 0.0)
-        self.setup_test_rank_good_hosts(
-            10, [103870, 52139, 3.19892], [5348, 45, 5.2321], 0.52323)
-        self.setup_test_rank_good_hosts(
-            50, [10000, 20000, 0.00000001], [400, 1000000, 1.1232982], 0.11)
-
-    def test_appoint_host(self):
-        """Test the 'appoint_host' method.
-
-           This method calls all other methods in the class directly or
-           indirectly, hence this is essentially a full-class test. The
-           following phase space is covered:
-
-               1. Number of hosts: none, one or multiple.
-               2. Rank method: random, load (use just 5 min average case),
-                               memory or disk space.
-               3. Thresholds: without or with, including all measures.
-        """
-
-        # Define phase space.
-        hosts_space = ([], ['HOST_1'],
-                       ['HOST_1', 'HOST_2', 'HOST_3', 'HOST_4', 'HOST_5'])
-        rank_method_space = ('random', 'load:5', 'memory', 'disk-space:/')
-        thresholds_space = (None, 'load:1 2.0; load:5 1.10; load:15' +
-                            ' 1.31; memory 31000; disk-space:/ 1000')
-
-        # Enumerate all (24) correct results required to test equality with.
-        # Correct results deduced individually based on mock host set. Note
-        # only HOST_2 and HOST_3 pass all thresholds for thresholds_space[1].
-        correct_results = (8 * [EmptyHostList] +
-                           4 * ['HOST_1', EmptyHostList] +
-                           ['HOST_X', 'HOST_Y', 'HOST_1', 'HOST_2', 'HOST_5',
-                            'HOST_3', 'HOST_5', 'HOST_3'])
-
-        for index, (host_list, method, thresholds) in enumerate(
-                [(hosts, meth, thr) for hosts in hosts_space for meth in
-                 rank_method_space for thr in thresholds_space]):
-
-            # Use same group of mock hosts each time, but ensure compatible
-            # number (at host_list changeover only; avoid re-creating same).
-            if index in (0, 8, 16):
-                mock_hosts = dict(self.create_mock_hosts(
-                    len(host_list), [400000, 30000, 0.05], [50000, 1000, 0.2],
-                    0.4))
-
-            self.mock_global_config(
-                set_hosts=host_list, set_rank_method=method,
-                set_thresholds=thresholds)
-
-            if correct_results[index] == 'HOST_X':  # random, any X={1..5} fine
-                self.assertTrue(
-                    self.app.appoint_host(override_stats=mock_hosts) in
-                    host_list
-                )
-            elif correct_results[index] == 'HOST_Y':  # random + thr, X={2,3}
-                self.assertTrue(
-                    self.app.appoint_host(override_stats=mock_hosts) in
-                    host_list[1:3]
-                )
-            elif isinstance(correct_results[index], str):
-                self.assertEqual(
-                    self.app.appoint_host(override_stats=mock_hosts),
-                    correct_results[index]
-                )
-            else:
-                self.assertRaises(
-                    correct_results[index],
-                    self.app.appoint_host,
-                    override_stats=mock_hosts
-                )
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/lib/cylc/remote.py
+++ b/lib/cylc/remote.py
@@ -21,19 +21,25 @@ import os
 import sys
 import shlex
 import signal
+import unittest
+import json
+import socket
 from time import sleep
 from pipes import quote
 from posix import WIFSIGNALED
+from random import shuffle, choice
+from multiprocessing import Pool
 
 # CODACY ISSUE:
 #   Consider possible security implications associated with Popen module.
 # REASON IGNORED:
 #   Subprocess is needed, but we use it with security in mind.
-from subprocess import Popen, PIPE
+from subprocess import Popen, PIPE, CalledProcessError
 
 import cylc.flags
 from cylc.cfgspec.glbl_cfg import glbl_cfg
 from cylc.version import CYLC_VERSION
+from cylc.hostuserutil import get_fqdn_by_host
 
 
 def get_proc_ancestors():
@@ -62,91 +68,177 @@ def watch_and_kill(proc):
             break
 
 
-def remote_cylc_cmd(cmd, user=None, host=None, capture=False, manage=False,
-                    ssh_login_shell=None, ssh_cylc=None, stdin=None):
+def run_ssh_cmd(command, stdin=None, capture_process=False,
+                capture_status=False, manage=False):
     """Run a given cylc command on another account and/or host.
 
     Arguments:
-        cmd (list): command to run remotely.
-        user (string): user ID for the remote login.
-        host (string): remote host name. Use 'localhost' if not specified.
-        capture (boolean):
+        command (list):
+            command inclusive of all opts and args required to run via ssh.
+        stdin (file):
+            If specified, it should be a readable file object.
+            If None, `open(os.devnull)` is set if output is to be captured.
+        capture_process (boolean):
             If True, set stdout=PIPE and return the Popen object.
+        capture_status (boolean):
+            If True, and the remote command is unsuccessful, return the
+            associated exit code instead of exiting with an error.
         manage (boolean):
             If True, watch ancestor processes and kill command if they change
             (e.g. kill tail-follow commands when parent ssh connection dies).
-        ssh_login_shell (boolean):
-            If True, launch remote command with `bash -l -c 'exec "$0" "$@"'`.
-        ssh_cylc (string):
-            Location of the remote cylc executable.
-        stdin (file):
-            If specified, it should be a readable file object.
-            If None, it will be set to `open(os.devnull)` and the `-n` option
-            will be added to the SSH command line.
 
     Return:
-        If capture=True, return the Popen object if created successfully.
-        Otherwise, return the exit code of the remote command.
-    """
-    if host is None:
-        host = "localhost"
-    if user is None:
-        user_at_host = host
-    else:
-        user_at_host = '%s@%s' % (user, host)
+        * If capture_process=True, the Popen object if created successfully.
+        * Else True if the remote command is executed successfully, or
+          if unsuccessful and capture_status=True the remote command exit code.
+        * Otherwise exit with an error message."""
 
-    # Build the remote command
-    command = shlex.split(
-        str(glbl_cfg().get_host_item('ssh command', host, user)))
-    if stdin is None:
-        command.append('-n')
-        stdin = open(os.devnull)
-    command.append(user_at_host)
-
-    # Pass cylc version through.
-    command += ['env', r'CYLC_VERSION=%s' % CYLC_VERSION]
-
-    if ssh_login_shell is None:
-        ssh_login_shell = glbl_cfg().get_host_item(
-            'use login shell', host, user)
-    if ssh_login_shell:
-        # A login shell will always source /etc/profile and the user's bash
-        # profile file. To avoid having to quote the entire remote command
-        # it is passed as arguments to bash.
-        command += ['bash', '--login', '-c', quote(r'exec "$0" "$@"')]
-    if ssh_cylc is None:
-        ssh_cylc = glbl_cfg().get_host_item('cylc executable', host, user)
-        if not ssh_cylc.endswith('cylc'):
-            raise ValueError(
-                r'ERROR: bad cylc executable in global config: %s' % ssh_cylc)
-    command.append(ssh_cylc)
-    command += cmd
-    if cylc.flags.debug:
-        sys.stderr.write('%s\n' % command)
-    if capture:
-        stdout = PIPE
-    else:
-        stdout = None
     # CODACY ISSUE:
     #   subprocess call - check for execution of untrusted input.
     # REASON IGNORED:
     #   The command is read from the site/user global config file, but we check
     #   above that it ends in 'cylc', and in any case the user could execute
     #   any such command directly via ssh.
+    stdout = None
+    if capture_process:
+        stdout = PIPE
+        if stdin is None:
+            stdin = open(os.devnull)
 
-    proc = Popen(command, stdout=stdout, stdin=stdin)
-    if capture:
-        return proc
+    try:
+        popen = Popen(command, stdin=stdin, stdout=stdout)
+    except OSError as exc:
+        sys.exit(r'ERROR: remote command invocation failed %s' % exc)
+
+    if capture_process:
+        return popen
     else:
         if manage:
-            watch_and_kill(proc)
-        res = proc.wait()
+            watch_and_kill(popen)
+        res = popen.wait()
         if WIFSIGNALED(res):
-            sys.stderr.write(
-                'ERROR: remote command terminated by signal %d\n' % res)
+            sys.exit(r'ERROR: remote command terminated by signal %d' % res)
+        elif res and capture_status:
+            return res
         elif res:
-            sys.stderr.write('ERROR: remote command failed %d\n' % res)
-        return res
+            sys.exit(r'ERROR: remote command failed %d' % res)
+        else:
+            return True
+
+
+def construct_ssh_cmd(raw_cmd, user=None, host=None, forward_x11=False,
+                      set_stdin=False, ssh_login_shell=None, ssh_cylc=None,
+                      set_UTC=False, allow_flag_opts=False):
+    """Append a bare command with further options required to run via ssh.
+
+    Arguments:
+        raw_cmd (list): primitive command to run remotely.
+        user (string): user ID for the remote login.
+        host (string): remote host name. Use 'localhost' if not specified.
+        forward_x11 (boolean):
+            If True, use 'ssh -Y' to enable X11 forwarding, else just 'ssh'.
+        set_stdin (file):
+            If None, the `-n` option will be added to the SSH command line.
+        ssh_login_shell (boolean):
+            If True, launch remote command with `bash -l -c 'exec "$0" "$@"'`.
+        ssh_cylc (string):
+            Location of the remote cylc executable.
+        set_UTC (boolean):
+            If True, check UTC mode and specify if set to True (non-default).
+        allow_flag_opts (boolean):
+            If True, check CYLC_DEBUG and CYLC_VERBOSE and if non-default,
+            specify debug and/or verbosity as options to the 'raw cmd'.
+
+    Return:
+        A list containing a chosen command including all arguments and options
+        necessary to directly execute the bare command on a given host via ssh.
+    """
+    command = shlex.split(glbl_cfg().get_host_item('ssh command', host, user))
+
+    if forward_x11:
+        command.append('-Y')
+    if set_stdin is None:
+        command.append('-n')
+
+    user_at_host = ''
+    if user:
+        user_at_host = user + '@'
+    if host:
+        user_at_host += host
+    else:
+        user_at_host += 'localhost'
+    command.append(user_at_host)
+
+    # Pass cylc version (and optionally UTC mode) through.
+    command += ['env', quote(r'CYLC_VERSION=%s' % CYLC_VERSION)]
+    if set_UTC and os.getenv('CYLC_UTC') in ["True", "true"]:
+        command.append(quote(r'CYLC_UTC=True'))
+        command.append(quote(r'TZ=UTC'))
+
+    # Use bash -l?
+    if ssh_login_shell is None:
+        ssh_login_shell = glbl_cfg().get_host_item(
+            'use login shell', host, user)
+    if ssh_login_shell:
+        # A login shell will always source /etc/profile and the user's bash
+        # profile file. To avoid having to quote the entire remote command
+        # it is passed as arguments to the bash script.
+        command += ['bash', '--login', '-c', quote(r'exec "$0" "$@"')]
+
+    # 'cylc' on the remote host
+    if ssh_cylc:
+        command.append(ssh_cylc)
+    else:
+        ssh_cylc = glbl_cfg().get_host_item('cylc executable', host, user)
+        if ssh_cylc.endswith('cylc'):
+            command.append(ssh_cylc)
+        else:
+            raise ValueError(
+                r'ERROR: bad cylc executable in global config: %s' % ssh_cylc)
+
+    # Insert core raw command after ssh, but before its own, command options.
+    command += raw_cmd
+
+    if allow_flag_opts:
+        if (cylc.flags.verbose or os.getenv('CYLC_VERBOSE') in
+                ["True", "true"]):
+            command.append(r'--verbose')
+        if cylc.flags.debug or os.getenv('CYLC_DEBUG') in ["True", "true"]:
+            command.append(r'--debug')
+    if cylc.flags.debug:
+        sys.stderr.write(' '.join(quote(c) for c in command) + '\n')
+
+    return command
+
+
+def remote_cylc_cmd(
+        cmd, user=None, host=None, stdin=None, ssh_login_shell=None,
+        ssh_cylc=None, capture=False, manage=False):
+    """Run a given cylc command on another account and/or host.
+
+    Arguments:
+    Args are directly inputted to one of two functions; see those docstrings:
+            * See 'construct_ssh_cmd()' docstring:
+                * cmd (--> raw_cmd);
+                * user;
+                * host;
+                * stdin (--> set_stdin) [see also below];
+                * ssh_login_shell;
+                * ssh_cylc.
+            * See 'run_ssh_cmd()' docstring:
+                * stdin [see also above]
+                * capture (--> capture_process);
+                * manage.
+
+    Return:
+        If capture=True, return the Popen object if created successfully.
+        Otherwise, return the exit code of the remote command."""
+    command = construct_ssh_cmd(
+        cmd, user=user, host=host, set_stdin=stdin,
+        ssh_login_shell=ssh_login_shell, ssh_cylc=ssh_cylc)
+
+    return run_ssh_cmd(command, stdin=stdin, capture_process=capture,
+                       capture_status=True, manage=manage)
 
 
 def remrun(dry_run=False, forward_x11=False, abort_if=None):
@@ -175,9 +267,9 @@ class RemoteRunner(object):
 
         cylc.flags.verbose = '-v' in self.argv or '--verbose' in self.argv
 
+        # Detect and replace host and owner options
         argv = self.argv[1:]
         self.args = []
-        # detect and replace host and owner options
         while argv:
             arg = argv.pop(0)
             if arg.startswith('--user='):
@@ -203,9 +295,7 @@ class RemoteRunner(object):
         """Execute command on remote host.
 
         Returns False if remote re-invocation is not needed, True if it is
-        needed and executes successfully otherwise aborts.
-
-        """
+        needed and executes successfully otherwise aborts."""
         if not self.is_remote:
             return False
 
@@ -214,72 +304,597 @@ class RemoteRunner(object):
                 "ERROR: option '%s' not available for remote run\n" % abort_if)
             return True
 
-        # Build the remote command
-        command = shlex.split(glbl_cfg().get_host_item(
-            'ssh command', self.host, self.owner))
-        if forward_x11:
-            command.append('-Y')
-
-        user_at_host = ''
-        if self.owner:
-            user_at_host = self.owner + '@'
-        if self.host:
-            user_at_host += self.host
-        else:
-            user_at_host += 'localhost'
-        command.append(user_at_host)
-
-        # Pass cylc version through.
-        command += ['env', quote(r'CYLC_VERSION=%s' % CYLC_VERSION)]
-        if os.getenv('CYLC_UTC') in ["True", "true"]:
-            command.append(quote(r'CYLC_UTC=True'))
-            command.append(quote(r'TZ=UTC'))
-
-        # Use bash -l?
-        ssh_login_shell = self.ssh_login_shell
-        if ssh_login_shell is None:
-            ssh_login_shell = glbl_cfg().get_host_item(
-                'use login shell', self.host, self.owner)
-        if ssh_login_shell:
-            # A login shell will always source /etc/profile and the user's bash
-            # profile file. To avoid having to quote the entire remote command
-            # it is passed as arguments to the bash script.
-            command += ['bash', '--login', '-c', quote(r'exec "$0" "$@"')]
-
-        # 'cylc' on the remote host
-        if self.ssh_cylc:
-            command.append(self.ssh_cylc)
-        else:
-            command.append(glbl_cfg().get_host_item(
-                'cylc executable', self.host, self.owner))
-
-        # /path/to/cylc-foo => foo
-        command.append(os.path.basename(self.argv[0])[5:])
-
-        if cylc.flags.verbose or os.getenv('CYLC_VERBOSE') in ["True", "true"]:
-            command.append(r'--verbose')
-        if cylc.flags.debug or os.getenv('CYLC_DEBUG') in ["True", "true"]:
-            command.append(r'--debug')
+        cmd = [os.path.basename(self.argv[0])[5:]]  # /path/to/cylc-foo => foo
         for arg in self.args:
-            command.append(quote(arg))
+            cmd.append(quote(arg))
             # above: args quoted to avoid interpretation by the shell,
             # e.g. for match patterns such as '.*' on the command line.
 
-        if cylc.flags.debug:
-            sys.stderr.write(' '.join(quote(c) for c in command) + '\n')
+        command = construct_ssh_cmd(
+            cmd, user=self.owner, host=self.host, forward_x11=forward_x11,
+            ssh_login_shell=self.ssh_login_shell, ssh_cylc=self.ssh_cylc,
+            set_UTC=True, allow_flag_opts=True)
 
         if dry_run:
             return command
+        else:
+            return run_ssh_cmd(command)
+
+
+class EmptyHostList(Exception):
+    """Exception to be raised if there are no valid run hosts.
+
+       Raise if, from the global configuration settings, no hosts are listed
+       for potential appointment to run suites (as 'run hosts') or none
+       satisfy requirements to pass 'run host select' specifications.
+
+       Print message with the current state of relevant settings for info."""
+
+    def __str__(self):
+        msg = "No hosts currently compatible with this global configuration:\n"
+        suite_server_cfg_items = (['run hosts'], ['run host select', 'rank'],
+                                  ['run host select', 'thresholds'])
+        for cfg_end_ref in suite_server_cfg_items:
+            cfg_full_ref = cfg_end_ref.insert(0, 'suite servers')
+            # Add 2-space indentation for clarity in distinction of items.
+            msg = '\n  '.join([msg, cfg_item[-1] + ':',
+                               '  ' + glbl_cfg().get(cfg_full_ref)])
+        return msg
+
+
+class HostAppointer(object):
+    """Appoint the most suitable host to run a suite on.
+
+       Determine the one host most suitable to (re-)run a suite on from all
+       'run hosts' given the 'run host selection' ranking & threshold options
+       as specified (else taken as default) in the global configuration.
+    """
+
+    CMD_BASE = "get-host-metrics"  # 'cylc' prepended by remote_cylc_cmd.
+
+    def __init__(self):
+        self.use_disk_path = "/"
+        self.max_processes = 5
 
         try:
-            popen = Popen(command)
-        except OSError as exc:
-            sys.exit(r'ERROR: remote command invocation failed %s' % exc)
+            self.HOSTS = glbl_cfg().get(['suite servers', 'run hosts'])
+            self.RANK_METHOD = glbl_cfg().get(
+                ['suite servers', 'run host select', 'rank'])
+            self.THRESHOLDS = glbl_cfg().get(
+                ['suite servers', 'run host select', 'thresholds'])
+        except KeyError:  # Catch for unittest which updates these internally.
+            self.HOSTS = []
+            self.RANK_METHOD = 'random'
+            self.THRESHOLDS = None
 
-        res = popen.wait()
-        if WIFSIGNALED(res):
-            sys.exit(r'ERROR: remote command terminated by signal %d' % res)
-        elif res:
-            sys.exit(r'ERROR: remote command failed %d' % res)
+        self.PARSED_THRESHOLDS = self.parse_thresholds(self.THRESHOLDS)
+
+    @staticmethod
+    def parse_thresholds(raw_thresholds_spec):
+        """Parse raw 'thresholds' global configuration option to dict."""
+        if not raw_thresholds_spec:
+            return {}
+        valid_thresholds = {}
+        for threshold in raw_thresholds_spec.split(';'):
+            threshold = threshold.strip()
+            try:
+                measure, cutoff = threshold.split(' ')
+            except (AttributeError, ValueError):
+                raise AttributeError(
+                    "Invalid threshold component '%s'." % threshold)
+            try:
+                if measure.startswith("load"):
+                    cutoff = float(cutoff)
+                elif measure == "memory" or measure.startswith("disk-space"):
+                    cutoff = int(cutoff)
+                else:
+                    raise AttributeError("Invalid threshold measure '%s'." %
+                                         measure)
+            except ValueError:
+                raise ValueError(
+                    "Threshold value '%s' of wrong type." % cutoff)
+            else:
+                valid_thresholds[measure] = cutoff
+        return valid_thresholds
+
+    @staticmethod
+    def selection_complete(host_list):
+        """Check for and address a list (of hosts) with length zero or one.
+
+           Check length of a list (of hosts); for zero items raise an error,
+           for one return that item, else (for multiple items) return False."""
+        if len(host_list) == 0:
+            raise EmptyHostList()
+        elif len(host_list) == 1:
+            return host_list[0]
         else:
-            return True
+            return False
+
+    def _trivial_choice(self, host_list, ignore_if_thresholds_prov=False):
+        """Address run host configuration that can be dealt with trivially.
+
+           If thresholds are not provided or set to be ignored, test if
+           'host_list' has length zero or one, else if the ranking method is
+           random; if so return an exception or host selected appropriately."""
+        if ignore_if_thresholds_prov and self.PARSED_THRESHOLDS:
+            return False
+        if self.selection_complete(host_list):
+            return self.selection_complete(host_list)
+        elif self.RANK_METHOD == 'random':
+            return choice(host_list)
+        else:
+            return False
+
+    def _process_get_host_metrics_cmd(self):
+        """Return 'get_host_metrics' command to run with only required options.
+
+           Return the command string to run 'cylc get host metric' with only
+           the required options given rank method and thresholds specified."""
+
+        # Convert config keys to associated command options. Ignore 'random'.
+        considerations = [self.RANK_METHOD] + self.PARSED_THRESHOLDS.keys()
+        opts = set()
+        for spec in considerations:
+            if spec.startswith("load"):
+                opts.add("--load")
+            elif spec.startswith("disk-space"):
+                opts.add("--disk-space=" + self.use_disk_path)
+            elif spec == "memory":
+                opts.add("--memory")
+
+        cmd = [self.CMD_BASE] + list(opts)
+        return " ".join(cmd)
+
+    def _remove_bad_hosts(self, cmd_with_opts, mock_stats=False):
+        """Return dictionary of 'good' hosts with their metric stats.
+
+           Run 'get-host-metrics' on each run host in parallel & store
+           extracted stats for 'good' hosts only. Ignore 'bad' hosts whereby
+           either metric data cannot be accessed from the command or at least
+           one metric value does not pass a specified threshold."""
+        host_stats = {}
+        cmd = cmd_with_opts.split()
+        if mock_stats:  # Create fake data for unittest purposes (only).
+            host_stats = dict(mock_stats)  # Prevent mutable object issues.
+        else:
+            hosts = list(self.HOSTS)  # copy for safety.
+            processes = min(len(hosts), self.max_processes)
+            ordered_results = process_pool(processes, _process_host_unpack,
+                                           zip(hosts, len(hosts) * [cmd]))
+            proc_hosts = dict(zip(hosts, ordered_results))
+            host_stats = [dict(host, metr) for host, metr in
+                          proc_hosts.items() if metr is not None]
+
+        bad_hosts = []  # Get errors if alter dict during iteration. Use list.
+        for host in host_stats:
+            for measure, cutoff in self.PARSED_THRESHOLDS.items():
+                datum = host_stats[host][measure]
+                # Cutoff is a minimum or maximum depending on measure context.
+                if ((datum > cutoff and measure.startswith("load")) or
+                        (datum < cutoff and (measure == "memory" or
+                         measure.startswith("disk-space")))):
+                    bad_hosts.append(host)
+                    continue
+        return dict((host, metr) for host, metr in
+                    host_stats.items() if host not in bad_hosts)
+
+    def _rank_good_hosts(self, all_host_stats):
+        """Rank, by specified method, 'good' hosts to return the most suitable.
+
+           Take a dictionary of hosts considered 'good' with the corresponding
+           metric data, and rank them via the method specified in the global
+           configuration, returning the lowest-ranked (taken as best) host."""
+
+        # Convert all dict values from full metrics structures to single
+        # metric data values corresponding to the rank method to rank with.
+        hosts_with_vals_to_rank = dict((host, metric[self.RANK_METHOD]) for
+                                       host, metric in all_host_stats.items())
+
+        # Rank new dict by value and return list of hosts (only) in rank order.
+        sort_asc_hosts = sorted(
+            hosts_with_vals_to_rank, key=hosts_with_vals_to_rank.get)
+        if self.RANK_METHOD in ("memory", "disk-space:" + self.use_disk_path):
+            # Want 'most free' i.e. highest => final host in asc. list.
+            return sort_asc_hosts[-1]
+        else:  # A load av. is only poss. left; 'random' dealt with earlier.
+            return sort_asc_hosts[0]  # Want lowest => first host in asc. list.
+
+    def appoint_host(self, override_stats=False):
+        """Appoint the most suitable host to (re-)run a suite on."""
+
+        # Check if immediately 'trivial': no thresholds and zero or one hosts.
+        initial_check = self._trivial_choice(
+            self.HOSTS, ignore_if_thresholds_prov=True)
+        if initial_check:
+            return initial_check
+
+        good_host_stats = self._remove_bad_hosts(
+            self._process_get_host_metrics_cmd(), mock_stats=override_stats)
+
+        # Re-check for triviality after bad host removal; otherwise must rank.
+        pre_rank_check = self._trivial_choice(good_host_stats.keys())
+        if pre_rank_check:
+            return pre_rank_check
+
+        return self._rank_good_hosts(good_host_stats)
+
+
+class TestHostAppointer(unittest.TestCase):
+    """Unit tests for the HostAppointer class."""
+
+    def setUp(self):
+        """Create variables and templates to use in tests."""
+        self.app = HostAppointer()
+
+    def create_custom_metric(self, disk_int, mem_int, load_floats):
+        """Non-test method to create and return a dummy metric for testing.
+
+           Return a structure in the format of 'get_host_metric' output
+           containing fake data. 'disk_int' and 'mem_int' should be integers
+           and 'load_floats' a list of three floats. Use 'None' instead to not
+           add the associated top-level key to metric."""
+        metric = {}
+        if disk_int is not None:  # Distinguish None from '0', value to insert.
+            metric.update({'disk-space:' + self.app.use_disk_path: disk_int})
+        if mem_int is not None:
+            metric.update({"memory": mem_int})
+        if load_floats is not None:
+            load_1min, load_5min, load_15min = load_floats
+            load_data = {
+                "load:1": load_1min,
+                "load:5": load_5min,
+                "load:15": load_15min
+            }
+            metric.update(load_data)
+        return json.dumps(metric)
+
+    def create_mock_hosts(self, N_hosts, initial_values, increments, load_var):
+        """Non-test method to create list of tuples of mock hosts and metrics.
+
+           For mock hosts, 'N_hosts' in number, create associated metrics with
+           data values that are incremented to create known data variation. The
+           list is shuffled to remove ordering by sequence position; name label
+           numbers (lower for lower values) indicate the data ordering."""
+        mock_host_data = []
+        for label in range(1, N_hosts + 1):
+            val = []
+            # Indices {0,1,2} refer to {disk, memory, load} data respectively.
+            for index in range(3):
+                val.append(
+                    initial_values[index] + (label - 1) * increments[index])
+            # Load is special as it needs 3 values and they are floats not ints
+            val[2] = (val[2], float(val[2]) + load_var,
+                      float(val[2]) + 2 * load_var)
+            metric = self.create_custom_metric(val[0], val[1], val[2])
+            mock_host_data.append(('HOST_' + str(label), json.loads(metric)))
+        shuffle(mock_host_data)
+        return mock_host_data
+
+    def mock_global_config(self, set_hosts=None, set_rank_method='random',
+                           set_thresholds=None):
+        """Non-test method to edit global config input to HostAppointer()."""
+        if set_hosts is None:
+            set_hosts = []
+        self.app.HOSTS = set_hosts
+        self.app.RANK_METHOD = set_rank_method
+        self.app.PARSED_THRESHOLDS = self.app.parse_thresholds(set_thresholds)
+
+    def setup_test_rank_good_hosts(self, num, init, incr, var):
+        """Non-test method to setup routine tests for '_rank_good_hosts'.
+
+           Note:
+           * Host list input as arg so not reading from 'self.app.HOSTS' =>
+             only 'set_rank_method' arg to 'mock_global_config' is relevant.
+           * RANK_METHOD 'random' dealt with before this method is called;
+             '_rank_good_hosts' not written to cater for it, so not tested.
+           * Mock set {HOST_X} created so that lower X host has lower data
+             values (assuming positive 'incr') so for X = {1, ..., N} HOST_1
+             or HOST_N is always 'best', depending on rank method context.
+        """
+        self.mock_global_config(set_rank_method='memory')
+        self.assertEqual(
+            self.app._rank_good_hosts(dict(
+                self.create_mock_hosts(num, init, incr, var))),
+            'HOST_' + str(num)
+        )
+        self.mock_global_config(set_rank_method='disk-space:%s' %
+                                self.app.use_disk_path)
+        self.assertEqual(
+            self.app._rank_good_hosts(dict(
+                self.create_mock_hosts(num, init, incr, var))),
+            'HOST_' + str(num)
+        )
+        # Use 'load:5' as test case of load averages. No need to test all.
+        self.mock_global_config(set_rank_method='load:5')
+        self.assertEqual(
+            self.app._rank_good_hosts(dict(
+                self.create_mock_hosts(num, init, incr, var))),
+            'HOST_1'
+        )
+
+    def test_parse_thresholds(self):
+        """Test the 'parse_thresholds' method."""
+        self.mock_global_config()
+        self.assertEqual(
+            self.app.parse_thresholds(None),
+            {}
+        )
+        self.assertEqual(
+            self.app.parse_thresholds("load:5 0.5; load:15 1.0; memory" +
+                                      " 100000; disk-space:/ 9999999"),
+            {
+                "load:5": 0.5,
+                "load:15": 1.0,
+                "memory": 100000,
+                "disk-space:/": 9999999
+            }
+        )
+        self.assertRaises(
+            AttributeError,
+            self.app.parse_thresholds,
+            "memory 300000; gibberish 1.0"
+        )
+        self.assertRaises(
+            ValueError,
+            self.app.parse_thresholds,
+            "load:5 rogue_string"
+        )
+        # Note lack of semi-colon separator.
+        self.assertRaises(
+            AttributeError,
+            self.app.parse_thresholds,
+            "disk-space:/ 888 memory 300000"
+        )
+
+    def test_trivial_choice(self):
+        """Test '_trivial_choice' and by extension 'selection_complete'."""
+        self.mock_global_config()  # Case with defaults.
+        # assertIn not introduced until Python 2.7, so can't use.
+        self.assertTrue(
+            self.app._trivial_choice(['HOST_1', 'HOST_2', 'HOST_3'],
+                                     ignore_if_thresholds_prov=True) in
+            ('HOST_1', 'HOST_2', 'HOST_3')
+        )
+
+        # Case of defaults except with RANK_METHOD as anything but 'random';
+        # really tests 'selection_complete' method (via '_trivial_choice').
+        self.mock_global_config(set_rank_method='memory')
+        self.assertEqual(
+            self.app._trivial_choice(['HOST_1', 'HOST_2', 'HOST_3']),
+            False
+        )
+        self.assertEqual(
+            self.app._trivial_choice(['HOST_1']),
+            'HOST_1'
+        )
+        self.assertRaises(
+            EmptyHostList,
+            self.app._trivial_choice, []
+        )
+
+        # Case with (any) valid thresholds and ignore_if_thresholds_prov=True.
+        self.mock_global_config(set_thresholds='memory 10000')
+        self.assertEqual(
+            self.app._trivial_choice(['HOST_1', 'HOST_2', 'HOST_3'],
+                                     ignore_if_thresholds_prov=True),
+            False
+        )
+
+    def test_process_get_host_metric_cmd(self):
+        """Test the '_process_get_host_metrics_cmd' method."""
+        self.mock_global_config()
+        self.assertEqual(
+            self.app._process_get_host_metrics_cmd(),
+            'get-host-metrics'
+        )
+        self.mock_global_config(set_thresholds='memory 1000')
+        self.assertEqual(
+            self.app._process_get_host_metrics_cmd(),
+            'get-host-metrics --memory'
+        )
+        self.mock_global_config(set_rank_method='memory')
+        self.assertEqual(
+            self.app._process_get_host_metrics_cmd(),
+            'get-host-metrics --memory'
+        )
+        self.mock_global_config(
+            set_rank_method='disk-space:%s' % self.app.use_disk_path,
+            set_thresholds='load:1 1000')
+        self.assertEqual(
+            self.app._process_get_host_metrics_cmd(),
+            'get-host-metrics --disk-space=' + self.app.use_disk_path +
+            ' --load'
+        )
+        self.mock_global_config(
+            set_rank_method='memory',
+            set_thresholds='disk-space:/ 1000; memory 1000; load:15 1.0')
+        # self.PARSED_THRESHOLDS etc dict => unordered keys: opts order varies;
+        # instead of cataloging all combos or importing itertools, test split.
+        self.assertEqual(
+            set(self.app._process_get_host_metrics_cmd().split()),
+            set(['get-host-metrics', '--memory', '--disk-space=/', '--load'])
+        )
+
+    def test_remove_bad_hosts(self):
+        """Test the '_remove_bad_hosts' method.
+
+           Test using 'localhost' only since remote host functionality is
+           contained only inside remote_cylc_cmd() so is outside of the scope
+           of HostAppointer."""
+        self.mock_global_config(set_hosts=['localhost'])
+        self.failUnless(
+            self.app._remove_bad_hosts(
+                self.app.CMD_BASE).get('localhost', False)
+        )
+        # Test 'localhost' true identifier is treated properly too.
+        self.mock_global_config(set_hosts=[get_fqdn_by_host('localhost')])
+        self.failUnless(
+            self.app._remove_bad_hosts(
+                self.app.CMD_BASE).get(get_fqdn_by_host('localhost'), False)
+        )
+
+        self.mock_global_config(set_hosts=['localhost', 'FAKE_HOST'])
+        # Check for no exceptions and 'localhost' but not 'FAKE_HOST' data
+        # Difficult to unittest for specific stderr string; this is sufficient.
+        self.failUnless(
+            self.app._remove_bad_hosts(
+                self.app.CMD_BASE).get('localhost', False)
+        )
+        self.failUnless(
+            not self.app._remove_bad_hosts(
+                self.app.CMD_BASE).get('FAKE_HOST', False)
+        )
+        self.mock_global_config(set_hosts=['localhost'])  # see above RE stderr
+        self.assertEqual(
+            self.app._remove_bad_hosts(self.app.CMD_BASE + ' --nonsense'),
+            {}
+        )
+
+        # Apply thresholds impossible to pass; check results in host removal.
+        self.mock_global_config(
+            set_hosts=['localhost'], set_thresholds='load:15 0.0')
+        self.assertEqual(
+            self.app._remove_bad_hosts(self.app.CMD_BASE + " --load"),
+            {}
+        )
+        self.mock_global_config(
+            set_hosts=['localhost'], set_thresholds='memory 1000000000')
+        self.assertEqual(
+            self.app._remove_bad_hosts(self.app.CMD_BASE + " --memory"),
+            {}
+        )
+
+    def test_rank_good_hosts(self):
+        """Test the '_rank_good_hosts' method."""
+
+        # Considering special cases:
+        # Case with 0 or 1 hosts filtered out before method called, so ignore.
+        # Variation in load averages is irrelevant; no need to test lack of.
+
+        # Case with no increments => same stats for all hosts. Random result.
+        self.mock_global_config(set_rank_method='memory')  # Any except random.
+        self.assertTrue(
+            self.app._rank_good_hosts(dict(
+                self.create_mock_hosts(
+                    5, [100, 100, 1.0], [0, 0, 0.0], 0.1))) in
+            ('HOST_1', 'HOST_2', 'HOST_3', 'HOST_4', 'HOST_5')
+        )
+
+        # Test a selection of routine cases; only requirements are for types:
+        # init and incr in form [int, int, float] and int var, and for size:
+        # num > 1, all elements of init > 0(.0) and incr >= 0(.0), var >= 0.0.
+        self.setup_test_rank_good_hosts(
+            2, [100, 100, 1.0], [100, 100, 1.0], 0.2)
+        self.setup_test_rank_good_hosts(
+            10, [500, 200, 0.1], [100, 10, 10.0], 0.0)
+        self.setup_test_rank_good_hosts(
+            10, [103870, 52139, 3.19892], [5348, 45, 5.2321], 0.52323)
+        self.setup_test_rank_good_hosts(
+            50, [10000, 20000, 0.00000001], [400, 1000000, 1.1232982], 0.11)
+
+    def test_appoint_host(self):
+        """Test the 'appoint_host' method.
+
+           This method calls all other methods in the class directly or
+           indirectly, hence this is essentially a full-class test. The
+           following phase space is covered:
+
+               1. Number of hosts: none, one or multiple.
+               2. Rank method: random, load (use just 5 min average case),
+                               memory or disk space.
+               3. Thresholds: without or with, including all measures.
+        """
+
+        # Define phase space.
+        hosts_space = ([], ['HOST_1'],
+                       ['HOST_1', 'HOST_2', 'HOST_3', 'HOST_4', 'HOST_5'])
+        rank_method_space = ('random', 'load:5', 'memory', 'disk-space:/')
+        thresholds_space = (None, 'load:1 2.0; load:5 1.10; load:15' +
+                            ' 1.31; memory 31000; disk-space:/ 1000')
+
+        # Enumerate all (24) correct results required to test equality with.
+        # Correct results deduced individually based on mock host set. Note
+        # only HOST_2 and HOST_3 pass all thresholds for thresholds_space[1].
+        correct_results = (8 * [EmptyHostList] +
+                           4 * ['HOST_1', EmptyHostList] +
+                           ['HOST_X', 'HOST_Y', 'HOST_1', 'HOST_2', 'HOST_5',
+                            'HOST_3', 'HOST_5', 'HOST_3'])
+
+        for index, (host_list, method, thresholds) in enumerate(
+                [(hosts, meth, thr) for hosts in hosts_space for meth in
+                 rank_method_space for thr in thresholds_space]):
+
+            # Use same group of mock hosts each time, but ensure compatible
+            # number (at host_list changeover only; avoid re-creating same).
+            if index in (0, 8, 16):
+                mock_hosts = dict(self.create_mock_hosts(
+                    len(host_list), [400000, 30000, 0.05], [50000, 1000, 0.2],
+                    0.4))
+
+            self.mock_global_config(
+                set_hosts=host_list, set_rank_method=method,
+                set_thresholds=thresholds)
+
+            if correct_results[index] == 'HOST_X':  # random, any X={1..5} fine
+                self.assertTrue(
+                    self.app.appoint_host(override_stats=mock_hosts) in
+                    host_list
+                )
+            elif correct_results[index] == 'HOST_Y':  # random + thr, X={2,3}
+                self.assertTrue(
+                    self.app.appoint_host(override_stats=mock_hosts) in
+                    host_list[1:3]
+                )
+            elif isinstance(correct_results[index], str):
+                self.assertEqual(
+                    self.app.appoint_host(override_stats=mock_hosts),
+                    correct_results[index]
+                )
+            else:
+                self.assertRaises(
+                    correct_results[index],
+                    self.app.appoint_host,
+                    override_stats=mock_hosts
+                )
+
+
+def _process_host(host, cmd):
+    """Run 'get-host-metrics' on a host and return the extracted metric.
+
+       NB: this must lie outside HostAppointer for multiprocessing to work."""
+    host_alias = host
+    try:
+        host_fqdn = get_fqdn_by_host(host)
+        if host_fqdn == get_fqdn_by_host('localhost'):
+            host_alias = None
+    except socket.gaierror:
+        # no such host: don't consider for 'good' hosts, i.e. 'pass'.
+        sys.stderr.write("Invalid host '%s'." % host)
+    process = remote_cylc_cmd(cmd, capture=True, host=host_alias)
+    metric = process.communicate()[0]
+    process.wait()
+    ret_code = process.returncode
+    if ret_code:
+        # Can't access data => designate as 'bad' host & ignore ('pass');
+        # don't raise an exception, just print to error log.
+        sys.stderr.write("Can't obtain metric data from host " +
+                         "'%s'; return code '%s' from '%s'\n" % (
+                host, ret_code, cmd))
+    else:
+        return json.loads(metric)
+
+
+def _process_host_unpack(args):
+    """Enable multiple argument pass to multiprocess Pool for _process_host."""
+    return _process_host(*args)
+
+
+if __name__ == "__main__":
+
+    def process_pool(number_processes, function, *args):
+        """Generic muliprocessing Pool, which must lie within main()."""
+        proc_poll = Pool(number_processes)
+        result = proc_poll.map(function, *args)
+        return result
+
+    unittest.main()

--- a/lib/cylc/scheduler_cli.py
+++ b/lib/cylc/scheduler_cli.py
@@ -550,6 +550,19 @@ class TestHostAppointer(unittest.TestCase):
             'HOST_1'
         )
 
+    def test_simple(self):
+        """Simple end-to-end test of the host appointer."""
+        self.mock_global_config()
+        self.assertEqual(
+            self.app.appoint_host(),
+            'localhost'
+        )
+        self.mock_global_config(set_hosts=['foo'])
+        self.assertEqual(
+            self.app.appoint_host(),
+            'foo'
+        )
+
     def test_parse_thresholds(self):
         """Test the 'parse_thresholds' method."""
         self.mock_global_config()

--- a/tests/cli/01-help.t
+++ b/tests/cli/01-help.t
@@ -76,6 +76,7 @@ cylc get: is ambiguous for:
     cylc get-directory
     cylc get-global-config
     cylc get-gui-config
+    cylc get-host-metrics
     cylc get-site-config
     cylc get-suite-config
     cylc get-suite-contact

--- a/tests/cylc-get-host-metrics/00-simple.t
+++ b/tests/cylc-get-host-metrics/00-simple.t
@@ -83,7 +83,9 @@ __OUTPUT_FORMAT__
 # Disk space option, including a bad path.
 run_fail "${TEST_NAME_BASE}-get-host-metric-disk-bad" cylc get-host-metric \
 --disk-space=nonsense
-grep_ok "subprocess\.CalledProcessError: Command '\['df', '-Pk', 'nonsense'\]' returned non-zero exit status 1" "${TEST_NAME_BASE}-get-host-metric-disk-bad.stderr"
+MESSAGE="subprocess\.CalledProcessError: Command '\['df', '-Pk', 'nonsense'\]'"
+MESSAGE+=" returned non-zero exit status 1"
+grep_ok "$MESSAGE" "${TEST_NAME_BASE}-get-host-metric-disk-bad.stderr"
 #-------------------------------------------------------------------------------
 # Test the various options in combination. Use '0.10' and '1000000' as
 # examples in correct format as cannot test for exact values.

--- a/tests/cylc-get-host-metrics/00-simple.t
+++ b/tests/cylc-get-host-metrics/00-simple.t
@@ -1,0 +1,128 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test cylc get-host-metric.
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 20
+#-------------------------------------------------------------------------------
+# Test each option (load, memory and disk space) individually. Use '0.10' and
+# '1000000' as examples in correct format as cannot test for exact values.
+
+# Load option.
+run_ok "${TEST_NAME_BASE}-get-host-metric-load" cylc get-host-metric --load
+run_ok "${TEST_NAME_BASE}-get-host-metric-l" cylc get-host-metric -l
+for FILE in "${TEST_NAME_BASE}-get-host-metric-load.stdout" \
+    "${TEST_NAME_BASE}-get-host-metric-l.stdout"
+do
+    sed -i 's/\(\s\+\)\([0-9]\+\.[0-9]\+\)\(\s*\n*,*\)/\10.10\3/g' "${FILE}"
+    cmp_json_ok "${FILE}" "${FILE}" <<__OUTPUT_FORMAT__
+{
+    "load:5": 0.10,
+    "load:1": 0.10,
+    "load:15": 0.10
+}
+__OUTPUT_FORMAT__
+done
+
+# Memory option.
+run_ok "${TEST_NAME_BASE}-get-host-metric-memory" cylc get-host-metric --memory
+run_ok "${TEST_NAME_BASE}-get-host-metric-m" cylc get-host-metric -m
+for FILE in "${TEST_NAME_BASE}-get-host-metric-memory.stdout" \
+    "${TEST_NAME_BASE}-get-host-metric-m.stdout"
+do
+    sed -i 's/\(\s\+\)\([0-9]\+\)\(\s*\n*\)/\11000000\3/g' "${FILE}"
+    cmp_json_ok "${FILE}" "${FILE}" <<__OUTPUT_FORMAT__
+{
+    "memory": 1000000
+}
+__OUTPUT_FORMAT__
+done
+
+# Disk space option, with a single path specified correctly.
+run_ok "${TEST_NAME_BASE}-get-host-metric-disk-one" cylc get-host-metric \
+--disk-space=/
+sed -i 's/\(\s\+\)\([0-9]\+\)\(\s*\n*\)/\11000000\3/g' \
+    "${TEST_NAME_BASE}-get-host-metric-disk-one.stdout"
+cmp_json_ok "${TEST_NAME_BASE}-get-host-metric-disk-one.stdout" \
+"${TEST_NAME_BASE}-get-host-metric-disk-one.stdout" <<__OUTPUT_FORMAT__
+{
+    "disk-space:/": 1000000
+}
+__OUTPUT_FORMAT__
+
+# Disk space option, with multiple paths specified correctly.
+
+run_ok "${TEST_NAME_BASE}-get-host-metric-disk-mult" cylc get-host-metric \
+--disk-space=/,/  # Host only has root mount dir for certain; as such can only
+                  # specify this safely across envs. Just check multiple paths
+                  # are accepted, though they combine -> only one key:value.
+sed -i 's/\(\s\+\)\([0-9]\+\)\(\s*\n*,*\)/\11000000\3/g' \
+    "${TEST_NAME_BASE}-get-host-metric-disk-mult.stdout"
+cmp_json_ok "${TEST_NAME_BASE}-get-host-metric-disk-mult.stdout" \
+"${TEST_NAME_BASE}-get-host-metric-disk-mult.stdout" <<__OUTPUT_FORMAT__
+{
+    "disk-space:/": 1000000
+}
+__OUTPUT_FORMAT__
+
+# Disk space option, including a bad path.
+run_fail "${TEST_NAME_BASE}-get-host-metric-disk-bad" cylc get-host-metric \
+--disk-space=nonsense
+grep_ok "subprocess\.CalledProcessError: Command '\['df', '-Pk', 'nonsense'\]' returned non-zero exit status 1" "${TEST_NAME_BASE}-get-host-metric-disk-bad.stderr"
+#-------------------------------------------------------------------------------
+# Test the various options in combination. Use '0.10' and '1000000' as
+# examples in correct format as cannot test for exact values.
+
+# No options; defaults to providing load and memory.
+run_ok "${TEST_NAME_BASE}-get-host-metric-no-opts" cylc get-host-metric
+sed -i 's/\(\s\+\)\([0-9]\+\)\(\s*\n*,*\)/\11000000\3/g' \
+    "${TEST_NAME_BASE}-get-host-metric-no-opts.stdout"
+sed -i 's/\(\s\+\)\([0-9]\+\.[0-9]\+\)\(\s*\n*,*\)/\10.10\3/g' \
+    "${TEST_NAME_BASE}-get-host-metric-no-opts.stdout"
+cmp_json_ok "${TEST_NAME_BASE}-get-host-metric-no-opts.stdout" \
+"${TEST_NAME_BASE}-get-host-metric-no-opts.stdout" <<__OUTPUT_FORMAT__
+{
+    "load:5": 0.10,
+    "load:1": 0.10,
+    "load:15": 0.10,
+    "memory": 1000000
+}
+__OUTPUT_FORMAT__
+
+# All three options.
+run_ok "${TEST_NAME_BASE}-get-host-metric-all-opts" cylc get-host-metric \
+--load --memory --disk-space=/
+run_ok "${TEST_NAME_BASE}-get-host-metric-all-opts-short" cylc get-host-metric \
+-lm --disk-space=/
+for FILE in "${TEST_NAME_BASE}-get-host-metric-all-opts.stdout" \
+    "${TEST_NAME_BASE}-get-host-metric-all-opts-short.stdout"
+do
+    sed -i 's/\(\s\+\)\([0-9]\+\)\(\s*\n*,*\)/\11000000\3/g' "${FILE}"
+    sed -i 's/\(\s\+\)\([0-9]\+\.[0-9]\+\)\(\s*\n*,*\)/\10.10\3/g' "${FILE}"
+    cmp_json_ok "${FILE}" "${FILE}" <<__OUTPUT_FORMAT__
+{
+    "memory": 1000000, 
+    "load:5": 0.10000000000000001, 
+    "load:15": 0.10000000000000001, 
+    "load:1": 0.10000000000000001, 
+    "disk-space:/": 1000000
+}
+__OUTPUT_FORMAT__
+done
+#-------------------------------------------------------------------------------
+exit

--- a/tests/cylc-get-host-metrics/test_header
+++ b/tests/cylc-get-host-metrics/test_header
@@ -1,0 +1,1 @@
+../lib/bash/test_header

--- a/tests/cylc-poll/17-pbs-cant-connect.t
+++ b/tests/cylc-poll/17-pbs-cant-connect.t
@@ -31,7 +31,7 @@ then
     skip_all "\"[test battery][batch systems][${BATCH_SYS_NAME}]host\" not defined"
 fi
 
-set_test_number 3
+set_test_number 4
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 if [[ "${CYLC_TEST_BATCH_TASK_HOST}" != 'localhost' ]]; then
     ssh -n "${CYLC_TEST_BATCH_TASK_HOST}" "mkdir -p 'cylc-run/${SUITE_NAME}/'"
@@ -41,11 +41,17 @@ fi
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
 suite_run_ok "${TEST_NAME_BASE}-run" \
     cylc run --reference-test --debug --no-detach "${SUITE_NAME}"
-sed -n 's/^.*\(\[jobs-poll err\] Connection refused\).*$/\1/p;
+# ssh security warnings may appear between outputs => check separately too.
+sed -n 's/^.*\(\[jobs-poll err\]\) \(Connection refused\).*$/\1\n\2/p;
+        s/^.*\(\[jobs-poll err\]\).*$/\1/p;
+        s/^.*\(Connection refused\).*$/\1/p;
         s/^.*\(INFO - \[t1.1\] -(current:running)(polled) started\).*$/\1/p' \
     "${SUITE_RUN_DIR}/log/suite/log" >'sed-log.out'
 contains_ok 'sed-log.out' <<'__LOG__'
-[jobs-poll err] Connection refused
+[jobs-poll err]
+Connection refused
+__LOG__
+contains_ok 'sed-log.out' <<'__LOG__'
 INFO - [t1.1] -(current:running)(polled) started
 __LOG__
 

--- a/tests/cylc-scan/01-hosts.t
+++ b/tests/cylc-scan/01-hosts.t
@@ -19,9 +19,9 @@
 CYLC_TEST_IS_GENERIC=false
 . "$(dirname "$0")/test_header"
 HOSTS="$( \
-    cylc get-global-config '--item=[suite host scanning]hosts' 2>'/dev/null')"
+    cylc get-global-config '--item=[suite servers]scan hosts' 2>'/dev/null')"
 if [[ -z "${HOSTS}" || "${HOSTS}" == 'localhost' ]]; then
-    skip_all '"[suite host scanning]hosts" not defined with remote suite hosts'
+    skip_all '"[suite servers]scan hosts" not defined with remote suite hosts'
 fi
 #-------------------------------------------------------------------------------
 set_test_number "$(($(wc -w <<<"${HOSTS}") + 1))"

--- a/tests/cylc.scheduler_cli/00-host-appointer.t
+++ b/tests/cylc.scheduler_cli/00-host-appointer.t
@@ -18,7 +18,24 @@
 # Run unit tests to test HostAppointer class for selecting hosts.
 . "$(dirname "$0")/test_header"
 #-------------------------------------------------------------------------------
-set_test_number 1
+set_test_number 3
 
 run_ok "${TEST_NAME_BASE}" python -m 'cylc.scheduler_cli'
+
+# No run hosts list
+create_test_globalrc '' ''
+run_ok "${TEST_NAME_BASE}-no-host-list" python - <<'__PYTHON__'
+from cylc.scheduler_cli import HostAppointer
+assert HostAppointer().appoint_host() == 'localhost'
+__PYTHON__
+
+# Empty run hosts list
+create_test_globalrc '' '
+[suite servers]
+    run hosts =
+'
+run_ok "${TEST_NAME_BASE}-empty-host-list" python - <<'__PYTHON__'
+from cylc.scheduler_cli import HostAppointer
+assert HostAppointer().appoint_host() == 'localhost'
+__PYTHON__
 exit

--- a/tests/cylc.scheduler_cli/test_header
+++ b/tests/cylc.scheduler_cli/test_header
@@ -1,0 +1,1 @@
+../lib/bash/test_header

--- a/tests/remote/01-unittests.t
+++ b/tests/remote/01-unittests.t
@@ -1,8 +1,7 @@
-#!/usr/bin/env python2
-
+#!/bin/bash
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
-#
+# Copyright (C) 2008-2018 NIWA
+# 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
@@ -15,11 +14,11 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Run unit tests to test HostAppointer class for selecting hosts.
+. "$(dirname "$0")/test_header"
+#-------------------------------------------------------------------------------
+set_test_number 1
 
-"""CLI of "cylc restart". See cylc.scheduler_cli for detail."""
-
-from cylc.scheduler_cli import main
-
-
-if __name__ == '__main__':
-    main(is_restart=True)
+run_ok "${TEST_NAME_BASE}" python -m 'cylc.remote'
+exit

--- a/tests/remote/01-unittests.t
+++ b/tests/remote/01-unittests.t
@@ -20,5 +20,5 @@
 #-------------------------------------------------------------------------------
 set_test_number 1
 
-run_ok "${TEST_NAME_BASE}" python -m 'cylc.remote'
+run_ok "${TEST_NAME_BASE}" python -m 'cylc.scheduler_cli'
 exit


### PR DESCRIPTION
Close #2323 & partially address #1885 & #988. To cover the **first three major points** in the host-selection master plan outlined by @matthewrmshin, copied verbatim into the following checklist:

1. Using `rose.host_select` as reference, develop new logic in cylc to select
   the best suite host:
   - [x] New `cylc` sub-command to get host metrics in a data structure, e.g.:
     - load (uptime)
     - memory (free)
     - df (disk usage)
   - [x] Logic to interpret returned data structure from each host.
   - [x] Logic to discard bad hosts and rank remaining hosts.
2. New settings in `global.rc`:
   - [x] Hosts (+ ranking method + thresholds) and port range for launching suites.
   - [x] Hosts and port range to scan for running suites.
   - [x] ~~(May~~ replace existing `[suite host scanning]`, `[communication]base port`
     and `[communication]maximum number of ports` settings.~~)~~
3. - [x] Modify start up logic of `cylc run` and `cylc restart` to make use of the
   new settings and host select logic where appropriate.
4. - [Later PR] Scheduler main loop to reload `global.rc` at regular intervals. Check if
   current suite host is still a good host for running suites. Shutdown and
   restart itself if required.
5. - [Later PR] Document new behaviour in CUG.
6. - [(n/a)] Remove suite host select logic from Rose.

Whilst this essentially a migration of Rose functionality, the host selection logic was rewritten from ``rose host-select`` in order to be as lightweight / pared down as possible, e.g. by utilising existing cylc methods for remote host management & ssh.

**First round of feedback addressed. Ready for re-review.**