### PR TITLE
fix cylc run REG without cylc register

### DIFF
--- a/lib/cylc/scheduler_cli.py
+++ b/lib/cylc/scheduler_cli.py
@@ -88,6 +88,12 @@ def main(is_restart=False):
         reg = SuiteSrvFilesManager().register()
         # Replace this process with "cylc run REG ..." for easy identification.
         os.execv(sys.argv[0], [sys.argv[0]] + [reg] + sys.argv[1:])
+    elif not os.path.exists(
+            SuiteSrvFilesManager().get_suite_srv_dir(args[0], options.owner)):
+        # Source path is assumed to be the run directory
+        SuiteSrvFilesManager().register(
+            args[0],
+            glbl_cfg().get_derived_host_item(args[0], 'suite run directory'))
 
     # Check suite is not already running before start of host selection.
     try:

--- a/lib/cylc/scheduler_cli.py
+++ b/lib/cylc/scheduler_cli.py
@@ -88,12 +88,6 @@ def main(is_restart=False):
         reg = SuiteSrvFilesManager().register()
         # Replace this process with "cylc run REG ..." for easy identification.
         os.execv(sys.argv[0], [sys.argv[0]] + [reg] + sys.argv[1:])
-    elif not os.path.exists(
-            SuiteSrvFilesManager().get_suite_srv_dir(args[0], options.owner)):
-        # Source path is assumed to be the run directory
-        SuiteSrvFilesManager().register(
-            args[0],
-            glbl_cfg().get_derived_host_item(args[0], 'suite run directory'))
 
     # Check suite is not already running before start of host selection.
     try:
@@ -118,6 +112,14 @@ def main(is_restart=False):
             return remote_cylc_cmd(base_cmd, host=host)
     if remrun(set_rel_local=True):  # State localhost as above.
         sys.exit()
+
+    try:
+        SuiteSrvFilesManager().get_suite_source_dir(args[0], options.owner)
+    except SuiteServiceFileError:
+        # Source path is assumed to be the run directory
+        SuiteSrvFilesManager().register(
+            args[0],
+            glbl_cfg().get_derived_host_item(args[0], 'suite run directory'))
 
     try:
         scheduler = Scheduler(is_restart, options, args)

--- a/lib/cylc/suite_srv_files_mgr.py
+++ b/lib/cylc/suite_srv_files_mgr.py
@@ -489,9 +489,9 @@ To start a new run, stop the old one first with one or more of these:
 
     def create_auth_files(self, reg):
         """Create or renew passphrase and SSL files for suite 'reg'."""
-
         # Suite service directory.
         srv_d = self.get_suite_srv_dir(reg)
+        mkdir_p(srv_d)
 
         # Create a new passphrase for the suite if necessary.
         if not self._locate_item(self.FILE_BASE_PASSPHRASE, srv_d):

--- a/tests/registration/02-on-the-fly.t
+++ b/tests/registration/02-on-the-fly.t
@@ -14,11 +14,14 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#------------------------------------------------------------------------------
 # Test on-the-fly suite registration by "cylc run"
+#------------------------------------------------------------------------------
+# Test `cylc run` with no registration
 
 . "$(dirname "$0")/test_header"
-set_test_number 3 
+set_test_number 6
+
+TEST_NAME="${TEST_NAME_BASE}-pwd"
 
 TESTD="cylctb-cheese-${CYLC_TEST_TIME_INIT}"
 mkdir "${TESTD}"
@@ -27,20 +30,46 @@ cat >> "${TESTD}/suite.rc" <<'__SUITE_RC__'
     title = the quick brown fox
 [scheduling]
     [[dependencies]]
-        graph = foo 
+        graph = foo
 [runtime]
     [[foo]]
         script = true
 __SUITE_RC__
 
-TEST_NAME="${TEST_NAME_BASE}-run"
 cd "${TESTD}"
-run_ok "${TEST_NAME}" cylc run --hold
-contains_ok "${TEST_NAME}.stdout" <<__ERR__
+run_ok "${TEST_NAME}-run" cylc run --hold
+contains_ok "${TEST_NAME}-run.stdout" <<__ERR__
 REGISTERED ${TESTD} -> ${PWD}
 __ERR__
 
-TEST_NAME="${TEST_NAME_BASE}-stop"
-run_ok "${TEST_NAME}" cylc stop "${TESTD}"
+run_ok "${TEST_NAME}-stop" cylc stop "${TESTD}"
 
 purge_suite $TESTD
+#------------------------------------------------------------------------------
+# Test `cylc run` REG for an un-registered suite
+TESTD="cylctb-${CYLC_TEST_TIME_INIT}/${TEST_NAME_BASE}"
+CYLC_RUN_DIR=$(cylc get-global --print-run-dir)
+
+mkdir -p "${CYLC_RUN_DIR}/${TESTD}"
+cat >> "${CYLC_RUN_DIR}/${TESTD}/suite.rc" <<'__SUITE_RC__'
+[meta]
+    title = the quick brown fox
+[scheduling]
+    [[dependencies]]
+        graph = foo
+[runtime]
+    [[foo]]
+        script = true
+__SUITE_RC__
+
+TEST_NAME="${TEST_NAME_BASE}-cylc-run-dir"
+run_ok "${TEST_NAME}-run" cylc run --hold "${TESTD}"
+contains_ok "${TEST_NAME}-run.stdout" <<__ERR__
+REGISTERED ${TESTD} -> ${CYLC_RUN_DIR}/${TESTD}
+__ERR__
+
+run_ok "${TEST_NAME}stop-" cylc stop "${TESTD}"
+
+purge_suite $TESTD
+
+exit


### PR DESCRIPTION
With #2759 we accidentally broke the ability to write a suite in the `cylc-run` directory and execute it in place without registration. (see https://github.com/cylc/cylc/pull/2759/files#diff-cc8dd196aae04c5bc5e5df82839b59eaL425)

With this change if a suite directory exists but the `.service` doesn't, Cylc will register the suite as `cylc-run/REG`. Can we think of a better check than the presence of the `.service` dir?

Happy to change approach but feel free to take over this one if it will speed up the release.