### PR TITLE
Fix remote always in UTC

### DIFF
--- a/lib/cylc/remote.py
+++ b/lib/cylc/remote.py
@@ -231,7 +231,7 @@ class RemoteRunner(object):
 
         # Pass cylc version through.
         command += ['env', quote(r'CYLC_VERSION=%s' % CYLC_VERSION)]
-        if 'CYLC_UTC' in os.environ:
+        if os.getenv('CYLC_UTC') in ["True", "true"]:
             command.append(quote(r'CYLC_UTC=True'))
             command.append(quote(r'TZ=UTC'))
 

--- a/tests/job-submission/17-remote-localtime.t
+++ b/tests/job-submission/17-remote-localtime.t
@@ -1,0 +1,35 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test remote host job log NN link correctness.
+CYLC_TEST_IS_GENERIC=false
+. "$(dirname "$0")/test_header"
+
+set_test_remote_host
+set_test_number 2
+
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+suite_run_ok "${TEST_NAME_BASE}-run" \
+    cylc run --debug --no-detach --reference-test "${SUITE_NAME}"
+
+if [[ "${CYLC_TEST_HOST}" != 'localhost' ]]; then
+    purge_suite_remote "${CYLC_TEST_HOST}" "${SUITE_NAME}"
+fi
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/job-submission/17-remote-localtime.t
+++ b/tests/job-submission/17-remote-localtime.t
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test remote host job log NN link correctness.
+# Test that suite does not set remote job TZ when in local time.
 CYLC_TEST_IS_GENERIC=false
 . "$(dirname "$0")/test_header"
 

--- a/tests/job-submission/17-remote-localtime/reference.log
+++ b/tests/job-submission/17-remote-localtime/reference.log
@@ -1,0 +1,3 @@
+2014-08-14T20:15:16Z INFO - Initial point: 1
+2014-08-14T20:15:16Z INFO - Final point: 1
+2014-08-14T20:15:16Z INFO - [t1.1] -triggered off []

--- a/tests/job-submission/17-remote-localtime/suite.rc
+++ b/tests/job-submission/17-remote-localtime/suite.rc
@@ -1,0 +1,17 @@
+#!jinja2
+[cylc]
+    UTC mode = False
+    [[reference test]]
+        live mode suite timeout = PT10M
+
+[scheduling]
+    [[dependencies]]
+        graph=t1
+
+[runtime]
+    [[t1]]
+        script=test -z "${TZ:-}"
+        [[[job]]]
+            execution time limit = PT1M
+        [[[remote]]]
+            host={{environ["CYLC_TEST_HOST"]}}


### PR DESCRIPTION
This fixes remote commands running in UTC mode when UTC mode is `False` or not set.