### PR TITLE
gui: fix treeview traceback

### DIFF
--- a/lib/cylc/gui/updater_tree.py
+++ b/lib/cylc/gui/updater_tree.py
@@ -398,7 +398,7 @@ class TreeUpdater(threading.Thread):
                 try:
                     p_data = new_fam_data[point_string]["root"]
                 except KeyError:
-                    p_data = [None] * 11
+                    p_data = [None] * 10 + [-1]
                 p_path = (i,)
                 p_row_id = (point_string, point_string)
                 p_data = list(p_row_id) + p_data


### PR DESCRIPTION
Unable to reproduce reported traceback, however, this should prevent it from recurring. The `TreeStore` does not accept `None` as a value for integer fields (but does for string and `gtk.gdk.Pixbuf`).