### PR TITLE
pytest.ini: add ignores

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -17,11 +17,15 @@
 [pytest]
 addopts = --verbose
     --doctest-modules
+    --ignore=lib/parsec/empysupport.py
     --ignore=lib/parsec/tests/getcfg/bin/one-line.py
     --ignore=lib/parsec/tests/synonyms/bin/synonyms.py
     --ignore=lib/parsec/tests/nullcfg/bin/empty.py
     --ignore=lib/parsec/example
     --ignore=lib/cherrypy
+    --ignore=lib/cylc/cylc_xdot.py
+    --ignore=lib/cylc/graphing.py
+    --ignore=lib/cylc/gui
     --ignore=lib/isodatetime
     --ignore=lib/markupsafe
 testpaths =


### PR DESCRIPTION
Ignore code based on optional dependencies: GTK, PyGraphviz and EmPy. Follow up of #2766.