### PR TITLE
PBS 13 "multi-cluster" support.

### DIFF
--- a/lib/cylc/batch_sys_handlers/pbs_multi_cluster.py
+++ b/lib/cylc/batch_sys_handlers/pbs_multi_cluster.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python2
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""PBS batch system job submission and manipulation.
+
+This variant supports heteorogenous clusters where the Job ID returned by qsub
+is <job-id>.<server>. Prior to PBS 14 job query and kill need to target
+<job-id>@<server>.
+
+This is achieved by:
+  - providing a manip_job_id() method to append "@<server>" to the Job ID
+    returned by qsub, for writing to the job status file.
+  - providing a filter_poll_many_output() method to append "@<server>" to the
+    Job IDs returned by qstat, for comparison with those known by cylc.
+
+From PBS 14 the standard "pbs" module works ("@<server>" is not needed).
+"""
+
+from cylc.batch_sys_handlers.pbs import PBSHandler
+
+
+class PBSMulticlusterHandler(PBSHandler):
+
+    @classmethod
+    def filter_poll_many_output(cls, out):
+        out = out.strip()
+        job_ids = []
+        lines = out.split('\n')
+        for line in lines[2:]:
+            job = line.split()[0]
+            _, server = job.split('.')
+            job_ids.append(job + '@' + server)
+        return job_ids
+
+    @classmethod
+    def manip_job_id(cls, job_id):
+        """Manipulate the job ID returned by qsub."""
+        _, server = job_id.split('.')
+        return job_id + '@' + server
+
+
+BATCH_SYS_HANDLER = PBSMulticlusterHandler()

--- a/lib/cylc/batch_sys_handlers/pbs_multi_cluster.py
+++ b/lib/cylc/batch_sys_handlers/pbs_multi_cluster.py
@@ -38,14 +38,14 @@ class PBSMulticlusterHandler(PBSHandler):
         lines = out.split('\n')
         for line in lines[2:]:
             job = line.split()[0]
-            _, server = job.split('.')
+            _, server = job.split('.', 1)
             job_ids.append(job + '@' + server)
         return job_ids
 
     @classmethod
     def manip_job_id(cls, job_id):
         """For job_id of the form "id.server", return job_id@server."""
-        _, server = job_id.split('.')
+        _, server = job_id.split('.', 1)
         return job_id + '@' + server
 
 

--- a/lib/cylc/batch_sys_handlers/pbs_multi_cluster.py
+++ b/lib/cylc/batch_sys_handlers/pbs_multi_cluster.py
@@ -30,9 +30,9 @@ from cylc.batch_sys_handlers.pbs import PBSHandler
 
 
 # Match and extract PBS Job ID of the form "<job>.<host>"
-REC_JOB = re.compile('^ *(?P<job>[^ ]+?)\.(?P<host>[^ ]+) *$')
+REC_JOB = re.compile(r'^ *(?P<job>[^ ]+?)\.(?P<host>[^ ]+) *$')
 # Replace with "<job>.<host>@<host>"
-REP_JOB = '\g<job>.\g<host>@\g<host>'
+REP_JOB = r'\g<job>.\g<host>@\g<host>'
 
 
 class PBSMulticlusterHandler(PBSHandler):

--- a/lib/cylc/batch_sys_manager.py
+++ b/lib/cylc/batch_sys_manager.py
@@ -477,6 +477,8 @@ class BatchSysManager(object):
                 match = rec_id.match(line)
                 if match:
                     job_id = match.group("id")
+                    if hasattr(batch_sys, "manip_job_id"):
+                        job_id = batch_sys.manip_job_id(job_id)
                     job_status_file = open(st_file_path, "a")
                     job_status_file.write("%s=%s\n" % (
                         self.CYLC_BATCH_SYS_JOB_ID, job_id))

--- a/lib/cylc/batch_sys_manager.py
+++ b/lib/cylc/batch_sys_manager.py
@@ -63,6 +63,9 @@ batch_sys.submit(job_file_path) => ret_code, out, err
       beyond just running a system or shell command. See also
       "batch_sys.SUBMIT_CMD".
 
+batch_sys.manip_job_id(job_id) => job_id
+    * Modify the job ID that is returned by the job poll command.
+
 batch_sys.KILL_CMD_TMPL
     *  A Python string template for getting the batch system command to remove
        and terminate a job ID. The command is formed using the logic:

--- a/lib/cylc/tests/test_pbs_multi_cluster.py
+++ b/lib/cylc/tests/test_pbs_multi_cluster.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python2
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from cylc.batch_sys_handlers.pbs_multi_cluster import *
+
+
+def get_test_filter_poll_many_output():
+    return [
+        ("ignore\nignore\n123.localhost ignored", ["123.localhost@localhost"]),
+        ("\n\n#\n#\n10.samba", ["10.samba@samba"]),
+        (
+            """
+            a
+            a
+            12.localhost ____ # this is ignored
+            09.jd-01
+            """,
+            [
+                "12.localhost@localhost",
+                "09.jd-01@jd-01",
+            ]
+        ),
+        ("\n\n1.localhost", [])
+    ]
+
+
+def get_test_filter_poll_many_output_invalid():
+    return [
+        # could not find a `.`
+        ("a\nb\nnot_an_id", ValueError)
+    ]
+
+
+def get_test_manip_job_id():
+    return [
+        ("1.localhost", "1.localhost@localhost"),
+        ("10000.jd-01", "10000.jd-01@jd-01")
+    ]
+
+
+def get_test_manip_job_id_invalid():
+    return [
+        # could not find a `.`
+        ("103", ValueError)
+    ]
+
+
+class TestPBSMultiCluster(unittest.TestCase):
+
+    def test_filter_poll_many_output(self):
+        """Basic tests for filter_poll_many_output."""
+        for out, expected in get_test_filter_poll_many_output():
+            job_ids = PBSMulticlusterHandler.filter_poll_many_output(out)
+            self.assertEqual(expected, job_ids)
+
+    def test_filter_poll_many_output_invalid(self):
+        """Test filter_poll_many_output with invalid values."""
+        for out, ex in get_test_filter_poll_many_output_invalid():
+            with self.assertRaises(ex):
+                PBSMulticlusterHandler.filter_poll_many_output(out)
+
+    def test_manip_job_id(self):
+        """Basic tests for manip_job_id."""
+        for job_id, expected in get_test_manip_job_id():
+            mod_job_id = PBSMulticlusterHandler.manip_job_id(job_id)
+            self.assertEqual(expected, mod_job_id)
+
+    def test_manip_job_id_invalid(self):
+        """Basic tests for manip_job_id with invalid values."""
+        for job_id, ex in get_test_manip_job_id_invalid():
+            with self.assertRaises(ex):
+                PBSMulticlusterHandler.manip_job_id(job_id)
+
+    def test_export_handler(self):
+        import cylc.batch_sys_handlers.pbs_multi_cluster as m
+        self.assertTrue(hasattr(m, 'BATCH_SYS_HANDLER'))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/cylc/tests/test_pbs_multi_cluster.py
+++ b/lib/cylc/tests/test_pbs_multi_cluster.py
@@ -23,42 +23,27 @@ from cylc.batch_sys_handlers.pbs_multi_cluster import *
 
 def get_test_filter_poll_many_output():
     return [
-        ("ignore\nignore\n123.localhost ignored", ["123.localhost@localhost"]),
-        ("\n\n#\n#\n10.samba", ["10.samba@samba"]),
+        ("header1\nheader2\n123.localhost", ["123.localhost@localhost"]),
         (
-            """
-            a
-            a
-            12.localhost ____ # this is ignored
-            09.jd-01
-            """,
+            """header1
+            header2
+            12.localhost
+            job123
+            09.jd-01.foo.bar""",
             [
                 "12.localhost@localhost",
-                "09.jd-01@jd-01",
+                "job123",  # unchanged
+                "09.jd-01.foo.bar@jd-01.foo.bar",
             ]
         ),
-        ("\n\n1.localhost", [])
-    ]
-
-
-def get_test_filter_poll_many_output_invalid():
-    return [
-        # could not find a `.`
-        ("a\nb\nnot_an_id", ValueError)
     ]
 
 
 def get_test_manip_job_id():
     return [
         ("1.localhost", "1.localhost@localhost"),
-        ("10000.jd-01", "10000.jd-01@jd-01")
-    ]
-
-
-def get_test_manip_job_id_invalid():
-    return [
-        # could not find a `.`
-        ("103", ValueError)
+        ("10000.jd-01", "10000.jd-01@jd-01"),
+        ("   1077   ", "1077")  # unchanged
     ]
 
 
@@ -70,23 +55,11 @@ class TestPBSMultiCluster(unittest.TestCase):
             job_ids = PBSMulticlusterHandler.filter_poll_many_output(out)
             self.assertEqual(expected, job_ids)
 
-    def test_filter_poll_many_output_invalid(self):
-        """Test filter_poll_many_output with invalid values."""
-        for out, ex in get_test_filter_poll_many_output_invalid():
-            with self.assertRaises(ex):
-                PBSMulticlusterHandler.filter_poll_many_output(out)
-
     def test_manip_job_id(self):
         """Basic tests for manip_job_id."""
         for job_id, expected in get_test_manip_job_id():
             mod_job_id = PBSMulticlusterHandler.manip_job_id(job_id)
             self.assertEqual(expected, mod_job_id)
-
-    def test_manip_job_id_invalid(self):
-        """Basic tests for manip_job_id with invalid values."""
-        for job_id, ex in get_test_manip_job_id_invalid():
-            with self.assertRaises(ex):
-                PBSMulticlusterHandler.manip_job_id(job_id)
 
     def test_export_handler(self):
         import cylc.batch_sys_handlers.pbs_multi_cluster as m

--- a/lib/cylc/tests/test_pbs_multi_cluster.py
+++ b/lib/cylc/tests/test_pbs_multi_cluster.py
@@ -92,5 +92,6 @@ class TestPBSMultiCluster(unittest.TestCase):
         import cylc.batch_sys_handlers.pbs_multi_cluster as m
         self.assertTrue(hasattr(m, 'BATCH_SYS_HANDLER'))
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Close #2779

New batch system handler `lib/cylc/batch_sys_handlers/pbs_multi_cluster.py` docstring:
```
Support PBS clients that front heterogeneous clusters where the Job ID returned
by qsub is <id>.<server>. PBS 13 qstat and qdel need <id>.<server>@<server>.
From PBS 14, the standard cylc PBS module works ("@<server>" is not needed).

So this PBS handler writes "job_id@server" to the job status file, and appends
"@server" to Job IDs returned by qstat, to matched the stored IDs.
```

This should be an easy review: you might not be able to test it, but you can tell that it won't affect any existing cases. 

Not assigning @kinow to review as he doesn't have access to PBS.  I've tested this on an Azure cluster with PBS, set up to mimic this "multi cluster" heterogeneous environment. 

I don't think I can make an integration test for this - it requires a non-trivial cluster environment, and an old version of PBS Pro.  ~~Obviously could make a small unit test for the new function, once our new unit testing machinery is in place.~~ [unit tests added thanks to @kinow]

@matthewrmshin - please assign another reviewer from your team...