### PR TITLE
Log when the log retrieval command exited with error code

### DIFF
--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -578,6 +578,10 @@ class TaskEventsManager(object):
 
     def _job_logs_retrieval_callback(self, proc_ctx, schd_ctx):
         """Call back when log job retrieval completes."""
+        if proc_ctx.ret_code:
+            LOG.error(proc_ctx)
+        else:
+            LOG.debug(proc_ctx)
         for id_key in proc_ctx.cmd_kwargs["id_keys"]:
             key1, point, name, submit_num = id_key
             try:

--- a/lib/cylc/tests/test_task_events_mgr.py
+++ b/lib/cylc/tests/test_task_events_mgr.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python2
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+import mock
+from cylc.task_events_mgr import TaskEventsManager
+from cylc.subprocctx import SubProcContext
+
+
+class TestTaskEventsManager(unittest.TestCase):
+
+    @mock.patch("cylc.task_events_mgr.LOG")
+    def test_log_error_on_error_exit_code(self, cylc_log):
+        """Test that an error log is emitted when the log retrieval command
+        exited with a code different than zero.
+
+        :param cylc_log: mocked cylc logger
+        :type cylc_log: mock.MagicMock
+        """
+        task_events_manager = TaskEventsManager(None, None, None, None)
+        proc_ctx = SubProcContext(cmd_key=None, cmd="error", ret_code=1,
+                                  err="Error!", id_keys=[])
+        task_events_manager._job_logs_retrieval_callback(proc_ctx, None)
+        self.assertEqual(1, cylc_log.error.call_count)
+        self.assertTrue(cylc_log.error.call_args.contains("Error!"))
+
+    @mock.patch("cylc.task_events_mgr.LOG")
+    def test_log_debug_on_noerror_exit_code(self, cylc_log):
+        """Test that a debug log is emitted when the log retrieval command
+        exited with an non-error code (i.e. 0).
+
+        :param cylc_log: mocked cylc logger
+        :type cylc_log: mock.MagicMock
+        """
+        task_events_manager = TaskEventsManager(None, None, None, None)
+        proc_ctx = SubProcContext(cmd_key=None, cmd="ls /tmp/123", ret_code=0,
+                                  err="", id_keys=[])
+        task_events_manager._job_logs_retrieval_callback(proc_ctx, None)
+        self.assertEqual(1, cylc_log.debug.call_count)
+        self.assertTrue(cylc_log.debug.call_args.contains("ls /tmp/123"))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
From https://groups.google.com/forum/#!topic/cylc/dP2I1Gxqi20. Started testing it, and realized that I had copied the wrong command (`rsync -v -rltgoD --chmod=Du=rwx,Dgo=rx,Fu=rw, Fgo=r` it had a space after the last `F`).

Running locally it would exit with an error. But when I executed the job for Cylc with a remote task on another PBS server, it did not complain. Reason is that the `job.out` exists, and the task succeeded. However, it does not mean the log retrieval command succeeded as well.

Output without this patch: 

```bash
2018-12-22T04:24:57Z INFO - [a.1] -submit-num=1, owner@host=pbs
2018-12-22T04:24:58Z INFO - [a.1] -(current:ready) submitted at 2018-12-22T04:24:58Z
2018-12-22T04:24:58Z INFO - [a.1] -health check settings: submission timeout=None
2018-12-22T04:24:59Z INFO - [a.1] -(current:submitted)> started at 2018-12-22T04:24:58Z
2018-12-22T04:24:59Z INFO - [a.1] -health check settings: execution timeout=None
2018-12-22T04:24:59Z INFO - [a.1] -(current:running)> succeeded at 2018-12-22T04:24:58Z
2018-12-22T04:25:00Z INFO - [b.1] -submit-num=1, owner@host=7ce742eb050c
2018-12-22T04:25:00Z INFO - 1
2018-12-22T04:25:01Z INFO - [client-command] poll_tasks testuser@7ce742eb050c:cylc-poll cc1440f4-c061-4990-bd60-593dcf305dbb
```

Output after the patch:

```bash
2018-12-22T04:24:57Z INFO - [a.1] -submit-num=1, owner@host=pbs
2018-12-22T04:24:58Z INFO - [a.1] -(current:ready) submitted at 2018-12-22T04:24:58Z
2018-12-22T04:24:58Z INFO - [a.1] -health check settings: submission timeout=None
2018-12-22T04:24:59Z INFO - [a.1] -(current:submitted)> started at 2018-12-22T04:24:58Z
2018-12-22T04:24:59Z INFO - [a.1] -health check settings: execution timeout=None
2018-12-22T04:24:59Z INFO - [a.1] -(current:running)> succeeded at 2018-12-22T04:24:58Z
2018-12-22T04:25:00Z INFO - [b.1] -submit-num=1, owner@host=7ce742eb050c
2018-12-22T04:25:00Z WARNING - Log retrieval command exited with 1! Output: rsync: Invalid argument passed to --chmod (Du=rwx,Dgo=rx,Fu=rw,)
	rsync error: syntax or usage error (code 1) at main.c(1572) [client=3.1.1]

2018-12-22T04:25:00Z INFO - 1
2018-12-22T04:25:01Z INFO - [client-command] poll_tasks testuser@7ce742eb050c:cylc-poll cc1440f4-c061-4990-bd60-593dcf305dbb
```

Marking as `WIP`, as I am not sure this is the right/best fix. Note that if your log retrieval command has a typo in the executable, like `arsync ...`, instead there will be an error, but at `subprocpool`:

```bash
2018-12-22T04:26:18Z INFO - [a.1] -(current:running)> succeeded at 2018-12-22T04:26:18Z
2018-12-22T04:26:19Z ERROR - [Errno 2] No such file or directory: 'arsync'
	Traceback (most recent call last):
	  File "/opt/cylc/lib/cylc/subprocpool.py", line 322, in _run_command_init
	    shell=ctx.cmd_kwargs.get('shell'))
	  File "/usr/lib/python2.7/subprocess.py", line 711, in __init__
	    errread, errwrite)
	  File "/usr/lib/python2.7/subprocess.py", line 1343, in _execute_child
	    raise child_exception
	OSError: [Errno 2] No such file or directory: 'arsync'
2018-12-22T04:26:19Z WARNING - Log retrieval command exited with 1! Output: [Errno 2] No such file or directory: 'arsync'
2018-12-22T04:26:19Z INFO - 1
```

I do not feel like I have grokked the complete feature of log retrieval, so maybe others have a better idea for this.

Cheers
Bruno