### PR TITLE
Remove commented-out functional lines in tests

### DIFF
--- a/tests/execution-time-limit/02-slurm.t
+++ b/tests/execution-time-limit/02-slurm.t
@@ -51,8 +51,6 @@ suite_run_ok "${TEST_NAME_BASE}-run" \
 
 LOGD="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/log/job/1/foo"
 grep_ok '#SBATCH --time=1:10' "${LOGD}/01/job"
-#grep_ok 'CYLC_JOB_EXIT=EXIT' "${LOGD}/01/job.status"
-#grep_ok 'CYLC_JOB_EXIT=SUCCEEDED' "${LOGD}/02/job.status"
 
 if [[ "${CYLC_TEST_BATCH_TASK_HOST}" != 'localhost' ]]; then
     purge_suite_remote "${CYLC_TEST_BATCH_TASK_HOST}" "${SUITE_NAME}"

--- a/tests/execution-time-limit/03-pbs.t
+++ b/tests/execution-time-limit/03-pbs.t
@@ -51,8 +51,6 @@ suite_run_ok "${TEST_NAME_BASE}-run" \
 
 LOGD="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/log/job/1/foo"
 grep_ok '#PBS -l walltime=70' "${LOGD}/01/job"
-#grep_ok 'CYLC_JOB_EXIT=EXIT' "${LOGD}/01/job.status"
-#grep_ok 'CYLC_JOB_EXIT=SUCCEEDED' "${LOGD}/02/job.status"
 
 if [[ "${CYLC_TEST_BATCH_TASK_HOST}" != 'localhost' ]]; then
     purge_suite_remote "${CYLC_TEST_BATCH_TASK_HOST}" "${SUITE_NAME}"

--- a/tests/job-submission/07-multi/suite.rc
+++ b/tests/job-submission/07-multi/suite.rc
@@ -16,15 +16,6 @@ T[-P1Y]:succeed-all => T
 [runtime]
     [[T]]
         script = true
-#        script=sleep 120
-#        [[[remote]]]
-#            host=xcfl00
-#        [[[job]]]
-#            batch system = pbs
-#        [[[directives]]]
-#            -m = n
-#            -q = shared
-#            -r = n
     [[t0,t1,t2,t3]]
         inherit = T
     [[t4,t5,t6]]


### PR DESCRIPTION
Cut lines that are commented out but functional without the comment marker, clearly originating from development or testing or debug stages.

I've checked the tests don't rely on these lines e.g. via ``sed`` substitution to remove them & then incorporate the lines.

Trivial, hence lone reviewer sufficient (& I'll pick on the author :grin:).