### PR TITLE
fix exclusions get_nearest_prev_point traceback

### DIFF
--- a/lib/cylc/cycling/__init__.py
+++ b/lib/cylc/cycling/__init__.py
@@ -433,12 +433,11 @@ class ExclusionBase(object):
         pass
 
     def __contains__(self, point):
-        """Checks to see if the Exclusions object contains a point
-        in any of the exclusion sequences.
+        """Return True if the provided point is in this exclusion.
 
         Args:
-            point (str): The time point to check lies in the
-                ISO8601Sequence object.
+            point (PointBase): The cycle point to check.
+
         """
         if point in self.exclusion_points:
             return True

--- a/tests/cyclers/exclusions/graph.plain.ref
+++ b/tests/cyclers/exclusions/graph.plain.ref
@@ -11,6 +11,7 @@ node "nip.20000101T1800Z" "nip\n20000101T1800Z" unfilled ellipse black
 node "nip.20000102T0000Z" "nip\n20000102T0000Z" unfilled ellipse black
 node "nip.20000102T0600Z" "nip\n20000102T0600Z" unfilled ellipse black
 node "nip.20000102T1200Z" "nip\n20000102T1200Z" unfilled ellipse black
+node "pub.20000102T1200Z" "pub\n20000102T1200Z" unfilled ellipse black
 node "quux.20000101T0000Z" "quux\n20000101T0000Z" unfilled ellipse black
 node "quux.20000101T1000Z" "quux\n20000101T1000Z" unfilled ellipse black
 node "quux.20000101T1500Z" "quux\n20000101T1500Z" unfilled ellipse black

--- a/tests/cyclers/exclusions/reference.log
+++ b/tests/cyclers/exclusions/reference.log
@@ -19,6 +19,7 @@
 2017-04-13T11:34:36Z INFO - [quux.20000102T0100Z] -triggered off []
 2017-04-13T11:34:39Z INFO - [nip.20000102T0600Z] -triggered off []
 2017-04-13T11:34:39Z INFO - [quux.20000102T0600Z] -triggered off []
+2017-04-13T11:34:39Z INFO - [pub.20000102T1200Z] -triggered off []
 2017-04-13T11:34:40Z INFO - [qux.20000102T1200Z] -triggered off []
 2017-04-13T11:34:41Z INFO - [nip.20000102T1200Z] -triggered off []
 2017-04-13T11:34:41Z INFO - [quux.20000102T1100Z] -triggered off []

--- a/tests/cyclers/exclusions/suite.rc
+++ b/tests/cyclers/exclusions/suite.rc
@@ -28,6 +28,9 @@
         [[[ PT5H!(20000101T05Z,20000102T05Z) ]]]
             graph = quux
 
+        [[[ R1/$ ]]]
+            graph = pub
+
 [runtime]
     [[root]]
         script = echo success

--- a/tests/cyclers/exclusions_advanced/graph.plain.ref
+++ b/tests/cyclers/exclusions_advanced/graph.plain.ref
@@ -74,6 +74,7 @@ node "nip.20000102T0800Z" "nip\n20000102T0800Z" unfilled ellipse black
 node "nip.20000102T0900Z" "nip\n20000102T0900Z" unfilled ellipse black
 node "nip.20000102T1000Z" "nip\n20000102T1000Z" unfilled ellipse black
 node "nip.20000102T1100Z" "nip\n20000102T1100Z" unfilled ellipse black
+node "pub.20000102T1200Z" "pub\n20000102T1200Z" unfilled ellipse black
 node "quux.20000101T0030Z" "quux\n20000101T0030Z" unfilled ellipse black
 node "quux.20000101T0130Z" "quux\n20000101T0130Z" unfilled ellipse black
 node "quux.20000101T0230Z" "quux\n20000101T0230Z" unfilled ellipse black

--- a/tests/cyclers/exclusions_advanced/reference.log
+++ b/tests/cyclers/exclusions_advanced/reference.log
@@ -175,6 +175,7 @@
 2017-05-22T08:05:56Z INFO - [toot.20000102T1115Z] -triggered off []
 2017-05-22T08:05:56Z INFO - [bob.20000102T1115Z] -triggered off []
 2017-05-22T08:05:56Z INFO - [nip.20000102T1100Z] -triggered off []
+2017-05-22T08:05:56Z INFO - [pub.20000102T1200Z] -triggered off []
 2017-05-22T08:05:56Z INFO - [wibble.20000102T1100Z] -triggered off []
 2017-05-22T08:05:58Z INFO - [quux.20000102T1130Z] -triggered off []
 2017-05-22T08:05:59Z INFO - [qux.20000102T1200Z] -triggered off []

--- a/tests/cyclers/exclusions_advanced/suite.rc
+++ b/tests/cyclers/exclusions_advanced/suite.rc
@@ -4,7 +4,7 @@
     initial cycle point = 20000101T00Z
     final cycle point = 20000102T12Z
     [[dependencies]]
-        [[[ R1 ]]]
+        [[[ R1/^ ]]]
             graph = start => foo
 
         # Don't run at the initial cycle point
@@ -42,6 +42,10 @@
         # Stacked sequences
         [[[ T0230, PT3H!     (T09,    T12  ) , T1945 ]]]
             graph = dibble
+
+        [[[ R1/$ ]]]
+            graph = pub
+
 [runtime]
     [[root]]
         script = echo success


### PR DESCRIPTION
Fixes a curious runtime error caused by a combination of the later two recurrences in the following example:

```ini
[[[ R1 ]]]
    graph = initial => main

[[[ P1M ! $ ]]]
    graph = main => post

[[[ R1/$ ]]]
    graph = post => final
```

Cylc plays nicely with these recurrences individually but when both present in the same suite:

```
Traceback (most recent call last):
...
  File "cylc/lib/cylc/task_state.py", line 444, in _add_prerequisites
    prv = seq.get_nearest_prev_point(point)
  File "cylc/lib/cylc/cycling/iso8601.py", line 497, in get_nearest_prev_point
    recurrence_iso_point in self.exclusions.p_iso_exclusions)
  File "cylc/lib/isodatetime/data.py", line 1298, in __cmp__
    type(other).__name__
TypeError: Invalid comparison type 'str' - should be TimePoint.
```