### PR TITLE
New job env var: CYLC_TASK_LOG_DIR.

### DIFF
--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -32,7 +32,7 @@ If remote job logs are retrieved to the suite host on completion (global config
 '[JOB-HOST]retrieve job logs = True') and the job is not currently running, the
 local (retrieved) log will be accessed unless '-o/--force-remote' is used.
 
-Custom job logs (written to $CYLC_TASK_LOG_ROOT on the job host) are available
+Custom job logs (written to $CYLC_TASK_LOG_DIR on the job host) are available
 from the GUI if listed in 'extra log files' in the suite definition. The file
 name must be given here, but can be discovered with '--mode=l' (list-dir).
 

--- a/doc/src/cylc-user-guide/cug.tex
+++ b/doc/src/cylc-user-guide/cug.tex
@@ -4217,7 +4217,9 @@ CYLC_TASK_TRY_NUMBER            # Number of execution tries, e.g. 1
 CYLC_TASK_ID                    # Task instance identifier expressed as
                                 # TASK-NAME.CYCLE-POINT
                                 # e.g. t1.20110511T1800Z
-CYLC_TASK_LOG_ROOT              # Location of the job file
+CYLC_TASK_LOG_DIR               # Location of the job log directory
+                                # e.g. ~/cylc-run/foo/log/job/20110511T1800Z/t1/01/
+CYLC_TASK_LOG_ROOT              # The task job file path
                                 # e.g. ~/cylc-run/foo/log/job/20110511T1800Z/t1/01/job
 CYLC_TASK_WORK_DIR              # Location of task work directory (see below)
                                 # e.g. ~/cylc-run/foo/work/20110511T1800Z/t1

--- a/doc/src/cylc-user-guide/suiterc.tex
+++ b/doc/src/cylc-user-guide/suiterc.tex
@@ -1141,10 +1141,10 @@ for all tasks in the suite.
 \paragraph[inherit]{[runtime] \textrightarrow [[\_\_NAME\_\_]] \textrightarrow
 extra log files}
 
-A list of user defined log files associated with a task. Files defined here
+A list of user-defined log files associated with a task. Files defined here
 will appear alongside the default log files in the cylc gui. Log files
-must reside in the job log directory and ideally should be named using the
-\lstinline=$CYLC_TASK_LOG_ROOT= prefix
+must reside in the job log directory \lstinline=$CYLC_TASK_LOG_DIR= and ideally
+should be named using the \lstinline=$CYLC_TASK_LOG_ROOT= prefix
 (see~\ref{Task Job Script Variables}).
 
 \begin{myitemize}

--- a/lib/cylc/job.sh
+++ b/lib/cylc/job.sh
@@ -98,7 +98,8 @@ cylc__job__main() {
     # Otherwise, a zero padded number will be interpreted as an octal.
     export CYLC_TASK_SUBMIT_NUMBER=$((10#$(cut -d '/' -f 3 <<<"${CYLC_TASK_JOB}")))
     export CYLC_TASK_ID="${CYLC_TASK_NAME}.${CYLC_TASK_CYCLE_POINT}"
-    export CYLC_TASK_LOG_ROOT="${CYLC_SUITE_RUN_DIR}/log/job/${CYLC_TASK_JOB}/job"
+    export CYLC_TASK_LOG_DIR="${CYLC_SUITE_RUN_DIR}/log/job/${CYLC_TASK_JOB}"
+    export CYLC_TASK_LOG_ROOT="${CYLC_TASK_LOG_DIR}/job"
     if [[ -n "${CYLC_TASK_WORK_DIR_BASE:-}" ]]; then
         # Note: value of CYLC_TASK_WORK_DIR_BASE may contain variable
         # substitution syntax including some of the derived variables above, so

--- a/tests/job-submission/01-job-nn-localhost/suite.rc
+++ b/tests/job-submission/01-job-nn-localhost/suite.rc
@@ -16,7 +16,7 @@
 {% endif %}
     [[foo]]
         script="""
-JOB_LOG_DIR=$(dirname $(dirname "$CYLC_TASK_LOG_ROOT"))
+JOB_LOG_DIR=$(dirname "$CYLC_TASK_LOG_DIR")
 readlink "$JOB_LOG_DIR/NN" >>what-is-nn.txt
 echo "$JOB_LOG_DIR/NN"
 # bash 4.2.0 bug: ((VAR == VAL)) does not trigger 'set -e':


### PR DESCRIPTION
Fix a small but long-standing niggle.  Users (/jobs) can write custom files to task job log directories via `$CYLC_TASK_LOG_ROOT`, which is not very intuitively named and which is actually the full path of the job script.  I think(?) this was originally intended to encourage users to prefix all custom filenames with "job", but there's really no reason why they can't have entirely different filenames in the job log directory (in fact I'd argue the "job" prefix should be reserved for files automatically generated by cylc, to make custom ones stand out) ... and this doesn't stop them anyway (via `$(dirname $CYLC_TASK_LOG_ROOT)/my-file`).  

So this PR adds `$CYLC_TASK_LOG_DIR` to job environments.  (And modifies one test enough to ensure that the variable exists).