### PR TITLE
Remove a few unused imports

### DIFF
--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -32,7 +32,6 @@ from cylc.cfgvalidate import (
     cylc_config_validate, CylcConfigValidator as VDR, DurationFloat)
 from cylc.hostuserutil import is_remote_user
 from cylc.mkdir_p import mkdir_p
-import cylc.flags
 from cylc.network import PRIVILEGE_LEVELS, PRIV_STATE_TOTALS, PRIV_SHUTDOWN
 from cylc.version import CYLC_VERSION
 

--- a/lib/cylc/log_diagnosis.py
+++ b/lib/cylc/log_diagnosis.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import sys
 import re
 from difflib import unified_diff
 

--- a/lib/cylc/rundb.py
+++ b/lib/cylc/rundb.py
@@ -19,7 +19,6 @@
 
 import json
 import sqlite3
-import sys
 import traceback
 
 

--- a/lib/cylc/suite_srv_files_mgr.py
+++ b/lib/cylc/suite_srv_files_mgr.py
@@ -21,7 +21,6 @@
 # imported on demand.
 import os
 import re
-import sys
 from uuid import uuid4
 from string import ascii_letters, digits
 

--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -38,7 +38,6 @@ from parsec.config import ItemNotFoundError
 
 from cylc import LOG
 from cylc.cfgspec.glbl_cfg import glbl_cfg
-import cylc.flags
 from cylc.hostuserutil import get_host, get_user
 from cylc.subprocctx import SubProcContext
 from cylc.task_action_timer import TaskActionTimer

--- a/lib/cylc/task_job_mgr.py
+++ b/lib/cylc/task_job_mgr.py
@@ -38,7 +38,6 @@ from parsec.util import pdeepcopy, poverride
 from cylc import LOG
 from cylc.batch_sys_manager import JobPollContext
 from cylc.cfgspec.glbl_cfg import glbl_cfg
-import cylc.flags
 from cylc.hostuserutil import get_host, is_remote_host, is_remote_user
 from cylc.job_file import JobFileWriter
 from cylc.task_job_logs import (

--- a/lib/cylc/task_state.py
+++ b/lib/cylc/task_state.py
@@ -20,7 +20,6 @@
 
 
 from cylc import LOG
-import cylc.flags
 from cylc.prerequisite import Prerequisite
 from cylc.task_id import TaskID
 from cylc.task_outputs import (


### PR DESCRIPTION
I think the `cylc.flags` ones are from #2865 & #2871. The other `sys` imports must have crawled somewhere over the last changes.

Not removing the unused `LOG`, as even though they are not used, I remember disabling one somewhere some time ago, and logging/debug stopped working. I think that's by design.