### PR TITLE
make cylc logo/blurb fit on 80 character terminal

### DIFF
--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -293,8 +293,8 @@ class Scheduler(object):
         )
         cylc_license = """
 The Cylc Suite Engine [%s]
-Copyright (C) 2008-2018 NIWA & British Crown
-(Met Office) & Contributors.
+Copyright (C) 2008-2018 NIWA
+& British Crown (Met Office) & Contributors.
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
 This program comes with ABSOLUTELY NO WARRANTY;
 see `cylc warranty`.  It is free software, you

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -293,7 +293,8 @@ class Scheduler(object):
         )
         cylc_license = """
 The Cylc Suite Engine [%s]
-Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
+Copyright (C) 2008-2018 NIWA & British Crown
+(Met Office) & Contributors.
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
 This program comes with ABSOLUTELY NO WARRANTY;
 see `cylc warranty`.  It is free software, you


### PR DESCRIPTION
Trivial change.

Since the change in copyright notice the cylc logo and blurb no longer fit on an 80 character display.