### PR TITLE
travis-ci: chunk cylc test battery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,18 @@
 ---
 language: python
 
+matrix:
+    include:
+    - name: "1"
+      env: CHUNK='1/4'
+    - name: "2"
+      env: CHUNK='2/4'
+    - name: "3"
+      env: CHUNK='3/4'
+    - name: "4"
+      env: CHUNK='4/4'
+
+
 # General environment setup before we start installing stuff
 before_install:
     # Clear bashrc - the default does nothing if not in an interactive shell.
@@ -66,7 +78,7 @@ script:
     # Only run the generic tests on Travis CI.
     - export CYLC_TEST_RUN_PLATFORM=false
     # Run tests with virtual frame buffer for X support.
-    - xvfb-run -a cylc test-battery --state=save -j 5 || (echo -e "\n\nRerunning Failed Tests...\n\n"; cylc test-battery --state=save,failed -j 5)
+    - xvfb-run -a cylc test-battery --chunk $CHUNK --state=save -j 5 || (echo -e "\n\nRerunning Failed Tests...\n\n"; cylc test-battery --state=save,failed -j 5)
 
 # Check output (more useful if you narrow down what tests get run)
 after_script:

--- a/bin/cylc-test-battery
+++ b/bin/cylc-test-battery
@@ -70,7 +70,11 @@ is not otherwise a Cylc software prerequisite):
 | fi
 
 Options:
-  -h, --help   Print this help message and exit.
+  -h, --help       Print this help message and exit.
+  --chunk CHUNK    Divide the test battery into chunks and run the specified
+                   chunk. CHUNK takes the format 'a/b' where 'b' is the number
+                   of chunks to divide the battery into and 'a' is the number
+                   of the chunk to run (1 >= a >= b).
 
 Examples:
 
@@ -85,6 +89,8 @@ Run only "tests/cyclers/16-weekly.t" in verbose mode
 Run only tests under "tests/cyclers/", and skip 00-daily.t
   export CYLC_TEST_SKIP=tests/cyclers/00-daily.t
   cylc test-battery tests/cyclers
+Run the first quarter of the test battery
+  cylc test-battery --chunk '1/4'
 eof
 }
 

--- a/bin/cylc-test-battery
+++ b/bin/cylc-test-battery
@@ -97,17 +97,55 @@ export CYLC_TEST_SKIP=${CYLC_TEST_SKIP:-}
 export CYLC_TEST_IS_GENERIC=true
 export CYLC_TEST_TIME_INIT="$(date -u +'%Y%m%dT%H%M%SZ')"
 
-for ARG in "$@"; do
-    if [[ "$ARG" == '--help' || "$ARG" == '-h' ]]; then
-        usage
-        exit 0
-    fi
-done
-
 if [[ "$PWD" != "$CYLC_DIR" ]]; then
     echo "cd \"$CYLC_DIR\""
     cd "$CYLC_DIR"
 fi
+
+ARGS=()
+OPTS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        --chunk)
+            # argument in the format chunk_no/no_chunks
+            IFS=$'/' read CHUNK_NO CHUNKS <<< "$2"
+            # create lists of tests in a tempdir
+            TMPDIR="$(mktemp -d)"
+            TEST_FILE="$TMPDIR/cylc_tests"
+            prove -r 'tests' --dry > "$TEST_FILE"
+            LINES_PER_FILE=$(( ( $(wc -l "$TEST_FILE" | cut -d ' ' -f 1) \
+                + $CHUNKS - 1 ) / $CHUNKS ))
+            # chunk tests
+            split -d -l "$LINES_PER_FILE" "$TEST_FILE" "$TEST_FILE"
+            # select chunk
+            FILENO="$(printf '%02d' $(( $CHUNK_NO - 1 )) )"
+            ARGS+=($(cat "${TEST_FILE}${FILENO}"))
+            shift
+            shift
+            ;;
+        --exec|--harness|--formatter|--source|--archive|--jobs|\
+        -I|-P|-M|-e|-a|-j)
+            # prove options which take separate arguments
+            OPTS+=("$1" "$2")
+            shift
+            shift
+            ;;
+        -*)
+            # prove single item options
+            OPTS+=("$1")
+            shift
+            ;;
+        *)
+            # prove arguments
+            ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
 
 # Recompile *.pyc files to ensure we are running the current code.
 if [[ -w "$CYLC_DIR/lib" ]]; then
@@ -120,8 +158,8 @@ if perl -e 'use Test::Harness 3.00' 2>/dev/null; then
     if [[ -z "${NPROC}" ]]; then
         NPROC=$(python -c 'import multiprocessing as mp; print mp.cpu_count()')
     fi
-    exec prove -j "$NPROC" -s -r "${@:-tests}"
+    exec prove -j "$NPROC" -s -r ${ARGS[@]:-tests} ${OPTS[@]:-}
 else
-    echo "WARNING: cannot run tests in parallel (Test::Harness < 3.00)" >&2
-    exec prove -s -r "${@:-tests}"
+    echo 'WARNING: cannot run tests in parallel (Test::Harness < 3.00)' >&2
+    exec prove -s -r ${ARGS[@]:-tests} ${OPTS[@]:-}
 fi

--- a/tests/rnd/00-test-battery-chunking.t
+++ b/tests/rnd/00-test-battery-chunking.t
@@ -1,0 +1,40 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test the cylc test-battery --chunk option
+. $(dirname $0)/test_header
+NO_CHUNKS=2
+set_test_number $(( 2 + $NO_CHUNKS ))
+#-------------------------------------------------------------------------------
+# list all tests
+DRY_TEST_NAME="$TEST_NAME_BASE-all"
+run_ok "$DRY_TEST_NAME" cylc test-battery --dry
+# list tests for each chunk (from prove not cylc test-battery)
+temp_file=$(mktemp)
+for chunk_no in $(seq $NO_CHUNKS); do
+    TEST_NAME="$TEST_NAME_BASE-chunk-$chunk_no"
+    run_ok "$TEST_NAME" cylc test-battery --chunk "$chunk_no/$NO_CHUNKS" --dry
+    cat "$TEST_NAME.stdout" >> "$temp_file"
+done
+# sort files (cylc test-battery uses --shuffle)
+sort -o "$DRY_TEST_NAME.stdout" "$DRY_TEST_NAME.stdout"
+sort -o "$temp_file" "$temp_file"
+# remove cd "$CYLC_HOME" lines
+sed -i '/^cd "/d' "$DRY_TEST_NAME.stdout"
+sed -i '/^cd "/d' "$temp_file"
+# compare test plan for the full and chunked versions
+cmp_ok "$DRY_TEST_NAME.stdout" "$temp_file"

--- a/tests/rnd/test_header
+++ b/tests/rnd/test_header
@@ -1,0 +1,1 @@
+../lib/bash/test_header


### PR DESCRIPTION
Deal with our travis-ci time limit woes. Chunk the battery into four parts which run in parallel, these take 10-15 mins to complete so we get faster results. On failure, we only need to re-run the failed chunk(s).

Due to the large amount of installation required for the cylc test battery 10 min jobs seem sensible.