### PR TITLE
Fix a couple broken links in the site

### DIFF
--- a/users.md
+++ b/users.md
@@ -27,14 +27,14 @@ Known users include:
   * [Centre of Excellence in Simulation of Weather and Climate in
       Europe](https://verc.enes.org/esiwace/services/sup_cylc) - Europe
   * [National Center for Atmospheric Reserach (NCAR)](https://ncar.ucar.edu) - USA
-  * [NOAA Environmental Modeling Center](https://www.emc.ncep.noaa.gov/) - USA
+  * [NOAA Environmental Modeling Center](http://www.emc.ncep.noaa.gov/) - USA
   * [Euro-Mediterranean Center on Climate Change (CMCC)](https://www.cmcc.it) - Italy
   * [Plymouth Marine Laboratory](https://www.pml.ac.uk/) - UK
   * [Barcelona Supercomputing Center (BSC)](https://www.bsc.es) - Spain
   * [National Centre for Atmospheric Science (NCAS)](https://www.ncas.ac.uk) - UK
   * [Centre for Environmental Data Analysis (CEDA)](http://www.ceda.ac.uk) - UK
   * [ARC Centre of Excellence for Climate Extremes (CLEX)](https://climateextremes.org.au/) - Australia
-  * [eWaterCycle](forecast.ewatercycle.org) - Netherlands eScience Center, Univerity of Utrecht, TUDelft
+  * [eWaterCycle](http://forecast.ewatercycle.org/) - Netherlands eScience Center, Univerity of Utrecht, TUDelft
  
 Many of these centers use Cylc with [Rose](https://github.com/metomi/rose), a
 framework for managing and running meteorological suites.


### PR DESCRIPTION
www.emc.ncep.noaa.gov/ is a bit weird with HTTPS, but works OK with HTTP for me. The other link is missing the protocol, so the browser tries something like cylc.github.io/cylc/forecast...