### PR TITLE
parsec configuration dump: nicer int list values

### DIFF
--- a/lib/parsec/tests/unit/01-util.t
+++ b/lib/parsec/tests/unit/01-util.t
@@ -1,0 +1,24 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Run unittest for parsec.util
+. "$(dirname "$0")/test_header"
+
+set_test_number 1
+
+run_ok "${TEST_NAME_BASE}" python -m 'doctest' "${CYLC_DIR}/lib/parsec/util.py"
+exit

--- a/lib/parsec/util.py
+++ b/lib/parsec/util.py
@@ -26,6 +26,75 @@ from copy import copy
 from parsec.OrderedDict import OrderedDictWithDefaults
 
 
+def intlistjoin(lst):
+    """Return dump string for int list.
+
+    Attempt grouping on sequences with 3 or more numbers:
+    * Consider sequential int values in list, group them together in
+      `START..END[..STEP]` syntax where relevant.
+    * Consider same numbers in list, group them together in `N*INT` syntax.
+
+    Arguments:
+        lst (list): a list of int numbers.
+
+    Return (str):
+        The (hopefully) nicely formatted dump string.
+
+    Examples:
+        >>> intlistjoin([])
+        ''
+        >>> intlistjoin([10])
+        '10'
+        >>> intlistjoin([10, 10])
+        '10, 10'
+        >>> intlistjoin([10, 10, 10])
+        '3*10'
+        >>> intlistjoin([10, 11])
+        '10, 11'
+        >>> intlistjoin([10, 11, 12])
+        '10..12'
+        >>> intlistjoin([-1, 1, 3, 5, 0, 0, 0, 8, 9, 11, -1, 0, 1, 2])
+        '-1..5..2, 3*0, 8, 9, 11, -1..2'
+        >>> intlistjoin([-1, 1, 3, 5, 0, 0, 0, 8, 9, 11, 11, 12])
+        '-1..5..2, 3*0, 8, 9, 11, 11, 12'
+        >>> intlistjoin(
+        ...     [-10, -10, -1, 1, 3, 5, 0, 0, 0, 8, 9, 11, -1, 0, 1, 2])
+        '-10, -10, -1..5..2, 3*0, 8, 9, 11, -1..2'
+        >>> intlistjoin(
+        ...     [64747, -10, -10, -10, -1, 1, 3, 5, 0, 0, 0, 8, 9, 11, -1, 0,
+        ...      1, 2, 3, 4, 19, 19, 19, 20, 20, 20, 21, 22, 23])
+        '64747, 3*-10, -1..5..2, 3*0, 8, 9, 11, -1..4, 3*19, 3*20, 21..23'
+    """
+    rets = []
+    items = list(lst)
+    while items:
+        group = [items.pop(0)]
+        while items:
+            if (len(group) == 1 or
+                    items[0] - group[-1] == group[-1] - group[-2]):
+                group.append(items.pop(0))
+            else:
+                # If 2 numbers only, return 1 back if grouping still possible
+                # in subsequent lots.
+                if len(group) == 2 and len(items) >= 2:
+                    items.insert(0, group.pop())
+                break
+        if len(group) <= 2:
+            # Less than 2 numbers
+            rets += [str(item) for item in group]
+        elif group[1] - group[0] > 1:
+            # Sequence of numbers with equal steps > 1
+            rets.append(
+                '%d..%d..%d' % (group[0], group[-1], group[1] - group[0]))
+        elif group[1] - group[0] == 1:
+            # Sequence of incremental numbers
+            rets.append('%d..%d' % (group[0], group[-1]))
+        else:
+            # Sequence of same number
+            rets.append('%d*%d' % (len(group), group[0]))
+    return ', '.join(rets)
+
+
 def listjoin(lst, none_str=''):
     """Return string from joined list.
 
@@ -37,6 +106,8 @@ def listjoin(lst, none_str=''):
     if not lst:
         # empty list
         return none_str
+    if len(lst) > 2 and all(isinstance(item, int) for item in lst):
+        return intlistjoin(lst)
     items = []
     for item in lst:
         if item is None:


### PR DESCRIPTION
Group sequences of 3 or more integers, equal steps `START..END[..STEP]`
syntax or same number `N*INT` syntax.

(It writes the full list currently, so for something like the port range, we can get 100 numbers written out, which is not very nice.)