### PR TITLE
graphing: spaces in min expressions

### DIFF
--- a/lib/cylc/time_parser.py
+++ b/lib/cylc/time_parser.py
@@ -327,7 +327,8 @@ class CylcTimeParser(object):
         return self.duration_parser.parse(expr)
 
     def _get_min_from_expression(self, expr, context):
-        points = re.findall(self.MIN_REGEX, expr)[0].split(",")
+        points = [x.strip()
+                  for x in re.findall(self.MIN_REGEX, expr)[0].split(",")]
         ptslist = []
         min_entry = ""
         for point in points:

--- a/tests/recurrence-min/00-basic/suite.rc
+++ b/tests/recurrence-min/00-basic/suite.rc
@@ -6,7 +6,7 @@ live mode suite timeout = PT1M # minutes
 [scheduling]
 initial cycle point = 20100101T03
 [[dependencies]]
-[[[R1/min(T00,T06,T12,T18)]]]
+[[[R1/min(T00, T06, T12 , T18 )]]]
 graph = foo
 
 [runtime]


### PR DESCRIPTION
In the cylc documentation there are spaces between the arguments to the `min()` function (at least when you copy the examples from the PDF).

These spaces result in cryptic error messages. This PR permits arbitrary whitespace between the parenthesis as well as between the arguments and the argument separator.

*I've put this against "soon" to make the release easier, can promote if reviewed in time?*