### PR TITLE
Fix parsec example code

### DIFF
--- a/lib/parsec/example/cfgspec.py
+++ b/lib/parsec/example/cfgspec.py
@@ -17,29 +17,29 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Legal items and validators for the parsec test config file."""
 
-from parsec.validate import validator as vdr
+from parsec.validate import ParsecValidator as vdr
 
 
 SPEC = {
-        'title' : vdr( vtype="string" ),
+        'title' : [vdr.V_STRING],
         'single values' :
         {
-            'integers' : { '__MANY__' : vdr( vtype="integer" ) },
-            'booleans' : { '__MANY__' : vdr( vtype="boolean" ) },
-            'floats'   : { '__MANY__' : vdr( vtype="float"   ) },
-            'strings'  : { '__MANY__' : vdr( vtype="string"  ) },
-            'strings with internal comments'  : { '__MANY__' : vdr( vtype="string"  ) },
-            'multiline strings'  : { '__MANY__' : vdr( vtype="string"  ) },
-            'multiline strings with internal comments'  : { '__MANY__' : vdr( vtype="string"  ) },
+            'integers' : { '__MANY__' : [vdr.V_INTEGER] },
+            'booleans' : { '__MANY__' : [vdr.V_BOOLEAN] },
+            'floats'   : { '__MANY__' : [vdr.V_FLOAT] },
+            'strings'  : { '__MANY__' : [vdr.V_STRING] },
+            'strings with internal comments'  : { '__MANY__' : [vdr.V_STRING] },
+            'multiline strings'  : { '__MANY__' : [vdr.V_STRING] },
+            'multiline strings with internal comments'  : { '__MANY__' : [vdr.V_STRING] },
              },
         'list values' :
         {
             'string lists' :
             {
-                '__MANY__'   : vdr( vtype="string_list"  ),
-                'compulsory' : vdr( vtype="string_list", default=["jumped","over","the"], compulsory=True )
+                '__MANY__'   : [vdr.V_STRING_LIST],
+                'compulsory' : [vdr.V_STRING_LIST, ["jumped","over","the"]]
                 },
-            'integer lists' : { '__MANY__' : vdr( vtype="integer_list", allow_zeroes=False ) },
-            'float lists'   : { '__MANY__' : vdr( vtype="float_list", allow_zeroes=False   ) },
+            'integer lists' : { '__MANY__' : [vdr.V_INTEGER_LIST] },
+            'float lists'   : { '__MANY__' : [vdr.V_FLOAT_LIST] },
             },
         }

--- a/lib/parsec/example/test.py
+++ b/lib/parsec/example/test.py
@@ -24,11 +24,11 @@ sys.path.append( os.path.join( os.path.dirname(os.path.abspath(__file__)), '..' 
 sys.path.append( os.path.join( os.path.dirname(os.path.abspath(__file__)), '../..' ))
 
 from cfgspec import SPEC
-from config import config
+from parsec.config import ParsecConfig
 import cylc.flags
 
 cylc.flags.verbose = True
-class testcfg( config ):
+class testcfg( ParsecConfig ):
     def check( self, sparse ):
         # TEMPORARY EXAMPLE
         if 'missing item' not in self.sparse.keys():
@@ -39,10 +39,10 @@ strict = False
 cfg.loadcfg( os.path.join( os.path.dirname( __file__ ), 'site.rc' )) # TODO: test strict=False (fail but accept defaults)
 cfg.loadcfg( os.path.join( os.path.dirname( __file__ ), 'user.rc' ))
 
-cfg.printcfg()
+cfg.dump()
 #print
-#cfg.printcfg( ['list values'] )
+#cfg.dump( ['list values'] )
 #print
-#cfg.printcfg( ['list values', 'integers'] )
+#cfg.dump( ['list values', 'integers'] )
 #print
-#cfg.printcfg( ['single values', 'strings with internal comments'] )
+#cfg.dump( ['single values', 'strings with internal comments'] )


### PR DESCRIPTION
Had fixed the examples before while working on the `setup.py` #2834 PR, but removed it as it doesn't really belong there.

Instead submitting a separated PR. After fixing it, the `test.py` prints:

```bash
title = parsec torture test
[list values]
    [[integer lists]]
        foo = 1..3, 3, 3, 4, 4
        bar = 1..3, 3, 3, 4, 4
    [[float lists]]
        foo = 1.0, 2.0, 2.0, 2.0, 3.0, 4.0, 4.0
        bar = 1.0, 2.0, 2.0, 2.0, 3.0, 4.0, 4.0
    [[string lists]]
        compulsory = one, two
        one = the quick, brown fox
        two = the quick, brown fox
        thr = the quick, brown fox
        fou = 'the, quick', 'brown , fox'
        fiv = 'the #quick', 'brown #fox'
[single values]
    [[integers]]
        one = 1
        two = 1
        thr = 1
    [[multiline strings with internal comments]]
        one = """
            the quick # or slow
            brown fox # or lazy dog
        """
        two = """
            the quick # or slow
            brown fox # or lazy dog
        """
    [[booleans]]
        one = False
        two = False
        thr = False
        fou = False
        fiv = False
        six = False
    [[multiline strings]]
        one = """
            the quick
            brown fox
        """
        two = """
            the quick
            brown fox
        """
    [[strings with internal comments]]
        fou = the quick brown fox # jumped over
        fiv = the quick brown fox # jumped over
        eig = the quick BROWN fox # jumped over
        nin = the quick BROWN fox # jumped over
    [[strings]]
        one = the quick brown fox
        two = the quick brown fox
        thr = the quick brown fox
        six = the quick brown fox
        sev = the quick brown fox
        an item = the quick brown fox
        override me = OVERRIDDEN
    [[floats]]
        one = 9.9
        two = 9.9
        thr = 9.9
```

Not sure whether the examples are important/used right now, but maybe once fixed, later we could port to documentation, or to doctests, or even to parsec unit tests; I think.