### PR TITLE
Relative NN symlink on edit-run backout.

### DIFF
--- a/bin/cylc-trigger
+++ b/bin/cylc-trigger
@@ -185,8 +185,7 @@ def main():
             else:
                 # Reset to previous NN symlink and delete the log directory.
                 dirname = os.path.dirname(real_log_dir)
-                os.symlink(os.path.join(dirname, prev_nn),
-                           os.path.join(dirname, "NN"))
+                os.symlink(prev_nn, os.path.join(dirname, "NN"))
                 shutil.rmtree(real_log_dir)
             aborted = True
 


### PR DESCRIPTION
Restore nice relative symlink `NN -> [submit-number]` on edit-run back-out.  See https://github.com/cylc/cylc/pull/2803#issuecomment-430435400

No test needed - just a cosmetic change.