### PR TITLE
gcylc: fix log viewer bug with zero submits

### DIFF
--- a/lib/cylc/gui/combo_logviewer.py
+++ b/lib/cylc/gui/combo_logviewer.py
@@ -66,7 +66,8 @@ class ComboLogViewer(logviewer):
         for snum in snums:
             combobox2.append_text(str(snum))
         combobox2.connect("changed", self.switch_snum)
-        combobox2.set_active(snums.index(self.nsubmit))
+        if self.nsubmit in snums:
+            combobox2.set_active(snums.index(self.nsubmit))
         self.hbox.pack_end(combobox2, False)
         self.hbox.pack_end(label2, False)
 


### PR DESCRIPTION
As reported by a Met Office user:
```
  File "/net/home/h03/fcm/cylc-7.7.2/lib/cylc/gui/app_gcylc.py", line 1271, in view_task_logs
    self._popup_logview(task_id, task_state_summary, choice)
  File "/net/home/h03/fcm/cylc-7.7.2/lib/cylc/gui/app_gcylc.py", line 2210, in _popup_logview
    nsubmits, self.get_remote_run_opts())
  File "/net/home/h03/fcm/cylc-7.7.2/lib/cylc/gui/combo_logviewer.py", line 47, in __init__
    logviewer.__init__(self)
  File "/net/home/h03/fcm/cylc-7.7.2/lib/cylc/gui/logviewer.py", line 37, in __init__
    self.create_gui_panel()
  File "/net/home/h03/fcm/cylc-7.7.2/lib/cylc/gui/combo_logviewer.py", line 69, in create_gui_panel
    combobox2.set_active(snums.index(self.nsubmit))
ValueError: list.index(x): x not in list
```
Solving ``x not in range(1, x+1)`` with ``self.nsubmit`` as ``x``, we see that the ``= 0`` case is not handled, causing the observed traceback. I believe this case is trivial to bypass, but let me know if there are subtleties I have not foreseen.