### PR TITLE
Out of bounds warning

### DIFF
--- a/bin/cylc-validate
+++ b/bin/cylc-validate
@@ -25,6 +25,7 @@ will correspond to the inlined version seen by the parser; use
 'cylc view -i,--inline SUITE' for comparison."""
 
 import sys
+import textwrap
 from cylc.remote import remrun
 if remrun():
     sys.exit(0)
@@ -85,15 +86,24 @@ def main():
         cli_initial_point_string=options.icp,
         is_validate=True, strict=options.strict, run_mode=options.run_mode,
         output_fname=options.output, mem_log_func=profiler.log_memory)
+
     # Check bounds of sequences
-    for seq in cfg.sequences:
-        if seq.get_first_point(cfg.start_point) is None:
-            mesg = '%s: sequence out of bound for initial cycle point %s' % (
-                seq, cfg.start_point)
-            if options.strict:
-                raise SuiteConfigError(mesg)
-            elif cylc.flags.verbose:
-                sys.stderr.write(' + %s\n' % mesg)
+    out_of_bounds = [str(seq) for seq in cfg.sequences
+                     if seq.get_first_point(cfg.start_point) is None]
+    if out_of_bounds:
+        if len(out_of_bounds) > 1:
+            # avoid spamming users with multiple warnings
+            msg = ('multiple sequences out of bounds for initial cycle point '
+                   '%s:\n%s' % (
+                       cfg.start_point,
+                       '\n'.join(textwrap.wrap(', '.join(out_of_bounds), 70))))
+        else:
+            msg = '%s: sequence out of bounds for initial cycle point %s' % (
+                out_of_bounds[0], cfg.start_point)
+        if options.strict:
+            LOG.warning(msg)
+        elif cylc.flags.verbose:
+            sys.stderr.write(' + %s\n' % msg)
 
     # Instantiate tasks and force evaluation of trigger expressions.
     # (Taken from config.py to avoid circular import problems.)

--- a/bin/cylc-validate
+++ b/bin/cylc-validate
@@ -29,8 +29,10 @@ from cylc.remote import remrun
 if remrun():
     sys.exit(0)
 
+from cylc import LOG
 import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
+from cylc.loggingutil import CylcLogFormatter
 from cylc.version import CYLC_VERSION
 from cylc.config import SuiteConfig, SuiteConfigError
 from cylc.prerequisite import TriggerExpressionError
@@ -70,6 +72,11 @@ def main():
 
     profiler = Profiler(options.profile_mode)
     profiler.start()
+
+    if not cylc.flags.debug:
+        # for readability omit timestamps from logging unless in debug mode
+        for handler in LOG.handlers:
+            handler.setFormatter(CylcLogFormatter(timestamp=False))
 
     suite, suiterc = SuiteSrvFilesManager().parse_suite_arg(options, args[0])
     cfg = SuiteConfig(

--- a/lib/cylc/loggingutil.py
+++ b/lib/cylc/loggingutil.py
@@ -44,10 +44,10 @@ class CylcLogFormatter(logging.Formatter):
     Date time in ISO date time with correct time zone.
     """
 
-    def __init__(self):
+    def __init__(self, timestamp=True):
         logging.Formatter.__init__(
-            self,
-            '%(asctime)s %(levelname)-2s - %(message)s',
+            self, ('%(asctime)s ' if timestamp else '')
+            + '%(levelname)-2s - %(message)s',
             '%Y-%m-%dT%H:%M:%S%Z')
 
     def format(self, record):

--- a/tests/deprecations/00-all.t
+++ b/tests/deprecations/00-all.t
@@ -27,7 +27,7 @@ run_ok $TEST_NAME cylc validate -v $SUITE_NAME
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-cmp
 cylc validate -v "${SUITE_NAME}" 2>&1 \
-    | sed  -n -e 's/^.* WARNING - \( \* (.*$\)/\1/p' > 'val.out'
+    | sed  -n -e 's/^WARNING - \( \* (.*$\)/\1/p' > 'val.out'
 cmp_ok val.out <<__END__
  * (6.1.3) [visualization][enable live graph movie] - DELETED (OBSOLETE)
  * (6.4.0) [runtime][foo, cat, dog][environment scripting] -> [runtime][foo, cat, dog][env-script] - value unchanged

--- a/tests/validate/04-builtin-suites.t
+++ b/tests/validate/04-builtin-suites.t
@@ -27,7 +27,7 @@ function filter_warnings() {
     python2 - "$@" <<'__PYTHON__'
 import re, sys
 msgs = [
-    r'.* (?:INFO|DEBUG) - .*\n(\t.*\n)*',
+    r'(?:INFO|DEBUG) - .*\n(\t.*\n)*',
     r'.*naked dummy tasks detected.*\n(\t.*\n)+',
     r'.*clock-(trigger|expire) offsets are normally positive.*\n']
 file_name = sys.argv[1]

--- a/tests/validate/67-task-proxy-sequence-bounds-err.t
+++ b/tests/validate/67-task-proxy-sequence-bounds-err.t
@@ -36,12 +36,12 @@ __END__
 run_ok "${TEST_NAME_BASE}" cylc validate 'suite.rc'
 run_ok "${TEST_NAME_BASE}-v" cylc validate -v 'suite.rc'
 contains_ok "${TEST_NAME_BASE}-v.stderr" <<'__ERR__'
- + R1/P0Y/19990101T0000Z: sequence out of bound for initial cycle point 20000101T0000Z
+ + R1/P0Y/19990101T0000Z: sequence out of bounds for initial cycle point 20000101T0000Z
  + Task out of bounds for 20000101T0000Z: t1
 __ERR__
 run_ok "${TEST_NAME_BASE}-strict" cylc validate --strict 'suite.rc'
 cmp_ok "${TEST_NAME_BASE}-strict.stderr" <<'__ERR__'
-WARNING - R1/P0Y/19990101T0000Z: sequence out of bound for initial cycle point 20000101T0000Z
+WARNING - R1/P0Y/19990101T0000Z: sequence out of bounds for initial cycle point 20000101T0000Z
 __ERR__
 
 cat > suite.rc <<__END__
@@ -50,9 +50,7 @@ cat > suite.rc <<__END__
 [scheduling]
     initial cycle point = 2000
     [[dependencies]]
-        [[[R1//1998]]]
-            graph = t1
-        [[[R1//1999]]]
+        [[[R1//1996, R1//1997, R1//1998, R1//1999]]]
             graph = t1
 [runtime]
     [[t1]]
@@ -61,8 +59,8 @@ __END__
 
 run_ok "${TEST_NAME_BASE}-strict" cylc validate --strict 'suite.rc'
 cmp_ok "${TEST_NAME_BASE}-strict.stderr" <<'__ERR__'
-WARNING - multiple sequences out of bound for intial cycle point 20000101T0000Z:
-	R1/P0Y/19980101T0000Z
+WARNING - multiple sequences out of bounds for initial cycle point 20000101T0000Z:
+	R1/P0Y/19960101T0000Z, R1/P0Y/19970101T0000Z, R1/P0Y/19980101T0000Z,
 	R1/P0Y/19990101T0000Z
 __ERR__
 


### PR DESCRIPTION
#### tldr;
* Changed an error to a warning in cylc validate as it would drive users nuts.
* Removed timestamps from `cylc validate` log output (unless in debug mode). *Contriversial?*

#### tfm;

*Background: "Out of bounds error" refers to recurrences which lie before the `initial cycle point`.*

In #2738 (7.8.0) we added nicer handling of exceptions in `cylc validate` which can result from out of bounds recurrences in some niche cases. `cylc validate` now fails for out of bounds sequences when running in `--strict` mode for *all* cases (not just the ones resulting in traceback).

There are some cases where it might be sensible to hard code behaviour for certain cycle points up front allowing users choice of initial and final cycle points.


writing suites with out of bounds sequences might make some sort of sense, e.g. hardcoding special logic for certain dates, case studies, etc:

```ini
[scheduling]
    [[dependencies]]
        [[[P1Y]]]
            graph = foo => bar => baz
        [[[R1/2018]]]
            graph = foo => pub => baz  # 2018 was a special year
```

We see suites hardcoding cycles like this quite a lot. As `rose suite-run` invokes `cylc validate --strict` this is going to inconvenience a lot of users.

This PR demotes the error to a warning and batches up warnings if multiple out of bounds sequences are present to avoid spamming the user.

I have also removed timestamps from `cylc validate` output for readability (unless in debug mode). Time information isn't important here and the output isn't written out to log files where it might be useful.