### PR TITLE
Remove cylc.flags.iflag

### DIFF
--- a/lib/cylc/flags.py
+++ b/lib/cylc/flags.py
@@ -18,10 +18,6 @@
 
 """Some global flags used in cylc"""
 
-# Set iflag = True to simulate an update of the suite state summary
-# structure accessed by gcylc and commands.
-iflag = False
-
 # verbose mode
 verbose = False
 

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -160,6 +160,7 @@ class Scheduler(object):
         self.owner = get_user()
         self.host = get_host()
 
+        self.is_updated = False
         self.is_stalled = False
 
         self.contact_data = None
@@ -627,7 +628,7 @@ conditions; see `cylc conditions`.
                         (n_warnings, cmdstr))
                 else:
                     LOG.info('Command succeeded: ' + cmdstr)
-                cylc.flags.iflag = True
+                self.is_updated = True
                 if name in self.PROC_CMDS:
                     self.task_events_mgr.pflag = True
             self.command_queue.task_done()
@@ -939,7 +940,7 @@ conditions; see `cylc conditions`.
         if self.options.genref or self.options.reftest:
             self.configure_reftest(recon=True)
         self.suite_db_mgr.put_suite_params(self)
-        cylc.flags.iflag = True
+        self.is_updated = True
 
     def set_suite_timer(self):
         """Set suite's timeout timer."""
@@ -1215,7 +1216,7 @@ conditions; see `cylc conditions`.
         self.run_event_handlers(self.EVENT_STARTUP, 'suite starting')
         self.profiler.log_memory("scheduler.py: begin run while loop")
         self.time_next_fs_check = None
-        cylc.flags.iflag = True
+        self.is_updated = True
         if self.options.profile_mode:
             self.previous_profile_point = 0
             self.count = 0
@@ -1235,7 +1236,7 @@ conditions; see `cylc conditions`.
         if self.stop_mode is None:
             itasks = self.pool.get_ready_tasks()
             if itasks:
-                cylc.flags.iflag = True
+                self.is_updated = True
             done_tasks = self.task_job_mgr.submit_task_jobs(
                 self.suite, itasks, self.run_mode == 'simulation')
             if self.config.cfg['cylc']['log resolved dependencies']:
@@ -1247,7 +1248,7 @@ conditions; see `cylc conditions`.
                 self.pool.remove_spent_tasks,
                 self.pool.remove_suiciding_tasks]:
             if meth():
-                cylc.flags.iflag = True
+                self.is_updated = True
 
         self.broadcast_mgr.expire_broadcast(self.pool.get_min_point())
         self.xtrigger_mgr.housekeep()
@@ -1404,11 +1405,11 @@ conditions; see `cylc conditions`.
             if self.pool.do_reload:
                 self.pool.reload_taskdefs()
                 self.suite_db_mgr.checkpoint("reload-done")
-                cylc.flags.iflag = True
+                self.is_updated = True
 
             self.process_command_queue()
             if self.pool.release_runahead_tasks():
-                cylc.flags.iflag = True
+                self.is_updated = True
                 self.task_events_mgr.pflag = True
             self.proc_pool.process()
 
@@ -1422,12 +1423,9 @@ conditions; see `cylc conditions`.
             self.process_command_queue()
             self.task_events_mgr.process_events(self)
 
-            # Update database
+            # Update state summary and database
             self.suite_db_mgr.put_task_event_timers(self.task_events_mgr)
-            has_changes = cylc.flags.iflag
-            if cylc.flags.iflag:
-                self.suite_db_mgr.put_task_pool(self.pool)
-                self.update_state_summary()  # Will reset cylc.flags.iflag
+            has_updated = self.update_state_summary()
             self.process_suite_db_queue()
 
             # If public database is stuck, blast it away by copying the content
@@ -1441,7 +1439,7 @@ conditions; see `cylc conditions`.
             self.suite_shutdown()
 
             # Suite health checks
-            self.suite_health_check(has_changes)
+            self.suite_health_check(has_updated)
 
             if self.options.profile_mode:
                 self.update_profiler_logs(tinit)
@@ -1466,16 +1464,24 @@ conditions; see `cylc conditions`.
 
     def update_state_summary(self):
         """Update state summary, e.g. for GUI."""
-        self.state_summary_mgr.update(self)
-        cylc.flags.iflag = False
-        self.is_stalled = False
-        if self.suite_timer_active:
-            self.suite_timer_active = False
-            LOG.debug(
-                "%s suite timer stopped NOW: %s",
-                get_seconds_as_interval_string(
-                    self._get_events_conf(self.EVENT_TIMEOUT)),
-                get_current_time_string())
+        updated_tasks = [
+            t for t in self.pool.get_all_tasks() if t.state.is_updated]
+        has_updated = self.is_updated or updated_tasks
+        if has_updated:
+            self.state_summary_mgr.update(self)
+            self.suite_db_mgr.put_task_pool(self.pool)
+            self.is_updated = False
+            self.is_stalled = False
+            for itask in updated_tasks:
+                itask.state.is_updated = False
+            if self.suite_timer_active:
+                self.suite_timer_active = False
+                LOG.debug(
+                    "%s suite timer stopped NOW: %s",
+                    get_seconds_as_interval_string(
+                        self._get_events_conf(self.EVENT_TIMEOUT)),
+                    get_current_time_string())
+        return has_updated
 
     def check_suite_timer(self):
         """Check if suite has timed out or not."""

--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -337,10 +337,10 @@ class TaskEventsManager(object):
             return
 
         # always update the suite state summary for latest message
-        itask.summary['latest_message'] = message
         if flag == self.POLLED_FLAG:
-            itask.summary['latest_message'] += ' %s' % self.POLLED_FLAG
-        cylc.flags.iflag = True
+            itask.set_summary_message('%s %s' % (message, self.POLLED_FLAG))
+        else:
+            itask.set_summary_message(message)
 
         # Satisfy my output, if possible, and record the result.
         completed_trigger = itask.state.outputs.set_msg_trg_completion(
@@ -632,7 +632,7 @@ class TaskEventsManager(object):
                 itask.try_timers[TASK_STATUS_RETRYING].delay_timeout_as_str())
             msg = "failed, %s" % (delay_msg)
             LOG.info("[%s] -job(%02d) %s", itask, itask.submit_num, msg)
-            itask.summary['latest_message'] = msg
+            itask.set_summary_message(msg)
             if itask.state.reset_state(TASK_STATUS_RETRYING):
                 self.setup_event_handlers(
                     itask, "retry", "%s, %s" % (self.JOB_FAILED, delay_msg))
@@ -708,7 +708,7 @@ class TaskEventsManager(object):
             delay_msg = "submit-retrying in %s" % timer.delay_timeout_as_str()
             msg = "%s, %s" % (self.EVENT_SUBMIT_FAILED, delay_msg)
             LOG.info("[%s] -job(%02d) %s", itask, itask.submit_num, msg)
-            itask.summary['latest_message'] = msg
+            itask.set_summary_message(msg)
             if itask.state.reset_state(TASK_STATUS_SUBMIT_RETRYING):
                 self.setup_event_handlers(
                     itask, self.EVENT_SUBMIT_RETRY,
@@ -744,7 +744,7 @@ class TaskEventsManager(object):
         # Unset started and finished times in case of resubmission.
         itask.set_summary_time('started')
         itask.set_summary_time('finished')
-        itask.summary['latest_message'] = TASK_OUTPUT_SUBMITTED
+        itask.set_summary_message(TASK_OUTPUT_SUBMITTED)
 
         self.pflag = True
         if itask.state.status == TASK_STATUS_READY:

--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -376,6 +376,15 @@ class TaskProxy(object):
             for timer in self.try_timers.values():
                 timer.timeout = None
 
+    def set_summary_message(self, message):
+        """Set `.summary['latest_message']` if necessary.
+
+        Set `.state.is_updated` to `True` if message is updated.
+        """
+        if self.summary['latest_message'] != message:
+            self.summary['latest_message'] = message
+            self.state.is_updated = True
+
     def set_summary_time(self, event_key, time_str=None):
         """Set an event time in self.summary
 

--- a/lib/cylc/task_state.py
+++ b/lib/cylc/task_state.py
@@ -192,18 +192,68 @@ def status_geq(status_a, status_b):
 
 
 class TaskState(object):
-    """Task status and utilities."""
+    """Task status and utilities.
+
+    Attributes:
+        .external_triggers (dict):
+            External triggers as {trigger (str): satisfied (boolean), ...}.
+        .hold_swap (str):
+            While the task is in `held` status, this holds the actual status if
+            the task is not held. For tasks in `submitted` or `running`
+            statuses, setting this to `held` will cause the task to hold when
+            the task is reset to anything other than the `submitted` or
+            `running` statuses.
+        .identity (str):
+            The task ID as `TASK.CYCLE` associated with this object.
+        .is_updated (boolean):
+            Has the status been updated since previous update?
+        .kill_failed (boolean):
+            Has a job kill attempt failed since previous status change?
+        .outputs (cylc.task_outputs.TaskOutputs):
+            Known outputs of the task.
+        .prerequisites (list<cylc.prerequisite.Prerequisite>):
+            List of prerequisites of the task.
+        .status (str):
+            The current status of the task.
+        .suicide_prerequisites (list<cylc.prerequisite.Prerequisite>):
+            List of prerequisites that will cause the task to suicide.
+        .time_updated (str):
+            Time string of latest update time.
+        .xclock (tuple):
+            A tuple (clock_label (str), is_done (boolean)) to indicate if a
+            clock trigger is satisfied or not. Set to `None` if the task has no
+            clock trigger.
+        .xtriggers (dict):
+            xtriggers as {trigger (str): satisfied (boolean), ...}.
+        ._is_satisfied (boolean):
+            Are prerequisites satisified?
+        ._suicide_is_satisfied (boolean):
+            Are prerequisites to trigger suicide satisified?
+    """
 
     # Memory optimization - constrain possible attributes to this list.
-    __slots__ = ["identity", "status", "hold_swap",
-                 "_is_satisfied", "_suicide_is_satisfied", "prerequisites",
-                 "suicide_prerequisites", "external_triggers", "outputs",
-                 "xtriggers", "xclock", "kill_failed", "time_updated"]
+    __slots__ = [
+        "external_triggers",
+        "hold_swap",
+        "identity",
+        "is_updated",
+        "kill_failed",
+        "outputs",
+        "prerequisites",
+        "status",
+        "suicide_prerequisites",
+        "time_updated",
+        "xclock",
+        "xtriggers",
+        "_is_satisfied",
+        "_suicide_is_satisfied",
+    ]
 
     def __init__(self, tdef, point, status, hold_swap):
         self.identity = TaskID.get(tdef.name, str(point))
         self.status = status
         self.hold_swap = hold_swap
+        self.is_updated = False
         self.time_updated = None
 
         self._is_satisfied = None
@@ -235,6 +285,13 @@ class TaskState(object):
         # Message outputs.
         self.outputs = TaskOutputs(tdef)
         self.kill_failed = False
+
+    def __str__(self):
+        """Print status (hold_swap)."""
+        ret = self.status
+        if self.hold_swap:
+            ret += ' (%s)' % self.hold_swap
+        return ret
 
     def satisfy_me(self, all_task_outputs):
         """Attempt to get my prerequisites satisfied."""
@@ -414,7 +471,7 @@ class TaskState(object):
             self.hold_swap = None
         self.status = status
         self.time_updated = get_current_time_string()
-        cylc.flags.iflag = True
+        self.is_updated = True
         # Log
         message = str(prev_status)
         if prev_hold_swap:


### PR DESCRIPTION
Remove a global state variable.
* Record same info using object attributes of scheduler and tasks.
* Update to any task's `.summary['latest_message']` now correctly triggers a summary update.

Inspired by our recent discussion (#2865), I thought I'll have a go at migrating the global `cylc.flags.iflag` variable to become local object attributes. The solution is not perfect, because I am no longer able to use a single variable (without making this change a lot bigger), but it is a workable solution without compromising the current logic.