### PR TITLE
Fix issues on deployment of 7.8.0

### DIFF
--- a/bin/cylc-jobscript
+++ b/bin/cylc-jobscript
@@ -47,7 +47,7 @@ __END__
 }
 
 editor () {
-    python -c "
+    python2 -c "
 import sys
 from cylc.cfgspec.glbl_cfg import glbl_cfg
 if sys.argv[1] in ['-g', '--gedit']:

--- a/bin/cylc-test-battery
+++ b/bin/cylc-test-battery
@@ -146,13 +146,13 @@ done
 # Recompile *.pyc files to ensure we are running the current code.
 if [[ -w "$CYLC_DIR/lib" ]]; then
     find "$CYLC_DIR/lib" -name '*.pyc' -type 'f' -delete
-    python -mcompileall -q "$CYLC_DIR/lib"
+    python2 -mcompileall -q "$CYLC_DIR/lib"
 fi
 
 if perl -e 'use Test::Harness 3.00' 2>/dev/null; then
     NPROC=$(cylc get-global-config '--item=process pool size')
     if [[ -z "${NPROC}" ]]; then
-        NPROC=$(python -c 'import multiprocessing as mp; print mp.cpu_count()')
+        NPROC=$(python2 -c 'import multiprocessing as mp; print mp.cpu_count()')
     fi
     exec prove -j "$NPROC" -s -r "${@:-tests}"
 else

--- a/lib/cylc/hostuserutil.py
+++ b/lib/cylc/hostuserutil.py
@@ -161,6 +161,10 @@ class HostUtil(object):
         """Return name of current user."""
         return self._get_user_pwent().pw_name
 
+    def get_user_home(self):
+        """Return home directory of current user."""
+        return self._get_user_pwent().pw_dir
+
     def _get_user_pwent(self):
         """Ensure self.user_pwent is set to current user's password entry."""
         if self.user_pwent is None:
@@ -237,6 +241,11 @@ def get_fqdn_by_host(target):
 def get_user():
     """Shorthand for HostUtil.get_inst().get_user()."""
     return HostUtil.get_inst().get_user()
+
+
+def get_user_home():
+    """Shorthand for HostUtil.get_inst().get_user_home()."""
+    return HostUtil.get_inst().get_user_home()
 
 
 def is_remote(host, owner):

--- a/lib/cylc/tests/test_hostuserutil.py
+++ b/lib/cylc/tests/test_hostuserutil.py
@@ -20,7 +20,8 @@ import os
 import unittest
 
 from cylc.hostuserutil import (
-    get_fqdn_by_host, get_host, is_remote_host, is_remote_user)
+    get_fqdn_by_host, get_host, get_user, get_user_home, is_remote_host,
+    is_remote_user)
 
 
 class TestHostUserUtil(unittest.TestCase):
@@ -48,6 +49,14 @@ class TestHostUserUtil(unittest.TestCase):
             self.assertEqual(
                 "[Errno -2] Name or service not known: '%s'" % bad_host,
                 str(exc))
+
+    def test_get_user(self):
+        """get_user."""
+        self.assertEqual(os.getenv('USER'), get_user())
+
+    def test_get_user_home(self):
+        """get_user_home."""
+        self.assertEqual(os.getenv('HOME'), get_user_home())
 
 
 if __name__ == '__main__':

--- a/lib/isodatetime/run_tests
+++ b/lib/isodatetime/run_tests
@@ -19,4 +19,4 @@
 # Run tests for the ISO 8601 parsing and data model functionality."""
 #-----------------------------------------------------------------------------
 cd "$(dirname "$0")/../"
-TZ=UTC python -m isodatetime.tests
+TZ=UTC python2 -m isodatetime.tests

--- a/tests/api-suite-info/05-get-latest-state-1.t
+++ b/tests/api-suite-info/05-get-latest-state-1.t
@@ -22,7 +22,7 @@ json_keys_cmp() {
     # Return True if data structure is a dict containing all and only the keys
     # specified in the remaining arguments
     local TEST_KEY="$1"
-    run_ok "${TEST_KEY}" python - "$@" <<'__PYTHON__'
+    run_ok "${TEST_KEY}" python2 - "$@" <<'__PYTHON__'
 import json
 import sys
 data = json.load(open(sys.argv[1]))

--- a/tests/cylc-get-config/00-simple.t
+++ b/tests/cylc-get-config/00-simple.t
@@ -58,7 +58,7 @@ cmp_ok $TEST_NAME.stderr - </dev/null
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-python
 run_ok $TEST_NAME cylc get-config --python --sparse $SUITE_NAME
-run_ok $TEST_NAME-parse-config python -c "
+run_ok $TEST_NAME-parse-config python2 -c "
 import sys
 from parsec.OrderedDict import OrderedDictWithDefaults
 with open(sys.argv[1], 'r') as file_:

--- a/tests/cylc-get-site-config/04-homeless.t
+++ b/tests/cylc-get-site-config/04-homeless.t
@@ -1,0 +1,30 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test on absence HOME (cylc/cylc#2895)
+
+. "$(dirname "$0")/test_header"
+set_test_number 3
+
+create_test_globalrc '' ''
+
+run_ok "${TEST_NAME_BASE}" \
+    env -u HOME \
+    cylc get-global-config --item='[hosts][localhost]work directory'
+cmp_ok "${TEST_NAME_BASE}.stdout" <<<"${HOME}/cylc-run"
+cmp_ok "${TEST_NAME_BASE}.stderr" <'/dev/null'
+exit

--- a/tests/cylc-poll/16-execution-time-limit.t
+++ b/tests/cylc-poll/16-execution-time-limit.t
@@ -36,7 +36,7 @@ suite_run_ok "${TEST_NAME_BASE}-run" \
 #-------------------------------------------------------------------------------
 cmp_times () {
     # Test if the times $1 and $2 are within $3 seconds of each other.
-    python - "$@" <<'__PYTHON__'
+    python2 - "$@" <<'__PYTHON__'
 import sys
 from isodatetime.parsers import TimePointParser
 parser = TimePointParser()
@@ -48,7 +48,7 @@ __PYTHON__
 }
 time_offset () {
     # Add an ISO8601 duration to an ISO8601 date-time.
-    python - "$@" <<'__PYTHON__'
+    python2 - "$@" <<'__PYTHON__'
 import sys
 from isodatetime.parsers import TimePointParser, DurationParser
 print TimePointParser().parse(sys.argv[1]) + DurationParser().parse(sys.argv[2])

--- a/tests/cylc-review/00-basic.t
+++ b/tests/cylc-review/00-basic.t
@@ -18,7 +18,7 @@
 # Basic tests for "cylc review".
 #-------------------------------------------------------------------------------
 . "$(dirname "$0")/test_header"
-if ! python -c 'import cherrypy' 2>'/dev/null'; then
+if ! python2 -c 'import cherrypy' 2>'/dev/null'; then
     skip_all '"cherrypy" not installed'
 fi
 

--- a/tests/cylc-review/01-title.t
+++ b/tests/cylc-review/01-title.t
@@ -18,7 +18,7 @@
 # Tests for "cylc review", "logo", "title" and "host" settings.
 #-------------------------------------------------------------------------------
 . "$(dirname "$0")/test_header"
-if ! python -c 'import cherrypy' 2>'/dev/null'; then
+if ! python2 -c 'import cherrypy' 2>'/dev/null'; then
     skip_all '"cherrypy" not installed'
 fi
 

--- a/tests/cylc-review/02-no-job-out.t
+++ b/tests/cylc-review/02-no-job-out.t
@@ -18,7 +18,7 @@
 # Test for "cylc review", behaviour of job entry with no "job.out".
 #-------------------------------------------------------------------------------
 . "$(dirname "$0")/test_header"
-if ! python -c 'import cherrypy' 2>'/dev/null'; then
+if ! python2 -c 'import cherrypy' 2>'/dev/null'; then
     skip_all '"cherrypy" not installed'
 fi
 

--- a/tests/cylc-review/03-no-statuses.t
+++ b/tests/cylc-review/03-no-statuses.t
@@ -18,7 +18,7 @@
 # Test for "cylc review", jobs list no statuses filter logic, #1762.
 #-------------------------------------------------------------------------------
 . "$(dirname "$0")/test_header"
-if ! python -c 'import cherrypy' 2>'/dev/null'; then
+if ! python2 -c 'import cherrypy' 2>'/dev/null'; then
     skip_all '"cherrypy" not installed'
 fi
 

--- a/tests/cylc-review/04-time-sort.t
+++ b/tests/cylc-review/04-time-sort.t
@@ -19,7 +19,7 @@
 # submit/run/run exit.
 #-------------------------------------------------------------------------------
 . "$(dirname "$0")/test_header"
-if ! python -c 'import cherrypy' 2>'/dev/null'; then
+if ! python2 -c 'import cherrypy' 2>'/dev/null'; then
     skip_all '"cherrypy" not installed'
 fi
 

--- a/tests/cylc-review/05-cycles-job-fails.t
+++ b/tests/cylc-review/05-cycles-job-fails.t
@@ -18,7 +18,7 @@
 # Test for "cylc review", cycles list, number of failed jobs.
 #-------------------------------------------------------------------------------
 . "$(dirname "$0")/test_header"
-if ! python -c 'import cherrypy' 2>'/dev/null'; then
+if ! python2 -c 'import cherrypy' 2>'/dev/null'; then
     skip_all '"cherrypy" not installed'
 fi
 

--- a/tests/cylc-review/06-host-port.t
+++ b/tests/cylc-review/06-host-port.t
@@ -19,7 +19,7 @@
 # Require a version of cylc with cylc/cylc#1705 merged in.
 #-------------------------------------------------------------------------------
 . "$(dirname "$0")/test_header"
-if ! python -c 'import cherrypy' 2>'/dev/null'; then
+if ! python2 -c 'import cherrypy' 2>'/dev/null'; then
     skip_all '"cherrypy" not installed'
 fi
 

--- a/tests/cylc-review/07-cycles-page.t
+++ b/tests/cylc-review/07-cycles-page.t
@@ -18,7 +18,7 @@
 # Test for "cylc review", cycles list, paging.
 #-------------------------------------------------------------------------------
 . "$(dirname "$0")/test_header"
-if ! python -c 'import cherrypy' 2>'/dev/null'; then
+if ! python2 -c 'import cherrypy' 2>'/dev/null'; then
     skip_all '"cherrypy" not installed'
 fi
 

--- a/tests/cylc-review/08-suites-page.t
+++ b/tests/cylc-review/08-suites-page.t
@@ -18,7 +18,7 @@
 # Test for "cylc review", suites list, glob, sort and page.
 #-------------------------------------------------------------------------------
 . "$(dirname "$0")/test_header"
-if ! python -c 'import cherrypy' 2>'/dev/null'; then
+if ! python2 -c 'import cherrypy' 2>'/dev/null'; then
     skip_all '"cherrypy" not installed'
 fi
 

--- a/tests/cylc-review/09-jobs-fuzzy-time.t
+++ b/tests/cylc-review/09-jobs-fuzzy-time.t
@@ -18,7 +18,7 @@
 # Test for "cylc review", jobs list, fuzzy time flag.
 #-------------------------------------------------------------------------------
 . "$(dirname "$0")/test_header"
-if ! python -c 'import cherrypy' 2>'/dev/null'; then
+if ! python2 -c 'import cherrypy' 2>'/dev/null'; then
     skip_all '"cherrypy" not installed'
 fi
 

--- a/tests/cylc-review/10-jobs-task-status.t
+++ b/tests/cylc-review/10-jobs-task-status.t
@@ -18,7 +18,7 @@
 # Test for "cylc review", jobs list, task status.
 #-------------------------------------------------------------------------------
 . "$(dirname "$0")/test_header"
-if ! python -c 'import cherrypy' 2>'/dev/null'; then
+if ! python2 -c 'import cherrypy' 2>'/dev/null'; then
     skip_all '"cherrypy" not installed'
 fi
 

--- a/tests/cylc-review/11-view-unicode.t
+++ b/tests/cylc-review/11-view-unicode.t
@@ -18,7 +18,7 @@
 # Test for "cylc review", view file with unicode characters.
 #-------------------------------------------------------------------------------
 . "$(dirname "$0")/test_header"
-if ! python -c 'import cherrypy' 2>'/dev/null'; then
+if ! python2 -c 'import cherrypy' 2>'/dev/null'; then
     skip_all '"cherrypy" not installed'
 fi
 

--- a/tests/cylc-review/12-cycle-counts.t
+++ b/tests/cylc-review/12-cycle-counts.t
@@ -18,7 +18,7 @@
 # Test for "cylc review", cycles list, paging.
 #-------------------------------------------------------------------------------
 . "$(dirname "$0")/test_header"
-if ! python -c 'import cherrypy' 2>'/dev/null'; then
+if ! python2 -c 'import cherrypy' 2>'/dev/null'; then
     skip_all '"cherrypy" not installed'
 fi
 

--- a/tests/cylc-review/13-jobs-path-in-tar.t
+++ b/tests/cylc-review/13-jobs-path-in-tar.t
@@ -18,7 +18,7 @@
 # Test for "cylc review", links to job logs in tar
 #-------------------------------------------------------------------------------
 . "$(dirname "$0")/test_header"
-if ! python -c 'import cherrypy' 2>'/dev/null'; then
+if ! python2 -c 'import cherrypy' 2>'/dev/null'; then
     skip_all '"cherrypy" not installed'
 fi
 

--- a/tests/cylc.host_appointer/00-host-appointer.t
+++ b/tests/cylc.host_appointer/00-host-appointer.t
@@ -22,7 +22,7 @@ set_test_number 8
 
 # No run hosts list
 create_test_globalrc '' ''
-run_ok "${TEST_NAME_BASE}-no-host-list" python - <<'__PYTHON__'
+run_ok "${TEST_NAME_BASE}-no-host-list" python2 - <<'__PYTHON__'
 from cylc.host_appointer import HostAppointer
 assert HostAppointer().appoint_host() == 'localhost'
 __PYTHON__
@@ -32,7 +32,7 @@ create_test_globalrc '' '
 [suite servers]
     run hosts =
 '
-run_ok "${TEST_NAME_BASE}-empty-host-list" python - <<'__PYTHON__'
+run_ok "${TEST_NAME_BASE}-empty-host-list" python2 - <<'__PYTHON__'
 from cylc.host_appointer import HostAppointer
 assert HostAppointer().appoint_host() == 'localhost'
 __PYTHON__
@@ -42,7 +42,7 @@ create_test_globalrc '' "
 [suite servers]
     run hosts = localhost, elephant
 "
-run_ok "${TEST_NAME_BASE}-uncontactable" python -c '
+run_ok "${TEST_NAME_BASE}-uncontactable" python2 -c '
 import sys
 from cylc.host_appointer import HostAppointer
 appointer = HostAppointer()
@@ -58,7 +58,7 @@ create_test_globalrc '' "
 [suite servers]
     condemned hosts = localhost
 "
-run_fail "${TEST_NAME_BASE}-invalid" python -c '
+run_fail "${TEST_NAME_BASE}-invalid" python2 -c '
 from cylc.host_appointer import HostAppointer
 HostAppointer().appoint_host()
 '
@@ -80,7 +80,7 @@ create_test_globalrc '' "
 [suite servers]
     condemned hosts = localhost
 "
-run_ok "${TEST_NAME_BASE}-condemned-local" python -c '
+run_ok "${TEST_NAME_BASE}-condemned-local" python2 -c '
 import sys
 from cylc.host_appointer import HostAppointer
 appointer = HostAppointer()
@@ -96,7 +96,7 @@ create_test_globalrc '' "
 [suite servers]
     condemned hosts = $(hostname -f)
 "
-run_ok "${TEST_NAME_BASE}-condemned-variants" python -c '
+run_ok "${TEST_NAME_BASE}-condemned-variants" python2 -c '
 import sys
 from cylc.host_appointer import HostAppointer
 appointer = HostAppointer()
@@ -112,7 +112,7 @@ create_test_globalrc '' "
 [suite servers]
     condemned hosts = localhost
 "
-run_fail "${TEST_NAME_BASE}-condemned-all" python -c '
+run_fail "${TEST_NAME_BASE}-condemned-all" python2 -c '
 from cylc.host_appointer import HostAppointer
 HostAppointer().appoint_host()
 '

--- a/tests/events/47-long-output.t
+++ b/tests/events/47-long-output.t
@@ -18,7 +18,7 @@
 # Test that a long output from an event handler is not going to hang or die.
 
 . "$(dirname "$0")/test_header"
-if ! python -c 'from select import poll' 2>'/dev/null'; then
+if ! python2 -c 'from select import poll' 2>'/dev/null'; then
     skip_all '"select.poll" not supported on this OS'
 fi
 

--- a/tests/lib/bash/test_header
+++ b/tests/lib/bash/test_header
@@ -255,7 +255,7 @@ cmp_ok() {
 }
 
 cmp_json_ok() {
-    run_ok "$1" python -c "import sys
+    run_ok "$1" python2 -c "import sys
 import re
 import json
 from cylc.task_state import TASK_STATUSES_ORDERED
@@ -516,7 +516,7 @@ ssh_install_cylc() {
 
 _ssh_mkdtemp_cylc_dir() {
     local RHOST="$1"
-    ssh -oBatchMode=yes -oConnectTimeout=5 "${RHOST}" python - <<'__PYTHON__'
+    ssh -oBatchMode=yes -oConnectTimeout=5 "${RHOST}" python2 - <<'__PYTHON__'
 import os
 from tempfile import mkdtemp
 print mkdtemp(dir=os.path.expanduser("~"), prefix="cylc-")
@@ -528,7 +528,7 @@ mock_smtpd_init() {  # Logic borrowed from Rose
     for SMTPD_PORT in 8025 8125 8225 8325 8425 8525 8625 8725 8825 8925; do 
         local SMTPD_HOST="localhost:${SMTPD_PORT}"
         local SMTPD_LOG="${TEST_DIR}/smtpd.log"
-        python -m 'smtpd' -c 'DebuggingServer' -d -n "${SMTPD_HOST}" \
+        python2 -m 'smtpd' -c 'DebuggingServer' -d -n "${SMTPD_HOST}" \
             1>"${SMTPD_LOG}" 2>&1 &
         local SMTPD_PID="$!"
         while ! grep -q 'DebuggingServer started' "${SMTPD_LOG}" 2>'/dev/null'
@@ -675,7 +675,7 @@ cylc_ws_kill() {
 cylc_ws_json_greps() {
     local TEST_NAME="$1"
     shift 1
-    run_ok "${TEST_NAME}" python - "$@" <<'__PYTHON__'
+    run_ok "${TEST_NAME}" python2 - "$@" <<'__PYTHON__'
 import ast
 import json
 import sys

--- a/tests/profile-battery/00-compatability.t
+++ b/tests/profile-battery/00-compatability.t
@@ -21,7 +21,7 @@
 set_test_number 4
 #-------------------------------------------------------------------------------
 # Check the format of `cylc version --long`.
-run_ok "${TEST_NAME_BASE}-cylc-version" python -c "
+run_ok "${TEST_NAME_BASE}-cylc-version" python2 -c "
 import os
 import sys
 os.chdir('${CYLC_DIR}/lib')

--- a/tests/restart/21-task-elapsed.t
+++ b/tests/restart/21-task-elapsed.t
@@ -22,7 +22,7 @@ install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 test_dump() {
     local TEST_NAME="$1"
-    run_ok "${TEST_NAME}" python - "$@" <<'__PYTHON__'
+    run_ok "${TEST_NAME}" python2 - "$@" <<'__PYTHON__'
 import ast
 import sys
 

--- a/tests/restart/37-auto-restart-delay.t
+++ b/tests/restart/37-auto-restart-delay.t
@@ -25,7 +25,7 @@ if [[ -z "${CYLC_TEST_HOST}" ]]; then
 fi
 set_test_number 6
 time_gt () {
-    python -c "
+    python2 -c "
 import sys
 from isodatetime.parsers import TimePointParser
 parser = TimePointParser()

--- a/tests/suite-host-self-id/00-address.t
+++ b/tests/suite-host-self-id/00-address.t
@@ -22,7 +22,7 @@ set_test_number 2
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 get_local_ip_address() {
-    python - "$1" <<'__PYTHON__'
+    python2 - "$1" <<'__PYTHON__'
 import sys
 from cylc.hostuserutil import get_local_ip_address
 sys.stdout.write("%s\n" % get_local_ip_address(sys.argv[1]))

--- a/tests/validate/04-builtin-suites.t
+++ b/tests/validate/04-builtin-suites.t
@@ -24,7 +24,7 @@ ABS_PATH_LENGTH=${#CYLC_DIR}
 #-------------------------------------------------------------------------------
 # Filter out certain warnings to prevent tests being failed by them.
 function filter_warnings() {
-    python - "$@" <<'__PYTHON__'
+    python2 - "$@" <<'__PYTHON__'
 import re, sys
 msgs = [
     r'.* (?:INFO|DEBUG) - .*\n(\t.*\n)*',


### PR DESCRIPTION
As you do... Found the first set of issues on deployment of 7.8.0 on site.

Cylc Review on WSGI - may not have HOME environment variable, so it was failing when attempting to use the `cylc.cfgspec.globalcfg` module to load the `global.rc`. Use `pwd` module instead via `cylc.hostuserutil` instead.

Modify remaining `python` invocation to use `python2`.