### PR TITLE
Auto-generate number of sub-tests in 'cli/01-help.t'

### DIFF
--- a/tests/cli/01-help.t
+++ b/tests/cli/01-help.t
@@ -18,7 +18,8 @@
 # cylc help and basic invocation.
 
 . "$(dirname "$0")/test_header"
-set_test_number 136
+# Number of tests depends on the number of 'cylc' commands.
+set_test_number $(( 45 + $(cd "${CYLC_DIR}/bin" && ls 'cylc-'* | wc -l) ))
 
 # Top help
 run_ok "${TEST_NAME_BASE}-0" cylc


### PR DESCRIPTION
After #2690, the number of sub-tests run for `cli/01-help.t` depends on the number of cylc 'library' commands, so whenever a command is added or removed, this test will throw an exit status of 1 & needs to be edited (as I discovered in creating a new command in a separate PR). For orthogonality, we can determine this number on the fly.