### PR TITLE
Fix WSGI docs (s/rose/cylc)

### DIFF
--- a/doc/src/cylc-user-guide/cug.tex
+++ b/doc/src/cylc-user-guide/cug.tex
@@ -1257,12 +1257,12 @@ You will find the access and error logs under \lstinline=~/.cylc/cylc-review*=.
 Alternatively you can run the Cylc Review web service under Apache
 \lstinline=mod_wsgi=. To do this you will need to set up an Apache module
 configuration file (typically in
-\lstinline=/etc/httpd/conf.d/rose-wsgi.conf=) containing the following (with
+\lstinline=/etc/httpd/conf.d/cylc-wsgi.conf=) containing the following (with
 the paths set appropriately):
 
 \lstset{language=bash}
 \begin{lstlisting}
-WSGIPythonPath /path/to/rose/lib/python
+WSGIPythonPath /path/to/cylc/lib
 WSGIScriptAlias /cylc-review /path/to/lib/cylc/review.py
 \end{lstlisting}
 


### PR DESCRIPTION
A PR, but also a question. Should it be `rose` in the instructions for setting up Apache httpd + Cylc Review, or should it be `cylc` now?