### PR TITLE
Tidy up tests/temporary locations on success

### DIFF
--- a/lib/cylc/task_remote_mgr.py
+++ b/lib/cylc/task_remote_mgr.py
@@ -290,7 +290,7 @@ class TaskRemoteMgr(object):
                 LOG.warning(TaskRemoteMgmtError(
                     TaskRemoteMgmtError.MSG_TIDY,
                     (host, owner), ' '.join(quote(item) for item in cmd),
-                    proc.ret_code, out, err))
+                    proc.returncode, out, err))
 
     def _remote_host_select_callback(self, proc_ctx, cmd_str):
         """Callback when host select command exits"""

--- a/tests/communication-method/00-simple-https.t
+++ b/tests/communication-method/00-simple-https.t
@@ -15,27 +15,19 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test cylc scan is picking up running suite
-. $(dirname $0)/test_header
-#-------------------------------------------------------------------------------
+# Test communication protocol HTTPS
+. "$(dirname "$0")/test_header"
 set_test_number 2
+
 create_test_globalrc '
 [communication]
     method=https'
-#-------------------------------------------------------------------------------
-install_suite ${TEST_NAME_BASE} simple
-#-------------------------------------------------------------------------------
-TEST_NAME=${TEST_NAME_BASE}-validate
-run_ok ${TEST_NAME} cylc validate ${SUITE_NAME}
-#-------------------------------------------------------------------------------
-TEST_NAME=${TEST_NAME_BASE}-check-suite-contact-https
-cylc run ${SUITE_NAME} --hold
-cylc get-suite-contact ${SUITE_NAME} | grep "CYLC_COMMS_PROTOCOL=https" > log1.txt 
-cylc release ${SUITE_NAME}
-cmp_ok log1.txt << __END__
-CYLC_COMMS_PROTOCOL=https
-__END__
-#-------------------------------------------------------------------------------
-purge_suite ${SUITE_NAME}
-exit
+install_suite "${TEST_NAME_BASE}" 'simple'
 
+run_ok "${TEST_NAME_BASE}-validate" \
+    cylc validate "${SUITE_NAME}" --set=EXPECTED=https
+suite_run_ok "${TEST_NAME_BASE}-run" \
+    cylc run "${SUITE_NAME}" --no-detach --reference-test --set=EXPECTED=https
+
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/communication-method/01-simple-http.t
+++ b/tests/communication-method/01-simple-http.t
@@ -15,27 +15,19 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test cylc scan is picking up running suite
-. $(dirname $0)/test_header
-#-------------------------------------------------------------------------------
+# Test communication protocol HTTP
+. "$(dirname "$0")/test_header"
 set_test_number 2
+
 create_test_globalrc '
 [communication]
     method=http'
-#-------------------------------------------------------------------------------
-install_suite ${TEST_NAME_BASE} simple
-#-------------------------------------------------------------------------------
-TEST_NAME=${TEST_NAME_BASE}-validate
-run_ok ${TEST_NAME} cylc validate ${SUITE_NAME}
-#-------------------------------------------------------------------------------
-TEST_NAME=${TEST_NAME_BASE}-check-suite-contact-http
-cylc run ${SUITE_NAME} --hold
-cylc get-suite-contact ${SUITE_NAME} | grep "CYLC_COMMS_PROTOCOL=http" > log1.txt 
-cylc release ${SUITE_NAME}
-cmp_ok log1.txt << __END__
-CYLC_COMMS_PROTOCOL=http
-__END__
-#-------------------------------------------------------------------------------
-purge_suite ${SUITE_NAME}
-exit
+install_suite "${TEST_NAME_BASE}" 'simple'
 
+run_ok "${TEST_NAME_BASE}-validate" \
+    cylc validate "${SUITE_NAME}" --set=EXPECTED=http
+suite_run_ok "${TEST_NAME_BASE}-run" \
+    cylc run "${SUITE_NAME}" --no-detach --reference-test --set=EXPECTED=http
+
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/communication-method/02-simple-defaultcomms.t
+++ b/tests/communication-method/02-simple-defaultcomms.t
@@ -15,24 +15,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test cylc scan is picking up running suite
-. $(dirname $0)/test_header
-#-------------------------------------------------------------------------------
+# Test communication protocol (default)
+. "$(dirname "$0")/test_header"
 set_test_number 2
-#-------------------------------------------------------------------------------
-install_suite ${TEST_NAME_BASE} simple
-#-------------------------------------------------------------------------------
-TEST_NAME=${TEST_NAME_BASE}-validate
-run_ok ${TEST_NAME} cylc validate ${SUITE_NAME}
-#-------------------------------------------------------------------------------
-TEST_NAME=${TEST_NAME_BASE}-check-suite-contact-defaultcomms
-cylc run ${SUITE_NAME} --hold
-cylc get-suite-contact ${SUITE_NAME} | grep "CYLC_COMMS_PROTOCOL=https" > log1.txt 
-cylc release ${SUITE_NAME}
-cmp_ok log1.txt << __END__
-CYLC_COMMS_PROTOCOL=https
-__END__
-#-------------------------------------------------------------------------------
-purge_suite ${SUITE_NAME}
-exit
 
+install_suite "${TEST_NAME_BASE}" 'simple'
+
+run_ok "${TEST_NAME_BASE}-validate" \
+    cylc validate "${SUITE_NAME}" --set=EXPECTED=https
+suite_run_ok "${TEST_NAME_BASE}-run" \
+    cylc run "${SUITE_NAME}" --no-detach --reference-test --set=EXPECTED=https
+
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/communication-method/simple/reference.log
+++ b/tests/communication-method/simple/reference.log
@@ -1,0 +1,3 @@
+2013/09/30 16:48:11 INFO - Initial point: 1
+2013/09/30 16:48:11 INFO - Final point: 1
+2013/09/30 16:48:11 INFO - [t1.1] -triggered off []

--- a/tests/communication-method/simple/suite.rc
+++ b/tests/communication-method/simple/suite.rc
@@ -1,10 +1,11 @@
+#!Jinja2
 [cylc]
    [[reference test]]
        required run mode = live
        live mode suite timeout = PT1M
 [scheduling]
     [[dependencies]]
-        graph = "foo"
+        graph = t1
 [runtime]
-    [[foo]]
-        script = true 
+    [[t1]]
+        script = grep -q 'CYLC_COMMS_PROTOCOL={{EXPECTED}}' < <(cylc get-suite-contact "${CYLC_SUITE_NAME}")

--- a/tests/profile-battery/00-compatability.t
+++ b/tests/profile-battery/00-compatability.t
@@ -37,13 +37,8 @@ cmp_ok "${TEST_NAME}.stdout" "${TEST_NAME}.stdout" "hello-world"
 #-------------------------------------------------------------------------------
 # Run the test experiment.
 TEST_NAME="${TEST_NAME_BASE}-run-test-experiment"
-LOG_DIR="${TEST_LOG_DIR}/${TEST_NAME}"
-mkdir "${LOG_DIR}" -p
 RET_CODE=0
-cylc profile-battery -e 'test' -v 'HEAD' --test \
-    >"${LOG_DIR}.log" \
-    2>"${LOG_DIR}.stderr" \
-    || RET_CODE=$?
+cylc profile-battery -e 'test' -v 'HEAD' --test >'log' 2>'err' || RET_CODE=$?
 if [[ ${RET_CODE} == 0 ]]
 then
     ok "${TEST_NAME}"
@@ -53,6 +48,9 @@ then
     skip 1
 else
     fail "${TEST_NAME}"
+    LOG_DIR="${TEST_LOG_DIR}/${TEST_NAME}"
+    mkdir -p "${LOG_DIR}"
+    mv 'log' 'err' "${LOG_DIR}"
     # Move/rename profiling files so they will be cat'ed out by travis-ci.
     while read; do
         file_path="${REPLY}"
@@ -66,3 +64,4 @@ else
     done < <(sed -n 's/Profile files:\(.*\)/\1/p' "${LOG_DIR}.stderr")
     mv "${LOG_DIR}.log" "${LOG_DIR}.profile-battery-log-err"
 fi
+exit

--- a/tests/restart/bad-job-host/suite.rc
+++ b/tests/restart/bad-job-host/suite.rc
@@ -1,5 +1,6 @@
 #!jinja2
 [cylc]
+    abort if any task fails = True
     [[events]]
         timeout = PT2M
         abort on timeout = True


### PR DESCRIPTION
Reduce chance of restart/13 test hanging.
Tidy up temporary logs on success of profile-battery/00 test.
Allow communication-method/* tests to complete before tidy by using no-detach reference tests.
Fix attribute that should be `subprocess.Popen.returncode`.