### PR TITLE
Small fixes and typos

### DIFF
--- a/lib/cylc/batch_sys_handlers/at.py
+++ b/lib/cylc/batch_sys_handlers/at.py
@@ -75,7 +75,7 @@ class AtCommandHandler(object):
     def filter_submit_output(self, out, err):
         """Suppress at's routine output to stderr.
 
-        Otherwises we get warning messages that suggest something is wrong.
+        Otherwise we get warning messages that suggest something is wrong.
         1) move the standard job ID message from stderr to stdout
         2) suppress the message warning that commands will be executed with
         /bin/sh (this refers to the command line that runs the job script).

--- a/lib/cylc/batch_sys_manager.py
+++ b/lib/cylc/batch_sys_manager.py
@@ -134,7 +134,7 @@ class JobPollContext(object):
         'batch_sys_job_id',  # job id in batch system
         'batch_sys_exit_polled',  # 0 for false, 1 for true
         'run_status',  # 0 for success, 1 for failure
-        'run_signal',  # signal recieved on run failure
+        'run_signal',  # signal received on run failure
         'time_submit_exit',  # submit (exit) time
         'time_run',  # run start time
         'time_run_exit',  # run exit time

--- a/lib/cylc/cfgvalidate.py
+++ b/lib/cylc/cfgvalidate.py
@@ -44,7 +44,7 @@ class CylcConfigValidator(ParsecValidator):
         .coercers (dict):
             Map value type keys with coerce methods.
     """
-    # Paramterized names containing at least one comma.
+    # Parameterized names containing at least one comma.
     _REC_NAME_SUFFIX = re.compile(r'\A[\w\-+%@]+\Z')
     _REC_TRIG_FUNC = re.compile(r'(\w+)\((.*)\)(?:\:(\w+))?')
 

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -189,7 +189,7 @@ class SuiteConfig(object):
         if 'dependencies' not in self.cfg['scheduling']:
             raise SuiteConfigError(
                 "ERROR: missing [scheduling][[dependencies]] section.")
-        # (The check that 'graph' is definied is below).
+        # (The check that 'graph' is defined is below).
         # The two runahead limiting schemes are mutually exclusive.
         rlim = self.cfg['scheduling'].get('runahead limit')
         mact = self.cfg['scheduling'].get('max active cycle points')
@@ -1048,7 +1048,7 @@ class SuiteConfig(object):
                 # completed MRO (full or partial) as we go, and re-use
                 # these wherever possible. This ought to be a lot more
                 # efficient for big namespaces (e.g. lots of environment
-                # variables) in deep hiearchies, but results may vary...
+                # variables) in deep hierarchies, but results may vary...
                 prev_shortcut = False
                 mro = []
                 for name in hierarchy:

--- a/lib/cylc/cycling/iso8601.py
+++ b/lib/cylc/cycling/iso8601.py
@@ -487,7 +487,7 @@ class ISO8601Sequence(SequenceBase):
 
         for recurrence_iso_point in self.recurrence:
 
-            # Is recurrence point greater than aribitrary point?
+            # Is recurrence point greater than arbitrary point?
             if recurrence_iso_point > p_iso_point:
                 break
             recurrence_cycle_point = ISO8601Point(str(recurrence_iso_point))
@@ -978,7 +978,7 @@ class TestISO8601Sequence(unittest.TestCase):
 
     def test_exclusions_to_string(self):
         init(time_zone='Z')
-        # Chack that exclusions are not included where they should not be.
+        # Check that exclusions are not included where they should not be.
         basic = ISO8601Sequence('PT1H', '2000', '2001')
         self.assertFalse('!' in str(basic))
 

--- a/lib/cylc/cylc-review/template/cycles.html
+++ b/lib/cylc/cylc-review/template/cycles.html
@@ -198,7 +198,7 @@ class="table table-bordered table-condensed table-striped">
       </a>
     </td>
     {% else -%}
-    <td><small class="pull-right">{{n_state}}</span></small></td>
+    <td><small class="pull-right">{{n_state}}</small></td>
     {% endif -%}
 
   {% endfor -%}{# end task and jobs states -#}

--- a/lib/cylc/cylc-review/template/suites.html
+++ b/lib/cylc/cylc-review/template/suites.html
@@ -156,7 +156,6 @@ class="table table-bordered table-condensed table-striped">
         last active time
       </th>
 
-      </th>
       <th>
         project
       </th>

--- a/lib/cylc/cylc_xdot.py
+++ b/lib/cylc/cylc_xdot.py
@@ -350,7 +350,7 @@ class MyDotWindow(CylcDotViewerCommon):
         # Add the actiongroup to the uimanager
         uimanager.insert_action_group(actiongroup, 0)
 
-        # Add a UI descrption
+        # Add a UI description
         uimanager.add_ui_from_string(self.ui)
 
         left_to_right_toolitem = uimanager.get_widget('/ToolBar/LeftToRight')

--- a/lib/cylc/dump.py
+++ b/lib/cylc/dump.py
@@ -56,7 +56,7 @@ def get_stop_state_summary(lines):
         items = dict(p.split("=") for p in info.split(', '))
         state = items.get("status")
         if state == 'submitting':
-            # backward compabitility for state dumps generated prior to #787
+            # backward compatibility for state dumps generated prior to #787
             state = TASK_STATUS_READY
         task_summary[task_id].update({"state": state})
         task_summary[task_id].update({"spawned": items.get("spawned")})

--- a/lib/cylc/graph_parser.py
+++ b/lib/cylc/graph_parser.py
@@ -81,7 +81,7 @@ class GraphParser(object):
           Think of this as describing the graph structure first, then
           annotating each node with a trigger type that is only meaningful on
           the left side of each pair (in the default ':succeed' case the
-          trigger type can be ommitted, but it is still there in principle).
+          trigger type can be omitted, but it is still there in principle).
     """
 
     OP_AND = '&'

--- a/lib/cylc/gui/app_gcylc.py
+++ b/lib/cylc/gui/app_gcylc.py
@@ -108,7 +108,6 @@ def run_get_stdout(command, filter_=False):
             else:
                 res.append(line)
         return (True, res)
-    return (False, [])
 
 
 class TaskFilterWindow(gtk.Window):

--- a/lib/cylc/gui/gscan.py
+++ b/lib/cylc/gui/gscan.py
@@ -934,7 +934,7 @@ class ScanAppUpdater(threading.Thread):
                 title = suite_info.get(KEY_TITLE)
                 group = suite_info.get(KEY_GROUP)
             # For the purpose of this method, it is OK to handle both
-            # witheld (None) and unset (empty string) together
+            # withheld (None) and unset (empty string) together
             if not group:
                 group = self.UNGROUPED
 
@@ -1002,7 +1002,7 @@ class ScanAppUpdater(threading.Thread):
                 # Compat:<=7.5.0
                 group_id = suite_info.get(KEY_GROUP)
             # For the purpose of this method, it is OK to handle both
-            # witheld (None) and unset (empty string) together
+            # withheld (None) and unset (empty string) together
             if not group_id:
                 group_id = self.UNGROUPED
 

--- a/lib/cylc/gui/updater_dot.py
+++ b/lib/cylc/gui/updater_dot.py
@@ -33,8 +33,8 @@ from cylc.gui.util import get_id_summary
 
 class DotUpdater(threading.Thread):
 
-    RIGHT_ARROW = u'\u25b7'  # Unicode enpty triangle facing right.
-    DOWN_ARROW = u'\u25bd'  # Unicode enpty triangle facing down.
+    RIGHT_ARROW = u'\u25b7'  # Unicode empty triangle facing right.
+    DOWN_ARROW = u'\u25bd'  # Unicode empty triangle facing down.
     INDENT = 5  # Number of spaces to indent nested items in transpose view.
 
     def __init__(self, cfg, updater, treeview, info_bar, theme, dot_size):

--- a/lib/cylc/gui/updater_tree.py
+++ b/lib/cylc/gui/updater_tree.py
@@ -253,7 +253,7 @@ class TreeUpdater(threading.Thread):
                         tetc_unix = tstart + meant
                         tnow = time()
                         if tstart > tnow:
-                            # Reportably possible via interraction with
+                            # Reportably possible via interaction with
                             # cylc reset.
                             t_info['progress'] = 0
                         elif tnow > tetc_unix:

--- a/lib/cylc/gui/util.py
+++ b/lib/cylc/gui/util.py
@@ -100,7 +100,7 @@ def get_image_dir():
     try:
         cylc_dir = os.environ['CYLC_DIR']
     except KeyError:
-        # This should not happen (unecessary)
+        # This should not happen (unnecessary)
         raise SystemExit("ERROR: $CYLC_DIR is not defined!")
     return os.path.join(cylc_dir, "images")
 

--- a/lib/cylc/job_file.py
+++ b/lib/cylc/job_file.py
@@ -243,7 +243,7 @@ class JobFileWriter(object):
             #   export FOO=$( ecko foo )  # error not trapped!
             #   FOO=$( ecko foo )  # error trapped
             # The export is done before variable definition to enable
-            # use of already defiend variables by command substitutions
+            # use of already defined variables by command substitutions
             # in later definitions:
             #   FOO='foo'
             #   BAR=$(script_using_FOO)

--- a/lib/cylc/network/__init__.py
+++ b/lib/cylc/network/__init__.py
@@ -34,6 +34,6 @@ PRIVILEGE_LEVELS = [
     PRIV_DESCRIPTION,
     PRIV_STATE_TOTALS,
     PRIV_FULL_READ,
-    PRIV_SHUTDOWN,  # (Not used yet - for the post-passhprase era.)
+    PRIV_SHUTDOWN,  # (Not used yet - for the post-passphrase era.)
     PRIV_FULL_CONTROL,
 ]

--- a/lib/cylc/option_parsers.py
+++ b/lib/cylc/option_parsers.py
@@ -152,7 +152,7 @@ Arguments:"""
                 action="store_true", default=False, dest="use_ssh")
             self.add_std_option(
                 "--ssh-cylc",
-                help="Location of cylc executable on remote ssh comamnds.",
+                help="Location of cylc executable on remote ssh commands.",
                 action="store", default="cylc", dest="ssh_cylc")
             self.add_std_option(
                 "--no-login",

--- a/lib/cylc/prerequisite.py
+++ b/lib/cylc/prerequisite.py
@@ -59,7 +59,7 @@ class Prerequisite(object):
         # cylc.cycling.PointBase
         self.start_point = start_point
 
-        # List of cycle point strings that this prerequiste depends on.
+        # List of cycle point strings that this prerequisite depends on.
         self.target_point_strings = []
 
         # Dictionary of messages pertaining to this prerequisite.
@@ -76,7 +76,7 @@ class Prerequisite(object):
 
         # The cashed state of this prerequisite:
         # * `None` (no cached state)
-        # * `True` (prereuisite satisfied)
+        # * `True` (prerequisite satisfied)
         # * `False` (prerequisite unsatisfied).
         self._all_satisfied = None
 
@@ -234,7 +234,7 @@ class Prerequisite(object):
         return res
 
     def set_satisfied(self):
-        """Force this prerequiste into the satisfied state.
+        """Force this prerequisite into the satisfied state.
 
         State can be overridden by calling `self.satisfy_me`.
 

--- a/lib/cylc/profiling/analysis.py
+++ b/lib/cylc/profiling/analysis.py
@@ -19,7 +19,7 @@ import os
 import re
 import sys
 
-# Import modules required for plotting if avaliable.
+# Import modules required for plotting if available.
 try:
     import numpy
     import warnings
@@ -459,7 +459,7 @@ def plot_results(results, versions, experiment, plt_dir=None,
 
         # Output graph.
         if not plt_dir:
-            # Output directory not specified, use interractive mode.
+            # Output directory not specified, use interactive mode.
             plt.show()
         else:
             # Output directory specified, save figure as a pdf.

--- a/lib/cylc/profiling/git.py
+++ b/lib/cylc/profiling/git.py
@@ -67,7 +67,7 @@ def checkout(branch, delete_pyc=False):
 
 
 def get_commit_date(commit):
-    """Returns the commit date (in unix time) of the profided commit."""
+    """Returns the commit date (in unix time) of the provided commit."""
     try:
         return int(Popen(['git', 'show', '-s', '--format=%at', commit],
                          stdout=PIPE, stderr=PIPE

--- a/lib/cylc/profiling/profile.py
+++ b/lib/cylc/profiling/profile.py
@@ -63,7 +63,7 @@ class SuiteFailedException(Exception):
 
 class ProfilingKilledException(SuiteFailedException):
     """Exception to handle the event that a user has canceled profiling whilst
-    a suite is runnnig."""
+    a suite is running."""
     pass
 
 
@@ -111,7 +111,7 @@ def run_suite(reg, options, out_file, profile_modes, mode='live',
         reg (str): The registration of the suite to run.
         options (list): List of jinja2 setting=value pairs.
         out_file (str): The file to redirect stdout to.
-        profile_modes (list): List of profileing systems to employ
+        profile_modes (list): List of profiling systems to employ
             (i.e. cylc, time).
         mode (str - optional): The mode to run the suite in, simulation, dummy,
             live or validate.
@@ -134,7 +134,7 @@ def run_suite(reg, options, out_file, profile_modes, mode='live',
         else:  # Assume Linux
             cmds += ['/usr/bin/time', '-v']
 
-        # Run using `sh -c` to enable the redirecton of output (darwins
+        # Run using `sh -c` to enable the redirection of output (darwins
         # /usr/bin/time command does not have a -o option).
         cmds += ['sh', '-c', "'"]
 

--- a/lib/cylc/review.py
+++ b/lib/cylc/review.py
@@ -619,7 +619,7 @@ class CylcReviewService(object):
                         continue
                     start, end = match.span()
                 else:
-                    # ERROR: un-reccognised search_mode
+                    # ERROR: un-recognised search_mode
                     break
                 # if line matches search string include in results
                 results.append([line[:start], line[start:end],
@@ -814,7 +814,7 @@ class CylcReviewService(object):
 
     @classmethod
     def _check_file_path(cls, path):
-        """Raise HTTP 403 error if the path is not indended to be served.
+        """Raise HTTP 403 error if the path is not intended to be served.
 
         Examples:
             >>> CylcReviewService._check_file_path('.service/contact')

--- a/lib/cylc/rundb.py
+++ b/lib/cylc/rundb.py
@@ -136,7 +136,7 @@ class CylcSuiteDAOTable(object):
     def add_update_item(self, set_args, where_args):
         """Queue an UPDATE item.
 
-        set_args should be a dict, with colum keys and values to be set.
+        set_args should be a dict, with column keys and values to be set.
         where_args should be a dict, update will only apply to rows matching
         all these items.
 
@@ -363,7 +363,7 @@ class CylcSuiteDAO(object):
     def add_update_item(self, table_name, set_args, where_args=None):
         """Queue an UPDATE item for a given table.
 
-        set_args should be a dict, with colum keys and values to be set.
+        set_args should be a dict, with column keys and values to be set.
         where_args should be a dict, update will only apply to rows matching
         all these items.
 
@@ -995,7 +995,7 @@ class CylcSuiteDAO(object):
         n_skips = 0
         # Codacy: Possible SQL injection vector through string-based query
         # construction.
-        # This is highly unlikely - all strings in the constuct are from
+        # This is highly unlikely - all strings in the construct are from
         # constants in this module.
         for i, row in enumerate(conn.execute(
                 r"SELECT " + ",".join(cols) + " FROM " + t_name + "_old")):

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -100,7 +100,7 @@ class Scheduler(object):
     START_MESSAGE_TMPL = (
         START_MESSAGE_PREFIX + 'server=%(host)s:%(port)s pid=%(pid)s')
 
-    # Dependency negotation etc. will run after these commands
+    # Dependency negotiation etc. will run after these commands
     PROC_CMDS = (
         'release_suite',
         'release_tasks',
@@ -1087,7 +1087,7 @@ conditions; see `cylc conditions`.
         # Make suite vars available to [cylc][environment]:
         for var, val in self.task_job_mgr.job_file_writer.suite_env.items():
             os.environ[var] = val
-        # Set local values of variables that are potenitally task-specific
+        # Set local values of variables that are potentially task-specific
         # due to different directory paths on different task hosts. These
         # are overridden by tasks prior to job submission, but in
         # principle they could be needed locally by event handlers:
@@ -1281,7 +1281,7 @@ conditions; see `cylc conditions`.
             # Task failure + abort if any task fails
             self._set_stop(TaskPool.STOP_AUTO_ON_TASK_FAILURE)
         elif self.options.reftest and self.ref_test_allowed_failures:
-            # In reference test mode and unexpected failures occured
+            # In reference test mode and unexpected failures occurred
             bad_tasks = []
             for itask in self.pool.get_failed_tasks():
                 if itask.identity not in self.ref_test_allowed_failures:

--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -146,7 +146,7 @@ class TaskEventsManager(object):
         # Set pflag = True to stimulate task dependency negotiation whenever a
         # task changes state in such a way that others could be affected. The
         # flag should only be turned off again after use in
-        # Scheduler.process_tasks, to ensure that dependency negotation occurs
+        # Scheduler.process_tasks, to ensure that dependency negotiation occurs
         # when required.
         self.pflag = False
 
@@ -219,7 +219,7 @@ class TaskEventsManager(object):
     def process_events(self, schd_ctx):
         """Process task events that were created by "setup_event_handlers".
 
-        schd_ctx is an instance of "Schduler" in "cylc.scheduler".
+        schd_ctx is an instance of "Scheduler" in "cylc.scheduler".
         """
         ctx_groups = {}
         now = time()
@@ -941,7 +941,7 @@ class TaskEventsManager(object):
                 time_limit_delays = batch_sys_conf.get(
                     'execution time limit polling intervals', [60, 120, 420])
                 timeout = time_limit + sum(time_limit_delays)
-                # Remove execessive polling before time limit
+                # Remove excessive polling before time limit
                 while sum(delays) > time_limit:
                     del delays[-1]
                 # But fill up the gap before time limit
@@ -966,7 +966,7 @@ class TaskEventsManager(object):
         itask.poll_timer = TaskActionTimer(ctx=ctx, delays=delays)
         # Log timeout and polling schedule
         message = 'health check settings: %s=%s' % (timeout_key, timeout_str)
-        # Attempt to group idenitical consecutive delays as N*DELAY,...
+        # Attempt to group identical consecutive delays as N*DELAY,...
         if itask.poll_timer.delays:
             items = []  # [(number of item - 1, item), ...]
             for delay in itask.poll_timer.delays:

--- a/lib/cylc/task_job_mgr.py
+++ b/lib/cylc/task_job_mgr.py
@@ -225,7 +225,7 @@ class TaskJobManager(object):
             now_str = get_current_time_string()
             done_tasks.extend(itasks)
             for itask in itasks:
-                # Log and perist
+                # Log and persist
                 LOG.info(
                     'submit-num=%d, owner@host=%s' % (
                         itask.submit_num, owner_at_host),
@@ -780,7 +780,7 @@ class TaskJobManager(object):
             SubProcContext(self.JOBS_SUBMIT, action, err=exc, ret_code=1),
             suite, itask.point, itask.tdef.name, submit_num=itask.submit_num)
         if not dry_run:
-            # Perist
+            # Persist
             self.suite_db_mgr.put_insert_task_jobs(itask, {
                 'is_manual_submit': itask.is_manual_submit,
                 'try_num': itask.get_try_num(),

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -332,10 +332,10 @@ class TaskPool(object):
         as submitted or running are polled to confirm their true status.
 
         Prerequisite status (satisfied or not) is inferred from task status:
-           WAITING or HELD  - all prerequisites unsatisified
+           WAITING or HELD  - all prerequisites unsatisfied
            status > QUEUED - all prerequisites satisfied.
         TODO - this is not correct, e.g. a held task may have some (but not
-        all) satisified prerequisites; and a running task (etc.) could have
+        all) satisfied prerequisites; and a running task (etc.) could have
         been manually triggered with unsatisfied prerequisites. See comments
         in GitHub #2329 on how to fix this in the future.
 

--- a/lib/cylc/task_state.py
+++ b/lib/cylc/task_state.py
@@ -161,7 +161,7 @@ TASK_STATUSES_TRIGGERABLE = set([
     TASK_STATUS_RETRYING
 ])
 
-# Tasks statuses to auto-exand in the gcylc tree view.
+# Tasks statuses to auto-expand in the gcylc tree view.
 TASK_STATUSES_AUTO_EXPAND = set([
     TASK_STATUS_QUEUED,
     TASK_STATUS_READY,

--- a/lib/parsec/fileparse.py
+++ b/lib/parsec/fileparse.py
@@ -342,7 +342,6 @@ def parse(fpath, output_fname=None, template_vars=None):
 
     nesting_level = 0
     config = OrderedDictWithDefaults()
-    sect_name = None
     parents = []
 
     maxline = len(flines) - 1

--- a/lib/parsec/jinja2support.py
+++ b/lib/parsec/jinja2support.py
@@ -100,7 +100,7 @@ def jinja2environment(dir_=None):
     # Load any custom Jinja2 filters, tests or globals in the suite
     # definition directory
     # Example: a filter to pad integer values some fill character:
-    # |(file SUITE_DEFINIION_DIRECTORY/Jinja2/foo.py)
+    # |(file SUITE_DEFINITION_DIRECTORY/Jinja2/foo.py)
     # |  #!/usr/bin/env python2
     # |  def foo( value, length, fillchar ):
     # |     return str(value).rjust( int(length), str(fillchar) )

--- a/lib/parsec/validate.py
+++ b/lib/parsec/validate.py
@@ -99,7 +99,7 @@ class ParsecValidator(object):
     # integer range syntax START..END[..STEP]
     _REC_INT_RANGE = re.compile(
         r'\A([\+\-]?\d+)\s*\.\.\s*([\+\-]?\d+)(?:\s*\.\.\s*(\d+))?\Z')
-    # Paramterized names containing at least one comma.
+    # Parameterized names containing at least one comma.
     _REC_MULTI_PARAM = re.compile(r'<[\w]+,.*?>')
 
     # Value type constants


### PR DESCRIPTION
This pull request is separated in a few commits, so that any of them can be edited or dropped if necessary (no hard feelings). I had a couple simple changes left after writing the parsec unit tests, so decided to include a few more typos I had seen before.

i. on typos, happy to delete the commit with typos to make it easier to review if it's better. There's just one important I think, in `option_parsers.py`, part of the output presented to users - I think - has a typo on the word _command_

ii. the only change in `app_gcylc.py` is to delete the last return statement. That code cannot be reached (easier to see by clicking on the _"View"_ button to see the rest of the function).

iii. the only change in `fileparse.py` is the removal of a variable that is never used. Later in the code, another variable with same name is declared (or re-declared?). It seems to be no need in declaring it there...

iv. the changes in the new cylc review HTML files are what appears to me as unbalanced HTML tags... that were either not opened or closed.