### PR TITLE
Amend invalid documented run-once recurrence

### DIFF
--- a/doc/src/cylc-user-guide/cug.tex
+++ b/doc/src/cylc-user-guide/cug.tex
@@ -2659,7 +2659,7 @@ with example graph headings for each form being:
 [[[ R//PT1H ]]]          # Run every hour (Note the R// is redundant)
 [[[ 20000101T00Z/P1D ]]] # Run every day starting at 00:00 1st Jan 2000
 [[[ R1 ]]]               # Run once at the initial cycle point
-[[[ 20000101T00Z ]]]     # Run once at 00:00 1st Jan 2000
+[[[ R1/20000101T00Z ]]]  # Run once at 00:00 1st Jan 2000
 [[[ P1Y ]]]              # Run every year
 \end{lstlisting}
 


### PR DESCRIPTION
Correct an invalid example recurrence graph section heading from **page 58 of the User Guide**, as picked up by validation as ``ERROR: Cannot process recurrence ...``. I cannot find any further instances of a similar invalid format nearby, or by searching for the pattern ``[[[ <digit>``, in the CUG.