### PR TITLE
Fix security issue reported in Codacy for CylcSuiteDAO.select_task_job in rundb

### DIFF
--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -239,7 +239,7 @@ def get_task_job_attrs(suite_name, point, task, submit_num):
                 suite_name, "suite run directory"),
             "log", CylcSuiteDAO.DB_FILE_BASE_NAME),
         is_public=True)
-    task_job_data = suite_dao.select_task_job(None, point, task, submit_num)
+    task_job_data = suite_dao.select_task_job(point, task, submit_num)
     suite_dao.close()
     if task_job_data is None:
         return (None, None, None)

--- a/doc/src/cylc-user-guide/cug.tex
+++ b/doc/src/cylc-user-guide/cug.tex
@@ -419,6 +419,12 @@ the Cylc GUIs:
           \end{myitemize}
 \end{myitemize}
 
+The following packages are necessary for running all the tests in Cylc:
+
+\begin{myitemize}
+  \item {\bf mock} - \url{https://mock.readthedocs.io}
+\end{myitemize}
+
 The User Guide is generated from \LaTeX source files by running
 \lstinline=make= in the top level Cylc directory. The specific packages
 required may vary by distribution, e.g.:

--- a/lib/cylc/rundb.py
+++ b/lib/cylc/rundb.py
@@ -568,16 +568,15 @@ class CylcSuiteDAO(object):
         for row_idx, row in enumerate(self.connect().execute(stmt)):
             callback(row_idx, list(row))
 
-    def select_task_job(self, keys, cycle, name, submit_num=None):
+    def select_task_job(self, cycle, name, submit_num=None):
         """Select items from task_jobs by (cycle, name, submit_num).
 
-        Return a dict for mapping keys to the column values.
-
+        :return: a dict for mapping keys to the column values
+        :rtype: dict
         """
-        if keys is None:
-            keys = []
-            for column in self.tables[self.TABLE_TASK_JOBS].columns[3:]:
-                keys.append(column.name)
+        keys = []
+        for column in self.tables[self.TABLE_TASK_JOBS].columns[3:]:
+            keys.append(column.name)
         if submit_num in [None, "NN"]:
             stmt = (r"SELECT %(keys_str)s FROM %(table)s"
                     r" WHERE cycle==? AND name==?"

--- a/lib/cylc/tests/test_rundb.py
+++ b/lib/cylc/tests/test_rundb.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python2
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+import mock
+from cylc.rundb import CylcSuiteDAO
+from sqlite3 import DatabaseError
+
+
+class TestRunDb(unittest.TestCase):
+
+    def setUp(self):
+        self.dao = CylcSuiteDAO(':memory:')
+        self.mocked_connection = mock.Mock()
+        self.dao.connect = mock.MagicMock(return_value=self.mocked_connection)
+
+    get_select_task_job = [
+        ["cycle", "name", "NN"],
+        ["cycle", "name", None],
+        ["cycle", "name", "02"],
+    ]
+
+    def test_select_task_job(self):
+        """Test the rundb CylcSuiteDAO select_task_job method"""
+        columns = self.dao.tables[CylcSuiteDAO.TABLE_TASK_JOBS].columns[3:]
+        expected_values = [[2 for _ in columns]]
+
+        self.mocked_connection.execute.return_value = expected_values
+
+        # parameterized test
+        for cycle, name, submit_num in self.get_select_task_job:
+            returned_values = self.dao.select_task_job(cycle, name, submit_num)
+
+            for column in columns:
+                self.assertEqual(2, returned_values[column.name])
+
+    def test_select_task_job_sqlite_error(self):
+        """Test that when the rundb CylcSuiteDAO select_task_job method raises
+        a SQLite exception, the method returns None"""
+
+        self.mocked_connection.execute.side_effect = DatabaseError
+
+        r = self.dao.select_task_job("it'll", "raise", "an error!")
+        self.assertIsNone(r)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
There is one security issue in Codacy that looks possible to be exploited. This pull request follows up a [recent discussion in another ticket](https://github.com/cylc/cylc/issues/2800#issuecomment-430166049), and removes a parameter that was not used, but that if used would change the columns used for the returned values.

Removing that part of the code, I expect Codacy to ignore the error now too. It may still report the issue due to other string concatenations, but at least this one is not a parameter, reducing the risk I believe.