### PR TITLE
validate: handle task proxy sequence bounds error

### DIFF
--- a/bin/cylc-validate
+++ b/bin/cylc-validate
@@ -35,7 +35,7 @@ from cylc.version import CYLC_VERSION
 from cylc.config import SuiteConfig, SuiteConfigError
 from cylc.prerequisite import TriggerExpressionError
 from cylc.suite_srv_files_mgr import SuiteSrvFilesManager
-from cylc.task_proxy import TaskProxy
+from cylc.task_proxy import TaskProxy, TaskProxySequenceBoundsError
 from cylc.templatevars import load_template_vars
 from cylc.profiler import Profiler
 
@@ -78,6 +78,15 @@ def main():
         cli_initial_point_string=options.icp,
         is_validate=True, strict=options.strict, run_mode=options.run_mode,
         output_fname=options.output, mem_log_func=profiler.log_memory)
+    # Check bounds of sequences
+    for seq in cfg.sequences:
+        if seq.get_first_point(cfg.start_point) is None:
+            mesg = '%s: sequence out of bound for initial cycle point %s' % (
+                seq, cfg.start_point)
+            if options.strict:
+                raise SuiteConfigError(mesg)
+            elif cylc.flags.verbose:
+                sys.stderr.write(' + %s\n' % mesg)
 
     # Instantiate tasks and force evaluation of trigger expressions.
     # (Taken from config.py to avoid circular import problems.)
@@ -87,15 +96,15 @@ def main():
     for name, taskdef in cfg.taskdefs.items():
         try:
             itask = TaskProxy(taskdef, cfg.start_point, is_startup=True)
-        except Exception as exc:
-            print >> sys.stderr, str(exc)
-            raise SuiteConfigError(
-                'ERROR, failed to instantiate task %s' % name)
-        if itask.point is None:
+        except TaskProxySequenceBoundsError:
+            # Should already failed above in strict mode.
+            mesg = 'Task out of bounds for %s: %s\n' % (cfg.start_point, name)
             if cylc.flags.verbose:
-                print >> sys.stderr, (' + Task out of bounds for %s: %s' % (
-                    cfg.start_point, name))
+                sys.stderr.write(' + %s\n' % mesg)
             continue
+        except Exception as exc:
+            raise SuiteConfigError(
+                'ERROR, failed to instantiate task %s: %s' % (name, exc))
 
         # force trigger evaluation now
         try:

--- a/tests/validate/67-task-proxy-sequence-bounds-err.t
+++ b/tests/validate/67-task-proxy-sequence-bounds-err.t
@@ -1,0 +1,47 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test for handling task proxy sequence bounds error. #2735 
+
+. "$(dirname "$0")/test_header"
+set_test_number 5
+
+cat > suite.rc <<__END__
+[cylc]
+    UTC mode = True
+[scheduling]
+    initial cycle point = 2000
+    [[dependencies]]
+        [[[R1//1999]]]
+            graph = t1
+[runtime]
+    [[t1]]
+        script = true
+__END__
+
+run_ok "${TEST_NAME_BASE}" cylc validate 'suite.rc'
+run_ok "${TEST_NAME_BASE}-v" cylc validate -v 'suite.rc'
+contains_ok "${TEST_NAME_BASE}-v.stderr" <<'__ERR__'
+ + R1/P0Y/19990101T0000Z: sequence out of bound for initial cycle point 20000101T0000Z
+ + Task out of bounds for 20000101T0000Z: t1
+__ERR__
+run_fail "${TEST_NAME_BASE}-strict" cylc validate --strict 'suite.rc'
+cmp_ok "${TEST_NAME_BASE}-strict.stderr" <<'__ERR__'
+'R1/P0Y/19990101T0000Z: sequence out of bound for initial cycle point 20000101T0000Z'
+__ERR__
+
+exit


### PR DESCRIPTION
Allow in normal mode (like `cylc run` will do).
Fail in strict mode.
Report in verbose mode.

Fix #2735.