### PR TITLE
Remove unused constant from config.py

### DIFF
--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -64,7 +64,6 @@ RE_EXT_TRIGGER = re.compile(r'(.*)\s*\(\s*(.+)\s*\)\s*')
 RE_SEC_MULTI_SEQ = re.compile(r'(?![^(]+\)),')
 RE_SUITE_NAME_VAR = re.compile(r'\${?CYLC_SUITE_(REG_)?NAME}?')
 RE_TASK_NAME_VAR = re.compile(r'\${?CYLC_TASK_NAME}?')
-NUM_RUNAHEAD_SEQ_POINTS = 5  # Number of cycle points to look at per sequence.
 
 # Message trigger offset regex.
 BCOMPAT_MSG_RE_C6 = re.compile(r'^(.*)\[\s*(([+-])?\s*(.*))?\s*\](.*)$')


### PR DESCRIPTION
Hi, I was not able to find any reference to the constant `NUM_RUNAHEAD_SEQ_POINTS`. 

Looking at the Cylc User Guide, it looks like the `runahead limiting` is set to three by default, and superseded by `max active cyclepoints`, also set to three by default.

I guess it's OK to remove it then?

Cheers