### PR TITLE
Replace range(len) by enumeration

### DIFF
--- a/lib/cylc/conditional_simplifier.py
+++ b/lib/cylc/conditional_simplifier.py
@@ -188,9 +188,7 @@ class ConditionalSimplifier(object):
                 flattened[i] = cls.flatten_nested_expr(flattened[i])
         if isinstance(flattened, list):
             flattened = " ".join(flattened)
-        flattened = "(" + flattened
-        flattened += ")"
-        return flattened
+        return "({})".format(flattened)
 
 
 if __name__ == "__main__":

--- a/lib/cylc/conditional_simplifier.py
+++ b/lib/cylc/conditional_simplifier.py
@@ -116,7 +116,7 @@ class ConditionalSimplifier(object):
     def nest_by_oper(cls, nest_me, oper):
         """Nest a list based on a specified logical operation"""
         found = False
-        for i in range(len(nest_me)):
+        for i, _ in enumerate(nest_me):
             if isinstance(nest_me[i], list):
                 nest_me[i] = cls.nest_by_oper(nest_me[i], oper)
             if nest_me[i] == oper:
@@ -154,7 +154,7 @@ class ConditionalSimplifier(object):
 
         # Recurse through the nested list and remove criterion.
         found = None
-        for i in range(0, len(cleaned)):
+        for i, _ in enumerate(cleaned):
             if isinstance(cleaned[i], list):
                 cleaned[i] = cls.clean_expr(cleaned[i], criterion)
             if cleaned[i] in [criterion, '']:
@@ -183,7 +183,7 @@ class ConditionalSimplifier(object):
     def flatten_nested_expr(cls, expr):
         """Convert a logical expression in a nested list back to a string"""
         flattened = copy.deepcopy(expr)
-        for i in range(len(flattened)):
+        for i, _ in enumerate(flattened):
             if isinstance(flattened[i], list):
                 flattened[i] = cls.flatten_nested_expr(flattened[i])
         if isinstance(flattened, list):

--- a/lib/cylc/conditional_simplifier.py
+++ b/lib/cylc/conditional_simplifier.py
@@ -187,7 +187,7 @@ class ConditionalSimplifier(object):
             if isinstance(flattened[i], list):
                 flattened[i] = cls.flatten_nested_expr(flattened[i])
         if isinstance(flattened, list):
-            flattened = (" ").join(flattened)
+            flattened = " ".join(flattened)
         flattened = "(" + flattened
         flattened += ")"
         return flattened

--- a/lib/cylc/graph_parser.py
+++ b/lib/cylc/graph_parser.py
@@ -205,7 +205,7 @@ class GraphParser(object):
         # Join incomplete lines (beginning or ending with an arrow).
         full_lines = []
         part_lines = []
-        for i in range(0, len(non_blank_lines)):
+        for i, _ in enumerate(non_blank_lines):
             this_line = non_blank_lines[i]
             if i == 0:
                 # First line can't start with an arrow.

--- a/lib/cylc/profiling/analysis.py
+++ b/lib/cylc/profiling/analysis.py
@@ -316,8 +316,8 @@ def print_table(table, transpose=False):
         table = map(list, zip(*table))
     if not table:
         return
-    for row_no in range(len(table)):
-        for col_no in range(len(table[0])):
+    for row_no, _ in enumerate(table):
+        for col_no, _ in enumerate(table[0]):
             cell = table[row_no][col_no]
             if cell is None:
                 table[row_no][col_no] = []
@@ -325,12 +325,12 @@ def print_table(table, transpose=False):
                 table[row_no][col_no] = str(cell)
 
     col_widths = []
-    for col_no in range(len(table[0])):
+    for col_no, _ in enumerate(table[0]):
         col_widths.append(
-            max(len(table[row_no][col_no]) for row_no in range(len(table))))
+            max(len(table[row_no][col_no]) for row_no, _ in enumerate(table)))
 
-    for row_no in range(len(table)):
-        for col_no in range(len(table[row_no])):
+    for row_no, _ in enumerate(table):
+        for col_no, _ in enumerate(table[row_no]):
             if col_no != 0:
                 sys.stdout.write('  ')
             cell = table[row_no][col_no]
@@ -370,7 +370,8 @@ def plot_scale(results, run_names, versions, metric, experiment,
     """Create a scatter plot with line of best fit interpreting float(run_name)
     as the x-axis value."""
     x_data = [int(run_name) for run_name in run_names]
-    colours = [c_map(x / (len(versions) - 0.99)) for x in range(len(versions))]
+    colours = [c_map(x / (len(versions) - 0.99))
+               for x, _ in enumerate(versions)]
 
     for ver_no, version in enumerate(reversed(versions)):
         y_data = []

--- a/lib/cylc/tests/test_conditional_simplifier.py
+++ b/lib/cylc/tests/test_conditional_simplifier.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python2
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from cylc.conditional_simplifier import ConditionalSimplifier
+
+
+class TestConditionalSimplifier(unittest.TestCase):
+    """Test the Cylc ConditionalSimplifier"""
+
+    def test_nest_by_oper_simple(self):
+        """Test the case where we have a simple expression."""
+        nested_expr = ConditionalSimplifier.nest_by_oper(['a', '||', 'b',
+                                                          '||', 'c'], '||')
+        self.assertIsInstance(nested_expr, list)
+        self.assertEqual([['a', '||', 'b'], '||', 'c'], nested_expr)
+
+    def test_nest_by_oper_with_arrays(self):
+        """Test and expression with arrays (combined expressions)."""
+        nested_expr = ConditionalSimplifier.nest_by_oper(
+            [['a', '&', 'b'], '&', ['b', '&', 'c']], '&')
+        self.assertIsInstance(nested_expr, list)
+        self.assertEqual([['a', '&', 'b'], '&', ['b', '&', 'c']],
+                         nested_expr)
+
+    def test_nest_by_oper_not_matching_operator(self):
+        """Test when the operation is simply not found. Same input returned."""
+        input_expr = ['a', 'xor', 'b', 'not', 'c']
+        nested_expr = ConditionalSimplifier.nest_by_oper(input_expr, 'mod')
+        self.assertIsInstance(nested_expr, list)
+        self.assertEqual(input_expr, nested_expr)
+
+    def test_flatten_nested_expr(self):
+        """Test flattened expressions"""
+        flattened = ConditionalSimplifier.flatten_nested_expr(['a', '&', 'b'])
+        self.assertEqual('(a & b)', flattened)
+
+    def test_flatten_nested_expr_with_arrays(self):
+        """Test flattened expressions with nested arrays"""
+        flattened = ConditionalSimplifier.flatten_nested_expr(
+            [['a', '&', 'b'], '&', 'c'])
+        self.assertEqual('((a & b) & c)', flattened)
+
+    get_clean_expr = [
+        [[], None, []],
+        [['a'], None, 'a'],
+        [['a'], 'a', ""],
+        [['a', '&', 'b'], 'b', "a"],
+        [[['a', '&', 'b'], '&', 'c'], '&', 'c'],
+        [['foo', '|', 'bar', '|'], 'foo', ['bar', '|']],
+        [[['a', '&', 'b']], 'a', 'b']
+    ]
+
+    def test_clean_expr(self):
+        """Test clean expressions"""
+        for expr, criterion, expected in self.get_clean_expr:
+            self.assertEqual(expected,
+                             ConditionalSimplifier.clean_expr(expr, criterion))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/cylc/tests/test_graph_parser.py
+++ b/lib/cylc/tests/test_graph_parser.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python2
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from cylc.graph_parser import GraphParser, GraphParseError
+
+
+class TestGraphParser(unittest.TestCase):
+    """Tests for Cylc's GraphParser"""
+
+    def setUp(self):
+        self.parser = GraphParser()
+
+    def test_parse_graph_fails_if_starts_with_arrow(self):
+        """Test that the graph parse will fail when the graph starts with an
+        arrow."""
+        with self.assertRaises(GraphParseError):
+            self.parser.parse_graph("=> b")
+
+    def test_parse_graph_fails_if_ends_with_arrow(self):
+        """Test that the graph parse will fail when the graph ends with an
+        arrow."""
+        with self.assertRaises(GraphParseError):
+            self.parser.parse_graph("a =>")
+
+    def test_parse_graph_fails_with_spaces_in_task_name(self):
+        """Test that the graph parse will fail when the task name contains
+        spaces."""
+        with self.assertRaises(GraphParseError):
+            self.parser.parse_graph("a b => c")
+
+    def test_parse_graph_fails_with_invalid_and_operator(self):
+        """Test that the graph parse will fail when the and operator is not
+        correctly used."""
+        with self.assertRaises(GraphParseError):
+            self.parser.parse_graph("a => c &&")
+
+    def test_parse_graph_fails_with_invalid_or_operator(self):
+        """Test that the graph parse will fail when the or operator is not
+        correctly used."""
+        with self.assertRaises(GraphParseError):
+            self.parser.parse_graph("a => c ||")
+
+    def test_parse_graph_simple(self):
+        """Test parsing graphs."""
+        # added white spaces and comments to show that these change nothing
+        self.parser.parse_graph('a => b\n  \n# this is a comment\n')
+        original = self.parser.original
+        triggers = self.parser.triggers
+        families = self.parser.family_map
+        self.assertEqual(
+            {'a': {'': ''}, 'b': {'a:succeed': 'a:succeed'}},
+            original
+        )
+        self.assertEqual(
+            {'a': {'': ([], False)},
+             'b': {'a:succeed': (['a:succeed'], False)}},
+            triggers
+        )
+        self.assertEqual({}, families)
+
+    def test_parse_graph_simple_with_break_line_01(self):
+        """Test parsing graphs."""
+        self.parser.parse_graph('a => b\n'
+                                '=> c')
+        original = self.parser.original
+        triggers = self.parser.triggers
+        families = self.parser.family_map
+
+        self.assertEqual({'': ''}, original['a'])
+        self.assertEqual({'a:succeed': 'a:succeed'}, original['b'])
+        self.assertEqual({'b:succeed': 'b:succeed'}, original['c'])
+
+        self.assertEqual({'': ([], False)}, triggers['a'])
+        self.assertEqual({'a:succeed': (['a:succeed'], False)}, triggers['b'])
+        self.assertEqual({'b:succeed': (['b:succeed'], False)}, triggers['c'])
+
+        self.assertEqual({}, families)
+
+    def test_parse_graph_simple_with_break_line_02(self):
+        """Test parsing graphs."""
+        self.parser.parse_graph('a => b\n'
+                                '=> c =>\n'
+                                'd')
+        original = self.parser.original
+        triggers = self.parser.triggers
+        families = self.parser.family_map
+
+        self.assertEqual({'': ''}, original['a'])
+        self.assertEqual({'a:succeed': 'a:succeed'}, original['b'])
+        self.assertEqual({'b:succeed': 'b:succeed'}, original['c'])
+        self.assertEqual({'c:succeed': 'c:succeed'}, original['d'])
+
+        self.assertEqual({'': ([], False)}, triggers['a'])
+        self.assertEqual({'a:succeed': (['a:succeed'], False)}, triggers['b'])
+        self.assertEqual({'b:succeed': (['b:succeed'], False)}, triggers['c'])
+        self.assertEqual({'c:succeed': (['c:succeed'], False)}, triggers['d'])
+
+        self.assertEqual({}, families)
+
+    # --- parameterized graphs
+
+    def test_parse_graph_with_parameters(self):
+        """Test parsing graphs with parameters."""
+        parameterized_parser = GraphParser(
+            None, ({'city': ['la_paz']}, {'city': '_%(city)s'}))
+        parameterized_parser.parse_graph('a => b<city>')
+        original = parameterized_parser.original
+        triggers = parameterized_parser.triggers
+        families = parameterized_parser.family_map
+        self.assertEqual(
+            {'a': {'': ''}, 'b_la_paz': {'a:succeed': 'a:succeed'}},
+            original
+        )
+        self.assertEqual(
+            {'a': {'': ([], False)},
+             'b_la_paz': {'a:succeed': (['a:succeed'], False)}},
+            triggers
+        )
+        self.assertEqual({}, families)
+
+    def test_parse_graph_with_invalid_parameters(self):
+        """Test parsing graphs with invalid parameters."""
+        parameterized_parser = GraphParser(
+            None, ({'city': ['la_paz']}, {'city': '_%(city)s'}))
+        with self.assertRaises(GraphParseError):
+            # no state in the parameters list
+            parameterized_parser.parse_graph('a => b<state>')
+
+    # --- inter-suite dependence
+
+    def test_inter_suite_dependence_simple(self):
+        """Test invalid inter-suite dependence"""
+        self.parser.parse_graph('a<SUITE::TASK:fail> => b')
+        original = self.parser.original
+        triggers = self.parser.triggers
+        families = self.parser.family_map
+        suite_state_polling_tasks = self.parser.suite_state_polling_tasks
+        self.assertEqual(
+            {'a': {'': ''}, 'b': {'a:succeed': 'a:succeed'}},
+            original
+        )
+        self.assertEqual(
+            {'a': {'': ([], False)},
+             'b': {'a:succeed': (['a:succeed'], False)}},
+            triggers
+        )
+        self.assertEqual({}, families)
+        self.assertEqual(('SUITE', 'TASK', 'fail', '<SUITE::TASK:fail>'),
+                         suite_state_polling_tasks['a'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This pull request addresses issues reported in Coday about replacing `for x in range(len(abc))` by `for x, _ in enumerate(abc)`.

Using `range(len)` can be [faster](https://stackoverflow.com/a/11990189), but loses in readability (arguably, we could write assembly/cython/c/etc in parts of the `GraphParser` instead, and get better microbenchmarking, but read/maintainability would reduce?) . So I think it's OK to replace the entries in `ConditionalSimplifier` and `GraphParser`. Also changed the `profiling/analysis.py` entries, though I didn't write unit tests for those.

If changing this is too risky, or others think it is not necessary, I would still like to keep the pull request, remove the changes, and leave the tests :grimacing: as that would increase more the coverage for Python 3. No hard feelings at all, especially as I learned a bit more about the `GraphParser`, `GraphExpander`, and `ConditionalSimplifier` - though still very little of everything I need to learn.

Cheers
Bruno