### PR TITLE
2739 doc fixes

### DIFF
--- a/bin/cylc-suite-state
+++ b/bin/cylc-suite-state
@@ -28,9 +28,6 @@ it (consider max-polls*interval as an overall timeout).
 
 Note for non-cycling tasks --point=1 must be provided.
 
-Important: cylc suite-state only works with task states and does not work with
-task messages.
-
 For your own suites the database location is determined by your
 site/user config. For other suites, e.g. those owned by others, or
 mirrored suite databases, use --run-dir=DIR to specify the location.

--- a/doc/src/cylc-user-guide/cug.tex
+++ b/doc/src/cylc-user-guide/cug.tex
@@ -7934,16 +7934,8 @@ at \lstinline=3,9,15,21=:
             graph = "my-dog[-PT3H] => cat"
 \end{lstlisting}
 
-For suite-state polling the cycle point of the target task is treated as a
-literal string so the polling command has to be told if the remote suite has a
-different cycle point format. Use the \lstinline=--template= option for this,
-or in-suite:
-\begin{lstlisting}
-[runtime]
-    [[my-foo]]
-        [[[suite state polling]]]
-            template = %Y-%m-%dT%H
-\end{lstlisting}
+For suite-state polling, the cycle point is automatically converted to the
+cycle point format of the target suite.
 
 The remote suite does not have to be running when polling commences because the
 command interrogates the suite run database, not the suite server program.

--- a/doc/src/cylc-user-guide/cug.tex
+++ b/doc/src/cylc-user-guide/cug.tex
@@ -7875,10 +7875,12 @@ using the older inter-suite triggering mechanism described in this section.}
 The \lstinline=cylc suite-state= command interrogates suite run databases. It
 has a polling mode that waits for a given task in the target suite to achieve a
 given state, or receive a given message. This can be used to make task
-scripting wait for a remote task
-to succeed (for example). The suite graph notation also provides a way to
-define automatic suite-state polling tasks, which use the same polling command
-under the hood.
+scripting wait for a remote task to succeed (for example).
+
+Automatic suite-state polling tasks can be defined with in the graph. They get
+automatically-generated task scripting that uses \lstinline=cylc suite-state=
+appropriately (it is an error to give your own \lstinline=script= item for these
+tasks).
 
 Here's how to trigger a task \lstinline=bar= off a task \lstinline=foo= in
 a remote suite called \lstinline=other.suite=:
@@ -7911,7 +7913,7 @@ configured if necessary under the local polling task runtime section:
 \end{lstlisting}
 
 To poll for the target task to receive a message rather than achieve a state,
-give the message in the runtime configuration (in which case the status
+give the message in the runtime configuration (in which case the task status
 inferred from the graph syntax will be ignored):
 
 \begin{lstlisting}
@@ -7920,7 +7922,6 @@ inferred from the graph syntax will be ignored):
         [[[suite state polling]]]
             message = "the quick brown fox"
 \end{lstlisting}
-
 
 For suites owned by others, or those with run databases in non-standard
 locations, use the \lstinline=--run-dir= option, or in-suite:

--- a/doc/src/cylc-user-guide/cug.tex
+++ b/doc/src/cylc-user-guide/cug.tex
@@ -7874,12 +7874,11 @@ using the older inter-suite triggering mechanism described in this section.}
 
 The \lstinline=cylc suite-state= command interrogates suite run databases. It
 has a polling mode that waits for a given task in the target suite to achieve a
-given state. This can be used to make task scripting wait for a remote task
+given state, or receive a given message. This can be used to make task
+scripting wait for a remote task
 to succeed (for example). The suite graph notation also provides a way to
 define automatic suite-state polling tasks, which use the same polling command
-under the hood. Note that cylc suite-state can only trigger off task
-{\em states} in remote suites and does not support triggering off task
-messages.
+under the hood.
 
 Here's how to trigger a task \lstinline=bar= off a task \lstinline=foo= in
 a remote suite called \lstinline=other.suite=:
@@ -7910,6 +7909,18 @@ configured if necessary under the local polling task runtime section:
             max-polls = 100
             interval = PT10S
 \end{lstlisting}
+
+To poll for the target task to receive a message rather than achieve a state,
+give the message in the runtime configuration (in which case the status
+inferred from the graph syntax will be ignored):
+
+\begin{lstlisting}
+[runtime]
+    [[my-foo]]
+        [[[suite state polling]]]
+            message = "the quick brown fox"
+\end{lstlisting}
+
 
 For suites owned by others, or those with run databases in non-standard
 locations, use the \lstinline=--run-dir= option, or in-suite:

--- a/doc/src/cylc-user-guide/suiterc.tex
+++ b/doc/src/cylc-user-guide/suiterc.tex
@@ -2050,6 +2050,16 @@ will be invoked on the remote account.
     \item {\em default:} (none)
 \end{myitemize}
 
+\subparagraph[host]{[runtime] \textrightarrow [[\_\_NAME\_\_]] \textrightarrow [[[suite state polling]]] \textrightarrow message}
+
+Wait for the target task in the target suite to receive a specified message
+rather than achieve a state.
+
+\begin{myitemize}
+    \item {\em type:} string (hostname)
+    \item {\em default:} (none)
+\end{myitemize}
+
 \subparagraph[verbose]{[runtime] \textrightarrow [[\_\_NAME\_\_]] \textrightarrow [[[suite state polling]]] \textrightarrow verbose}
 
 Run the polling \lstinline=cylc suite-state= command in verbose output mode.

--- a/doc/src/cylc-user-guide/suiterc.tex
+++ b/doc/src/cylc-user-guide/suiterc.tex
@@ -2056,7 +2056,7 @@ Wait for the target task in the target suite to receive a specified message
 rather than achieve a state.
 
 \begin{myitemize}
-    \item {\em type:} string (hostname)
+    \item {\em type:} string (the message)
     \item {\em default:} (none)
 \end{myitemize}
 

--- a/doc/src/cylc-user-guide/suiterc.tex
+++ b/doc/src/cylc-user-guide/suiterc.tex
@@ -2011,16 +2011,6 @@ suite-name sub-directory of this location).
     \item {\em default:} as configured by site/user config (for your own suites)
 \end{myitemize}
 
-\subparagraph[template]{[runtime] \textrightarrow [[\_\_NAME\_\_]] \textrightarrow [[[suite state polling]]] \textrightarrow template}
-
-Cycle point template of the target suite, if different from that of the polling suite.
-
-\begin{myitemize}
-    \item {\em type:} string
-    \item {\em default:} cycle point format of the polling suite
-    \item {\em example:} \lstinline=%Y-%m-%dT%H=
-\end{myitemize}
-
 \subparagraph[interval]{[runtime] \textrightarrow [[\_\_NAME\_\_]] \textrightarrow [[[suite state polling]]] \textrightarrow interval}
 
 Polling interval expressed as an ISO 8601 duration/interval.

--- a/lib/cylc/cfgspec/suite.py
+++ b/lib/cylc/cfgspec/suite.py
@@ -378,7 +378,8 @@ def upg(cfg, descr):
     u.obsolete('7.2.2', ['runtime', '__MANY__', 'dummy mode'])
     u.obsolete('7.2.2', ['runtime', '__MANY__', 'simulation mode'])
     u.obsolete('7.6.0', ['runtime', '__MANY__', 'enable resurrection'])
-    u.obsolete('7.8.0', ['runtime', '__MANY__', 'suite state polling', 'template'])
+    u.obsolete('7.8.0', ['runtime', '__MANY__', 'suite state polling',
+                         'template'])
     u.upgrade()
 
 

--- a/lib/cylc/cfgspec/suite.py
+++ b/lib/cylc/cfgspec/suite.py
@@ -241,7 +241,6 @@ SPEC = {
                 'interval': [VDR.V_INTERVAL],
                 'max-polls': [VDR.V_INTEGER],
                 'run-dir': [VDR.V_STRING],
-                'template': [VDR.V_STRING],
                 'verbose mode': [VDR.V_BOOLEAN],
             },
             'environment': {
@@ -378,6 +377,7 @@ def upg(cfg, descr):
     u.obsolete('7.2.2', ['runtime', '__MANY__', 'dummy mode'])
     u.obsolete('7.2.2', ['runtime', '__MANY__', 'simulation mode'])
     u.obsolete('7.6.0', ['runtime', '__MANY__', 'enable resurrection'])
+    u.obsolete('7.8.0', ['runtime', '__MANY__', 'suite state polling', 'template'])
     u.upgrade()
 
 

--- a/lib/cylc/cfgspec/suite.py
+++ b/lib/cylc/cfgspec/suite.py
@@ -240,6 +240,7 @@ SPEC = {
                 'host': [VDR.V_STRING],
                 'interval': [VDR.V_INTERVAL],
                 'max-polls': [VDR.V_INTEGER],
+                'message': [VDR.V_STRING],
                 'run-dir': [VDR.V_STRING],
                 'verbose mode': [VDR.V_BOOLEAN],
             },

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -1230,8 +1230,7 @@ class SuiteConfig(object):
                     ('host', ' --%s=%s'),
                     ('interval', ' --%s=%d'),
                     ('max-polls', ' --%s=%s'),
-                    ('run-dir', ' --%s=%s'),
-                    ('template', ' --%s=%s')]:
+                    ('run-dir', ' --%s=%s')]:
                 if rtc['suite state polling'][key]:
                     comstr += fmt % (key, rtc['suite state polling'][key])
             comstr += " " + tdef.suite_polling_cfg['suite']

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -1223,8 +1223,7 @@ class SuiteConfig(object):
             rtc = tdef.rtconfig
             comstr = "cylc suite-state" + \
                      " --task=" + tdef.suite_polling_cfg['task'] + \
-                     " --point=$CYLC_TASK_CYCLE_POINT" + \
-                     " --status=" + tdef.suite_polling_cfg['status']
+                     " --point=$CYLC_TASK_CYCLE_POINT"
             for key, fmt in [
                     ('user', ' --%s=%s'),
                     ('host', ' --%s=%s'),
@@ -1233,6 +1232,11 @@ class SuiteConfig(object):
                     ('run-dir', ' --%s=%s')]:
                 if rtc['suite state polling'][key]:
                     comstr += fmt % (key, rtc['suite state polling'][key])
+            if rtc['suite state polling']['message']:
+                comstr += " --message='%s'" % (
+                    rtc['suite state polling']['message'])
+            else:
+                comstr += " --status=" + tdef.suite_polling_cfg['status']
             comstr += " " + tdef.suite_polling_cfg['suite']
             script = "echo " + comstr + "\n" + comstr
             rtc['script'] = script

--- a/lib/cylc/task_job_mgr.py
+++ b/lib/cylc/task_job_mgr.py
@@ -359,7 +359,7 @@ class TaskJobManager(object):
             # Automatic suite state polling script
             comstr = "cylc suite-state " + \
                      " --task=" + itask.tdef.suite_polling_cfg['task'] + \
-                     " --point=" + str(itask.point) 
+                     " --point=" + str(itask.point)
             if cylc.flags.debug:
                 comstr += ' --debug'
             for key, fmt in [

--- a/lib/cylc/task_job_mgr.py
+++ b/lib/cylc/task_job_mgr.py
@@ -368,8 +368,7 @@ class TaskJobManager(object):
                     ('host', ' --%s=%s'),
                     ('interval', ' --%s=%d'),
                     ('max-polls', ' --%s=%s'),
-                    ('run-dir', ' --%s=%s'),
-                    ('template', ' --%s=%s')]:
+                    ('run-dir', ' --%s=%s')]:
                 if rtconfig['suite state polling'][key]:
                     comstr += fmt % (key, rtconfig['suite state polling'][key])
             comstr += " " + itask.tdef.suite_polling_cfg['suite']

--- a/lib/cylc/task_job_mgr.py
+++ b/lib/cylc/task_job_mgr.py
@@ -359,8 +359,7 @@ class TaskJobManager(object):
             # Automatic suite state polling script
             comstr = "cylc suite-state " + \
                      " --task=" + itask.tdef.suite_polling_cfg['task'] + \
-                     " --point=" + str(itask.point) + \
-                     " --status=" + itask.tdef.suite_polling_cfg['status']
+                     " --point=" + str(itask.point) 
             if cylc.flags.debug:
                 comstr += ' --debug'
             for key, fmt in [
@@ -371,6 +370,11 @@ class TaskJobManager(object):
                     ('run-dir', ' --%s=%s')]:
                 if rtconfig['suite state polling'][key]:
                     comstr += fmt % (key, rtconfig['suite state polling'][key])
+            if rtconfig['suite state polling']['message']:
+                comstr += " --message='%s'" % (
+                    rtconfig['suite state polling']['message'])
+            else:
+                comstr += " --status=" + itask.tdef.suite_polling_cfg['status']
             comstr += " " + itask.tdef.suite_polling_cfg['suite']
             script = "echo " + comstr + "\n" + comstr
         return pre_script, script, post_script

--- a/tests/cylc-get-config/00-simple/section2.stdout
+++ b/tests/cylc-get-config/00-simple/section2.stdout
@@ -58,9 +58,9 @@
         interval = 
         host = 
         max-polls = 
+        message = 
         run-dir = 
         user = 
-        template = 
         verbose mode = 
     [[[remote]]]
         owner = 
@@ -137,9 +137,9 @@
         interval = 
         host = 
         max-polls = 
+        message = 
         run-dir = 
         user = 
-        template = 
         verbose mode = 
     [[[remote]]]
         owner = 
@@ -217,9 +217,9 @@
         interval = 
         host = 
         max-polls = 
+        message = 
         run-dir = 
         user = 
-        template = 
         verbose mode = 
     [[[remote]]]
         owner = 
@@ -297,9 +297,9 @@
         interval = 
         host = 
         max-polls = 
+        message = 
         run-dir = 
         user = 
-        template = 
         verbose mode = 
     [[[remote]]]
         owner = 
@@ -377,9 +377,9 @@
         interval = 
         host = 
         max-polls = 
+        message = 
         run-dir = 
         user = 
-        template = 
         verbose mode = 
     [[[remote]]]
         owner = 
@@ -457,9 +457,9 @@
         interval = 
         host = 
         max-polls = 
+        message = 
         run-dir = 
         user = 
-        template = 
         verbose mode = 
     [[[remote]]]
         owner = 
@@ -537,9 +537,9 @@
         interval = 
         host = 
         max-polls = 
+        message = 
         run-dir = 
         user = 
-        template = 
         verbose mode = 
     [[[remote]]]
         owner = 
@@ -616,9 +616,9 @@
         interval = 
         host = 
         max-polls = 
+        message = 
         run-dir = 
         user = 
-        template = 
         verbose mode = 
     [[[remote]]]
         owner = 
@@ -696,9 +696,9 @@
         interval = 
         host = 
         max-polls = 
+        message = 
         run-dir = 
         user = 
-        template = 
         verbose mode = 
     [[[remote]]]
         owner = 
@@ -776,9 +776,9 @@
         interval = 
         host = 
         max-polls = 
+        message = 
         run-dir = 
         user = 
-        template = 
         verbose mode = 
     [[[remote]]]
         owner = 
@@ -855,9 +855,9 @@
         interval = 
         host = 
         max-polls = 
+        message = 
         run-dir = 
         user = 
-        template = 
         verbose mode = 
     [[[remote]]]
         owner = 
@@ -935,9 +935,9 @@
         interval = 
         host = 
         max-polls = 
+        message = 
         run-dir = 
         user = 
-        template = 
         verbose mode = 
     [[[remote]]]
         owner = 
@@ -1015,9 +1015,9 @@
         interval = 
         host = 
         max-polls = 
+        message = 
         run-dir = 
         user = 
-        template = 
         verbose mode = 
     [[[remote]]]
         owner = 

--- a/tests/suite-state/00-polling.t
+++ b/tests/suite-state/00-polling.t
@@ -45,15 +45,15 @@ cylc run $UPSTREAM
 # check auto-generated task script for lbad
 cylc get-config --set UPSTREAM=$UPSTREAM -i '[runtime][lbad]script' $SUITE_NAME > lbad.script
 cmp_ok lbad.script << __END__
-echo cylc suite-state --task=bad --point=\$CYLC_TASK_CYCLE_POINT --status=fail --interval=2 --max-polls=20 $UPSTREAM
-cylc suite-state --task=bad --point=\$CYLC_TASK_CYCLE_POINT --status=fail --interval=2 --max-polls=20 $UPSTREAM
+echo cylc suite-state --task=bad --point=\$CYLC_TASK_CYCLE_POINT --interval=2 --max-polls=20 --status=fail $UPSTREAM
+cylc suite-state --task=bad --point=\$CYLC_TASK_CYCLE_POINT --interval=2 --max-polls=20 --status=fail $UPSTREAM
 __END__
 
 # check auto-generated task script for l-good
 cylc get-config --set UPSTREAM=$UPSTREAM -i '[runtime][l-good]script' $SUITE_NAME > l-good.script
 cmp_ok l-good.script << __END__
-echo cylc suite-state --task=good-stuff --point=\$CYLC_TASK_CYCLE_POINT --status=succeed --interval=2 --max-polls=20 $UPSTREAM
-cylc suite-state --task=good-stuff --point=\$CYLC_TASK_CYCLE_POINT --status=succeed --interval=2 --max-polls=20 $UPSTREAM
+echo cylc suite-state --task=good-stuff --point=\$CYLC_TASK_CYCLE_POINT --interval=2 --max-polls=20 --status=succeed $UPSTREAM
+cylc suite-state --task=good-stuff --point=\$CYLC_TASK_CYCLE_POINT --interval=2 --max-polls=20 --status=succeed $UPSTREAM
 __END__
 
 #-------------------------------------------------------------------------------

--- a/tests/suite-state/01-polling.t
+++ b/tests/suite-state/01-polling.t
@@ -41,15 +41,15 @@ run_ok $TEST_NAME cylc val --debug --set UPSTREAM=$UPSTREAM $SUITE_NAME
 # check auto-generated task script for lbad
 cylc get-config --set UPSTREAM=$UPSTREAM -i '[runtime][lbad]script' $SUITE_NAME > lbad.script
 cmp_ok lbad.script << __END__
-echo cylc suite-state --task=bad --point=\$CYLC_TASK_CYCLE_POINT --status=fail --interval=2 --max-polls=20 $UPSTREAM
-cylc suite-state --task=bad --point=\$CYLC_TASK_CYCLE_POINT --status=fail --interval=2 --max-polls=20 $UPSTREAM
+echo cylc suite-state --task=bad --point=\$CYLC_TASK_CYCLE_POINT --interval=2 --max-polls=20 --status=fail $UPSTREAM
+cylc suite-state --task=bad --point=\$CYLC_TASK_CYCLE_POINT --interval=2 --max-polls=20 --status=fail $UPSTREAM
 __END__
 
 # check auto-generated task script for l-good
 cylc get-config --set UPSTREAM=$UPSTREAM -i '[runtime][l-good]script' $SUITE_NAME > l-good.script
 cmp_ok l-good.script << __END__
-echo cylc suite-state --task=good-stuff --point=\$CYLC_TASK_CYCLE_POINT --status=succeed --interval=2 --max-polls=20 $UPSTREAM
-cylc suite-state --task=good-stuff --point=\$CYLC_TASK_CYCLE_POINT --status=succeed --interval=2 --max-polls=20 $UPSTREAM
+echo cylc suite-state --task=good-stuff --point=\$CYLC_TASK_CYCLE_POINT --interval=2 --max-polls=20 --status=succeed $UPSTREAM
+cylc suite-state --task=good-stuff --point=\$CYLC_TASK_CYCLE_POINT --interval=2 --max-polls=20 --status=succeed $UPSTREAM
 __END__
 
 #-------------------------------------------------------------------------------

--- a/tests/suite-state/polling/reference.log
+++ b/tests/suite-state/polling/reference.log
@@ -1,4 +1,6 @@
-2013/10/04 16:54:07 INFO - Initial point: 1
-2013/10/04 16:54:07 INFO - Final point: 1
-2013/10/04 16:54:07 INFO - [lbad.1] -triggered off []
-2013/10/04 16:54:07 INFO - [l-good.1] -triggered off []
+2018-10-30T13:14:12+13 INFO - Initial point: 1
+2018-10-30T13:14:12+13 INFO - Final point: 1
+2018-10-30T13:14:12+13 INFO - [l-good.1] -triggered off []
+2018-10-30T13:14:12+13 INFO - [lbad.1] -triggered off []
+2018-10-30T13:14:12+13 INFO - [l-mess.1] -triggered off []
+2018-10-30T13:14:17+13 INFO - [done.1] -triggered off ['l-mess.1']

--- a/tests/suite-state/polling/suite.rc
+++ b/tests/suite-state/polling/suite.rc
@@ -7,9 +7,17 @@
         live mode suite timeout = PT1M
 [scheduling]
     [[dependencies]]
-        graph = "l-good<{{UPSTREAM}}::good-stuff> & lbad<{{UPSTREAM}}::bad:fail>"
+        graph = """
+          l-good<{{UPSTREAM}}::good-stuff> & lbad<{{UPSTREAM}}::bad:fail>
+          l-mess<{{UPSTREAM}}::messenger> => done
+                """
 [runtime]
     [[l-good,lbad]]
         [[[suite state polling]]]
             interval = PT2S
             max-polls = 20
+    [[l-mess]]
+        [[[suite state polling]]]
+            interval = PT2S
+            max-polls = 20
+            message = "the quick brown fox"

--- a/tests/suite-state/upstream/suite.rc
+++ b/tests/suite-state/upstream/suite.rc
@@ -1,5 +1,5 @@
 [meta]
-    title = "One task takes 20 sec to succeed, another to fail."
+    title = "One task takes 20 sec to succeed, another to fail, another to send a message."
 [cylc]
     [[reference test]]
         live mode suite timeout = PT10M
@@ -8,9 +8,18 @@
         graph = """
              good-stuff & bad
           bad:fail => !bad
+             messenger:x => done
                 """
 [runtime]
+    [[done]]
     [[good-stuff]]
         script = "sleep 20"
     [[bad]]
         script = "sleep 20; /bin/false"
+    [[messenger]]
+        script = """
+          sleep 20
+          cylc message 'the quick brown fox'
+                 """
+        [[[outputs]]]
+          x = "the quick brown fox"


### PR DESCRIPTION
Close #2739 (fix `cylc suite-state` and automatic polling task documentation omissions).

Also, for completeness, makes auto suite-state polling tasks work with the newer `--message` option (poll for task message instead of status). 

