### PR TITLE
Remove unused imports

### DIFF
--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -49,11 +49,8 @@ if remrun(abort_if='edit', forward_x11=True):
     sys.exit(0)
 
 import os
-import re
 import shlex
-import traceback
 from glob import glob
-from time import sleep
 from pipes import quote
 from stat import S_IRUSR
 from tempfile import mkstemp
@@ -68,7 +65,6 @@ from cylc.task_id import TaskID
 from cylc.suite_logging import SUITE_LOG_OPTS
 from cylc.task_job_logs import (
     JOB_LOG_OUT, JOB_LOG_ERR, JOB_LOG_OPTS, NN, JOB_LOGS_LOCAL)
-from parsec.fileparse import read_and_proc
 
 
 # Immortal tail-follow processes on job hosts can be cleaned up by killing

--- a/bin/cylc-get-host-metrics
+++ b/bin/cylc-get-host-metrics
@@ -47,7 +47,6 @@ import re
 from subprocess import Popen, PIPE, CalledProcessError
 import json
 
-import cylc.flags
 from cylc.option_parsers import OptionParser
 
 

--- a/bin/cylc-ping
+++ b/bin/cylc-ping
@@ -32,7 +32,6 @@ import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.task_id import TaskID
 from cylc.network.httpclient import SuiteRuntimeServiceClient
-from cylc.cfgspec.glbl_cfg import glbl_cfg
 
 
 def main():

--- a/bin/cylc-scan
+++ b/bin/cylc-scan
@@ -46,7 +46,6 @@ if "--use-ssh" in sys.argv[1:]:
     if remrun():
         sys.exit(0)
 
-import re
 import json
 
 from cylc.cfgspec.glbl_cfg import glbl_cfg


### PR DESCRIPTION
A few unused imports (did not touch a few `import cylc` as they appear to be expected to be there even if unused to initialize the environment/dirs/etc).

Waited till Travis-CI passed the tests in my fork, so hopefully it won't fail this pull request :haircut_man: 