### PR TITLE
Prevent re-declaring variable i in another for-loop

### DIFF
--- a/lib/cylc/gui/updater_tree.py
+++ b/lib/cylc/gui/updater_tree.py
@@ -438,7 +438,7 @@ class TreeUpdater(threading.Thread):
                     f_iter = p_iter
                     f_path = p_path
                     fam = point_string
-                    for i, fam in enumerate(named_path[:-1]):
+                    for j, fam in enumerate(named_path[:-1]):
                         # Construct family nesting for this task.
                         if fam in family_iters:
                             # Family already in tree
@@ -450,8 +450,8 @@ class TreeUpdater(threading.Thread):
                                 f_data = new_fam_data[point_string][fam]
                             except KeyError:
                                 f_data = [None] * 7
-                            if i > 0:
-                                parent_fam = named_path[i - 1]
+                            if j > 0:
+                                parent_fam = named_path[j - 1]
                             else:
                                 # point_string is the implicit parent here.
                                 parent_fam = point_string


### PR DESCRIPTION
Hi, I believe sometimes when `should_rebuild_tree` is `True`, we are missing a few entries in the `for`-loop for updating the UI due to the variable `i` being used in both outer and inner loop.

Did a quick test printing values in both `for`'s (having a small glitch with debugger, and can't run the GUI in Eclipse), using the example suite for cycling hourly daily, and the output was slightly different in the logs.

The output in the GUI looks OK though.

Cheers
Bruno