### PR TITLE
Update isodatetime to 2018.11.0

### DIFF
--- a/lib/cylc/cycling/iso8601.py
+++ b/lib/cylc/cycling/iso8601.py
@@ -301,16 +301,16 @@ class ISO8601Exclusions(ExclusionBase):
     def build_exclusions(self, excl_points):
         for point in excl_points:
             try:
+                # Try making an ISO8601Sequence
+                exclusion = ISO8601Sequence(point, self.exclusion_start_point,
+                                            self.exclusion_end_point)
+                self.exclusion_sequences.append(exclusion)
+            except (AttributeError, TypeError, ValueError):
                 # Try making an ISO8601Point
                 exclusion_point = ISO8601Point.from_nonstandard_string(
                     str(point)) if point else None
                 if exclusion_point not in self.exclusion_points:
                     self.exclusion_points.append(exclusion_point)
-            except (AttributeError, TypeError, ValueError):
-                # Try making an ISO8601Sequence
-                exclusion = ISO8601Sequence(point, self.exclusion_start_point,
-                                            self.exclusion_end_point)
-                self.exclusion_sequences.append(exclusion)
 
 
 class ISO8601Sequence(SequenceBase):

--- a/lib/cylc/cycling/iso8601.py
+++ b/lib/cylc/cycling/iso8601.py
@@ -24,7 +24,7 @@ import unittest
 from isodatetime.data import Calendar, Duration
 from isodatetime.dumpers import TimePointDumper
 from isodatetime.timezone import (
-    get_local_time_zone, get_local_time_zone_format)
+    get_local_time_zone, get_local_time_zone_format, TimeZoneFormatMode)
 from cylc.time_parser import CylcTimeParser
 from cylc.cycling import (
     PointBase, IntervalBase, SequenceBase, ExclusionBase, PointParsingError,
@@ -676,7 +676,7 @@ def init(num_expanded_year_digits=0, custom_dump_format=None, time_zone=None,
             time_zone = "Z"
             time_zone_hours_minutes = (0, 0)
         else:
-            time_zone = get_local_time_zone_format(reduced_mode=True)
+            time_zone = get_local_time_zone_format(TimeZoneFormatMode.reduced)
             time_zone_hours_minutes = get_local_time_zone()
     else:
         time_zone_hours_minutes = TimePointDumper().get_time_zone(time_zone)

--- a/lib/cylc/wallclock.py
+++ b/lib/cylc/wallclock.py
@@ -21,7 +21,7 @@ from calendar import timegm
 from datetime import datetime, timedelta
 
 from isodatetime.timezone import (
-    get_local_time_zone_format, get_local_time_zone)
+    get_local_time_zone_format, get_local_time_zone, TimeZoneFormatMode)
 
 
 DATE_TIME_FORMAT_BASIC = "%Y%m%dT%H%M%S"
@@ -39,9 +39,10 @@ TIME_FORMAT_BASIC_SUB_SECOND = "%H%M%S.%f"
 TIME_FORMAT_EXTENDED = "%H:%M:%S"
 TIME_FORMAT_EXTENDED_SUB_SECOND = "%H:%M:%S.%f"
 
-TIME_ZONE_STRING_LOCAL_BASIC = get_local_time_zone_format(reduced_mode=True)
+TIME_ZONE_STRING_LOCAL_BASIC = get_local_time_zone_format(
+    TimeZoneFormatMode.reduced)
 TIME_ZONE_STRING_LOCAL_EXTENDED = get_local_time_zone_format(
-    extended_mode=True, reduced_mode=True)
+    TimeZoneFormatMode.extended)
 TIME_ZONE_STRING_UTC = "Z"
 TIME_ZONE_UTC_UTC_OFFSET = (0, 0)
 TIME_ZONE_LOCAL_UTC_OFFSET = get_local_time_zone()

--- a/lib/isodatetime/__init__.py
+++ b/lib/isodatetime/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------------
-# (C) British Crown Copyright 2013-2018 Met Office.
+# Copyright (C) 2013-2018 British Crown (Met Office) & Contributors.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by
@@ -17,4 +17,4 @@
 # ----------------------------------------------------------------------------
 """Python ISO 8601 date time parser and data model/manipulation utilities."""
 
-__version__ = "2018.09.0"
+__version__ = "2018.11.0"

--- a/lib/isodatetime/data.py
+++ b/lib/isodatetime/data.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------------
-# (C) British Crown Copyright 2013-2018 Met Office.
+# Copyright (C) 2013-2018 British Crown (Met Office) & Contributors.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by
@@ -530,6 +530,7 @@ class Duration(object):
         new.hours //= other
         new.minutes //= other
         new.seconds //= other
+        return new
 
     def __cmp__(self, other):
         if not isinstance(other, Duration):
@@ -717,10 +718,10 @@ class TimePoint(object):
         "day_of_year", "day_of_month", "day_of_week",
         "week_of_year", "hour_of_day", "minute_of_hour",
         "second_of_minute", "truncated", "truncated_property",
-        "dump_format", "time_zone"
+        "truncated_dump_format", "dump_format", "time_zone"
     ]
 
-    __slots__ = DATA_ATTRIBUTES + ["truncated_dump_format"]
+    __slots__ = DATA_ATTRIBUTES
 
     def __init__(self, expanded_year_digits=0, year=None, month_of_year=None,
                  week_of_year=None, day_of_year=None, day_of_month=None,
@@ -1119,24 +1120,19 @@ class TimePoint(object):
         if not self.truncated:
             return None
         prop_dict = self.get_truncated_properties()
-        attr_keys = ["year_of_century", "decade_of_century",
-                     "year_of_decade", "month_of_year",
-                     "week_of_year", "day_of_year", "day_of_month",
-                     "day_of_week", "hour_of_day", "minute_of_hour",
-                     "second_of_minute"]
-        attr_dict = {"year_of_century": "century",
-                     "year_of_decade": "decade_of_century",
-                     "month_of_year": "year_of_century",
-                     "week_of_year": "year_of_century",
-                     "day_of_year": "year_of_century",
-                     "day_of_month": "month_of_year",
-                     "day_of_week": "week_of_year",
-                     "hour_of_day": "day_of_month",
-                     "minute_of_hour": "hour_of_day",
-                     "second_of_minute": "minute_of_hour"}
-        for attr in attr_keys:
-            if attr in prop_dict:
-                return attr_dict[attr]
+        attr_list = (("year_of_century", "century"),
+                     ("year_of_decade", "decade_of_century"),
+                     ("month_of_year", "year_of_century"),
+                     ("week_of_year", "year_of_century"),
+                     ("day_of_year", "year_of_century"),
+                     ("day_of_month", "month_of_year"),
+                     ("day_of_week", "week_of_year"),
+                     ("hour_of_day", "day_of_month"),
+                     ("minute_of_hour", "hour_of_day"),
+                     ("second_of_minute", "minute_of_hour"))
+        for attr_key, attr_value in attr_list:
+            if attr_key in prop_dict:
+                return attr_value
         return None
 
     def get_truncated_properties(self):
@@ -1293,11 +1289,11 @@ class TimePoint(object):
                     new.day_of_month = max_day_in_new_month
             elif new.get_is_ordinal_date():
                 max_days_in_year = get_days_in_year(new.year)
-                if max_days_in_year > new.day_of_year:
+                if max_days_in_year < new.day_of_year:
                     new.day_of_year = max_days_in_year
             elif new.get_is_week_date():
                 max_weeks_in_year = get_weeks_in_year(new.year)
-                if max_weeks_in_year > new.week_of_year:
+                if max_weeks_in_year < new.week_of_year:
                     new.week_of_year = max_weeks_in_year
         return new
 

--- a/lib/isodatetime/dumpers.py
+++ b/lib/isodatetime/dumpers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------------
-# (C) British Crown Copyright 2013-2018 Met Office.
+# Copyright (C) 2013-2018 British Crown (Met Office) & Contributors.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/lib/isodatetime/parser_spec.py
+++ b/lib/isodatetime/parser_spec.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------------
-# (C) British Crown Copyright 2013-2018 Met Office.
+# Copyright (C) 2013-2018 British Crown (Met Office) & Contributors.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by
@@ -242,7 +242,7 @@ LOCAL_TIME_ZONE_BASIC_NO_Z = LOCAL_TIME_ZONE_BASIC
 if LOCAL_TIME_ZONE_BASIC_NO_Z == "Z":
     LOCAL_TIME_ZONE_BASIC_NO_Z = "+0000"
 LOCAL_TIME_ZONE_EXTENDED = timezone.get_local_time_zone_format(
-    extended_mode=True)
+    timezone.TimeZoneFormatMode.extended)
 LOCAL_TIME_ZONE_EXTENDED_NO_Z = LOCAL_TIME_ZONE_EXTENDED
 if LOCAL_TIME_ZONE_EXTENDED_NO_Z == "Z":
     LOCAL_TIME_ZONE_EXTENDED_NO_Z = "+0000"

--- a/lib/isodatetime/parsers.py
+++ b/lib/isodatetime/parsers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------------
-# (C) British Crown Copyright 2013-2018 Met Office.
+# Copyright (C) 2013-2018 British Crown (Met Office) & Contributors.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/lib/isodatetime/run_tests
+++ b/lib/isodatetime/run_tests
@@ -1,7 +1,7 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
 #-----------------------------------------------------------------------------
-# (C) British Crown Copyright 2013-2018 Met Office.
+# Copyright (C) 2013-2018 British Crown (Met Office) & Contributors.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by
@@ -19,4 +19,4 @@
 # Run tests for the ISO 8601 parsing and data model functionality."""
 #-----------------------------------------------------------------------------
 cd "$(dirname "$0")/../"
-python -m isodatetime.tests
+TZ=UTC python -m isodatetime.tests

--- a/lib/isodatetime/timezone.py
+++ b/lib/isodatetime/timezone.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------------
-# (C) British Crown Copyright 2013-2018 Met Office.
+# Copyright (C) 2013-2018 British Crown (Met Office) & Contributors.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by
@@ -16,9 +16,16 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # ----------------------------------------------------------------------------
 
-"""This provides utilites for extracting the local time zone."""
+"""This provides utilities for extracting the local time zone."""
 
 import time
+import math
+
+
+class TimeZoneFormatMode(object):
+    normal = "normal"
+    reduced = "reduced"
+    extended = "extended"
 
 
 def get_local_time_zone():
@@ -27,21 +34,26 @@ def get_local_time_zone():
     if time.localtime().tm_isdst == 1 and time.daylight:
         utc_offset_seconds = -time.altzone
     utc_offset_minutes = (utc_offset_seconds // 60) % 60
-    utc_offset_hours = utc_offset_seconds // 3600
-    return utc_offset_hours, utc_offset_minutes
+    utc_offset_hours = math.floor(utc_offset_seconds / float(3600)) if \
+        utc_offset_seconds > 0 else math.ceil(utc_offset_seconds / float(3600))
+    return int(utc_offset_hours), utc_offset_minutes
 
 
-def get_local_time_zone_format(extended_mode=False, reduced_mode=False):
-    """Return a string denoting the current local UTC offset."""
+def get_local_time_zone_format(tz_fmt_mode=TimeZoneFormatMode.normal):
+    """Return a string denoting the current local UTC offset.
+
+    :param tz_fmt_mode:
+    :type tz_fmt_mode: TimeZoneFormat:
+    """
     utc_offset_hours, utc_offset_minutes = get_local_time_zone()
     if utc_offset_hours == 0 and utc_offset_minutes == 0:
         return "Z"
     reduced_timezone_template = "%s%02d"
     timezone_template = "%s%02d%02d"
-    if extended_mode:
+    if tz_fmt_mode == TimeZoneFormatMode.extended:
         timezone_template = "%s%02d:%02d"
     sign = "-" if (utc_offset_hours < 0 or utc_offset_minutes < 0) else "+"
-    if reduced_mode and utc_offset_minutes == 0:
+    if tz_fmt_mode == TimeZoneFormatMode.reduced and utc_offset_minutes == 0:
         return reduced_timezone_template % (sign, abs(utc_offset_hours))
     return timezone_template % (
         sign, abs(utc_offset_hours), abs(utc_offset_minutes))

--- a/lib/isodatetime/util.py
+++ b/lib/isodatetime/util.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------------
-# (C) British Crown Copyright 2013-2018 Met Office.
+# Copyright (C) 2013-2018 British Crown (Met Office) & Contributors.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by
@@ -38,7 +38,7 @@ def cache_results(func):
             return cache[key]
         else:
             results = func(*args, **kwargs)
-            if len(cache) > MAX_CACHE_SIZE:
+            if len(cache) >= MAX_CACHE_SIZE:
                 cache.popitem()
             cache[key] = results
             return results


### PR DESCRIPTION
Updates `isodatetime` to the latest version available (thanks @matthewrmshin !), and fixes code for compatibility.

There was one [bug](https://github.com/metomi/isodatetime/issues/102) which I fixed in [pr#103](https://github.com/metomi/isodatetime/pull/103), but it caused an issue in Cylc fixed in this commit:

https://github.com/cylc/cylc/commit/4aa8a8bc117819e2f67fcadfa3c608916a0be5e6

I will wait for Travis-CI to kick in and verify this pull request, but it is also important that others with more experience with the `iso8601.py` have a look to see if they agree with the change.

To me, it appears it was always working, because we were always having a `KeyError` coming from `isodatetime`, but after fixing this behaviour in `isodatetime`, I think it makes sense to switch the order of the `try/catch`, but I am concerned if I am not being short-sighted with this changed, missing some second/third-level bug that could occur.

Cheers
Bruno