### PR TITLE
Fix parameterized chunking task examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ cylc.  If not, see [GNU licenses](http://www.gnu.org/licenses/).
  *  Kevin Pulo
  *  Lois Hugget
  *  Martin Dix
+ *  Ivor Blockley
  
 ## Acknowledgement For Non-Cylc Work:
 Licences for non-cylc work included in this distribution can be found in the

--- a/etc/examples/parameters/chunking1/suite.rc
+++ b/etc/examples/parameters/chunking1/suite.rc
@@ -20,11 +20,11 @@ sim<r,n,c-1> => sim<r,n,c>  # inter-chunk dependence
 [runtime]
     [[root]]
         script = """
-[[ -n ${r:-} ]] && echo "run.....$r"
-[[ -n ${n:-} ]] && echo "member..$n"
-if [[ -n ${c:-} ]]; then
-    echo "chunk...$c"
-    OFFSET=P$((c*{{MODEL_CHUNK_MONTHS}}))M
+[[ -n ${CYLC_TASK_PARAM_r:-} ]] && echo "run.....$CYLC_TASK_PARAM_r"
+[[ -n ${CYLC_TASK_PARAM_n:-} ]] && echo "member..$CYLC_TASK_PARAM_n"
+if [[ -n ${CYLC_TASK_PARAM_c:-} ]]; then
+    echo "chunk...$CYLC_TASK_PARAM_c"
+    OFFSET=P$((CYLC_TASK_PARAM_c*{{MODEL_CHUNK_MONTHS}}))M
     echo "model start date: \
         $(cylc cyclepoint --offset=$OFFSET {{MODEL_START_DATE}})"
 fi

--- a/etc/examples/parameters/chunking2/suite.rc
+++ b/etc/examples/parameters/chunking2/suite.rc
@@ -22,11 +22,11 @@ prep => init<r> => start<r,n> => sim<r,n,c=0>
 [runtime]
     [[root]]
         script = """
-[[ -n ${r:-} ]] && echo "run.....$r"
-[[ -n ${n:-} ]] && echo "member..$n"
-if [[ -n ${c:-} ]]; then
-    echo "chunk...$c"
-    OFFSET=P$((c*{{MODEL_CHUNK_MONTHS}}))M
+[[ -n ${CYLC_TASK_PARAM_r:-} ]] && echo "run.....$CYLC_TASK_PARAM_r"
+[[ -n ${CYLC_TASK_PARAM_n:-} ]] && echo "member..$CYLC_TASK_PARAM_n"
+if [[ -n ${CYLC_TASK_PARAM_c:-} ]]; then
+    echo "chunk...$CYLC_TASK_PARAM_c"
+    OFFSET=P$((CYLC_TASK_PARAM_c*{{MODEL_CHUNK_MONTHS}}))M
     echo "model start date: \
         $(cylc cyclepoint --offset=$OFFSET {{MODEL_START_DATE}})"
 fi


### PR DESCRIPTION
Added the CYLC_TASK_PARAM prefix to environment variable names referenced by runtime scripts in the etc/examples/parameters/chunking*/suite.rc examples