### PR TITLE
Remote tests tidy

### DIFF
--- a/tests/cylc-cat-log/10-remote-no-retrieve.t
+++ b/tests/cylc-cat-log/10-remote-no-retrieve.t
@@ -45,4 +45,6 @@ TEST_NAME=${TEST_NAME_BASE}-task-out
 run_ok $TEST_NAME cylc cat-log -f o $SUITE_NAME a-task.1
 grep_ok '^the quick brown fox$' ${TEST_NAME}.stdout
 
-purge_suite $SUITE_NAME
+purge_suite_remote "${CYLC_TEST_HOST}" "${SUITE_NAME}"
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/cylc-cat-log/11-remote-retrieve.t
+++ b/tests/cylc-cat-log/11-remote-retrieve.t
@@ -53,4 +53,6 @@ TEST_NAME=${TEST_NAME_BASE}-out-loc
 run_ok $TEST_NAME cylc cat-log -f o $SUITE_NAME a-task.1
 grep_ok '^the quick brown FOX$' ${TEST_NAME}.stdout
 
-purge_suite $SUITE_NAME
+purge_suite_remote "${CYLC_TEST_HOST}" "${SUITE_NAME}"
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/host-select/00-simple.t
+++ b/tests/host-select/00-simple.t
@@ -27,5 +27,6 @@ suite_run_ok "${TEST_NAME_BASE}-run" \
 
 N_HOST_SELECT_CMDS="$(ls "${SUITE_RUN_DIR}/host-select-"* | wc -l)"
 run_ok "${TEST_NAME_BASE}-n-host-select-cmds" test "${N_HOST_SELECT_CMDS}" -eq 1
+purge_suite_remote "${CYLC_TEST_HOST}" "${SUITE_NAME}"
 purge_suite "${SUITE_NAME}"
 exit

--- a/tests/job-kill/04-pbs/suite.rc
+++ b/tests/job-kill/04-pbs/suite.rc
@@ -18,7 +18,7 @@
             batch system=pbs
         [[[directives]]]
             -l walltime=120
-            -l select=1:ncpus=1:mem=10mb
+            -l select=1:ncpus=1:mem=15mb
 {% if "CYLC_TEST_BATCH_SITE_DIRECTIVES" in environ and environ["CYLC_TEST_BATCH_SITE_DIRECTIVES"] %}
             {{environ["CYLC_TEST_BATCH_SITE_DIRECTIVES"]}}
 {% endif %}

--- a/tests/job-submission/05-activity-log.t
+++ b/tests/job-submission/05-activity-log.t
@@ -33,7 +33,6 @@ grep_ok '\[jobs-kill out\] [^|]*|1/t1/01|1' "${T1_ACTIVITY_LOG}"
 grep_ok '\[jobs-poll out\] [^|]*|1/t1/01|{"batch_sys_name": "background", "batch_sys_job_id": "[^\"]*", "batch_sys_exit_polled": 1, "time_submit_exit": "[^\"]*", "time_run": "[^\"]*"}' "${T1_ACTIVITY_LOG}"
 grep_ok "\\[(('event-handler-00', 'failed'), 1) out\\] failed ${SUITE_NAME} \
 t1\\.1 job failed" "${T1_ACTIVITY_LOG}"
-cat "${T1_ACTIVITY_LOG}" >&2
 #-------------------------------------------------------------------------------
 purge_suite "${SUITE_NAME}"
 exit

--- a/tests/remote/00-basic.t
+++ b/tests/remote/00-basic.t
@@ -44,4 +44,6 @@ sqlite3 "${SUITE_RUN_DIR}/log/db" \
     'select user_at_host from task_jobs where name=="bar"' >'bar-host.txt'
 cmp_ok 'bar-host.txt' - <<<"${CYLC_TEST_HOST}"
 #-------------------------------------------------------------------------------
-purge_suite $SUITE_NAME
+purge_suite_remote "${CYLC_TEST_HOST}" "${SUITE_NAME}"
+purge_suite "${SUITE_NAME}"
+exit


### PR DESCRIPTION
Purge remote suite directory.
Fix job-kill 04 PBS out of memory issue.

(1 review probably sufficient, as it is only a tidy up of the tests.)