### PR TITLE
Fix new test: event order can change.

### DIFF
--- a/tests/events/45-task-event-handler-multi-warning.t
+++ b/tests/events/45-task-event-handler-multi-warning.t
@@ -48,7 +48,7 @@ suite_run_ok "${TEST_NAME_BASE}-run" \
 cylc cat-log "${SUITE_NAME}" \
     | sed -n -e 's/^.*\(\[(('"'"'event-handler-00'"'"'.*$\)/\1/p' >'log'
 
-cmp_ok log <<__END__
+contains_ok log <<__END__
 [(('event-handler-00', 'warning-1'), 1) cmd] echo "HANDLED cat"
 [(('event-handler-00', 'warning-1'), 1) ret_code] 0
 [(('event-handler-00', 'warning-1'), 1) out] HANDLED cat


### PR DESCRIPTION
Follow-up to #2807 

@kinow - one review will do on this, if you have the time today.  This illustrates the event timing issue discussed in 2807.  See documentation of `contains_ok` vs `cmp_ok` in `tests/lib/bash/test_header`.