### PR TITLE
Print simple socket error.

### DIFF
--- a/lib/cylc/hostuserutil.py
+++ b/lib/cylc/hostuserutil.py
@@ -47,10 +47,12 @@ returning the IP address associated with this socket.
 """
 
 import os
+import sys
 import pwd
 import socket
 from time import time
 
+import cylc.flags
 from cylc.cfgspec.glbl_cfg import glbl_cfg
 
 
@@ -111,7 +113,13 @@ class HostUtil(object):
     @staticmethod
     def get_host_ip_by_name(target):
         """Return internal IP address of target."""
-        return socket.gethostbyname(target)
+        try:
+            return socket.gethostbyname(target)
+        except socket.error as exc:
+            if cylc.flags.debug:
+                raise
+            sys.stderr.write("ERROR: %s: %s\n" % (exc, target))
+            return None
 
     def _get_host_info(self, target=None):
         """Return the extended info of the current host."""

--- a/lib/cylc/hostuserutil.py
+++ b/lib/cylc/hostuserutil.py
@@ -47,12 +47,10 @@ returning the IP address associated with this socket.
 """
 
 import os
-import sys
 import pwd
 import socket
 from time import time
 
-import cylc.flags
 from cylc.cfgspec.glbl_cfg import glbl_cfg
 
 
@@ -113,13 +111,7 @@ class HostUtil(object):
     @staticmethod
     def get_host_ip_by_name(target):
         """Return internal IP address of target."""
-        try:
-            return socket.gethostbyname(target)
-        except socket.error as exc:
-            if cylc.flags.debug:
-                raise
-            sys.stderr.write("ERROR: %s: %s\n" % (exc, target))
-            return None
+        return socket.gethostbyname(target)
 
     def _get_host_info(self, target=None):
         """Return the extended info of the current host."""


### PR DESCRIPTION
As reported by @jonnyhtw on the mail forum, 
```
cylc (g)scan zilch
``` 

drops a large number of nasty tracebacks if host `zilch` does not exist - difficult for users to understand.

On this branch, you get multiple lines of this instead:
```
ERROR: [Errno -2] Name or service not known: zilch
```

There are multiple errors because we attempt to scan multiple ports.  It would be a bit harder to report the error only once, but probably not necessary.