### PR TITLE
Jinja2 enhancements

### DIFF
--- a/doc/src/cylc-user-guide/cug.tex
+++ b/doc/src/cylc-user-guide/cug.tex
@@ -5357,8 +5357,8 @@ Cylc extends this functionality to allow import of arbitrary Python modules.
 \begin{lstlisting}
 {% from "itertools" import product %}
 [runtime]
-{% for group, memeber in product(['a', 'b'], [0, 1, 2]) %}
-    [[{{group}}_{{memeber}}]]
+{% for group, member in product(['a', 'b'], [0, 1, 2]) %}
+    [[{{group}}_{{member}}]]
 {% endfor %}
 \end{lstlisting}
 

--- a/doc/src/cylc-user-guide/cug.tex
+++ b/doc/src/cylc-user-guide/cug.tex
@@ -2050,8 +2050,8 @@ A cylc {\em suite configuration directory} contains:
         \begin{myitemize}
             \item For custom job submission modules
                 (see~\ref{CustomJobSubmissionMethods})
-                and local Python modules imported by custom Jinja2 filters
-                (see~\ref{CustomJinja2Filters}).
+                and local Python modules imported by custom Jinja2 filters,
+                tests and globals (see~\ref{CustomJinja2Filters}).
         \end{myitemize}
     \item {\bf Any other sub-directories and files} - documentation,
         control files, etc. (optional)
@@ -5049,8 +5049,9 @@ Figure~\ref{fig-jinja2-cities}.
 \subsubsection{Accessing Environment Variables With Jinja2}
 
 This functionality is not provided by Jinja2 by default, but cylc
-automatically imports the user environment to the template in a
-dictionary structure called {\em environ}. A usage example:
+automatically imports the user environment to template's global namespace
+(see~\ref{CustomJinja2Filters}) in a dictionary structure called
+{\em environ}. A usage example:
 \begin{lstlisting}
 #!Jinja2
 #...
@@ -5063,32 +5064,45 @@ This example is emphasizes that {\em the environment is read on the suite
 host at the time the suite configuration is parsed} - it is not, for
 instance, read at task run time on the task host.
 
-\subsubsection{Custom Jinja2 Filters}
+\subsubsection{Custom Jinja2 Filters, Tests and Globals}
 \label{CustomJinja2Filters}
 
-Jinja2 variable values can be modified by ``filters'', using pipe
-notation. For example, the built-in \lstinline=trim= filter strips
-leading and trailing white space from a string:
+Jinja2 has three different namespaces used to separate ``globals'',
+``filters'' and ``tests''. Globals are template-wide accessible variables
+and functions. Cylc extends this namespace with ``environ'' dictionary and
+``raise'' and ``assert'' functions for raising exceptions
+(see~\ref{Jinja2RaisingExceptions}).
+
+Filters can be used to modify variable values and are applied using pipe
+notation. For example, the built-in \lstinline=trim= filter strips leading
+and trailing white space from a string:
 \lstset{language=suiterc}
 \begin{lstlisting}
 {% set MyString = "   dog   " %}
 {{ MyString | trim() }}  # "dog"
 \end{lstlisting}
-(See official Jinja2 documentation for available built-in filters.)
 
-Cylc also supports custom Jinja2 filters. A custom filter is a
-single Python function in a source file with the same name as the
-function (plus ``.py'' extension) and stored in one of the following
+Additionally, variable values can be tested using ``is'' keyword followed by
+the name of the test, e.g.\ \lstinline=VARIABLE is defined=.
+See official Jinja2 documentation for available built-in globals, filters
+and tests.
+
+Cylc also supports custom Jinja2 globals, filters and tests. A custom global,
+filter or test is a single Python function in a source file with the same name
+as the function (plus ``.py'' extension) and stored in one of the following
 locations:
 \begin{myitemize}
-    \item \lstinline=<cylc-dir>/lib/Jinja2Filters/=
-    \item \lstinline=[suite configuration directory]/Jinja2Filters/=
-    \item \lstinline=$HOME/.cylc/Jinja2Filters/=
+    \item \lstinline=<cylc-dir>/lib/Jinja2[namespace]/=
+    \item \lstinline=[suite configuration directory]/Jinja2[namespace]/=
+    \item \lstinline=$HOME/.cylc/Jinja2[namespace]/=
 \end{myitemize}
+where \lstinline=[namespace]/= is one of \lstinline=Globals/=,
+\lstinline=Filters/= or \lstinline=Tests/=.
 
-In the filter function argument list, the first argument is the variable
-value to be ``filtered'', and subsequent arguments can be whatever is
-needed. Currently there are two custom filters:
+In the argument list of filter or test function, the first argument is
+the variable value to be ``filtered'' or ``tested'', respectively, and
+subsequent arguments can be whatever else is needed. Currently there are two
+custom filters:
 
 
 \paragraph{pad}
@@ -5294,6 +5308,7 @@ For detail, see:
 \href{http://jinja.pocoo.org/docs/2.10/templates/#assignments}{Jinja2 Template Designer Documentation > Assignments}
 
 \subsubsection{Raising Exceptions}
+\label{Jinja2RaisingExceptions}
 
 Cylc provides two functions for raising exceptions using Jinja2. These
 exceptions are raised when the suite.rc file is loaded and will prevent a suite
@@ -5322,6 +5337,37 @@ following example is equivalent to the ``raise'' example above.
 \lstset{language=suiterc}
 \begin{lstlisting}
 {{ assert(VARIABLE is defined, 'VARIABLE must be defined for this suite.') }}
+\end{lstlisting}
+
+\subsubsection{Importing additional Python modules}
+
+Jinja2 allows to gather variable and macro definitions in a separate template
+that can be imported into (and thus shared among) other templates.
+
+\lstset{language=suiterc}
+\begin{lstlisting}
+{% import "suite-utils.rc" as utils %}
+{% from "suite-utils.rc" import VARIABLE as ALIAS %}
+{{ utils.VARIABLE is equalto(ALIAS)) }}
+\end{lstlisting}
+
+Cylc extends this functionality to allow import of arbitrary Python modules.
+
+\lstset{language=suiterc}
+\begin{lstlisting}
+{% from "itertools" import product %}
+[runtime]
+{% for group, memeber in product(['a', 'b'], [0, 1, 2]) %}
+    [[{{group}}_{{memeber}}]]
+{% endfor %}
+\end{lstlisting}
+
+For better clarity and disambiguation Python modules can be prefixed with
+``__python__'':
+
+\lstset{language=suiterc}
+\begin{lstlisting}
+{% from "__python__.itertools" import product %}
 \end{lstlisting}
 
 \subsection{Omitting Tasks At Runtime}

--- a/lib/parsec/jinja2support.py
+++ b/lib/parsec/jinja2support.py
@@ -42,8 +42,11 @@ def assert_helper(logical, message):
     return ''  # Prevent None return value polluting output.
 
 
-def jinja2process(flines, dir_, template_vars=None):
-    """Pass configure file through Jinja2 processor."""
+def jinja2environment(dir_=None):
+    """Set up and return Jinja2 environment."""
+    if dir_ is None:
+        dir_ = os.getcwd()
+
     env = Environment(
         loader=FileSystemLoader(dir_),
         undefined=StrictUndefined,
@@ -72,6 +75,13 @@ def jinja2process(flines, dir_, template_vars=None):
     env.globals['environ'] = os.environ
     env.globals['raise'] = raise_helper
     env.globals['assert'] = assert_helper
+    return env
+
+
+def jinja2process(flines, dir_, template_vars=None):
+    """Pass configure file through Jinja2 processor."""
+    # Set up Jinja2 environment.
+    env = jinja2environment(dir_)
 
     # Load file lines into a template, excluding '#!jinja2' so that
     # '#!cylc-x.y.z' rises to the top. Callers should handle jinja2

--- a/lib/parsec/jinja2support.py
+++ b/lib/parsec/jinja2support.py
@@ -47,7 +47,9 @@ class PyModuleLoader(BaseLoader):
         # prefix that can be used to avoid name collisions with template files
         self._python_namespace_prefix = prefix + '.'
 
+    # pylint: disable-msg=redefined-builtin
     def load(self, environment, name, globals=None):
+        """Imports Python module and returns it as Jinja2 template."""
         if name.startswith(self._python_namespace_prefix):
             name = name[len(self._python_namespace_prefix):]
         try:
@@ -58,12 +60,15 @@ class PyModuleLoader(BaseLoader):
             mdict = __import__(name, fromlist=['*']).__dict__
         except ImportError:
             raise TemplateNotFound(name)
+
         # inject module dict into the context of an empty template
         def root_render_func(context, *args, **kwargs):
+            """Template render function."""
             if False:
                 yield None  # to make it a generator
             context.vars.update(mdict)
             context.exported_vars.update(mdict)
+
         templ = environment.from_string('')
         templ.root_render_func = root_render_func
         self._templates[name] = templ

--- a/tests/validate/44-jinja2-template-not-found.t
+++ b/tests/validate/44-jinja2-template-not-found.t
@@ -27,8 +27,12 @@ sed -i 's/^  File ".*/  File "FILE", line NN, in ROUTINE/g' "$TEST_NAME.stderr"
 cmp_ok "$TEST_NAME.stderr" <<'__ERROR__'
 Jinja2Error:
   File "FILE", line NN, in ROUTINE
-    raise TemplateNotFound(template)
 TemplateNotFound: suite-foo.rc
+Context lines:
+    [[dependencies]]
+        graph = foo
+[runtime]
+{% include 'suite-foo.rc' %}	<-- Jinja2Error
 __ERROR__
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME


### PR DESCRIPTION
The future plan is to have proper API for Cylc, but this future is still quite far away. In the meantime, we could have some improvements to make the templating experience better. This PR adds two such improvements:
1) Support for Jinja2Tests and Jinja2Globals to complement the existing Jinja2Filters (thus enabling custom additions to all three namespaces used in Jinja2). This is useful as some Jinja2 functionality is awkward to use without them, e.g., `select`/`reject` filters, which use the `tests` namespace.
2) Support for importing Python modules in the same way as the template modules. This is useful, because the default Jinja2 functionality is fairly bare bones and there are some glaring omissions, like no Python `zip` equivalent, which makes some basic programming tasks quite awkward. Rather than keep adding useful bits of functionality one-by-one, it is left up to the user to decide which packages are of the most use.

TODO:
- [x] CUG documentation (I didn't want to spend time on it before hearing some feedback first)