### PR TITLE
Remove unnecessary assignment to target variable

### DIFF
--- a/lib/parsec/util.py
+++ b/lib/parsec/util.py
@@ -210,7 +210,6 @@ def poverride(target, sparse, prepend=False):
 
     """
     if not sparse:
-        target = OrderedDictWithDefaults()
         return
     for key, val in sparse.items():
         if isinstance(val, dict):
@@ -235,7 +234,6 @@ def m_override(target, sparse):
     the right position.
     """
     if not sparse:
-        target = OrderedDictWithDefaults()
         return
     stack = [(sparse, target, [], OrderedDictWithDefaults())]
     defaults_list = []


### PR DESCRIPTION
Another one found while writing unit tests for parsec, and reading the code of some of the Python files within the package.

In this case, I believe this assignment of `target = OrderedDictWithDefaults()` creates a local variable `target`, and returns.

There is another `target`, an argument, that is unaffected by this. So I think we can safely remove it.