### PR TITLE
emacs syntax lexer: bad mix of greediness & laziness

### DIFF
--- a/etc/syntax/cylc-mode.el
+++ b/etc/syntax/cylc-mode.el
@@ -47,7 +47,7 @@
 
   ;; Cylc setting keys/names
   (font-lock-add-keywords nil
-    '(("^\\( *[a-zA-Z0-9\-]+ *\\)=+" 1 font-lock-variable-name-face t)))
+    '(("^\\( *[a-zA-Z0-9\-]+ *\\)=+[^>]" 1 font-lock-variable-name-face t)))
 
   ;; Account for section headings (see below) with internal patterns, e.g. a
   ;; Jinja2 statement, inside by matching start and end heading groups. Note:
@@ -86,11 +86,11 @@
     '(("^#\\(\\([^{].{2}\\|.[^#]\\).*\\|.{0,1}\\)$"
       . font-lock-comment-face)))
   (font-lock-add-keywords nil
-    '(("{#\\(\n?.?\\)*?.*#}" . font-lock-comment-face)))  ;; not in-line
+    '(("{#\\(.\\|\n\\)*?#}" . font-lock-comment-face)))  ;; not in-line
 
   ;; All Jinja2 excl. comments: '{% ... %}' and '{{ ... }}' incl. multiline
   (font-lock-add-keywords nil
-    '(("{%\\(\n?.?\\)*?.*%}" . font-lock-constant-face)))
+    '(("{%\\(.\\|\n\\)*?%}" . font-lock-constant-face)))
   (font-lock-add-keywords nil '(("{{.*?}}" . font-lock-constant-face)))
 
   ;; Highlight triple quotes for a multi-line setting value


### PR DESCRIPTION
#2784 provides correct highlighting by eyeball, as tested, however I have since discovered through dev use that it is occasionally slowed, & sometimes hangs, in practice. I have traced this back to the typing of the **opening but not yet closing** marker for specific syntactical expressions, namely:

* ``{#``  towards ``{# ... #}``
* ``{%`` towards ``{% ... %}``

... & in turn to a mix of greedy & lazy quantifiers in the associated regular expressions, which have identical format bar the ``#``/``%`` distinction. This PR replaces those instances at fault.

(This bug disocvery will be another lesson to label on my steep learning curve in regular expressions.)

Also amend one other issue manifest with regular use; a task with plain-text name on the first line of a graph string is recognised as a key for a ``key = value`` pair from not considering the subsequent ``>``, e.g:

```ini
graph = """
    plaintexttask => not_just_plain_text_task
    """
```
highlights ``plaintexttask`` in the same colour as ``graph`` & not ``not_just_plain_text_task`` as makes sense contextually.