### PR TITLE
improve poll logging

### DIFF
--- a/lib/cylc/batch_sys_manager.py
+++ b/lib/cylc/batch_sys_manager.py
@@ -103,6 +103,7 @@ batch_sys.SUBMIT_CMD_TMPL
 """
 
 import os
+import json
 import shlex
 from shutil import rmtree
 from signal import SIGKILL
@@ -110,6 +111,7 @@ import stat
 from subprocess import Popen, PIPE
 import sys
 import traceback
+
 from cylc.mkdir_p import mkdir_p
 from cylc.task_message import (
     CYLC_JOB_PID, CYLC_JOB_INIT_TIME, CYLC_JOB_EXIT_TIME, CYLC_JOB_EXIT,
@@ -119,23 +121,30 @@ from cylc.task_job_logs import (
     JOB_LOG_JOB, JOB_LOG_OUT, JOB_LOG_ERR, JOB_LOG_STATUS)
 from cylc.wallclock import get_current_time_string
 
+from parsec.OrderedDict import OrderedDict
+
 
 class JobPollContext(object):
-    """Context object for a job poll.
+    """Context object for a job poll."""
+    CONTEXT_ATTRIBUTES = (
+        'job_log_dir',  # cycle/task/submit_num
+        'batch_sys_name',  # batch system name
+        'batch_sys_job_id',  # job id in batch system
+        'batch_sys_exit_polled',  # 0 for false, 1 for true
+        'run_status',  # 0 for success, 1 for failure
+        'run_signal',  # signal recieved on run failure
+        'time_submit_exit',  # submit (exit) time
+        'time_run',  # run start time
+        'time_run_exit',  # run exit time
+        'batch_sys_call_no_lines',  # number of lines in batch sys call stdout
+    )
 
-    0 ctx.job_log_dir -- cycle/task/submit_num
-    1 ctx.batch_sys_name -- batch system name
-    2 ctx.batch_sys_job_id -- job ID in batch system
-    3 ctx.batch_sys_exit_polled -- 0 for false, 1 for true
-    4 ctx.run_status -- 0 for success, 1 for failure
-    5 ctx.run_signal -- signal received on run failure
-    6 ctx.time_submit_exit -- submit (exit) time
-    7 ctx.time_run -- run start time
-    8 ctx.time_run_exit -- run exit time
+    __slots__ = CONTEXT_ATTRIBUTES + (
+        'pid',
+        'messages'
+    )
 
-    """
-
-    def __init__(self, job_log_dir):
+    def __init__(self, job_log_dir, **attrs):
         self.job_log_dir = job_log_dir
         self.batch_sys_name = None
         self.batch_sys_job_id = None
@@ -146,26 +155,25 @@ class JobPollContext(object):
         self.time_submit_exit = None
         self.time_run = None
         self.time_run_exit = None
+        self.batch_sys_call_no_lines = None
         self.messages = []
+
+        if attrs:
+            for key, value in attrs.items():
+                if key in self.CONTEXT_ATTRIBUTES:
+                    setattr(self, key, value)
+                else:
+                    raise ValueError('Invalid kwarg "%s"' % key)
 
     def get_summary_str(self):
         """Return the poll context as a summary string delimited by "|"."""
-        items = []
-        for item in [
-                self.job_log_dir,
-                self.batch_sys_name,
-                self.batch_sys_job_id,
-                self.batch_sys_exit_polled,
-                self.run_status,
-                self.run_signal,
-                self.time_submit_exit,
-                self.time_run,
-                self.time_run_exit]:
-            if item is None:
-                items.append("")
-            else:
-                items.append(str(item))
-        return "|".join(items)
+        ret = OrderedDict()
+        for key in self.CONTEXT_ATTRIBUTES:
+            value = getattr(self, key)
+            if key == 'job_log_dir' or value is None:
+                continue
+            ret[key] = value
+        return '%s|%s' % (self.job_log_dir, json.dumps(ret))
 
 
 class BatchSysManager(object):
@@ -522,6 +530,7 @@ class BatchSysManager(object):
             exp_pids = [ctx.pid for ctx in my_ctx_list if ctx.pid is not None]
             bad_pids.extend(exp_pids)
             items.append([self._get_sys("background"), exp_pids, bad_pids])
+        debug_messages = []
         for batch_sys, exp_ids, bad_ids in items:
             if hasattr(batch_sys, "get_poll_many_cmd"):
                 # Some poll commands may not be as simple
@@ -541,6 +550,7 @@ class BatchSysManager(object):
                 return
             ret_code = proc.wait()
             out, err = proc.communicate()
+            debug_messages.append('%s - %s' % (batch_sys, len(out.split('\n'))))
             sys.stderr.write(err)
             if (ret_code and hasattr(batch_sys, "POLL_CANT_CONNECT_ERR") and
                     batch_sys.POLL_CANT_CONNECT_ERR in err):
@@ -569,14 +579,16 @@ class BatchSysManager(object):
                         except ValueError:
                             pass
 
+        debug_flag = False
         for ctx in my_ctx_list:
-            ctx.batch_sys_exit_polled = int(
-                ctx.batch_sys_job_id in bad_job_ids)
+            ctx.batch_sys_exit_polled = int(ctx.batch_sys_job_id in bad_job_ids)
             # Exited batch system, but process still running
             # This can happen to jobs in some "at" implementation
-            if (ctx.batch_sys_exit_polled and
-                    ctx.pid in exp_pids and ctx.pid not in bad_pids):
-                ctx.batch_sys_exit_polled = 0
+            if ctx.batch_sys_exit_polled and ctx.pid in exp_pids:
+                if ctx.pid not in bad_pids:
+                    ctx.batch_sys_exit_polled = 0
+                else:
+                    debug_flag = True
             # Add information to "job.status"
             if ctx.batch_sys_exit_polled:
                 try:
@@ -588,6 +600,9 @@ class BatchSysManager(object):
                     handle.close()
                 except IOError as exc:
                     sys.stderr.write(str(exc) + "\n")
+
+        if debug_flag:
+            ctx.batch_sys_call_no_lines = ', '.join(debug_messages)
 
     def _job_submit_impl(
             self, job_file_path, batch_sys_name, submit_opts):

--- a/lib/cylc/batch_sys_manager.py
+++ b/lib/cylc/batch_sys_manager.py
@@ -550,7 +550,8 @@ class BatchSysManager(object):
                 return
             ret_code = proc.wait()
             out, err = proc.communicate()
-            debug_messages.append('%s - %s' % (batch_sys, len(out.split('\n'))))
+            debug_messages.append('%s - %s' % (
+                batch_sys, len(out.split('\n'))))
             sys.stderr.write(err)
             if (ret_code and hasattr(batch_sys, "POLL_CANT_CONNECT_ERR") and
                     batch_sys.POLL_CANT_CONNECT_ERR in err):
@@ -581,7 +582,8 @@ class BatchSysManager(object):
 
         debug_flag = False
         for ctx in my_ctx_list:
-            ctx.batch_sys_exit_polled = int(ctx.batch_sys_job_id in bad_job_ids)
+            ctx.batch_sys_exit_polled = int(
+                ctx.batch_sys_job_id in bad_job_ids)
             # Exited batch system, but process still running
             # This can happen to jobs in some "at" implementation
             if ctx.batch_sys_exit_polled and ctx.pid in exp_pids:

--- a/lib/cylc/task_job_mgr.py
+++ b/lib/cylc/task_job_mgr.py
@@ -521,9 +521,9 @@ class TaskJobManager(object):
             # back compat for cylc 7.7.1 and previous
             try:
                 values = line.split('|')
-                values[9]  # force IndexError, splicing does not raise this
-                items = dict(zip(JobPollContext.CONTEXT_ATTRIBUTES,
-                                 values[4:10]))
+                items = dict(  # done this way to ensure IndexError is raised
+                    (key, values[x]) for
+                    x, key in enumerate(JobPollContext.CONTEXT_ATTRIBUTES))
                 job_log_dir = items.pop('job_log_dir')
             except (ValueError, IndexError):
                 itask.summary['latest_message'] = 'poll failed'

--- a/lib/cylc/task_job_mgr.py
+++ b/lib/cylc/task_job_mgr.py
@@ -26,6 +26,7 @@ This module provides logic to:
 * Prepare task jobs poll/kill, and manage the callbacks.
 """
 
+import json
 from logging import DEBUG, CRITICAL, INFO, WARNING
 import os
 from shutil import rmtree
@@ -34,7 +35,7 @@ import traceback
 
 from parsec.util import pdeepcopy, poverride
 
-from cylc.batch_sys_manager import BatchSysManager
+from cylc.batch_sys_manager import BatchSysManager, JobPollContext
 from cylc.cfgspec.glbl_cfg import glbl_cfg
 from cylc.envvar import expandvars
 import cylc.flags
@@ -512,60 +513,71 @@ class TaskJobManager(object):
         ctx.out = line
         ctx.ret_code = 0
 
-        items = line.split("|")
         # See cylc.batch_sys_manager.JobPollContext
         try:
-            (
-                batch_sys_exit_polled, run_status, run_signal,
-                time_submit_exit, time_run, time_run_exit
-            ) = items[4:10]
-        except IndexError:
-            itask.summary['latest_message'] = 'poll failed'
-            cylc.flags.iflag = True
-            ctx.cmd = cmd_ctx.cmd  # print original command on failure
-            return
+            job_log_dir, context = line.split('|')[1:4]
+            items = json.loads(context)
+        except ValueError:
+            # back compat for cylc 7.7.1 and previous
+            try:
+                values = line.split('|')
+                values[9]  # force IndexError, splicing does not raise this
+                items = dict(zip(JobPollContext.CONTEXT_ATTRIBUTES,
+                                 values[4:10]))
+                job_log_dir = items.pop('job_log_dir')
+            except (ValueError, IndexError):
+                itask.summary['latest_message'] = 'poll failed'
+                cylc.flags.iflag = True
+                ctx.cmd = cmd_ctx.cmd  # print original command on failure
+                return
         finally:
             log_task_job_activity(ctx, suite, itask.point, itask.tdef.name)
+
+        jp_ctx = JobPollContext(job_log_dir, **items)
+
         flag = self.task_events_mgr.POLLED_FLAG
-        if run_status == "1" and run_signal in ["ERR", "EXIT"]:
+        if jp_ctx.run_status == 1 and jp_ctx.run_signal in ["ERR", "EXIT"]:
             # Failed normally
             self.task_events_mgr.process_message(
-                itask, INFO, TASK_OUTPUT_FAILED, time_run_exit, flag)
-        elif run_status == "1" and batch_sys_exit_polled == "1":
+                itask, INFO, TASK_OUTPUT_FAILED, jp_ctx.time_run_exit, flag)
+        elif jp_ctx.run_status == 1 and jp_ctx.batch_sys_exit_polled == 1:
             # Failed by a signal, and no longer in batch system
             self.task_events_mgr.process_message(
-                itask, INFO, TASK_OUTPUT_FAILED, time_run_exit, flag)
+                itask, INFO, TASK_OUTPUT_FAILED, jp_ctx.time_run_exit, flag)
             self.task_events_mgr.process_message(
-                itask, INFO, FAIL_MESSAGE_PREFIX + run_signal, time_run_exit,
+                itask, INFO, FAIL_MESSAGE_PREFIX + jp_ctx.run_signal,
+                jp_ctx.time_run_exit,
                 flag)
-        elif run_status == "1":
+        elif jp_ctx.run_status == 1:
             # The job has terminated, but is still managed by batch system.
             # Some batch system may restart a job in this state, so don't
             # mark as failed yet.
             self.task_events_mgr.process_message(
-                itask, INFO, TASK_OUTPUT_STARTED, time_run, flag)
-        elif run_status == "0":
+                itask, INFO, TASK_OUTPUT_STARTED, jp_ctx.time_run, flag)
+        elif jp_ctx.run_status == 0:
             # The job succeeded
             self.task_events_mgr.process_message(
-                itask, INFO, TASK_OUTPUT_SUCCEEDED, time_run_exit, flag)
-        elif time_run and batch_sys_exit_polled == "1":
+                itask, INFO, TASK_OUTPUT_SUCCEEDED, jp_ctx.time_run_exit,
+                flag)
+        elif jp_ctx.time_run and jp_ctx.batch_sys_exit_polled == 1:
             # The job has terminated without executing the error trap
             self.task_events_mgr.process_message(
                 itask, INFO, TASK_OUTPUT_FAILED, get_current_time_string(),
                 flag)
-        elif time_run:
+        elif jp_ctx.time_run:
             # The job has started, and is still managed by batch system
             self.task_events_mgr.process_message(
-                itask, INFO, TASK_OUTPUT_STARTED, time_run, flag)
-        elif batch_sys_exit_polled == "1":
+                itask, INFO, TASK_OUTPUT_STARTED, jp_ctx.time_run, flag)
+        elif jp_ctx.batch_sys_exit_polled == 1:
             # The job never ran, and no longer in batch system
             self.task_events_mgr.process_message(
                 itask, INFO, self.task_events_mgr.EVENT_SUBMIT_FAILED,
-                time_submit_exit, flag)
+                jp_ctx.time_submit_exit, flag)
         else:
             # The job never ran, and is in batch system
             self.task_events_mgr.process_message(
-                itask, INFO, TASK_STATUS_SUBMITTED, time_submit_exit, flag)
+                itask, INFO, TASK_STATUS_SUBMITTED, jp_ctx.time_submit_exit,
+                flag)
 
     def _poll_task_job_message_callback(self, suite, itask, cmd_ctx, line):
         """Helper for _poll_task_jobs_callback, on message of one task job."""

--- a/tests/job-submission/05-activity-log.t
+++ b/tests/job-submission/05-activity-log.t
@@ -27,15 +27,14 @@ suite_run_ok "${TEST_NAME_BASE}-run" \
     cylc run --debug --no-detach --reference-test "${SUITE_NAME}"
 
 T1_ACTIVITY_LOG="${SUITE_RUN_DIR}/log/job/1/t1/NN/job-activity.log"
-
 grep_ok '\[jobs-submit ret_code\] 0' "${T1_ACTIVITY_LOG}"
 grep_ok '\[jobs-kill ret_code\] 1' "${T1_ACTIVITY_LOG}"
-grep_ok '\[jobs-kill out\] [^|]*\|1/t1/01\|1' "${T1_ACTIVITY_LOG}"
-grep_ok '\[jobs-poll out\] [^|]*\|1/t1/01\|background\|[^|]*\|1\|\|\|\|[^|]*\|' \
-    "${T1_ACTIVITY_LOG}"
-grep_ok \
-    "\\[(('event-handler-00', 'failed'), 1) out\\] failed ${SUITE_NAME} t1\\.1 job failed" \
-    "${T1_ACTIVITY_LOG}"
+grep_ok '\[jobs-kill out\] [^|]*|1/t1/01|1' "${T1_ACTIVITY_LOG}"
+grep_ok '\[jobs-poll out\] [^|]*\|1/t1/01\|{"batch_sys_name": "background", \
+"batch_sys_job_id": "\[^|\]*", "batch_sys_exit_polled": 1, "time_submit_exit": \
+"\[^\"\]+", "time_run": "\[^\"\]+"}' "${T1_ACTIVITY_LOG}"
+grep_ok "\\[(('event-handler-00', 'failed'), 1) out\\] failed ${SUITE_NAME} \
+t1\\.1 job failed" "${T1_ACTIVITY_LOG}"
 #-------------------------------------------------------------------------------
 purge_suite "${SUITE_NAME}"
 exit

--- a/tests/job-submission/05-activity-log.t
+++ b/tests/job-submission/05-activity-log.t
@@ -30,11 +30,10 @@ T1_ACTIVITY_LOG="${SUITE_RUN_DIR}/log/job/1/t1/NN/job-activity.log"
 grep_ok '\[jobs-submit ret_code\] 0' "${T1_ACTIVITY_LOG}"
 grep_ok '\[jobs-kill ret_code\] 1' "${T1_ACTIVITY_LOG}"
 grep_ok '\[jobs-kill out\] [^|]*|1/t1/01|1' "${T1_ACTIVITY_LOG}"
-grep_ok '\[jobs-poll out\] [^|]*\|1/t1/01\|{"batch_sys_name": "background", \
-"batch_sys_job_id": "\[^|\]*", "batch_sys_exit_polled": 1, "time_submit_exit": \
-"\[^\"\]+", "time_run": "\[^\"\]+"}' "${T1_ACTIVITY_LOG}"
+grep_ok '\[jobs-poll out\] [^|]*|1/t1/01|{"batch_sys_name": "background", "batch_sys_job_id": "[^\"]*", "batch_sys_exit_polled": 1, "time_submit_exit": "[^\"]*", "time_run": "[^\"]*"}' "${T1_ACTIVITY_LOG}"
 grep_ok "\\[(('event-handler-00', 'failed'), 1) out\\] failed ${SUITE_NAME} \
 t1\\.1 job failed" "${T1_ACTIVITY_LOG}"
+cat "${T1_ACTIVITY_LOG}" >&2
 #-------------------------------------------------------------------------------
 purge_suite "${SUITE_NAME}"
 exit


### PR DESCRIPTION
* Improve the readability of poll messages in the job activity log.
* Add a new metric `batch_sys_call_no_lines` which provides the number of lines of stdout output received from the batch system call (e.g. `qstat` for `pbs`) for help with debugging polling issues.