### PR TITLE
Fix dynamic remote host selection command syntax

### DIFF
--- a/doc/src/cylc-user-guide/suiterc.tex
+++ b/doc/src/cylc-user-guide/suiterc.tex
@@ -1550,7 +1550,7 @@ of cylc on the remote machine; if not, the corresponding local settings
         \item dynamic host selection:
         \begin{myitemize}
             \item shell command (1): \lstinline@host = $(host-selector.sh)@
-            \item shell command (2): \lstinline@host = `host-selector.sh)`@
+            \item shell command (2): \lstinline@host = `host-selector.sh`@
             \item environment variable: \lstinline@host = $MY_HOST@
         \end{myitemize}
     \end{myitemize}


### PR DESCRIPTION
Hi, I am writing (or trying to write) a few suites with dynamic host selection, and noticed that the syntax of the example changed in this pull request looked a bit odd. I think it had an extra `)`?

Thanks
Bruno