### PR TITLE
cylc ping: remove option to print port range

### DIFF
--- a/bin/cylc-ping
+++ b/bin/cylc-ping
@@ -40,19 +40,7 @@ def main():
         __doc__, comms=True,
         argdoc=[('REG', 'Suite name'), ('[TASK]', 'Task ' + TaskID.SYNTAX)])
 
-    parser.add_option(
-        "--print-ports",
-        help="Print the port range from the cylc site config file.",
-        action="store_true", default=False, dest="print_ports")
-
     (options, args) = parser.parse_args()
-
-    if options.print_ports:
-        base = glbl_cfg().get(['comms', 'base port'])
-        range = glbl_cfg().get(['comms', 'maximum number of ports'])
-        print base, '<= port <=', base + range
-        sys.exit(0)
-
     suite = args[0]
 
     pclient = SuiteRuntimeServiceClient(

--- a/tests/cylc-ping/simple/suite.rc
+++ b/tests/cylc-ping/simple/suite.rc
@@ -9,4 +9,4 @@
     [[foo]]
         script = cylc ping $CYLC_SUITE_NAME
     [[bar]]
-        script = [[ ! $(cylc ping $CYLC_SUITE_NAME-non-existant) ]]
+        script = [[ ! $(cylc ping $CYLC_SUITE_NAME-non-existent) ]]


### PR DESCRIPTION
While working on another Cylc PR (#2693) I noticed that within ``bin/cylc-ping`` there was a call to the global configuration that referenced a setting that was non-existent (either obsolete or a typo for a correct setting), breaking the ``--print-ports`` option. I am updating the setting in question anyway in that PR, so the bug will be fixed when that is merged (soon!), but given that it was not picked up by the test-battery, a new test should be added.

To aid review on the original PR I am requesting this new sub-test separately. To keep Travis CI etc. happy, this requires fixing the bug in the meantime.