### PR TITLE
restart: fix loading poll_timers

### DIFF
--- a/lib/cylc/suite_db_mgr.py
+++ b/lib/cylc/suite_db_mgr.py
@@ -334,7 +334,7 @@ class SuiteDatabaseManager(object):
                 self.db_inserts_map[self.TABLE_TASK_ACTION_TIMERS].append({
                     "name": itask.tdef.name,
                     "cycle": str(itask.point),
-                    "ctx_key": "poll_timer",
+                    "ctx_key": json.dumps("poll_timer"),
                     "ctx": self._namedtuple2json(itask.poll_timer.ctx),
                     "delays": json.dumps(itask.poll_timer.delays),
                     "num": itask.poll_timer.num,


### PR DESCRIPTION
Fix #2702. (Note: restarting a 7.7.0 suite will still trigger #2702, because this is an attempt to fix the problem at the source. Restarting a <7.6.0 suite should be OK because it should still be using the old pickle and multiple poll timers system.)