### PR TITLE
allow cylc commands to work with un-registered suites

### DIFF
--- a/lib/cylc/suite_srv_files_mgr.py
+++ b/lib/cylc/suite_srv_files_mgr.py
@@ -29,7 +29,8 @@ from cylc.cfgspec.glbl_cfg import glbl_cfg
 import cylc.flags
 from cylc.mkdir_p import mkdir_p
 from cylc.hostuserutil import (
-    get_local_ip_address, get_host, get_user, is_remote, is_remote_host)
+    get_local_ip_address, get_host, get_user, is_remote, is_remote_host,
+    is_remote_user)
 
 
 class SuiteServiceFileError(Exception):
@@ -328,7 +329,7 @@ To start a new run, stop the old one first with one or more of these:
             source = os.readlink(fname)
         except OSError:
             suite_d = os.path.dirname(srv_d)
-            if os.path.exists(suite_d):
+            if os.path.exists(suite_d) and not is_remote_user(suite_owner):
                 # suite exists but is not yet registered
                 self.register(reg=reg, source=suite_d)
                 return suite_d

--- a/tests/registration/02-on-the-fly.t
+++ b/tests/registration/02-on-the-fly.t
@@ -19,7 +19,7 @@
 # Test `cylc run` with no registration
 
 . "$(dirname "$0")/test_header"
-set_test_number 6
+set_test_number 9
 
 TEST_NAME="${TEST_NAME_BASE}-pwd"
 
@@ -69,6 +69,30 @@ REGISTERED ${TESTD} -> ${CYLC_RUN_DIR}/${TESTD}
 __ERR__
 
 run_ok "${TEST_NAME}stop-" cylc stop "${TESTD}"
+
+purge_suite $TESTD
+#------------------------------------------------------------------------------
+# Test `cylc run` REG for an un-registered suite
+mkdir -p "${CYLC_RUN_DIR}/${TESTD}"
+cat >> "${CYLC_RUN_DIR}/${TESTD}/suite.rc" <<'__SUITE_RC__'
+[meta]
+    title = the quick brown fox
+[sched]
+    [[dependencies]]
+        graph = foo
+[runtime]
+    [[foo]]
+        script = true
+__SUITE_RC__
+
+TEST_NAME="${TEST_NAME_BASE}-cylc-run-dir-2"
+run_fail "${TEST_NAME}-validate" cylc validate "${TESTD}"
+contains_ok "${TEST_NAME}-validate.stdout" <<__OUT__
+REGISTERED ${TESTD} -> ${CYLC_RUN_DIR}/${TESTD}
+__OUT__
+contains_ok "${TEST_NAME}-validate.stderr" <<__ERR__
+Illegal item: sched
+__ERR__
 
 purge_suite $TESTD
 


### PR DESCRIPTION
Follow on from the various registration fixes.

We lost, then regained the ability to write a suite in the `cylc-run` directory and run it without registration.

Unfortunately the fix only covered `cylc run`, this PR returns coverage of this feature to the other Cylc sub-commands.