### PR TITLE
Cylc registration fix.

### DIFF
--- a/bin/cylc-register
+++ b/bin/cylc-register
@@ -19,28 +19,35 @@
 """cylc [prep] register [OPTIONS] ARGS
 
 Register the name REG for the suite definition in PATH. The suite server
-program can subsequently be started, stopped, and targeted by name. (Note
-however that "cylc run" can register the target suite on the fly, too).
+program can then be started, stopped, and targeted by name REG. (Note that
+"cylc run" can also register suites on the fly).
 
 Registration creates a suite run directory "~/cylc-run/REG/" with a ".service/"
-sub-directory containing authentication files and source symlink to PATH. Suite
-names can be a '/'-delimited hierarchy, which becomes a path under ~/cylc-run/.
+sub-directory containing authentication files and a "source" symlink to PATH.
 
-REG defaults to "$(basename $PWD)" and PATH defaults to "$PWD", but if you give
-only a single argument it must be the name, not the path.
+Suite names can be hierarchical, corresponding to the path under ~/cylc-run.
 
-% cylc reg foo PATH
-register suite in PATH as foo
+  % cylc register dogs/fido PATH
+Register PATH/suite.rc as dogs/fido, with run directory ~/cylc-run/dogs/fido.
 
-% cylc reg foo
-register suite in $PWD as foo
+  % cylc register dogs/fido
+Register $PWD/suite.rc as dogs/fido.
 
-% cylc reg
-register suite in $PWD as the name of its parent directory: $(basename $PWD).
+  % cylc register
+Register $PWD/suite.rc as the parent directory name: $(basename $PWD).
 
-The same suite can be registered under multiple names (with corresponding
-different run directories) but the same name cannot be used for different
-suites; the command will abort if REG is already used by a different suite."""
+The same suite can be registered with multiple names; this results in multiple
+suite run directories that link to the same suite definition.
+
+To "unregister" a suite, delete or rename its run directory (renaming it under
+~/cylc-run effectively re-registers the original suite with the new name).
+
+Use of "--redirect" is required to allow an existing name (and run directory)
+to be associated with a different suite definition. This is potentially
+dangerous because the new suite will overwrite files in the existing run
+directory. You should consider deleting or renaming an existing run directory
+rather than just re-use it with another suite."""
+
 
 import sys
 from cylc.remote import remrun
@@ -57,7 +64,13 @@ def main():
         __doc__,
         argdoc=[("[REG]", "Suite name"),
                 ("[PATH]", "Suite definition directory (defaults to $PWD)")])
-    args = parser.parse_args()[1]
+
+    parser.add_option(
+        "--redirect", help="Allow an existing suite name and run directory "
+                           "to be used with another suite.",
+        action="store_true", default=False, dest="redirect")
+
+    opts, args = parser.parse_args()
     if len(args) == 2:
         reg, src = args
     elif len(args) == 1:
@@ -65,7 +78,8 @@ def main():
         src = None
     else:
         reg = src = None
-    SuiteSrvFilesManager().register(reg, src)
+    SuiteSrvFilesManager().register(reg, src, redirect=opts.redirect)
+
 
 if __name__ == "__main__":
     try:

--- a/bin/cylc-register
+++ b/bin/cylc-register
@@ -18,30 +18,29 @@
 
 """cylc [prep] register [OPTIONS] ARGS
 
-Register the suite definition located in PATH (or $PWD) as REG.
+Register the name REG for the suite definition in PATH. The suite server
+program can subsequently be started, stopped, and otherwise targetted by name.
+(Note however that "cylc run" can register the target suite on the fly, too).
 
-This creates the suite run directory, and authentication files in a
-sub-directory called ".service/".
+Registration creates a suite run directory "~/cylc-run/REG/" with a ".service/"
+sub-directory containing authentication files and source symlink to PATH. Suite
+names can be a '/'-delimited hierarchy, which becomes a path under ~/cylc-run/.
 
-Suite names are the same as the directory path under the suite run directory.
-They may contain alphanumeric characters plus '_' '-' and '/'.
+REG defaults to "$(basename $PWD)" and PATH defaults to "$PWD", but if you give
+only a single argument it must be the name, not the path.
 
-Example: if the cylc run directory is $HOME/cylc-run (the default) and
-/home/bob/suites/test is a suite source directory, then:
+% cylc reg foo PATH
+register suite in PATH as foo
 
-% cylc reg nwp/test1 /home/bob/suites/test
+% cylc reg foo
+register suite in $PWD as foo
 
-will create the following suite run directory:
+% cylc reg
+register suite in $PWD as $(basename $PWD)
 
-/home/bob/cylc-run/nwp/test1
-`-- .service
-    |-- passphrase
-    |-- source -> /home/bob/test
-    |-- ssl.cert
-    `-- ssl.pem
-
-The suite can subsequently be started and targeted by cylc commands using
-"nwp/test1" as the name."""
+The same suite can be registered under multiple names (with corresponding
+different run directories) but the same name cannot be used for different
+suites; the command will abort if REG is already used by a different suite."""
 
 import sys
 from cylc.remote import remrun
@@ -56,16 +55,17 @@ import cylc.flags
 def main():
     parser = COP(
         __doc__,
-        argdoc=[("REG", "Suite name"),
+        argdoc=[("[REG]", "Suite name"),
                 ("[PATH]", "Suite definition directory (defaults to $PWD)")])
     args = parser.parse_args()[1]
     if len(args) == 2:
-        SuiteSrvFilesManager().register(args[0], args[1])
-        print 'REGISTER %s: %s' % (args[0], args[1])
+        reg, src = args
+    elif len(args) == 1:
+        reg = args[0]
+        src = None
     else:
-        SuiteSrvFilesManager().register(args[0])
-        print 'REGISTER %s' % (args[0])
-
+        reg = src = None
+    SuiteSrvFilesManager().register(reg, src)
 
 if __name__ == "__main__":
     try:

--- a/bin/cylc-register
+++ b/bin/cylc-register
@@ -19,8 +19,8 @@
 """cylc [prep] register [OPTIONS] ARGS
 
 Register the name REG for the suite definition in PATH. The suite server
-program can subsequently be started, stopped, and otherwise targetted by name.
-(Note however that "cylc run" can register the target suite on the fly, too).
+program can subsequently be started, stopped, and targeted by name. (Note
+however that "cylc run" can register the target suite on the fly, too).
 
 Registration creates a suite run directory "~/cylc-run/REG/" with a ".service/"
 sub-directory containing authentication files and source symlink to PATH. Suite
@@ -36,7 +36,7 @@ register suite in PATH as foo
 register suite in $PWD as foo
 
 % cylc reg
-register suite in $PWD as $(basename $PWD)
+register suite in $PWD as the name of its parent directory: $(basename $PWD).
 
 The same suite can be registered under multiple names (with corresponding
 different run directories) but the same name cannot be used for different

--- a/doc/src/cylc-user-guide/cug.tex
+++ b/doc/src/cylc-user-guide/cug.tex
@@ -2024,10 +2024,9 @@ as the suite runs.
 \section{Suite Name Registration}
 \label{SuiteRegistration}
 
-Cylc commands target suites via their names, which are relative path names under
-the suite run directory (\lstinline=~/cylc-run/= by default). Suites can be
-grouped together under sub-directories.
-E.g.:
+Cylc commands target suites via their names, which are relative path names
+under the suite run directory (\lstinline=~/cylc-run/= by default). Suites can
+be grouped together under sub-directories. E.g.:
 \begin{lstlisting}
 $ cylc print -t nwp
 nwp
@@ -2038,10 +2037,9 @@ nwp
    `-region1  Local Model TEST Region1  /home/oliverh/cylc-run/nwp/test/region1
 \end{lstlisting}
 
-Suites can be pre-registered with a name using the \lstinline=cylc register=
-command. This creates the essential directory structure for the suite, and
-generates some service files underneath it. Otherwise, \lstinline=cylc run= will
-create these files on suite start up.
+Suite names can be pre-registered with the \lstinline=cylc register= command,
+which creates the suite run directory structure and some service files
+underneath it. Otherwise, \lstinline=cylc run= will do this at suite start up.
 
 %\pagebreak
 \section{Suite Configuration}

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -121,16 +121,7 @@ class Scheduler(object):
         self.options = options
         self.profiler = Profiler(self.options.profile_mode)
         self.suite_srv_files_mgr = SuiteSrvFilesManager()
-        try:
-            reg = args[0]
-        except IndexError:
-            reg = None
-        try:
-            self.suite = self.suite_srv_files_mgr.register(
-                reg, options.source, on_the_fly=True)
-        except SuiteServiceFileError as exc:
-            sys.exit(exc)
-        # Register suite if not already done
+        self.suite = args[0]
         self.suite_dir = self.suite_srv_files_mgr.get_suite_source_dir(
             self.suite)
         self.suiterc = self.suite_srv_files_mgr.get_suite_rc(self.suite)

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -119,11 +119,15 @@ class Scheduler(object):
 
     def __init__(self, is_restart, options, args):
         self.options = options
-        self.suite = args[0]
         self.profiler = Profiler(self.options.profile_mode)
         self.suite_srv_files_mgr = SuiteSrvFilesManager()
         try:
-            self.suite_srv_files_mgr.register(self.suite, options.source)
+            reg = args[0]
+        except IndexError:
+            reg = None
+        try:
+            self.suite = self.suite_srv_files_mgr.register(
+                reg, options.source, on_the_fly=True)
         except SuiteServiceFileError as exc:
             sys.exit(exc)
         # Register suite if not already done

--- a/lib/cylc/scheduler_cli.py
+++ b/lib/cylc/scheduler_cli.py
@@ -36,29 +36,26 @@ from cylc.suite_srv_files_mgr import (
 
 RUN_DOC = r"""cylc [control] run|start [OPTIONS] [ARGS]
 
-Start a suite run from scratch, wiping out any previous suite state. To
-restart from a previous state see 'cylc restart --help'.
+Start a suite run from scratch, ignoring dependence prior to the start point.
 
-The scheduler runs as a daemon unless you specify --no-detach.
+WARNING: this will wipe out previous suite state. To restart from a previous
+state, see 'cylc restart --help'.
 
-Dependence on cycle points earlier than the start cycle point is ignored.
+The scheduler will run as a daemon unless you specify --no-detach.
 
 If the suite is not already registered (by "cylc register" or a previous run)
-it will be registered on the fly before start up - so long as the name is not
-already registered to another suite.
+it will be registered on the fly before start up.
 
 % cylc run REG
-Run suite REG, or register $PWD/suite.rc as REG and run it. WARNING: if REG
-already points to a suite, this command will run that suite even if you run the
-command from another suite directory.
+  If suite REG exists, run it.
+  Otherwise, register $PWD/suite.rc as REG and run it.
 
-% cylc run REG --source=PATH
-Register PATH/suite.rc as REG, and run it.
+% cylc run --source=PATH REG
+  Register PATH/suite.rc as REG, and run it.
 
 % cylc run
-Register $PWD/suite.rc as "$(basename $PWD)", and run it.
-(In a suite directory /path/to/foo/, register and run the suite as "foo").
-(Note REG must be explicit if START_POINT is given on the command line.)
+  Register $PWD/suite.rc as its parent directory name, and run it.
+ (Note REG must be given if START_POINT is on the command line.)
 
 A "cold start" (the default) starts from the suite initial cycle point
 (specified in the suite.rc or on the command line). Any dependence on tasks
@@ -94,9 +91,9 @@ def main(is_restart=False):
         # Auto-registration: "cylc run" (no args) in source dir.
         reg = SuiteSrvFilesManager().register(on_the_fly=True)
         pth, exc = os.path.split(sys.argv[0])
-        # Replace process with explicit "cylc run REG ..." for easy
-        # identification in the process table.
+        # Replace with "cylc run REG ..." to identify suite in proc name.
         os.execv(sys.argv[0], [sys.argv[0]] + [reg] + sys.argv[1:])
+        # (This process no longer exists.)
 
     # Check suite is not already running before start of host selection.
     try:

--- a/lib/cylc/scheduler_cli.py
+++ b/lib/cylc/scheduler_cli.py
@@ -47,15 +47,11 @@ If the suite is not already registered (by "cylc register" or a previous run)
 it will be registered on the fly before start up.
 
 % cylc run REG
-  If suite REG exists, run it.
-  Otherwise, register $PWD/suite.rc as REG and run it.
-
-% cylc run --source=PATH REG
-  Register PATH/suite.rc as REG, and run it.
+  Run the suite registered with name REG.
 
 % cylc run
-  Register $PWD/suite.rc as its parent directory name, and run it.
- (Note REG must be given if START_POINT is on the command line.)
+  Register $PWD/suite.rc as $(basename $PWD) and run it.
+ (Note REG must be given explicitly if START_POINT is on the command line.)
 
 A "cold start" (the default) starts from the suite initial cycle point
 (specified in the suite.rc or on the command line). Any dependence on tasks
@@ -208,11 +204,6 @@ def parse_commandline(is_restart):
         "--reference-test",
         help="Do a test run against a previously generated reference log.",
         action="store_true", default=False, dest="reftest")
-
-    parser.add_option(
-        "--source", "-S",
-        help="Specify the suite source.",
-        metavar="SOURCE", action="store", dest="source")
 
     # Override standard parser option for specific help description.
     parser.add_option(

--- a/lib/cylc/scheduler_cli.py
+++ b/lib/cylc/scheduler_cli.py
@@ -113,7 +113,10 @@ def main(is_restart=False):
     if remrun(set_rel_local=True):  # State localhost as above.
         sys.exit()
 
-    scheduler = Scheduler(is_restart, options, args)
+    try:
+        scheduler = Scheduler(is_restart, options, args)
+    except SuiteServiceFileError as exc:
+        sys.exit(exc)
     scheduler.start()
 
 

--- a/lib/cylc/scheduler_cli.py
+++ b/lib/cylc/scheduler_cli.py
@@ -95,6 +95,10 @@ def main(is_restart=False):
     except SuiteServiceFileError as exc:
         sys.exit(exc)
 
+    # Create auth files if needed. On a shared FS if the suite host changes
+    # this may (will?) renew the ssl.cert to reflect the change in host name.
+    SuiteSrvFilesManager().create_auth_files(args[0])
+
     # Check whether a run host is explicitly specified, else select one.
     if not options.host:
         host = HostAppointer().appoint_host()

--- a/lib/cylc/scheduler_cli.py
+++ b/lib/cylc/scheduler_cli.py
@@ -89,11 +89,9 @@ def main(is_restart=False):
     options, args = parse_commandline(is_restart)
     if not args:
         # Auto-registration: "cylc run" (no args) in source dir.
-        reg = SuiteSrvFilesManager().register(on_the_fly=True)
-        pth, exc = os.path.split(sys.argv[0])
-        # Replace with "cylc run REG ..." to identify suite in proc name.
+        reg = SuiteSrvFilesManager().register()
+        # Replace this process with "cylc run REG ..." for easy identification.
         os.execv(sys.argv[0], [sys.argv[0]] + [reg] + sys.argv[1:])
-        # (This process no longer exists.)
 
     # Check suite is not already running before start of host selection.
     try:

--- a/lib/cylc/scheduler_cli.py
+++ b/lib/cylc/scheduler_cli.py
@@ -40,15 +40,32 @@ restart from a previous state see 'cylc restart --help'.
 
 The scheduler runs as a daemon unless you specify --no-detach.
 
-Any dependence on cycle points earlier than the start cycle point is ignored.
+Dependence on cycle points earlier than the start cycle point is ignored.
+
+If the suite is not already registered (by "cylc register" or a previous run)
+it will be registered on the fly before start up - so long as the name is not
+already registered to another suite.
+
+% cylc run REG
+Run suite REG, or register $PWD/suite.rc as REG and run it. WARNING: if REG
+already points to a suite, this command will run that suite even if you run the
+command from another suite directory.
+
+% cylc run REG --source=PATH
+Register PATH/suite.rc as REG, and run it.
+
+% cylc run
+Register $PWD/suite.rc as "basename(PWD)", and run it.
+(In a suite directory /path/to/foo/, register and run the suite as "foo").
+(Note REG must be explicit if START_POINT is given on the command line.)
 
 A "cold start" (the default) starts from the suite initial cycle point
-(specified in the suite.rc or on the command line).  Any dependence on tasks
+(specified in the suite.rc or on the command line). Any dependence on tasks
 prior to the suite initial cycle point is ignored.
 
 A "warm start" (-w/--warm) starts from a given cycle point later than the suite
-initial cycle point (specified in the suite.rc).  Any dependence on tasks prior
-to the given warm start cycle point is ignored.  The suite initial cycle point
+initial cycle point (specified in the suite.rc). Any dependence on tasks prior
+to the given warm start cycle point is ignored. The suite initial cycle point
 is preserved."""
 
 RESTART_DOC = r"""cylc [control] restart [OPTIONS] ARGS
@@ -61,7 +78,7 @@ The scheduler runs as a daemon unless you specify --no-detach.
 Tasks recorded as submitted or running are polled at start-up to determine what
 happened to them while the suite was down."""
 
-SUITE_NAME_ARG_DOC = ("REG", "Suite name")
+SUITE_NAME_ARG_DOC = ("[REG]", "Suite name")
 START_POINT_ARG_DOC = (
     "[START_POINT]",
     "Initial cycle point or 'now';\n" +

--- a/lib/cylc/suite_srv_files_mgr.py
+++ b/lib/cylc/suite_srv_files_mgr.py
@@ -412,15 +412,15 @@ To start a new run, stop the old one first with one or more of these:
         return name, path
 
     def register(self, reg=None, source=None, on_the_fly=False):
-        """Register a new suite.
+        """Register a suite, or renew its registration.
 
         Create the suite run directory and generate service files if they
         don't already exist, with a symlink to the suite source location.
 
         Args:
-            reg (str): suite name, default basename(PWD)
-            source (str): directory location of suite.rc file, default PWD
-            on_the_fly (bool): ...
+            reg (str): suite name, default basename($PWD)
+            source (str): directory location of suite.rc file, default $PWD
+            on_the_fly (bool): indicates on-the-fly registration by "cylc run".
 
         Return:
             The registered suite name (which may be computed here).
@@ -462,10 +462,11 @@ To start a new run, stop the old one first with one or more of these:
             raise SuiteServiceFileError("ERROR: no suite.rc in %s" % source)
         if orig_source is None:
             os.symlink(source, target)
-        else:
-            if orig_source != source:
-                raise SuiteServiceFileError(
-                    "ERROR: name %s already used for %s" % (reg, orig_source))
+        elif orig_source != source:
+            sys.stderr.write(
+                "WARNING: name %s repurposed from %s\n" % (reg, orig_source))
+            os.unlink(target)
+            os.symlink(source, target)
         # Create a new passphrase for the suite if necessary.
         if not self._locate_item(self.FILE_BASE_PASSPHRASE, srv_d):
             import random

--- a/lib/cylc/suite_srv_files_mgr.py
+++ b/lib/cylc/suite_srv_files_mgr.py
@@ -414,12 +414,12 @@ To start a new run, stop the old one first with one or more of these:
     def register(self, reg=None, source=None, redirect=False):
         """Register a suite, or renew its registration.
 
-        Create the suite run directory and generate service files if they
-        don't already exist, with a symlink to the suite source location.
+        Create suite service directory and symlink to suite source location.
 
         Args:
-            reg (str): suite name, default basename($PWD)
-            source (str): directory location of suite.rc file, default $PWD
+            reg (str): suite name, default basename($PWD).
+            source (str): directory location of suite.rc file, default $PWD.
+            redirect (bool): allow reuse of existing name and run directory.
 
         Return:
             The registered suite name (which may be computed here).
@@ -483,6 +483,16 @@ To start a new run, stop the old one first with one or more of these:
             os.unlink(target)
             os.symlink(source, target)
 
+        # Report the new (or renewed) registration.
+        print 'REGISTERED %s -> %s' % (reg, source)
+        return reg
+
+    def create_auth_files(self, reg):
+        """Create or renew passphrase and SSL files for suite 'reg'."""
+
+        # Suite service directory.
+        srv_d = self.get_suite_srv_dir(reg)
+
         # Create a new passphrase for the suite if necessary.
         if not self._locate_item(self.FILE_BASE_PASSPHRASE, srv_d):
             import random
@@ -492,9 +502,6 @@ To start a new run, stop the old one first with one or more of these:
         pkey_obj = self._get_ssl_pem(srv_d)
         # Load or create SSL certificate for the suite.
         self._get_ssl_cert(srv_d, pkey_obj)
-        # Report the new (or renewed) registration.
-        print 'REGISTERED %s -> %s' % (reg, source)
-        return reg
 
     def _get_ssl_pem(self, path):
         """Load or create ssl.pem file for suite in path.

--- a/lib/cylc/suite_srv_files_mgr.py
+++ b/lib/cylc/suite_srv_files_mgr.py
@@ -411,7 +411,8 @@ To start a new run, stop the old one first with one or more of these:
                 name = os.path.basename(os.path.dirname(arg))
         return name, path
 
-    def register(self, reg=None, source=None, on_the_fly=False):
+    def register(self, reg=None, source=None, on_the_fly=False,
+                 redirect=False):
         """Register a suite, or renew its registration.
 
         Create the suite run directory and generate service files if they
@@ -463,8 +464,11 @@ To start a new run, stop the old one first with one or more of these:
         if orig_source is None:
             os.symlink(source, target)
         elif orig_source != source:
+            if not redirect:
+                raise SuiteServiceFileError(
+                    "ERROR: name %s is used for %s" % (reg, orig_source))
             sys.stderr.write(
-                "WARNING: name %s repurposed from %s\n" % (reg, orig_source))
+                "WARNING: redirecting %s from %s\n" % (reg, orig_source))
             os.unlink(target)
             os.symlink(source, target)
         # Create a new passphrase for the suite if necessary.

--- a/lib/cylc/suite_srv_files_mgr.py
+++ b/lib/cylc/suite_srv_files_mgr.py
@@ -473,12 +473,12 @@ To start a new run, stop the old one first with one or more of these:
             # Redirecting an existing name and run directory to another suite.
             if not redirect:
                 raise SuiteServiceFileError(
-                    "ERROR: name %s is already used for %s" % (
+                    "ERROR: the suite name '%s' is already used for %s." % (
                         reg, orig_source))
             else:
                 sys.stderr.write(
-                    "WARNING: the suite name '%s' was used for %s\n"
-                    "The run directory will be reused for %s\n" % (
+                    "WARNING: the suite name '%s' was used for %s.\n"
+                    "The run directory will be reused for %s.\n" % (
                         reg, orig_source, source))
             os.unlink(target)
             os.symlink(source, target)

--- a/tests/authentication/08-shared-fs.t
+++ b/tests/authentication/08-shared-fs.t
@@ -35,7 +35,7 @@ SUITE_NAME="cylctb-${CYLC_TEST_TIME_INIT}/${TEST_SOURCE_DIR_BASE}/${TEST_NAME_BA
 SUITE_RUN_DIR="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}"
 mkdir -p "$(dirname "${SUITE_RUN_DIR}")"
 cp -r "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}" "${SUITE_RUN_DIR}"
-cylc register "${SUITE_NAME}" 2>'/dev/null'
+cylc register "${SUITE_NAME}" "${SUITE_RUN_DIR}" 2>'/dev/null'
 
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
 

--- a/tests/authentication/10-remote-suite-passphrase-cache.t
+++ b/tests/authentication/10-remote-suite-passphrase-cache.t
@@ -27,9 +27,10 @@ set_test_number 5
 SSH_OPTS='-oBatchMode=yes -oConnectTimeout=5'
 SUITE_NAME="cylctb-${CYLC_TEST_TIME_INIT}/${TEST_SOURCE_DIR_BASE}/${TEST_NAME_BASE}"
 
-cylc register --host="${CYLC_TEST_HOST}" "${SUITE_NAME}"
+ssh ${SSH_OPTS} "${CYLC_TEST_HOST}" mkdir -p "cylc-run/${SUITE_NAME}"
 scp ${SSH_OPTS} -pqr "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/"* \
     "${CYLC_TEST_HOST}:cylc-run/${SUITE_NAME}"
+cylc register --host="${CYLC_TEST_HOST}" "${SUITE_NAME}" "cylc-run/${SUITE_NAME}"
 run_ok "${TEST_NAME_BASE}-validate" \
     cylc validate --host="${CYLC_TEST_HOST}" "${SUITE_NAME}"
 

--- a/tests/authentication/11-suite2-stop-suite1.t
+++ b/tests/authentication/11-suite2-stop-suite1.t
@@ -20,15 +20,15 @@
 . "$(dirname "$0")/test_header"
 
 set_test_number 1
-
 RUND="$(cylc get-global-config --print-run-dir)"
 NAME1="cylctb-${CYLC_TEST_TIME_INIT}/${TEST_SOURCE_DIR_BASE}/${TEST_NAME_BASE}-1"
 NAME2="cylctb-${CYLC_TEST_TIME_INIT}/${TEST_SOURCE_DIR_BASE}/${TEST_NAME_BASE}-2"
 SUITE1_RUND="${RUND}/${NAME1}"
-SUITE2_RUND="${RUND}/${NAME2}"
-cylc register "${NAME1}"
+mkdir -p "${SUITE1_RUND}" 
 cp -p "${TEST_SOURCE_DIR}/basic/suite.rc" "${SUITE1_RUND}"
-cylc register "${NAME2}"
+cylc register "${NAME1}" "${SUITE1_RUND}"
+SUITE2_RUND="${RUND}/${NAME2}"
+mkdir -p "${SUITE2_RUND}"
 cat >"${SUITE2_RUND}/suite.rc" <<__SUITERC__
 [cylc]
     abort if any task fails=True
@@ -39,6 +39,7 @@ cat >"${SUITE2_RUND}/suite.rc" <<__SUITERC__
     [[t1]]
         script=cylc shutdown "${NAME1}"
 __SUITERC__
+cylc register "${NAME2}" "${SUITE2_RUND}"
 cylc run --no-detach "${NAME1}" 1>'1.out' 2>&1 &
 poll '!' test -e "${SUITE1_RUND}/.service/contact"
 run_ok "${TEST_NAME_BASE}" cylc run --no-detach "${NAME2}"

--- a/tests/registration/00-simple.t
+++ b/tests/registration/00-simple.t
@@ -18,7 +18,7 @@
 # Test suite registration
 
 . "$(dirname "$0")/test_header"
-set_test_number 23 
+set_test_number 19 
 
 init_suite "${TEST_NAME_BASE}" <<'__SUITE_RC__'
 [meta]
@@ -53,7 +53,6 @@ contains_ok "${TEST_NAME}.stdout" <<__OUT__
 REGISTERED $CHEESE -> ${PWD}
 __OUT__
 cd ..
-exists_ok "${CYLC_RUN_DIR}/$CHEESE/.service/passphrase"
 rm -rf "${CYLC_RUN_DIR}/$CHEESE"
 
 # Test default name: "cylc reg REG" (suite in $PWD)
@@ -65,7 +64,6 @@ contains_ok "${TEST_NAME}.stdout" <<__OUT__
 REGISTERED $TOAST -> ${PWD}
 __OUT__
 cd ..
-exists_ok "${CYLC_RUN_DIR}/$TOAST/.service/passphrase"
 rm -rf "${CYLC_RUN_DIR}/$TOAST"
 
 # Test "cylc reg REG PATH"
@@ -75,7 +73,6 @@ run_ok "${TEST_NAME}" cylc register $BAGELS $CHEESE
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
 REGISTERED $BAGELS -> ${PWD}/$CHEESE
 __OUT__
-exists_ok "${CYLC_RUN_DIR}/$BAGELS/.service/passphrase"
 rm -rf "${CYLC_RUN_DIR}/$BAGELS"
 
 # Test fail "cylc reg REG PATH" where REG already points to PATH2
@@ -100,7 +97,6 @@ __ERR__
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
 REGISTERED $CHEESE -> ${PWD}/$YOGHURT
 __OUT__
-exists_ok "${CYLC_RUN_DIR}/$CHEESE/.service/passphrase"
 rm -rf "${CYLC_RUN_DIR}/$CHEESE"
 
 run_ok "${TEST_NAME_BASE}-get-dir" cylc get-directory "${SUITE_NAME}"

--- a/tests/registration/00-simple.t
+++ b/tests/registration/00-simple.t
@@ -18,7 +18,7 @@
 # Test cylc suite registration
 
 . "$(dirname "$0")/test_header"
-set_test_number 7
+set_test_number 9
 
 init_suite "${TEST_NAME_BASE}" <<'__SUITE_RC__'
 [meta]
@@ -30,6 +30,12 @@ init_suite "${TEST_NAME_BASE}" <<'__SUITE_RC__'
     [[a,b,c]]
         script = true
 __SUITE_RC__
+
+TEST_NAME="${TEST_NAME_BASE}-noreg"
+run_fail "${TEST_NAME}" cylc register "${SUITE_NAME}" "${PWD}/zilch"
+contains_ok "${TEST_NAME}.stderr" <<__ERR__
+ERROR: no suite.rc in ${PWD}/zilch
+__ERR__
 
 run_ok "${TEST_NAME_BASE}-register" cylc register "${SUITE_NAME}"
 exists_ok "${SUITE_RUN_DIR}/.service/passphrase"

--- a/tests/registration/02-on-the-fly.t
+++ b/tests/registration/02-on-the-fly.t
@@ -1,0 +1,46 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#------------------------------------------------------------------------------
+# Test on-the-fly suite registration by "cylc run"
+
+. "$(dirname "$0")/test_header"
+set_test_number 3 
+
+TESTD="cylctb-cheese-${CYLC_TEST_TIME_INIT}"
+mkdir "${TESTD}"
+cat >> "${TESTD}/suite.rc" <<'__SUITE_RC__'
+[meta]
+    title = the quick brown fox
+[scheduling]
+    [[dependencies]]
+        graph = foo 
+[runtime]
+    [[foo]]
+        script = true
+__SUITE_RC__
+
+TEST_NAME="${TEST_NAME_BASE}-run"
+cd "${TESTD}"
+run_ok "${TEST_NAME}" cylc run --hold
+contains_ok "${TEST_NAME}.stdout" <<__ERR__
+REGISTERED ${TESTD} -> ${PWD}
+__ERR__
+
+TEST_NAME="${TEST_NAME_BASE}-stop"
+run_ok "${TEST_NAME}" cylc stop "${TESTD}"
+
+purge_suite $TESTD


### PR DESCRIPTION
Close #2758 
Close #2749 

[UPDATED description 15 Oct]:

Abort suite registration if:
* `suite.rc`not found in target directory (this allows us to distinguish correct arg order)
* name is an absolute path (can only be relative).
* name is already registered to another suite
  - but allow forced re-use of existing name and run directory with `--redirect`

Also support:
- auto-registration of suite in `$PWD`
  - `cylc reg NAME` (auto-reg)
  - `cylc reg` (auto reg and auto-name - with name of parent dir)
- on-the-fly  auto-registration by "cylc run" (of suite in `$PWD`, with name of parent dir).
  - replacing (via `exec`) process `cylc run` with `cylc run NAME` for easy identification with `ps` etc.

