### PR TITLE
get-suite-contact: add missing file for command alias

### DIFF
--- a/bin/cylc-print-contact
+++ b/bin/cylc-print-contact
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+exec "$(dirname "$0")/cylc-get-suite-contact" "$@"


### PR DESCRIPTION
``get-suite-contact`` is documented (including under ``cylc-help``) as having an alias ``print-contact``, but this command is not recognised as there is no corresponding file under ``bin/``.

This PR in its current form would add in the necessary file to set up the alias command, since it is technically a bug that it is documented but not currently there.

However, would it be preferable to simply remove this as an equivalent command? The fact it does not work implies either that nobody has ever used it or (more likely) that as it is not important enough to report as non-existent.