### PR TITLE
cylc-bash-complete completes registered suite names when a command takes suite names

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,7 @@ requests_).
  - Lois Hugget
  - (Martin Dix)
  - (Ivor Blockley)
+ - Alexander Paulsell
 
 (All contributors are identifiable with email addresses in the git version
 control logs or otherwise.)

--- a/etc/cylc-bash-completion
+++ b/etc/cylc-bash-completion
@@ -33,16 +33,22 @@
 
 _cylc() {
 
-    local cur prev opts base
+    local cur sec opts base 
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
+    sec="${COMP_WORDS[1]}"
+    opts="$(cylc print -x -y 2>/dev/null)"
+    suite_cmds="run|edit|5to6|cat-log|log|cat-state|checkpoint|dump|ext-trigger|external-trigger|get-directory|get-gui-config|get-site-config|get-global-config|get-suite-config|get-config|get-suite-contact|get-contact|print-contact|get-suite-version|get-cylc-version|graph|graph-diff|gui|hold|monitor|ping|release|unhold|reload|restart|start|set-verbosity|stop|shutdown|suite-state|validate|view"
 
-    CYLC_DIR=$(__cylc_get_cylc_dir)
-    cylc_cmds=$(cd $CYLC_DIR/bin && ls cylc-* | sed "s/^cylc-//g")
 
-    COMPREPLY=($(compgen -W "${cylc_cmds}" -- ${cur}))
+    if [[ ${COMP_CWORD} -eq 1 ]]; then
+        CYLC_DIR=$(__cylc_get_cylc_dir)
+        cylc_cmds=$(cd $CYLC_DIR/bin && ls cylc-* | sed "s/^cylc-//g")
+        COMPREPLY=($(compgen -W "${cylc_cmds}" -- ${cur}))
+    elif [[ ${sec} =~ ^($suite_cmds)$ ]]; then
+        COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+    fi
     return 0
-
 }
 
 __cylc_get_cylc_dir() {

--- a/etc/cylc-bash-completion
+++ b/etc/cylc-bash-completion
@@ -33,7 +33,7 @@
 
 _cylc() {
 
-    local cur sec opts base 
+    local cur sec opts base
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     sec="${COMP_WORDS[1]}"

--- a/etc/cylc-bash-completion
+++ b/etc/cylc-bash-completion
@@ -38,7 +38,7 @@ _cylc() {
     cur="${COMP_WORDS[COMP_CWORD]}"
     sec="${COMP_WORDS[1]}"
     opts="$(cylc print -x -y 2>/dev/null)"
-    suite_cmds="run|edit|5to6|cat-log|log|cat-state|checkpoint|dump|ext-trigger|external-trigger|get-directory|get-gui-config|get-site-config|get-global-config|get-suite-config|get-config|get-suite-contact|get-contact|print-contact|get-suite-version|get-cylc-version|graph|graph-diff|gui|hold|monitor|ping|release|unhold|reload|restart|start|set-verbosity|stop|shutdown|suite-state|validate|view"
+    suite_cmds="broadcast|bcast|cat-log|log|cat-state|check-versions|checkpoint|diff|compare|documentation|browse|dump|edit|ext-trigger|external-trigger|get-directory|get-suite-config|get-config|get-suite-version|get-cylc-version|graph|graph-diff|gui|hold|insert|kill|list|ls|ls-checkpoints|monitor|nudge|ping|poll|register|release|unhold|reload|remove|report-timings|reset|restart|run|start|search|grep|set-verbosity|show|spawn|stop|shutdown|submit|single|suite-state|trigger|upgrade-run-dir|validate|view"
 
 
     if [[ ${COMP_CWORD} -eq 1 ]]; then


### PR DESCRIPTION
Currently cylc-bash-complete will complete cylc commands if cylc is the first word.

This modification will complete cylc commands if cylc is the only word and will complete registered suite names when specific commands (which take suite names) are the second word.

suite_cmds is ugly but I felt manually inputting commands that take suite names was better than completing suite names for all commands.

First time contributing so please let me know if I am missing anything.
