### PR TITLE
Cylc reg tweak.

### DIFF
--- a/bin/cylc-register
+++ b/bin/cylc-register
@@ -22,8 +22,9 @@ Register the name REG for the suite definition in PATH. The suite server
 program can then be started, stopped, and targeted by name REG. (Note that
 "cylc run" can also register suites on the fly).
 
-Registration creates a suite run directory "~/cylc-run/REG/" with a ".service/"
-sub-directory containing authentication files and a "source" symlink to PATH.
+Registration creates a suite run directory "~/cylc-run/REG/" containing a
+".service/source" symlink to the suite definition PATH. The .service directory
+will also be used for server authentication files at run time.
 
 Suite names can be hierarchical, corresponding to the path under ~/cylc-run.
 

--- a/lib/cylc/scheduler_cli.py
+++ b/lib/cylc/scheduler_cli.py
@@ -85,8 +85,11 @@ def main(is_restart=False):
     options, args = parse_commandline(is_restart)
     if not args:
         # Auto-registration: "cylc run" (no args) in source dir.
-        reg = SuiteSrvFilesManager().register()
-        # Replace this process with "cylc run REG ..." for easy identification.
+        try:
+            reg = SuiteSrvFilesManager().register()
+        except SuiteServiceFileError as exc:
+            sys.exit(exc)
+        # Replace this process with "cylc run REG ..." for 'ps -f'.
         os.execv(sys.argv[0], [sys.argv[0]] + [reg] + sys.argv[1:])
 
     # Check suite is not already running before start of host selection.

--- a/tests/registration/00-simple.t
+++ b/tests/registration/00-simple.t
@@ -83,7 +83,8 @@ run_ok "${TEST_NAME}" cylc register $CHEESE $CHEESE
 TEST_NAME="${TEST_NAME_BASE}-repurpose1"
 run_fail "${TEST_NAME}" cylc register $CHEESE $YOGHURT
 contains_ok "${TEST_NAME}.stderr" <<__ERR__
-ERROR: the suite name '$CHEESE' is already used for ${PWD}/$CHEESE.
+ERROR: the name '$CHEESE' already points to ${PWD}/$CHEESE.
+Use --redirect to re-use an existing name and run directory.
 __ERR__
 
 # Test succeed "cylc reg REG PATH" where REG already points to PATH2
@@ -91,8 +92,9 @@ TEST_NAME="${TEST_NAME_BASE}-repurpose2"
 cp -r $CHEESE $YOGHURT
 run_ok "${TEST_NAME}" cylc register --redirect $CHEESE $YOGHURT
 contains_ok "${TEST_NAME}.stderr" <<__ERR__
-WARNING: the suite name '$CHEESE' was used for ${PWD}/$CHEESE.
-The run directory will be reused for ${PWD}/$YOGHURT.
+WARNING: the name '$CHEESE' points to ${PWD}/$CHEESE.
+It will now be redirected to ${PWD}/$YOGHURT.
+Files in the existing $CHEESE run directory will be overwritten.
 __ERR__
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
 REGISTERED $CHEESE -> ${PWD}/$YOGHURT


### PR DESCRIPTION
Follow-up to #2759 (sorry) to disallow a confusing edge case.

On master, `cylc reg NAME` (i.e. PATH arg omitted) does nothing if NAME is already registered to another suite, but it registers a suite in `$PWD` as NAME [if it isn't already registered]. 

The former case is not correct.  If deriving suite path or name from current directory path, it doesn't make sense to simply "re-register" an existing suite in a different location.

So now, on this branch `cylc reg NAME` always "tries to" point NAME at `$PWD/suite.rc`.  By "tries to" I mean does so if NAME is not already used, otherwise abort unless `--redirect` is used (because overwriting an existing run directory is potentially dangerous).  This is consistent with `cylc reg NAME PATH` always trying to register `$PWD/suite.rc` as NAME. 

In fixing this I tweaked the registration function logic again, to make it easier to follow.