### PR TITLE
Avoid creating an unnecessary SuiteProcPool and persist the instance of the SuiteLog on the first call

### DIFF
--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -235,7 +235,8 @@ class Scheduler(object):
                 daemonize(self)
 
             # Setup the suite log.
-            SuiteLog.get_inst(self.suite).pimp(detach)
+            self.suite_log = SuiteLog.get_inst(self.suite)
+            self.suite_log.pimp(detach)
             self.proc_pool = SuiteProcPool()
             self.httpserver = HTTPServer(self.suite)
             self.port = self.httpserver.port
@@ -312,8 +313,6 @@ conditions; see `cylc conditions`.
         self.profiler.log_memory("scheduler.py: start configure")
 
         # Start up essential services
-        self.proc_pool = SuiteProcPool()
-        self.suite_log = SuiteLog.get_inst(self.suite)
         self.state_summary_mgr = StateSummaryMgr()
         self.command_queue = Queue()
         self.message_queue = Queue()


### PR DESCRIPTION
I am debugging the code around `scheduler.py` to learn more about how it works, and while doing so, noticed that one instance of `SuiteProcPool` was always created just to be replaced by a new instance. Without ever being used.

`Scheduler()` (i.e. `__init__()`) will create a member variable `self.proc_pool = None`. Later, when  `scheduler_cli.py` calls the `Scheduler.start()` method, it will instantiate it with `self.proc_pool = SuiteProcPool()`.

At this point, `self.proc_pool` has been instantiated, but not used. Then the `start()` method calls the `configure()` method. One of the first things the `configure()` method does, is to replace the existing instance, by calling `self.proc_pool = SuiteProcPoo()` again.

This pull request simply prevents that by leaving only the first instance, without replacing it (but happy to change and use the instance from `configure()` if necessary).

Also found that we call the `SuiteLog.get_inst(self.suite)` method, but without creating a member variable for that. Instead we call this method again in the `configure()` method. So also moved the call to the `start()` method, so that we avoid calling it unnecessarily.

I do not expect any noticeable performance improvement, but thought it was worth submitting a PR for the sake of correctness.

Cheers
Bruno