### PR TITLE
Fix cylc message compat with <=7.6.X

### DIFF
--- a/lib/cylc/network/httpserver.py
+++ b/lib/cylc/network/httpserver.py
@@ -51,8 +51,6 @@ class HTTPServer(object):
 
     API = 2
     LOG_CONNECT_DENIED_TMPL = "[client-connect] DENIED %s@%s:%s %s"
-    RE_MESSAGE_TIME = re.compile(
-        r'\A(.+) at (' + RE_DATE_TIME_FORMAT_EXTENDED + r')\Z', re.DOTALL)
 
     def __init__(self, suite):
         # Suite only needed for back-compat with old clients (see below):
@@ -204,6 +202,8 @@ class SuiteRuntimeService(object):
     LOG_IDENTIFY_TMPL = '[client-identify] %d id requests in PT%dS'
     LOG_FORGET_TMPL = '[client-forget] %s'
     LOG_CONNECT_ALLOWED_TMPL = "[client-connect] %s@%s:%s privilege='%s' %s"
+    RE_MESSAGE_TIME = re.compile(
+        r'\A(.+) at (' + RE_DATE_TIME_FORMAT_EXTENDED + r')\Z', re.DOTALL)
 
     def __init__(self, schd):
         self.schd = schd


### PR DESCRIPTION
Regular expression constant at wrong class! This occurs only if a <=7.6.X job messages a 7.7.1 suite.