### PR TITLE
Add missing value cycling_mode to cylc.flags

### DIFF
--- a/lib/cylc/flags.py
+++ b/lib/cylc/flags.py
@@ -27,3 +27,6 @@ verbose = False
 
 # debug mode
 debug = False
+
+# cycling mode
+cycling_mode = None


### PR DESCRIPTION
While review #2809 and reading the code of `scheduler.py` in the IDE, I noticed it couldn't locate `cycling_mode` in `flags.py`. Even though it is missing, it is defined in `config.py`'s `SuiteConfig` constructor.

Might be worth adding the empty value by default for clarity?