### PR TITLE
loggingutil: fix infinite loop on IOError

### DIFF
--- a/lib/cylc/loggingutil.py
+++ b/lib/cylc/loggingutil.py
@@ -106,7 +106,12 @@ class TimestampRotatingFileHandler(logging.FileHandler):
         if max_bytes < self.MIN_BYTES:  # No silly value
             max_bytes = self.MIN_BYTES
         msg = "%s\n" % self.format(record)
-        self.stream.seek(0, 2)  # due to non-posix-compliant Windows feature
+        try:
+            # due to non-posix-compliant Windows feature
+            self.stream.seek(0, 2)
+        except ValueError as exc:
+            # intended to catch - ValueError: I/O operation on closed file
+            raise SystemExit(exc)
         return self.stream.tell() + len(msg.encode('utf8')) >= max_bytes
 
     def do_rollover(self):

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -301,7 +301,12 @@ class Scheduler(object):
         LOG.info("DONE")  # main thread exit
         self.profiler.stop()
         for handler in LOG.handlers:
-            handler.close()
+            try:
+                handler.close()
+            except IOError:
+                # suppress traceback which `logging` might try to write to the
+                # log we are trying to close
+                pass
 
     @staticmethod
     def _start_print_blurb():

--- a/lib/cylc/tests/test_loggingutil.py
+++ b/lib/cylc/tests/test_loggingutil.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python2
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import tempfile
+import unittest
+
+import mock
+
+from cylc import LOG
+from cylc.loggingutil import TimestampRotatingFileHandler
+
+
+class TestLoggingutil(unittest.TestCase):
+
+    @mock.patch("cylc.loggingutil.glbl_cfg")
+    def test_value_error_raises_system_exit(self, mocked_glbl_cfg):
+        """Test that a ValueError when writing to a log stream won't result
+        in multiple exceptions (what could lead to infinite loop in some
+        occasions. Instead, it **must** raise a SystemExit"""
+        with tempfile.NamedTemporaryFile() as tf:
+            # mock objects used when creating the file handler
+            mocked = mock.MagicMock()
+            mocked_glbl_cfg.return_value = mocked
+            mocked.get_derived_host_item.return_value = tf.name
+            file_handler = TimestampRotatingFileHandler("suiteA", False)
+            # next line is important as pytest can have a "Bad file descriptor"
+            # due to a FileHandler with default "a" (pytest tries to r/w).
+            file_handler.mode = "a+"
+
+            # enable the logger
+            LOG.setLevel(logging.INFO)
+            LOG.addHandler(file_handler)
+
+            # first message will initialize the stream and the handler
+            LOG.info("What could go")
+
+            # here we change the stream of the handler
+            old_stream = file_handler.stream
+            file_handler.stream = mock.MagicMock()
+            file_handler.stream.seek = mock.MagicMock()
+            # in case where
+            file_handler.stream.seek.side_effect = ValueError
+
+            try:
+                # next call will call the emit method and use the mocked stream
+                LOG.info("wrong?!")
+                self.fail("Exception SystemError was not raised")
+            except SystemExit:
+                pass
+            finally:
+                # clean up
+                file_handler.stream = old_stream
+                for log_handler in LOG.handlers:
+                    log_handler.close()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/cylc/tests/test_scheduler.py
+++ b/lib/cylc/tests/test_scheduler.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python2
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+import mock
+
+from cylc import LOG
+from cylc.scheduler import Scheduler
+
+
+class Options(object):
+    """To mimic the command line parsed options"""
+
+    def __init__(self):
+        # Variables needed to create a Scheduler instance
+        self.profile_mode = False
+        self.templatevars = {}
+        self.templatevars_file = ""
+        self.run_mode = ""
+
+
+class TestScheduler(unittest.TestCase):
+
+    @mock.patch("cylc.scheduler.SuiteSrvFilesManager")
+    def test_ioerror_is_ignored(self, mocked_suite_srv_files_mgr):
+        """Test that IOError's are ignored when closing Scheduler logs.
+        When a disk errors occurs, the scheduler.close_logs method may
+        result in an IOError. This, combined with other variables, may cause
+        an infinite loop. So it is better that it is ignored."""
+        options = Options()
+        args = ["suiteA"]
+        scheduler = Scheduler(is_restart=False, options=options, args=args)
+
+        handler = mock.MagicMock()
+        handler.close.side_effect = IOError
+        LOG.addHandler(handler)
+
+        scheduler.close_logs()
+        self.assertEqual(1, handler.close.call_count)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
In the event of a filesystem issue Cylc will attempt to shutdown and in the process it will try to close the logging handlers. This results in an `IOError` resulting in traceback which logging attempts to log, which will fail due to the filesystem issue resulting in traceback which logging attempts to log and so on so forth.

Example traceback:

```
  File "cylc/bin/cylc-run", line 25, in <module>
    main(is_restart=False)
  File "cylc/lib/cylc/scheduler_cli.py", line 134, in main
    scheduler.start()
  File "cylc/lib/cylc/scheduler.py", line 278, in start
    self.close_logs()
  File "cylc/lib/cylc/scheduler.py", line 291, in close_logs
    handler.close()
  File "/usr/lib64/python2.6/logging/__init__.py", line 844, in close
    self.stream.close()
IOError: [Errno 122] Disk quota exceeded
Traceback (most recent call last):
  File "cylc/lib/cylc/loggingutil.py", line 91, in emit
    if self.should_rollover(record):
  File "cylc/lib/cylc/loggingutil.py", line 109, in should_rollover
    self.stream.seek(0, 2)  # due to non-posix-compliant Windows feature
ValueError: I/O operation on closed file
Traceback (most recent call last):
  File "cylc/lib/cylc/loggingutil.py", line 91, in emit
    if self.should_rollover(record):
  File "cylc/lib/cylc/loggingutil.py", line 109, in should_rollover
    self.stream.seek(0, 2)  # due to non-posix-compliant Windows feature
ValueError: I/O operation on closed file
Traceback (most recent call last):
  File "cylc/lib/cylc/loggingutil.py", line 91, in emit
    if self.should_rollover(record):
  File "cylc/lib/cylc/loggingutil.py", line 109, in should_rollover
    self.stream.seek(0, 2)  # due to non-posix-compliant Windows feature
ValueError: I/O operation on closed file
```