### PR TITLE
Remove cylc.flags.cycling_mode

### DIFF
--- a/bin/cylc-submit
+++ b/bin/cylc-submit
@@ -116,7 +116,7 @@ def main():
         'CYLC_DEBUG': str(cylc.flags.debug).lower(),
         'CYLC_VERBOSE': str(cylc.flags.verbose).lower(),
         'CYLC_SUITE_NAME': suite,
-        'CYLC_CYCLING_MODE': str(cylc.flags.cycling_mode),
+        'CYLC_CYCLING_MODE': str(config.cfg['scheduling']['cycling mode']),
         'CYLC_SUITE_INITIAL_CYCLE_POINT': str(
             config.cfg['scheduling']['initial cycle point']),
         'CYLC_SUITE_FINAL_CYCLE_POINT': str(

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -339,8 +339,6 @@ class SuiteConfig(object):
             set_utc_mode(glbl_cfg().get(['cylc', 'UTC mode']))
         else:
             set_utc_mode(self.cfg['cylc']['UTC mode'])
-        # Capture cycling mode
-        cylc.flags.cycling_mode = self.cfg['scheduling']['cycling mode']
 
         # Initial point from suite definition (or CLI override above).
         icp = self.cfg['scheduling']['initial cycle point']

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -1105,7 +1105,8 @@ conditions; see `cylc conditions`.
             'CYLC_DEBUG': str(cylc.flags.debug).lower(),
             'CYLC_VERBOSE': str(cylc.flags.verbose).lower(),
             'CYLC_SUITE_NAME': self.suite,
-            'CYLC_CYCLING_MODE': str(cylc.flags.cycling_mode),
+            'CYLC_CYCLING_MODE': str(
+                self.config.cfg['scheduling']['cycling mode']),
             'CYLC_SUITE_INITIAL_CYCLE_POINT': str(self.initial_point),
             'CYLC_SUITE_FINAL_CYCLE_POINT': str(self.final_point),
         })


### PR DESCRIPTION
Remove a global variable that duplicates a suite configuration. Supersede #2865.