### PR TITLE
Reveal gscan menu-bar by default.

### DIFF
--- a/lib/cylc/cfgspec/gscan.py
+++ b/lib/cylc/cfgspec/gscan.py
@@ -37,7 +37,7 @@ SPEC = {
     'suite status update interval': vdr(
         vtype='interval', default=DurationFloat(15)),
     'window size': vdr(vtype='integer_list', default=[300, 200]),
-    'hide main menubar': vdr(vtype='boolean', default=True),
+    'hide main menubar': vdr(vtype='boolean', default=False),
 }
 
 


### PR DESCRIPTION
Response to the following comment from @jarich:

>  having spent a month giving training to folk on how to understand the cylc GUI, and having to ask you questions like **"how do I get the menu?" (alt-m I think it was) for gscan**; [...] it was .... an education

@dpmatthews - when gscan originally acquired more interactive functionality we left the menubar hidden by default for existing users who had come to like the minimalist UI (as I recall).  However, on reflection, that was clearly the wrong decision. (Those users can stil turn it off in their `gscan.rc`).