### PR TITLE
Improve config deprecated upgrade log, etc

### DIFF
--- a/bin/cylc-reset
+++ b/bin/cylc-reset
@@ -84,7 +84,7 @@ def main():
         cmd = sys.argv[0].replace('reset', 'spawn')
         try:
             os.execvp(cmd, [cmd] + args)
-        except OSError, exc:
+        except OSError as exc:
             if exc.filename is None:
                 exc.filename = cmd
             raise SystemExit(exc)

--- a/lib/cylc/cfgspec/gcylc.py
+++ b/lib/cylc/cfgspec/gcylc.py
@@ -110,18 +110,17 @@ class GcylcConfig(ParsecConfig):
         if cls._INST is None:
             cls._INST = cls(SPEC, upg)
             try:
-                cls._INST.loadcfg(SITE_FILE, "site config")
+                cls._INST.loadcfg(SITE_FILE, upgrader.SITE_CONFIG)
             except ParsecError as exc:
-                sys.stderr.write(
-                    "WARNING: ignoring bad site GUI config %s:\n"
-                    "%s\n" % (SITE_FILE, str(exc)))
+                LOG.warning(
+                    'ignoring bad %s %s\n%s',
+                    upgrader.SITE_CONFIG, SITE_FILE, exc)
 
             if os.access(USER_FILE, os.F_OK | os.R_OK):
                 try:
-                    cls._INST.loadcfg(USER_FILE, "user config")
+                    cls._INST.loadcfg(USER_FILE, upgrader.USER_CONFIG)
                 except ParsecError as exc:
-                    sys.stderr.write(
-                        "ERROR: bad user GUI config %s:\n" % USER_FILE)
+                    LOG.error('bad %s %s', upgrader.USER_CONFIG, USER_FILE)
                     raise
 
             # check and correct initial view config etc.

--- a/lib/cylc/cfgspec/gscan.py
+++ b/lib/cylc/cfgspec/gscan.py
@@ -22,6 +22,7 @@ import sys
 
 from parsec import ParsecError
 from parsec.config import ParsecConfig
+from parsec.upgrade import upgrader
 
 from cylc.cfgvalidate import (
     cylc_config_validate, CylcConfigValidator as VDR, DurationFloat)
@@ -70,10 +71,9 @@ class GScanConfig(ParsecConfig):
             cls._INST = cls(SPEC, validator=cylc_config_validate)
             if os.access(USER_FILE, os.F_OK | os.R_OK):
                 try:
-                    cls._INST.loadcfg(USER_FILE, 'user config')
+                    cls._INST.loadcfg(USER_FILE, upgrader.USER_CONFIG)
                 except ParsecError:
-                    sys.stderr.write(
-                        'ERROR: bad gscan config %s:\n' % USER_FILE)
+                    LOG.error('bad %s %s', upgrader.USER_CONFIG, USER_FILE)
                     raise
             cls._INST.check()
         return cls._INST

--- a/lib/cylc/daemonize.py
+++ b/lib/cylc/daemonize.py
@@ -106,10 +106,8 @@ def daemonize(server):
             })
             # exit parent 1
             sys.exit(0)
-    except OSError, exc:
-        sys.stderr.write(
-            "fork #1 failed: %d (%s)\n" % (exc.errno, exc.strerror))
-        sys.exit(1)
+    except OSError as exc:
+        sys.exit("fork #1 failed: %d (%s)\n" % (exc.errno, exc.strerror))
 
     # decouple from parent environment
     os.chdir("/")
@@ -122,13 +120,11 @@ def daemonize(server):
         if pid > 0:
             # exit parent 2
             sys.exit(0)
-    except OSError, exc:
-        sys.stderr.write(
-            "fork #2 failed: %d (%s)\n" % (exc.errno, exc.strerror))
-        sys.exit(1)
+    except OSError as exc:
+        sys.exit("fork #2 failed: %d (%s)\n" % (exc.errno, exc.strerror))
 
     # reset umask, octal
-    os.umask(022)
+    os.umask(0o22)
 
     # Redirect /dev/null to stdin.
     # Note that simply reassigning the sys streams is not sufficient

--- a/lib/cylc/log_diagnosis.py
+++ b/lib/cylc/log_diagnosis.py
@@ -21,6 +21,9 @@ import re
 from difflib import unified_diff
 
 
+from cylc import LOG
+
+
 class LogAnalyserError(Exception):
     def __init__(self, msg):
         Exception.__init__(self, msg)
@@ -123,9 +126,9 @@ class LogAnalyser(object):
 
         if new != ref:
             diff = unified_diff(new, ref)
-            sys.stderr.write('\n'.join(diff) + '\n')
             raise LogAnalyserError(
-                "ERROR: triggering is NOT consistent with the reference log")
+                "ERROR: triggering is NOT consistent with the reference log:" +
+                '\n' + '\n'.join(diff) + '\n')
         else:
-            print(
+            LOG.info(
                 "LogAnalyser: triggering is consistent with the reference log")

--- a/lib/cylc/mkdir_p.py
+++ b/lib/cylc/mkdir_p.py
@@ -43,7 +43,7 @@ def mkdir_p(path, mode=None):
         else:
             os.makedirs(path)
 
-    except OSError, err:
+    except OSError as err:
         if err.errno != errno.EEXIST:
             raise
         else:

--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -524,8 +524,7 @@ class TaskEventsManager(object):
                 else:
                     self.event_timers[id_key].unset_waiting()
             except KeyError as exc:
-                if cylc.flags.debug:
-                    LOG.exception(exc)
+                LOG.exception(exc)
 
     def _get_events_conf(self, itask, key, default=None):
         """Return an events setting from suite then global configuration."""
@@ -553,7 +552,7 @@ class TaskEventsManager(object):
             "retrieve job logs command", s_host, s_user))
 
         cmd = shlex.split(rsync_str) + ["--rsh=" + ssh_str]
-        if cylc.flags.debug:
+        if LOG.isEnabledFor(DEBUG):
             cmd.append("-v")
         if ctx.max_size:
             cmd.append("--max-size=%s" % (ctx.max_size,))
@@ -608,8 +607,7 @@ class TaskEventsManager(object):
                 log_task_job_activity(
                     log_ctx, schd_ctx.suite, point, name, submit_num)
             except KeyError as exc:
-                if cylc.flags.debug:
-                    LOG.exception(exc)
+                LOG.exception(exc)
 
     def _process_message_failed(self, itask, event_time, message):
         """Helper for process_message, handle a failed message."""

--- a/lib/cylc/task_job_mgr.py
+++ b/lib/cylc/task_job_mgr.py
@@ -267,7 +267,7 @@ class TaskJobManager(object):
                 continue
             # Build the "cylc jobs-submit" command
             cmd = ['cylc', self.JOBS_SUBMIT]
-            if cylc.flags.debug:
+            if LOG.isEnabledFor(DEBUG):
                 cmd.append('--debug')
             if get_utc_mode():
                 cmd.append('--utc-mode')
@@ -370,7 +370,7 @@ class TaskJobManager(object):
             comstr = "cylc suite-state " + \
                      " --task=" + itask.tdef.suite_polling_cfg['task'] + \
                      " --point=" + str(itask.point)
-            if cylc.flags.debug:
+            if LOG.isEnabledFor(DEBUG):
                 comstr += ' --debug'
             for key, fmt in [
                     ('user', ' --%s=%s'),
@@ -505,11 +505,10 @@ class TaskJobManager(object):
                         point, name, submit_num = path.split(os.sep, 2)
                         itask = tasks[(point, name, submit_num)]
                         callback(suite, itask, ctx, line)
-                    except (KeyError, ValueError):
-                        if cylc.flags.debug:
-                            LOG.warning('Unhandled %s output: %s' % (
-                                ctx.cmd_key, line))
-                            LOG.warning(traceback.format_exc())
+                    except (LookupError, ValueError) as exc:
+                        LOG.warning(
+                            'Unhandled %s output: %s', ctx.cmd_key, line)
+                        LOG.exception(exc)
 
     def _poll_task_jobs_callback(self, ctx, suite, itasks):
         """Callback when poll tasks command exits."""
@@ -625,7 +624,7 @@ class TaskJobManager(object):
             auth_itasks[(itask.task_host, itask.task_owner)].append(itask)
         for (host, owner), itasks in sorted(auth_itasks.items()):
             cmd = ["cylc", cmd_key]
-            if cylc.flags.debug:
+            if LOG.isEnabledFor(DEBUG):
                 cmd.append("--debug")
             if is_remote_host(host):
                 cmd.append("--host=%s" % (host))

--- a/tests/cylc-5to6/00-simple-start-up.t
+++ b/tests/cylc-5to6/00-simple-start-up.t
@@ -24,7 +24,7 @@ install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-validate
 run_fail "$TEST_NAME" cylc validate $SUITE_NAME
-cmp_ok "$TEST_NAME.stderr" <<'__ERR__'
+contains_ok "${TEST_NAME}.stderr" <<'__ERR__'
 Illegal item: [scheduling]initial cycle time
 __ERR__
 #-------------------------------------------------------------------------------

--- a/tests/deprecations/00-all.t
+++ b/tests/deprecations/00-all.t
@@ -27,7 +27,7 @@ run_ok $TEST_NAME cylc validate -v $SUITE_NAME
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-cmp
 cylc validate -v "${SUITE_NAME}" 2>&1 \
-    | sed  -n -e 's/^.* DEBUG - \( \* (.*$\)/\1/p' > 'val.out'
+    | sed  -n -e 's/^.* WARNING - \( \* (.*$\)/\1/p' > 'val.out'
 cmp_ok val.out <<__END__
  * (6.1.3) [visualization][enable live graph movie] - DELETED (OBSOLETE)
  * (6.4.0) [runtime][foo, cat, dog][environment scripting] -> [runtime][foo, cat, dog][env-script] - value unchanged

--- a/tests/registration/00-simple.t
+++ b/tests/registration/00-simple.t
@@ -91,8 +91,9 @@ __ERR__
 TEST_NAME="${TEST_NAME_BASE}-repurpose2"
 cp -r $CHEESE $YOGHURT
 run_ok "${TEST_NAME}" cylc register --redirect $CHEESE $YOGHURT
+sed -i 's/^\t//; s/^.* WARNING - /WARNING - /' "${TEST_NAME}.stderr"
 contains_ok "${TEST_NAME}.stderr" <<__ERR__
-WARNING: the name '$CHEESE' points to ${PWD}/$CHEESE.
+WARNING - the name '$CHEESE' points to ${PWD}/$CHEESE.
 It will now be redirected to ${PWD}/$YOGHURT.
 Files in the existing $CHEESE run directory will be overwritten.
 __ERR__

--- a/tests/restart/broadcast/suite.rc
+++ b/tests/restart/broadcast/suite.rc
@@ -19,13 +19,13 @@
             """
 [runtime]
     [[send_a_broadcast_task]]
-        description = "Broadcast setup task"
         script = """
             cylc broadcast -n broadcast_task -p $CYLC_TASK_CYCLE_POINT -s "[environment]MY_VALUE='something'" $CYLC_SUITE_NAME
             cylc broadcast -d $CYLC_SUITE_NAME
         """
+        [[[meta]]]
+            description = "Broadcast setup task"
     [[broadcast_task]]
-        description = "Broadcast-recipient task (runs after restart)"
         script = """
             if [[ "$MY_VALUE" != "something" ]]; then
                 echo "[FAIL] MY_VALUE ($MY_VALUE) not set correctly by broadcast" >&2
@@ -33,6 +33,8 @@
             fi
             echo "[PASS] MY_VALUE=$MY_VALUE"
         """
+        [[[meta]]]
+            description = "Broadcast-recipient task (runs after restart)"
         [[[environment]]]
             MY_VALUE=nothing
 {% include 'suite-runtime-restart.rc' %}

--- a/tests/restart/failed/suite.rc
+++ b/tests/restart/failed/suite.rc
@@ -17,9 +17,10 @@
             """
 [runtime]
     [[failed_task]]
-        description = "Failed task (runs before restart)"
         script = """
             sleep 10
             exit 1
         """
+        [[[meta]]]
+            description = "Failed task (runs before restart)"
 {% include 'suite-runtime-restart.rc' %}

--- a/tests/restart/lib/suite-runtime-restart.rc
+++ b/tests/restart/lib/suite-runtime-restart.rc
@@ -10,20 +10,22 @@
             done
         """
     [[shutdown]]
-        description = "Force a shutdown of the suite"
         inherit = OUTPUT
         post-script = """
             cylc shutdown $CYLC_SUITE_NAME
             sleep 5
         """
+        [[[meta]]]
+            description = "Force a shutdown of the suite"
         [[[environment]]]
             OUTPUT_SUFFIX=pre-restart
     [[output_states]]
-        description = "Wait for the restart to complete, then output states"
         inherit = OUTPUT
         pre-script = """
             sleep 5
         """
+        [[[meta]]]
+            description = "Wait for the restart to complete, then output states"
         [[[environment]]]
             OUTPUT_SUFFIX=post-restart
     [[finish]]

--- a/tests/restart/multicycle/suite.rc
+++ b/tests/restart/multicycle/suite.rc
@@ -21,10 +21,11 @@
             """
 [runtime]
     [[foo,bar]]
-        description = "Placeholder tasks for dependencies"
         script = """
             sleep 1
         """
+        [[[meta]]]
+            description = "Placeholder tasks for dependencies"
     [[OUTPUT]]
         script = """
             sleep 5
@@ -33,19 +34,21 @@
                 > {{ TEST_DIR }}/$OUTPUT_SUFFIX-db
         """
     [[shutdown]]
-        description = "Force a shutdown of the suite"
         inherit = OUTPUT
         post-script = """
             cylc shutdown $CYLC_SUITE_NAME
             sleep 5
         """
+        [[[meta]]]
+            description = "Force a shutdown of the suite"
         [[[environment]]]
             OUTPUT_SUFFIX=pre-restart
     [[output_states]]
-        description = "Wait for the restart to complete, then output states"
         inherit = OUTPUT
         pre-script = """
             sleep 5
         """
+        [[[meta]]]
+            description = "Wait for the restart to complete, then output states"
         [[[environment]]]
             OUTPUT_SUFFIX=post-restart

--- a/tests/restart/retrying/suite.rc
+++ b/tests/restart/retrying/suite.rc
@@ -23,7 +23,8 @@
                 exit 1
             fi
         """
-        description = "Retrying state task for restart"
+        [[[meta]]]
+            description = "Retrying state task for restart"
         [[[job]]]
             execution retry delays = PT40S, PT1S
 {% include 'suite-runtime-restart.rc' %}

--- a/tests/restart/running/suite.rc
+++ b/tests/restart/running/suite.rc
@@ -17,10 +17,11 @@
             """
 [runtime]
     [[running_task]]
-        description = "Running task (runs during restart)"
         script = """
             sleep 50
         """
+        [[[meta]]]
+            description = "Running task (runs during restart)"
 {% include 'suite-runtime-restart.rc' %}
     [[shutdown]]
         post-script = """

--- a/tests/restart/submit-failed/suite.rc
+++ b/tests/restart/submit-failed/suite.rc
@@ -17,10 +17,11 @@
             """
 [runtime]
     [[submit_failed_task]]
-        description = "Submit-failed task (runs before restart)"
         script = """
             exit 1  # Should not submit, so this shouldn't run!
         """
+        [[[meta]]]
+            description = "Submit-failed task (runs before restart)"
         [[[job]]]
             batch system = at
             batch submit command template = at oh-no

--- a/tests/restart/succeeded/suite.rc
+++ b/tests/restart/succeeded/suite.rc
@@ -17,8 +17,9 @@
             """
 [runtime]
     [[succeeded_task]]
-        description = "Succeeded task (runs before restart)"
         script = """
             sleep 1
         """
+        [[[meta]]]
+            description = "Succeeded task (runs before restart)"
 {% include 'suite-runtime-restart.rc' %}

--- a/tests/restart/waiting/suite.rc
+++ b/tests/restart/waiting/suite.rc
@@ -16,6 +16,7 @@
             """
 [runtime]
     [[waiting_task]]
-        description = "Waiting task (runs after restart)"
         script = true
+        [[[meta]]]
+            description = "Waiting task (runs after restart)"
 {% include 'suite-runtime-restart.rc' %}


### PR DESCRIPTION
Use DEBUG level for site files - users may not be able to fix them
easily. Use WARNING level for all other files to better alert users.
* See also #2781 and metomi/rose#2257.

Remove more `print` or `sys.std*.write` statements by converting them to use `logging`.
* Remove some unnecessary diagnostics.
* Remove some debug flag check in favour logging level check.
* Exit with error message instead of `print` error then `sys.exit(1)`.