### PR TITLE
improve test battery chunking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,13 @@ language: python
 
 matrix:
     include:
-    - name: "1"
+    - name: "1/4"
       env: CHUNK='1/4'
-    - name: "2"
+    - name: "2/4"
       env: CHUNK='2/4'
-    - name: "3"
+    - name: "3/4"
       env: CHUNK='3/4'
-    - name: "4"
+    - name: "4/4"
       env: CHUNK='4/4'
 
 
@@ -78,7 +78,7 @@ script:
     # Only run the generic tests on Travis CI.
     - export CYLC_TEST_RUN_PLATFORM=false
     # Run tests with virtual frame buffer for X support.
-    - xvfb-run -a cylc test-battery --chunk $CHUNK --state=save -j 5 || (echo -e "\n\nRerunning Failed Tests...\n\n"; cylc test-battery --state=save,failed -j 5)
+    - xvfb-run -a cylc test-battery --chunk $CHUNK --state=save -j 5 || (echo -e "\n\nRerunning Failed Tests...\n\n"; cylc test-battery --state=failed -j 5)
 
 # Check output (more useful if you narrow down what tests get run)
 after_script:

--- a/bin/cylc-test-battery
+++ b/bin/cylc-test-battery
@@ -91,10 +91,26 @@ Run only tests under "tests/cyclers/", and skip 00-daily.t
   cylc test-battery tests/cyclers
 Run the first quarter of the test battery
   cylc test-battery --chunk '1/4'
+Re-run failed tests
+  cylc test-battery --state=save
+  cylc test-battery --state=failed
 eof
 }
 
-TESTS=""
+chunk () {
+    # argument in the format chunk_no/no_chunks
+    IFS=$'/' read CHUNK_NO CHUNKS <<< "$1"
+    # create lists of tests in a temp file
+    TEST_FILE="$(mktemp)"
+    cylc test-battery --dry | sort > "$TEST_FILE"
+    LINES_PER_FILE=$(( ( $(wc -l "$TEST_FILE" | cut -d ' ' -f 1) \
+        + $CHUNKS - 1 ) / CHUNKS ))
+    # chunk tests
+    split -d -l "$LINES_PER_FILE" "$TEST_FILE" "$TEST_FILE"
+    # select chunk
+    FILENO="$(printf '%02d' $(( CHUNK_NO - 1 )) )"
+    tr '\n' ' ' < "${TEST_FILE}${FILENO}"
+}
 
 # Defaults.
 export CYLC_TEST_RUN_GENERIC=${CYLC_TEST_RUN_GENERIC:-true}
@@ -108,47 +124,21 @@ if [[ "$PWD" != "$CYLC_DIR" ]]; then
     cd "$CYLC_DIR"
 fi
 
-ARGS=()
-OPTS=()
-while [[ $# -gt 0 ]]; do
-    case "$1" in
+ARG_COUNT=1
+for ARG in "$@"; do
+    case "$ARG" in
         --help|-h)
             usage
             exit 0
             ;;
         --chunk)
-            # argument in the format chunk_no/no_chunks
-            IFS=$'/' read CHUNK_NO CHUNKS <<< "$2"
-            # create lists of tests in a tempdir
-            TMPDIR="$(mktemp -d)"
-            TEST_FILE="$TMPDIR/cylc_tests"
-            prove -r 'tests' --dry > "$TEST_FILE"
-            LINES_PER_FILE=$(( ( $(wc -l "$TEST_FILE" | cut -d ' ' -f 1) \
-                + $CHUNKS - 1 ) / $CHUNKS ))
-            # chunk tests
-            split -d -l "$LINES_PER_FILE" "$TEST_FILE" "$TEST_FILE"
-            # select chunk
-            FILENO="$(printf '%02d' $(( $CHUNK_NO - 1 )) )"
-            ARGS+=($(cat "${TEST_FILE}${FILENO}"))
-            shift
-            shift
-            ;;
-        --exec|--harness|--formatter|--source|--archive|--jobs|\
-        -I|-P|-M|-e|-a|-j)
-            # prove options which take separate arguments
-            OPTS+=("$1" "$2")
-            shift
-            shift
-            ;;
-        -*)
-            # prove single item options
-            OPTS+=("$1")
-            shift
+            # Replace "--chunk a/b" with the appropriate tests.
+            set -- "${@:1:$(( ARG_COUNT - 1 ))}" \
+                $(chunk ${@:$(( ARG_COUNT + 1 )):1}) \
+                "${@:$(( ARG_COUNT + 2 ))}"
             ;;
         *)
-            # prove arguments
-            ARGS+=("$1")
-            shift
+            ARG_COUNT=$(( ARG_COUNT + 1 ))
             ;;
     esac
 done
@@ -164,8 +154,8 @@ if perl -e 'use Test::Harness 3.00' 2>/dev/null; then
     if [[ -z "${NPROC}" ]]; then
         NPROC=$(python -c 'import multiprocessing as mp; print mp.cpu_count()')
     fi
-    exec prove -j "$NPROC" -s -r ${ARGS[@]:-tests} ${OPTS[@]:-}
+    exec prove -j "$NPROC" -s -r "${@:-tests}"
 else
-    echo 'WARNING: cannot run tests in parallel (Test::Harness < 3.00)' >&2
-    exec prove -s -r ${ARGS[@]:-tests} ${OPTS[@]:-}
+    echo "WARNING: cannot run tests in parallel (Test::Harness < 3.00)" >&2
+    exec prove -s -r "${@:-tests}"
 fi


### PR DESCRIPTION
Nicer approach to wrapping prove which get rid of the whole prove re-running all tests when supplying the `--state=failed` flag problem.