### PR TITLE
Increase coverage for assorted files from cylc package

### DIFF
--- a/lib/cylc/tests/test_c3mro.py
+++ b/lib/cylc/tests/test_c3mro.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python2
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from cylc.c3mro import *
+
+
+class TestC3mro(unittest.TestCase):
+
+    def test_tree_is_empty_by_default(self):
+        c3 = C3()
+        self.assertFalse(c3.tree)
+
+    def test_tree_parameter(self):
+        c3 = C3({'a': 1})
+        self.assertTrue(c3.tree)
+
+    def test_simple_inheritance(self):
+        parents = {}
+        parents['object'] = []
+        parents['string'] = ['object']
+        c3 = C3(parents)
+        string_hierarchy = c3.mro('string')
+        self.assertEqual(['string', 'object'], string_hierarchy)
+
+    def test_simple_inheritance_extra_nodes(self):
+        parents = {}
+        parents['object'] = []
+        parents['string'] = ['object']
+        # nodes not related to string
+        parents['root'] = []
+        parents['diamond'] = ['root']
+        c3 = C3(parents)
+        self.assertEqual(['string', 'object'], c3.mro('string'))
+        self.assertEqual(['diamond', 'root'], c3.mro('diamond'))
+
+    def test_empty_tree_key_error(self):
+        parents = {}
+        c3 = C3(parents)
+        with self.assertRaises(KeyError):
+            c3.mro('test')
+
+    def test_multiple_inheritance_error_py23(self):
+        parents = {}
+        parents['object'] = []
+        parents['x'] = ['object']
+        parents['y'] = ['object']
+        parents['a'] = ['x', 'y']
+        parents['b'] = ['y', 'x']
+        parents['z'] = ['a', 'b']
+        c3 = C3(parents)
+        # see class docstring, this is the case #2
+        with self.assertRaises(Exception) as cm:
+            c3.mro('z')
+        self.assertTrue("ERROR: z: bad runtime namespace inheritance hierarchy"
+                        in str(cm.exception))
+
+    def test_mro_of_none(self):
+        with self.assertRaises(Exception) as cm:
+            C3.merge([[], ['x', 'y', 'o'], ['y', 'x', 'o'], []], None)
+        self.assertTrue("ERROR: bad runtime namespace inheritance hierarchy"
+                        in str(cm.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/cylc/tests/test_exceptions.py
+++ b/lib/cylc/tests/test_exceptions.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python2
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from cylc.exceptions import CylcError
+
+
+class TestExceptions(unittest.TestCase):
+
+    def test_cylc_error(self):
+        error = CylcError("abcd")
+        self.assertEqual("abcd", error.msg)
+        self.assertEqual("'abcd'", str(error))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/cylc/tests/test_task_id.py
+++ b/lib/cylc/tests/test_task_id.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python2
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from cylc.task_id import TaskID
+
+
+class TestTaskId(unittest.TestCase):
+
+    def test_get(self):
+        self.assertEqual("a.1", TaskID.get("a", 1))
+        self.assertEqual("a._1", TaskID.get("a", "_1"))
+        self.assertEqual(
+            "WTASK.20101010T101010", TaskID.get("WTASK", "20101010T101010"))
+
+    def test_split(self):
+        self.assertEqual(["a", '1'], TaskID.split("a.1"))
+        self.assertEqual(["a", '_1'], TaskID.split("a._1"))
+        self.assertEqual(
+            ["WTAS", '20101010T101010'], TaskID.split("WTAS.20101010T101010"))
+
+    def test_is_valid_name(self):
+        for name in [
+            "abc", "123", "____", "_", "a_b", "a_1", "1_b", "ABC"
+        ]:
+            self.assertTrue(TaskID.is_valid_name(name))
+        for name in [
+            "a.1", None, "%abc", "", " "
+        ]:
+            self.assertFalse(TaskID.is_valid_name(name))
+
+    def test_is_valid_id(self):
+        for id1 in [
+            "a.1", "_.098098439535$#%#@!#~"
+        ]:
+            self.assertTrue(TaskID.is_valid_id(id1))
+        for id2 in [
+            "abc", "123", "____", "_", "a_b", "a_1", "1_b", "ABC", "a.A A"
+        ]:
+            self.assertFalse(TaskID.is_valid_id(id2))
+
+    def test_is_valid_id_2(self):
+        # TBD: a.A A is invalid for valid_id, but valid for valid_id_2?
+        # TBD: a/a.a is OK?
+        for id1 in [
+            "a.1", "_.098098439535$#%#@!#~", "a/1", "_/098098439535$#%#@!#~",
+            "a.A A", "a/a.a"
+        ]:
+            self.assertTrue(TaskID.is_valid_id_2(id1))
+        for id2 in [
+            "abc", "123", "____", "_", "a_b", "a_1", "1_b", "ABC"
+        ]:
+            self.assertFalse(TaskID.is_valid_id_2(id2))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/cylc/tests/test_task_state_prop.py
+++ b/lib/cylc/tests/test_task_state_prop.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python2
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from cylc.task_state_prop import *
+
+
+def get_test_extract_group_state_order():
+    return [
+        (
+            [TASK_STATUS_SUBMIT_FAILED, TASK_STATUS_FAILED],
+            False,
+            TASK_STATUS_SUBMIT_FAILED
+        ),
+        (
+            ["Who?", TASK_STATUS_FAILED],
+            False,
+            TASK_STATUS_FAILED
+        ),
+        (
+            [TASK_STATUS_RETRYING, TASK_STATUS_RUNNING],
+            False,
+            TASK_STATUS_RETRYING
+        ),
+        (
+            [TASK_STATUS_RETRYING, TASK_STATUS_RUNNING],
+            True,
+            TASK_STATUS_RUNNING
+        ),
+    ]
+
+
+def get_test_get_status_prop():
+    return [
+        (
+            TASK_STATUS_HELD,
+            "ascii_ctrl",
+            "ace",
+            "ace"
+        ),
+        (
+            TASK_STATUS_HELD,
+            "ascii_ctrl",
+            None,
+            TASK_STATUS_HELD
+        ),
+        (
+            TASK_STATUS_HELD,
+            "gtk_label",
+            None,
+            "_held"
+        ),
+    ]
+
+
+class TestTaskStateProp(unittest.TestCase):
+
+    def test_extract_group_state_childless(self):
+        self.assertTrue(extract_group_state(child_states=[]) is None)
+
+    def test_extract_group_state_order(self):
+        params = get_test_extract_group_state_order()
+        for child_states, is_stopped, expected in params:
+            r = extract_group_state(child_states=child_states,
+                                    is_stopped=is_stopped)
+            self.assertEqual(expected, r)
+
+    def test_get_status_prop(self):
+        params = get_test_get_status_prop()
+        for status, key, subst, expected in params:
+            r = get_status_prop(status=status, key=key, subst=subst)
+            self.assertTrue(expected in r)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/cylc/tests/test_templatevars.py
+++ b/lib/cylc/tests/test_templatevars.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python2
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import tempfile
+import unittest
+
+from cylc.templatevars import load_template_vars
+
+
+class TestTemplatevars(unittest.TestCase):
+
+    def test_load_template_vars_no_params(self):
+        self.assertFalse(load_template_vars())
+
+    def test_load_template_vars_from_string(self):
+        pairs = [
+            "name=John",
+            "type=Human",
+            "age=12"
+        ]
+        expected = {
+            "name": "John",
+            "type": "Human",
+            "age": "12"
+        }
+        self.assertEqual(expected, load_template_vars(template_vars=pairs))
+
+    def test_load_template_vars_from_file(self):
+        with tempfile.NamedTemporaryFile() as tf:
+            tf.write("""
+            name=John
+            type=Human
+            # a comment
+            # type=Test
+            age=12
+            """)
+            tf.flush()
+            expected = {
+                "name": "John",
+                "type": "Human",
+                "age": "12"
+            }
+            self.assertEqual(
+                expected, load_template_vars(template_vars=None,
+                                             template_vars_file=tf.name))
+
+    def test_load_template_vars_from_string_and_file(self):
+        """Text pair variables take precedence over file."""
+        pairs = [
+            "name=John",
+            "age=12"
+        ]
+        with tempfile.NamedTemporaryFile() as tf:
+            tf.write("""
+            name=Mariah
+            type=Human
+            # a comment
+            # type=Test
+            age=70
+            """)
+            tf.flush()
+            expected = {
+                "name": "John",
+                "type": "Human",
+                "age": "12"
+            }
+            self.assertEqual(
+                expected, load_template_vars(template_vars=pairs,
+                                             template_vars_file=tf.name))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/cylc/tests/test_unicode_util.py
+++ b/lib/cylc/tests/test_unicode_util.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python2
+# -*- coding: ascii -*-
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from cylc.unicode_util import utf8_enforce
+
+
+class TestUnicodeUtil(unittest.TestCase):
+
+    def test_utf8_encode_nothing_to_encode(self):
+        self.assertEqual("d", utf8_enforce("d"))
+
+    def test_utf8_encode_nothing_to_encode(self):
+        value = unicode("d?")
+        self.assertEqual("d?", utf8_enforce(value))
+
+    def test_utf8_encode_with_dictionary(self):
+        value = unicode("d?")
+        d = {
+            "simple": "d",
+            "complex": value
+        }
+        expected = {
+            "simple": "d",
+            "complex": "d?"
+        }
+        self.assertEqual(expected, utf8_enforce(d))
+
+    def test_utf8_encode_with_list(self):
+        value = unicode("d?")
+        d = ["d", value]
+        expected = ["d", "d?"]
+        self.assertEqual(expected, utf8_enforce(d))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/cylc/tests/test_unicode_util.py
+++ b/lib/cylc/tests/test_unicode_util.py
@@ -27,7 +27,7 @@ class TestUnicodeUtil(unittest.TestCase):
     def test_utf8_encode_nothing_to_encode(self):
         self.assertEqual("d", utf8_enforce("d"))
 
-    def test_utf8_encode_nothing_to_encode(self):
+    def test_utf8_encode(self):
         value = unicode("d?")
         self.assertEqual("d?", utf8_enforce(value))
 


### PR DESCRIPTION
Another batch of unit tests for the cylc package. These tests simply validate current behaviour, to allow us to quickly update these files to Python 3, while also increasing the coverage in unit tests, so that we can detect regressions faster in our build process.