### PR TITLE
localhost background/at jobs: record host name

### DIFF
--- a/lib/cylc/batch_sys_manager.py
+++ b/lib/cylc/batch_sys_manager.py
@@ -78,7 +78,9 @@ batch_sys.POLL_CANT_CONNECT_ERR
 
 batch_sys.SHOULD_KILL_PROC_GROUP
     * A boolean to indicate whether it is necessary to kill a job by sending
-      a signal to its Unix process group.
+      a signal to its Unix process group. This boolean also indicates that
+      a job submitted via this batch system will physically run on the same
+      host it is submitted to.
 
 batch_sys.SHOULD_POLL_PROC_GROUP
     * A boolean to indicate whether it is necessary to poll a job by its PID
@@ -246,6 +248,11 @@ class BatchSysManager(object):
         batch_sys = self._get_sys(job_conf['batch_system_name'])
         if hasattr(batch_sys, "get_vacation_signal"):
             return batch_sys.get_vacation_signal(job_conf)
+
+    def is_job_local_to_host(self, batch_sys_name):
+        """Return True if batch system runs jobs local to the submit host."""
+        return getattr(
+            self._get_sys(batch_sys_name), "SHOULD_KILL_PROC_GROUP", False)
 
     def jobs_kill(self, job_log_root, job_log_dirs):
         """Kill multiple jobs.

--- a/tests/cylc-review/00-basic.t
+++ b/tests/cylc-review/00-basic.t
@@ -136,7 +136,7 @@ cylc_ws_json_greps "${TEST_NAME}.stdout" "${TEST_NAME}.stdout" \
     "[('states', 'is_failed',), False]" \
     "[('of_n_entries',), 2]" \
     "[('entries', ${FOO0}, 'task_status',), 'succeeded']" \
-    "[('entries', ${FOO0}, 'host',), 'localhost']" \
+    "[('entries', ${FOO0}, 'host',), '$(hostname -f)']" \
     "[('entries', ${FOO0}, 'submit_method',), 'background']" \
     "[('entries', ${FOO0}, 'logs', 'job', 'path'), '${FOO0_JOB}']" \
     "[('entries', ${FOO0}, 'logs', 'job.err', 'path'), '${FOO0_JOB}.err']" \
@@ -160,7 +160,7 @@ cylc_ws_json_greps "${TEST_NAME}.stdout" "${TEST_NAME}.stdout" \
     "[('entries', ${FOO0}, 'seq_logs_indexes', 'job.trace.*.html', '32'), 'job.trace.32.html']" \
     "[('entries', ${FOO0}, 'seq_logs_indexes', 'job.trace.*.html', '256'), 'job.trace.256.html']" \
     "[('entries', ${FOO1}, 'task_status',), 'succeeded']" \
-    "[('entries', ${FOO1}, 'host',), 'localhost']" \
+    "[('entries', ${FOO1}, 'host',), '$(hostname -f)']" \
     "[('entries', ${FOO1}, 'submit_method',), 'background']" \
     "[('entries', ${FOO1}, 'logs', 'job', 'path'), '${FOO1_JOB}']" \
     "[('entries', ${FOO1}, 'logs', 'job.err', 'path'), '${FOO1_JOB}.err']" \

--- a/tests/database/00-simple.t
+++ b/tests/database/00-simple.t
@@ -56,7 +56,12 @@ sqlite3 "${DB_FILE}" \
             user_at_host, batch_sys_name
      FROM task_jobs ORDER BY name' \
     >"${NAME}"
-cmp_ok "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/${NAME}" "${NAME}"
+LOCALHOST="$(hostname -f)"
+cmp_ok - "${NAME}" <<__SELECT__
+1|bar|1|1|0|0|${LOCALHOST}|background
+1|baz|1|1|0|0|${LOCALHOST}|background
+1|foo|1|1|0|0|${LOCALHOST}|background
+__SELECT__
 
 NAME='select-task-jobs-times.out'
 sqlite3 "${DB_FILE}" \

--- a/tests/database/00-simple/select-task-jobs.out
+++ b/tests/database/00-simple/select-task-jobs.out
@@ -1,3 +1,0 @@
-1|bar|1|1|0|0|localhost|background
-1|baz|1|1|0|0|localhost|background
-1|foo|1|1|0|0|localhost|background

--- a/tests/database/01-broadcast.t
+++ b/tests/database/01-broadcast.t
@@ -52,10 +52,11 @@ sqlite3 "${DB_FILE}" \
             user_at_host, batch_sys_name
      FROM task_jobs ORDER BY name' \
     >"${NAME}"
-cmp_ok "${NAME}" <<'__SELECT__'
-1|recover-t1|1|0|0|0|localhost|background
-1|t1|1|0|0|1|localhost|background
-1|t1|2|1|0|0|localhost|background
+LOCALHOST="$(hostname -f)"
+cmp_ok "${NAME}" <<__SELECT__
+1|recover-t1|1|0|0|0|${LOCALHOST}|background
+1|t1|1|0|0|1|${LOCALHOST}|background
+1|t1|2|1|0|0|${LOCALHOST}|background
 __SELECT__
 
 purge_suite "${SUITE_NAME}"

--- a/tests/database/02-retry.t
+++ b/tests/database/02-retry.t
@@ -38,10 +38,11 @@ sqlite3 "${DB_FILE}" \
             user_at_host, batch_sys_name
      FROM task_jobs ORDER BY name' \
     >"${NAME}"
-cmp_ok "${NAME}" <<'__SELECT__'
-20200101T0000Z|t1|1|1|0|1|localhost|background
-20200101T0000Z|t1|2|2|0|1|localhost|background
-20200101T0000Z|t1|3|3|0|0|localhost|background
+LOCALHOST="$(hostname -f)"
+cmp_ok "${NAME}" <<__SELECT__
+20200101T0000Z|t1|1|1|0|1|${LOCALHOST}|background
+20200101T0000Z|t1|2|2|0|1|${LOCALHOST}|background
+20200101T0000Z|t1|3|3|0|0|${LOCALHOST}|background
 __SELECT__
 
 purge_suite "${SUITE_NAME}"

--- a/tests/database/03-remote.t
+++ b/tests/database/03-remote.t
@@ -41,7 +41,7 @@ sqlite3 "${DB_FILE}" \
      FROM task_jobs ORDER BY name' \
     >"${NAME}"
 cmp_ok "${NAME}" <<__SELECT__
-20200101T0000Z|t1|1|1|0|0|localhost|background
+20200101T0000Z|t1|1|1|0|0|$(hostname -f)|background
 20200101T0000Z|t2|1|1|0|0|${CYLC_TEST_HOST}|background
 __SELECT__
 


### PR DESCRIPTION
Ensure that `localhost` background/at jobs are recorded as running on the host name of the current suite host, rather than just `localhost`. On suite restart on a different suite host, this allows the restart logic to correctly poll the status of the background/at jobs that may still be running on the previous suite host.

Perfect companion of #2809.