### PR TITLE
cylc.hostuserutil: get_fqdn_by_host: include bad host name in error

### DIFF
--- a/lib/cylc/hostuserutil.py
+++ b/lib/cylc/hostuserutil.py
@@ -118,7 +118,12 @@ class HostUtil(object):
         if target not in self._host_exs:
             if target is None:
                 target = socket.getfqdn()
-            self._host_exs[target] = socket.gethostbyname_ex(target)
+            try:
+                self._host_exs[target] = socket.gethostbyname_ex(target)
+            except IOError as exc:
+                if exc.filename is None:
+                    exc.filename = target
+                raise
         return self._host_exs[target]
 
     @staticmethod

--- a/lib/cylc/tests/test_hostuserutil.py
+++ b/lib/cylc/tests/test_hostuserutil.py
@@ -19,23 +19,35 @@
 import os
 import unittest
 
-from cylc.hostuserutil import get_host, is_remote_host, is_remote_user
+from cylc.hostuserutil import (
+    get_fqdn_by_host, get_host, is_remote_host, is_remote_user)
 
 
-class TestLocal(unittest.TestCase):
-    """Test is_remote* behaves with local host and user."""
+class TestHostUserUtil(unittest.TestCase):
+    """Test aspects of "cylc.hostuserutil"."""
 
-    def test_users(self):
-        """is_remote_user with local users."""
+    def test_is_remote_user_on_current_user(self):
+        """is_remote_user with current user."""
         self.assertFalse(is_remote_user(None))
         self.assertFalse(is_remote_user(os.getenv('USER')))
 
-    def test_hosts(self):
-        """is_remote_host with local hosts."""
+    def test_is_remote_host_on_localhost(self):
+        """is_remote_host with localhost."""
         self.assertFalse(is_remote_host(None))
         self.assertFalse(is_remote_host('localhost'))
         self.assertFalse(is_remote_host(os.getenv('HOSTNAME')))
         self.assertFalse(is_remote_host(get_host()))
+
+    def test_get_fqdn_by_host_on_bad_host(self):
+        """get_fqdn_by_host bad host."""
+        bad_host = 'nosuchhost.nosuchdomain.org'
+        try:  # Future: Replace with assertRaises context manager syntax
+            get_fqdn_by_host(bad_host)
+        except IOError as exc:
+            self.assertEqual(exc.filename, bad_host)
+            self.assertEqual(
+                "[Errno -2] Name or service not known: '%s'" % bad_host,
+                str(exc))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
On failure of `socket.gethostbyname_ex`, add bad host name to error.

Fix #2875.