### PR TITLE
Typos in documentation

### DIFF
--- a/doc/src/cylc-user-guide/README
+++ b/doc/src/cylc-user-guide/README
@@ -4,7 +4,7 @@ To generate pdf and html (single and multi-page) Cylc User Guides:
  | cd <cylc-dir>/doc
  | make
 
-The following make targets are also avaialable:
+The following make targets are also available:
  | make pdf
  | make html
  | make html-single

--- a/doc/src/cylc-user-guide/cug.tex
+++ b/doc/src/cylc-user-guide/cug.tex
@@ -2800,7 +2800,7 @@ It is also valid to use sequences for exclusions. For example:
 \lstset{language=suiterc}
 \begin{lstlisting}
 [[[ PT1H ! PT6H ]]]         # Run hourly from the initial cycle point but
-                            # not 6-hourly from the intial cycle point.
+                            # not 6-hourly from the initial cycle point.
 [[[ T-00 ! PT6H ]]]         # Run hourly on the hour but not 6-hourly
                             # on the hour.
     # Same as [[[ T-00 ! T-00/PT6H ]]] (T-00 context is implied)
@@ -3192,7 +3192,7 @@ integer points, an integer sequence, or a combination of both:
 [[[ P1 ! +P1/P2 ]]]   # Run with step 1 from the initial cycle point,
                       # excluding every other step beginning one step
                       # after the initial cycle point.
-[[[ P1 !(P2,6,8) ]]]  # Run with step 1 from the intial cycle point,
+[[[ P1 !(P2,6,8) ]]]  # Run with step 1 from the initial cycle point,
                       # excluding every other step, and also excluding
                       # steps 6 and 8.
 \end{lstlisting}
@@ -5534,7 +5534,7 @@ the first line of the suite.rc file:
 # ...
 \end{lstlisting}
 
-An example suite \lstinline=empy.cities= demostrating its use is shown below.
+An example suite \lstinline=empy.cities= demonstrating its use is shown below.
 It is a translation of \lstinline=jinja2.cities= example from
 Section~\ref{Jinja2} and can be directly compared against it.
 
@@ -6456,7 +6456,7 @@ suite_state(suite, task, point, offset=None, status='succeeded',
 
 The first three arguments are compulsory; they single out the target suite name
 (\lstinline=suite=) task name (\lstinline=task=) and cycle point
-(\lstinline=point=). The function argments mirror the arguments and options of
+(\lstinline=point=). The function arguments mirror the arguments and options of
 the \lstinline=cylc suite-state= command - see
 \lstinline=cylc suite-state --help= for documentation.
 

--- a/doc/src/cylc-user-guide/job-host-2.tex
+++ b/doc/src/cylc-user-guide/job-host-2.tex
@@ -11,7 +11,7 @@ Done by \lstinline=rose suite-run= before suite start-up
 \begin{itemize}
   \item with \lstinline=--new= it invokes bash over SSH and a raw shell
     expression, to delete previous-run files
-  \item it invokes itself over over SSH to create top level suite directories
+  \item it invokes itself over SSH to create top level suite directories
     and install source files
     \begin{itemize}
       \item skips installation if server UUID file is found on the job host

--- a/doc/src/cylc-user-guide/siterc.tex
+++ b/doc/src/cylc-user-guide/siterc.tex
@@ -412,7 +412,7 @@ do not have to match through to the end of the string (use the
 string-end matching character `\lstinline=$=' in the expression to
 force this).
 
-A hierachy of host match expressions from specific to general can be
+A hierarchy of host match expressions from specific to general can be
 used because config items are processed in the order specified in the
 file.
 

--- a/doc/src/cylc-user-guide/suiterc.tex
+++ b/doc/src/cylc-user-guide/suiterc.tex
@@ -130,7 +130,7 @@ for \lstinline=+= or \lstinline=-= here) for writing down date-time cycle
 points, which follows one of the basic formats outlined in the ISO 8601
 standard. For example, a cycle point on the 3rd of February 2001 at 4:50 in
 the morning, UTC (+0000 timezone), would be written
-\lstinline=20010203T0450Z=. Similarly, for the the 3rd of February 2001 at
+\lstinline=20010203T0450Z=. Similarly, for the 3rd of February 2001 at
 4:50 in the morning, +1300 timezone, cylc would write
 \lstinline=20010203T0450+1300=.
 
@@ -492,7 +492,7 @@ default for this at the site level (see ~\ref{SiteCylcHooks}).
 
 If \lstinline=True= (the default) the suite timer will continually reset
 after any task changes state, so you can time out after some interval
-since the last activity occured rather than on absolute suite execution
+since the last activity occurred rather than on absolute suite execution
 time.
 
 \begin{myitemize}
@@ -615,7 +615,7 @@ verifies.
     \item {\em type:} string (event handler command name or path)
     \item {\em default:} \lstinline=cylc hook check-triggering=
 \end{myitemize}
-As for any event handler, the full path can be ommited if the script is
+As for any event handler, the full path can be ommitted if the script is
 located somewhere in \lstinline=$PATH= or in the suite bin directory.
 
 \paragraph[required run mode]{[cylc] \textrightarrow [[reference test]] \textrightarrow required run mode}
@@ -1110,7 +1110,7 @@ configuration can be factored out in a multiple-inheritance hierarchy of
 runtime namespaces that culminates in the tasks of the suite. Order of
 precedence is determined by the C3 linearization algorithm as used to
 find the {\em method resolution order} in Python language class
-hiearchies. For details and examples see~\ref{NIORP}.
+hierarchies. For details and examples see~\ref{NIORP}.
 
 \subsubsection[{[[}\_\_NAME\_\_{]]}]{[runtime] \textrightarrow [[\_\_NAME\_\_]]}
 
@@ -1767,7 +1767,7 @@ If a task has not finished after the specified ISO 8601 duration/interval, the
 If you set an execution timeout the timer can be reset to zero every
 time a message is received from the running task (which indicates the
 task is still alive).  Otherwise, the task will timeout if it does not
-finish in the alotted time regardless of incoming messages.
+finish in the allotted time regardless of incoming messages.
 
 \begin{myitemize}
 \item {\em type:} boolean

--- a/doc/src/suite-design-guide/portable-suites.tex
+++ b/doc/src/suite-design-guide/portable-suites.tex
@@ -21,7 +21,7 @@ The recommended way to do this, which we expand on below, is:
 \begin{itemize}
   \item Put all site-specific settings in include-files loaded at the end
     of a generic ``core'' suite definition.
-  \item Use ``optional optional'' app config files for site-specific variations
+  \item Use ``optional'' app config files for site-specific variations
     in the core suite's Rose apps.
   \item (Make minimal use of inlined site switches too, if necessary).
   \item When referencing files, reference them within the suite structure and
@@ -280,7 +280,7 @@ if a file is missing at the start of a suite rather than part way into a run.
 Typically a few but not all apps will need some site customization, e.g.\ for
 local archive configuration, local science options, or whatever. To avoid
 explicit site-customization of individual task-run command lines use Rose's
-built-in {\em optional optional app config} capability:
+built-in {\em optional app config} capability:
 
 \lstset{language=suiterc}
 \begin{lstlisting}
@@ -496,7 +496,7 @@ portability) into include-files that are only loaded in the operational
 environment. Improvements and upgrades can be developed on feature branches in
 the research environment. Operations staff can check out completed feature
 branches for testing in the operational environment before merging to trunk or
-refering back to research if problems are found. After sufficient testing the
+referring back to research if problems are found. After sufficient testing the
 new suite version can be deployed into operations.
 
 \note{This obviously glosses over the myriad complexities of the technical


### PR DESCRIPTION
Few typos found in documentation. Saw the typo that @lhuggett fixed in a pull request (intial I think) and decided to open some of the tex files with IDE and with `mwic`, and spotted a few ones that could be fixed.

I think this would have - if merged - to be included in @sadielbartholomew #2910 PR (if the typo is still there?).

Cheers
Bruno