### PR TITLE
remote-init: fix bad unlink taking down the suite

### DIFF
--- a/lib/cylc/task_remote_mgr.py
+++ b/lib/cylc/task_remote_mgr.py
@@ -309,7 +309,10 @@ class TaskRemoteMgr(object):
     def _remote_init_callback(self, proc_ctx, host, owner, tmphandle):
         """Callback when "cylc remote-init" exits"""
         self.ready = True
-        tmphandle.close()
+        try:
+            tmphandle.close()
+        except OSError:  # E.g. ignore bad unlink, etc
+            pass
         if proc_ctx.ret_code == 0:
             for status in (REMOTE_INIT_DONE, REMOTE_INIT_NOT_REQUIRED):
                 if status in proc_ctx.out:


### PR DESCRIPTION
A user has sent us a report that on closing the temporary file, the attempted `os.unlink` issued by the `tempfile` module on the temporary file was taking down the suite with `OSError: [Errno 2] No such file or directory`. Occurs on a platform that we have to support. However, I am still not sure how to repeat this in general.