### PR TITLE
WIP: Local run dir mode

### DIFF
--- a/bin/cylc-register
+++ b/bin/cylc-register
@@ -28,26 +28,26 @@ will also be used for server authentication files at run time.
 
 Suite names can be hierarchical, corresponding to the path under ~/cylc-run.
 
-  % cylc register dogs/fido PATH
-Register PATH/suite.rc as dogs/fido, with run directory ~/cylc-run/dogs/fido.
+  % cylc register NAME PATH
+Register PATH/suite.rc as NAME, with run directory ~/cylc-run/NAME/.
 
-  % cylc register dogs/fido
-Register $PWD/suite.rc as dogs/fido.
+  % cylc register NAME
+Register $PWD/suite.rc as NAME
 
   % cylc register
-Register $PWD/suite.rc as the parent directory name: $(basename $PWD).
+Register $PWD/suite.rc as $(basename $PWD).
 
-The same suite can be registered with multiple names; this results in multiple
-suite run directories that link to the same suite definition.
+The same suite can be registered with several names. This allows several suite
+daemons, each writing to a different run directory, to execute the same suite
+definition.
+
+The command will abort if the name is already used for another suite, unless
+"--redirect" is used (this is potentially dangerous because the new suite will
+overwrite files in the existing run directory - consider deleting or renaming
+an existing run directory rather than re-using it with another suite).
 
 To "unregister" a suite, delete or rename its run directory (renaming it under
-~/cylc-run effectively re-registers the original suite with the new name).
-
-Use of "--redirect" is required to allow an existing name (and run directory)
-to be associated with a different suite definition. This is potentially
-dangerous because the new suite will overwrite files in the existing run
-directory. You should consider deleting or renaming an existing run directory
-rather than just re-use it with another suite."""
+~/cylc-run effectively re-registers the original suite with the new name)."""
 
 
 import sys

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -491,15 +491,18 @@ class GlobalConfig(ParsecConfig):
             self, suite, item, host=None, owner=None, replace_home=False):
         """Compute hardwired paths relative to the configurable top dirs."""
 
-        # suite run dir
-        srdir = os.path.join(
-            self.get_host_item('run directory', host, owner, replace_home),
-            suite)
-        # suite workspace
-        swdir = os.path.join(
-            self.get_host_item('work directory', host, owner, replace_home),
-            suite)
-
+        if os.path.isabs(suite):
+            # Local run-dir mode.
+            srdir = os.path.join(suite, 'cylc-run')
+            swdir = srdir
+        else:
+            # Normal run-dir mode.
+            srdir = os.path.join(
+                self.get_host_item(
+                    'run directory', host, owner, replace_home), suite)
+            swdir = os.path.join(
+                self.get_host_item(
+                    'work directory', host, owner, replace_home), suite)
         if item == 'suite run directory':
             value = srdir
 

--- a/lib/cylc/scheduler_cli.py
+++ b/lib/cylc/scheduler_cli.py
@@ -43,14 +43,21 @@ The scheduler will run as a daemon unless you specify --no-detach.
 If the suite is not already registered (by "cylc register" or a previous run)
 it will be registered on the fly before start up.
 
-% cylc run REG
-  Run the suite registered with name REG.
-
 % cylc run
-  Register $PWD/suite.rc as $(basename $PWD) and run it.
- (Note REG must be given explicitly if START_POINT is on the command line.)
+  Register $PWD/suite.rc as $(basename $PWD) and run it. This will fail if the
+  name is already registered. (And note that REG must be given explicitly with
+  START_POINT on the command line.)
+
+% cylc run REG
+  Run the suite registered as REG. (Note unlike "cylc register REG" this will
+  not implicitly register $PWD/suite.rc and run it as REG, because of the risk
+  of mistyping an intended already-registered suite name).
+
+% cylc run ABS-PATH
+  Run the suite defintion located in ABS-PATH, in local run directory mode.
 
 A "cold start" (the default) starts from the suite initial cycle point
+
 (specified in the suite.rc or on the command line). Any dependence on tasks
 prior to the suite initial cycle point is ignored.
 
@@ -89,9 +96,9 @@ def main(is_restart=False):
         # Replace this process with "cylc run REG ..." for 'ps -f'.
         os.execv(sys.argv[0], [sys.argv[0]] + [reg] + sys.argv[1:])
 
-    # Check suite is not already running before start of host selection.
     try:
-        SuiteSrvFilesManager().detect_old_contact_file(args[0])
+        # If reg is given, the name must already be registered.
+        reg = SuiteSrvFilesManager().register(args[0], implicit=False)
     except SuiteServiceFileError as exc:
         sys.exit(exc)
 

--- a/tests/registration/00-simple.t
+++ b/tests/registration/00-simple.t
@@ -37,7 +37,7 @@ PRE=cylctb-reg-${CYLC_TEST_TIME_INIT}
 # Test fail no suite.rc file.
 CYLC_RUN_DIR=$(cylc get-global --print-run-dir)
 TEST_NAME="${TEST_NAME_BASE}-noreg"
-run_fail "${TEST_NAME}" cylc register "${SUITE_NAME}" "${PWD}/zilch"
+run_fail "${TEST_NAME}" cylc register "${SUITE_NAME}2" "${PWD}/zilch"
 contains_ok "${TEST_NAME}.stderr" <<__ERR__
 ERROR: no suite.rc in ${PWD}/zilch
 __ERR__
@@ -91,10 +91,10 @@ __ERR__
 TEST_NAME="${TEST_NAME_BASE}-repurpose2"
 cp -r $CHEESE $YOGHURT
 run_ok "${TEST_NAME}" cylc register --redirect $CHEESE $YOGHURT
-sed -i 's/^\t//; s/^.* WARNING - /WARNING - /' "${TEST_NAME}.stderr"
+cp $TEST_NAME.stderr ~
 contains_ok "${TEST_NAME}.stderr" <<__ERR__
-WARNING - the name '$CHEESE' points to ${PWD}/$CHEESE.
-It will now be redirected to ${PWD}/$YOGHURT.
+WARNING: the name '$CHEESE' points to ${PWD}/$CHEESE.
+It will now be redirected to $YOGHURT.
 Files in the existing $CHEESE run directory will be overwritten.
 __ERR__
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
@@ -104,7 +104,7 @@ rm -rf "${CYLC_RUN_DIR}/$CHEESE"
 
 run_ok "${TEST_NAME_BASE}-get-dir" cylc get-directory "${SUITE_NAME}"
 
-cd .. # necessary so the suite is being validated via the database not filepath
+cd .. # so the suite is being validated via the database not filepath
 run_ok "${TEST_NAME_BASE}-val" cylc validate "${SUITE_NAME}"
 cd "${OLDPWD}"
 


### PR DESCRIPTION
Close #2797 

Currently `cylc register NAME PATH` associates suite name NAME and run directory `~/cylc-run/NAME/` with a suite definition in PATH. At run time the server is targetted by name, the run directory located by name (and all task job logs are captured there). 

Following the discussion in https://github.com/cylc/cylc/issues/2749#issuecomment-414978342 this PR  supports a new mode in which suites are not registered and are identified by source path rather than name:
- `cylc run ABS-PATH`
- run directory is `ABS-PATH/cylc-run/`
- suite name is `ABS-PATH`  (thus `cylc stop ABS-PATH` etc.)
- the suite is invisible to plain `cylc scan/gscan` (which looks in the standard run dir) but can be seen with `cylc scan/gscan -a` (port scan) 

These suites still have the full verbose set of cylc job logs, BUT:
- they do not pollute the standard cylc-run directory
  - thus avoiding the sub-suite house-keeping problem
- they could be located on fast local filesystem or RAM disk
  - they can be house-kept by the main-suite tasks that run them.


This might be a good interim solution to some post-processing problems - ping @benfitzpatrick @TomekTrzeciak  - particularly for small quick-running sub-suites that can be treated like tasks (so no need to worry about the fact that mid-run restarts aren't handled automatically by the main suite).

If agreed, I will document (including advice on what to do about restarts etc.) and add tests.

It might be stretch to get this in next-release (next week) ... but it is a small change that is orthogonal to existing functionality.