### PR TITLE
Fix restart-reload release runahead bug

### DIFF
--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -495,7 +495,7 @@ conditions; see `cylc conditions`.
         for key_str, self_attr, option_ignore_attr in [
                 ("initial", "start_point", "ignore_start_point"),
                 ("final", "stop_point", "ignore_stop_point")]:
-            if key != key_str + "_point" or value is None:
+            if key != key_str + "_point" or value is None or value == 'None':
                 continue
             # the suite_params table prescribes a start/stop cycle
             # (else we take whatever the suite.rc file gives us)

--- a/lib/cylc/suite_db_mgr.py
+++ b/lib/cylc/suite_db_mgr.py
@@ -264,6 +264,12 @@ class SuiteDatabaseManager(object):
         Arguments:
             schd (cylc.scheduler.Scheduler): scheduler object.
         """
+        if schd.final_point is None:
+            # Store None as proper null value in database. No need to do this
+            # for initial cycle point, which should never be None.
+            final_point_str = None
+        else:
+            final_point_str = str(schd.final_point)
         self.db_inserts_map[self.TABLE_SUITE_PARAMS].extend([
             {"key": "uuid_str",
              "value": schd.task_job_mgr.task_remote_mgr.uuid_str},
@@ -271,7 +277,7 @@ class SuiteDatabaseManager(object):
             {"key": "cylc_version", "value": CYLC_VERSION},
             {"key": "UTC_mode", "value": cylc.flags.utc},
             {"key": "initial_point", "value": str(schd.initial_point)},
-            {"key": "final_point", "value": str(schd.final_point)},
+            {"key": "final_point", "value": final_point_str},
         ])
         if schd.config.cfg['cylc']['cycle point format']:
             self.db_inserts_map[self.TABLE_SUITE_PARAMS].append({

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -203,7 +203,7 @@ class TaskPool(object):
                 "holding (beyond suite hold point) %s" % self.hold_point,
                 itask=itask)
             itask.state.set_held()
-        elif (itask.point <= self.stop_point and
+        elif (self.stop_point and itask.point <= self.stop_point and
                 self.task_has_future_trigger_overrun(itask)):
             LOG.info("holding (future trigger beyond stop point)", itask=itask)
             self.held_future_tasks.append(itask.identity)
@@ -314,7 +314,7 @@ class TaskPool(object):
                         )
                     )
             self._prev_runahead_base_point = runahead_base_point
-        if latest_allowed_point > self.stop_point:
+        if self.stop_point and latest_allowed_point > self.stop_point:
             latest_allowed_point = self.stop_point
 
         for point, itask_id_map in self.runahead_pool.copy().items():
@@ -755,7 +755,7 @@ class TaskPool(object):
                 LOG.info('reloaded task definition', itask=itask)
                 if itask.state.status in TASK_STATUSES_ACTIVE:
                     LOG.warning(
-                        "job(%0d2) active with pre-reload settings" %
+                        "job(%02d) active with pre-reload settings" %
                         itask.submit_num,
                         itask=itask)
         LOG.info("Reload completed.")
@@ -822,8 +822,9 @@ class TaskPool(object):
             return False
         can_be_stalled = False
         for itask in self.get_tasks():
-            if itask.point > self.stop_point or itask.state.status in [
-                    TASK_STATUS_SUCCEEDED, TASK_STATUS_EXPIRED]:
+            if (self.stop_point and itask.point > self.stop_point or
+                    itask.state.status in [
+                        TASK_STATUS_SUCCEEDED, TASK_STATUS_EXPIRED]):
                 # Ignore: Task beyond stop point.
                 # Ignore: Succeeded and expired tasks.
                 continue

--- a/tests/restart/32-reload-runahead-no-stop-point.t
+++ b/tests/restart/32-reload-runahead-no-stop-point.t
@@ -1,0 +1,29 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test cylc/cylc#2722
+. "$(dirname "$0")/test_header"
+
+set_test_number 3
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+suite_run_ok "${TEST_NAME_BASE}-run" cylc run --no-detach "${SUITE_NAME}"
+suite_run_ok "${TEST_NAME_BASE}-restart" \
+    cylc restart --no-detach "${SUITE_NAME}"
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/restart/32-reload-runahead-no-stop-point/reference.log
+++ b/tests/restart/32-reload-runahead-no-stop-point/reference.log
@@ -1,0 +1,4 @@
+2017-07-19T14:54:42+01 INFO - Initial point: 2018
+2017-07-19T14:54:43+01 INFO - [t1.2018] -triggered off []
+2017-07-19T14:54:43+01 INFO - [t2.2018] -triggered off ['t1.2018']
+2017-07-19T14:54:43+01 INFO - [t3.2018] -triggered off ['t2.2018']

--- a/tests/restart/32-reload-runahead-no-stop-point/suite.rc
+++ b/tests/restart/32-reload-runahead-no-stop-point/suite.rc
@@ -1,0 +1,21 @@
+[cylc]
+    cycle point format = %Y
+[scheduling]
+    initial cycle point = 2018
+    max active cycle points = 2
+    [[dependencies]]
+        [[[P1Y]]]
+            graph = t1[-P3Y] => t1 => t2 => t3
+[runtime]
+    [[t1]]
+        script = """
+wait
+cylc stop --now "${CYLC_SUITE_NAME}"
+"""
+    [[t2]]
+        script = """
+wait
+cylc reload "${CYLC_SUITE_NAME}"
+"""
+    [[t3]]
+        script = true


### PR DESCRIPTION
For a suite with no final cycle point and tasks in the runahead point
(e.g. due to max active cycle points), a restart followed by a reload
would bring down the suite because the stop point was loaded from the
database as a string 'None' instead of a proper None.
This change should fix it.

Fix #2722.