### PR TITLE
gui: fix error on generic (argument-free) launch

### DIFF
--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -130,7 +130,7 @@ class TaskFilterWindow(gtk.Window):
 
 class InitData(object):
     """
-Class to hold initialisation data.
+    Class to hold initialisation data.
     """
     def __init__(self, suite, owner, host, port,
                  comms_timeout, template_vars, ungrouped_views,
@@ -179,7 +179,9 @@ Class to hold initialisation data.
 
 
 class InfoBar(gtk.VBox):
-    """Class to create an information bar."""
+    """
+    Class to create an information bar.
+    """
 
     DISCONNECTED_TEXT = "(not connected)"
 
@@ -490,7 +492,7 @@ Use *Connect Now* button to reconnect immediately.""")
 
 class ControlApp(object):
     """
-Main Control GUI that displays one or more views or interfaces to the suite.
+    Main Control GUI displaying one or more views or interfaces to the suite.
     """
 
     DEFAULT_VIEW = "text"
@@ -3314,6 +3316,8 @@ For more Stop options use the Control menu.""")
 
     def run_suite_log(self, w, log='l'):
         """View suite logs."""
+        if self.cfg.suite is None:
+            return
         foo = SuiteLogViewer(self.cfg.suite, log, self.get_remote_run_opts(),
                              self.updater.task_list)
         self.quitters.append(foo)


### PR DESCRIPTION
... & make all the docstrings in ``app_gcylc.py`` consistent in format.

#### Issue

To recreate, launch the GUI with no suite(s) as argument(s) i.e. ``gcylc &``. I get the traceback:
```
  File "<...>/lib/cylc/gui/app_gcylc.py", line 444, in _log_widget_launch_hook
    self.log_launch_hook()
  File "<...>/lib/cylc/gui/app_gcylc.py", line 3205, in <lambda>
    lambda: self.run_suite_log(None, log="e"))
  File "<...>/lib/cylc/gui/app_gcylc.py", line 3318, in run_suite_log
    self.updater.task_list)
AttributeError: 'NoneType' object has no attribute 'task_list'
```

#### Fix context (N.B. don't bother reading unless it isn't otherwise clear)

I started by trying to bypass this directly, via starting ``run_suite_log()`` with:

```
task_listing = None
if self.updater is not None:
     task_listing = self.updater.task_list
```
& making ``task_listing`` the new final argument to the following ``SuiteLogViewer()`` call, but further investigation revealed that, in ``run_suite_log()``, ``self.cfg.suite`` is also ``None`` for this situation, causing issue. To see this, add in as well as the snippet above debug statements along the lines of:

```python
print "suite_name is:", suite_name
print "args are:", args
print "looking for logs in %s", str(logpath)
```
to line (~)330 of ``bin/cylc-cat-log`` & you should see:

```
suite_name is: None
args are: ['None']
looking for logs in %s /home/h06/sbarth/cylc-run/None/log/suite/err
ERROR: max rotation -1
```
Where the error line appears intermittently but repeatedly (i.e. irregularly).

I went for the shortest / most elegant fix (as opposed to the 'direct bypass' above which has the same effect).