### PR TITLE
cylc --version backwards compatibility with older git versions

### DIFF
--- a/bin/cylc
+++ b/bin/cylc
@@ -27,8 +27,8 @@ get_version() {
         CYLC_VERSION="$(cat "${CYLC_DIR}/VERSION")"
     # Otherwise, use git (if in a git repo and not a bare clone)
     # to determine version
-    elif git -C "${CYLC_DIR}" rev-parse && \
-            [[ -n "$(git -C "${CYLC_DIR}" rev-parse --show-toplevel)" ]]; then
+    elif git --git-dir "${CYLC_DIR}/.git" rev-parse && \
+            [[ -n "$(git --git-dir "${CYLC_DIR}/.git" rev-parse --show-toplevel)" ]]; then
         CYLC_VERSION="$(cd "${CYLC_DIR}" && git describe --abbrev=4 --always)"
         # Append "-dirty" if there are uncommitted changes.
         if [[ -n "$(cd "${CYLC_DIR}" && git status \

--- a/bin/cylc
+++ b/bin/cylc
@@ -28,7 +28,8 @@ get_version() {
     # Otherwise, use git (if in a git repo and not a bare clone)
     # to determine version
     elif git --git-dir "${CYLC_DIR}/.git" rev-parse && \
-            [[ -n "$(git --git-dir "${CYLC_DIR}/.git" rev-parse --show-toplevel)" ]]; then
+            [[ -n "$(git --git-dir "${CYLC_DIR}/.git" rev-parse \
+                --show-toplevel)" ]]; then
         CYLC_VERSION="$(cd "${CYLC_DIR}" && git describe --abbrev=4 --always)"
         # Append "-dirty" if there are uncommitted changes.
         if [[ -n "$(cd "${CYLC_DIR}" && git status \


### PR DESCRIPTION
Uses the option `git --git-dir` instead of `git -C` to set the directory.

Resolves #2743 