### PR TITLE
Change validation order to prevent loops and unnecessary variable instantiation

### DIFF
--- a/lib/cylc/cfgvalidate.py
+++ b/lib/cylc/cfgvalidate.py
@@ -102,11 +102,11 @@ class CylcConfigValidator(ParsecValidator):
         value = cls.strip_and_unquote(keys, value)
         if not value:
             return None
+        if '/' in value:
+            raise IllegalValueError('cycle point format', keys, value)
         test_timepoint = TimePoint(year=2001, month_of_year=3, day_of_month=1,
                                    hour_of_day=4, minute_of_hour=30,
                                    second_of_minute=54)
-        if '/' in value:
-            raise IllegalValueError('cycle point format', keys, value)
         if '%' in value:
             try:
                 TimePointDumper().strftime(test_timepoint, value)
@@ -228,7 +228,6 @@ class CylcConfigValidator(ParsecValidator):
         value = self.strip_and_unquote(keys, value)
         if not value:
             raise IllegalValueError("xtrigger", keys, value)
-        fname = None
         args = []
         kwargs = {}
         match = self._REC_TRIG_FUNC.match(value)

--- a/lib/cylc/graph_parser.py
+++ b/lib/cylc/graph_parser.py
@@ -335,27 +335,27 @@ class GraphParser(object):
         if right and self.__class__.OP_OR in right:
             raise GraphParseError("ERROR, illegal OR on RHS: %s" % right)
 
-        # Remove qualifiers from right-side nodes.
-        if right:
-            for qual in self.__class__.REC_TRIG_QUAL.findall(right):
-                right = right.replace(qual, '')
-
         # Raise error if suicide triggers on the left of the trigger.
         if left and self.__class__.SUICIDE_MARK in left:
             raise GraphParseError(
                 "ERROR, suicide markers must be"
                 " on the right of a trigger: %s" % left)
 
+        # Check that parentheses match.
+        if left and left.count("(") != left.count(")"):
+            raise GraphParseError(
+                "ERROR, parenthesis mismatch in: \"" + left + "\"")
+
+        # Remove qualifiers from right-side nodes.
+        if right:
+            for qual in self.__class__.REC_TRIG_QUAL.findall(right):
+                right = right.replace(qual, '')
+
         # Cycle point offsets are not allowed on the right side (yet).
         if right and '[' in right:
             raise GraphParseError(
                 "ERROR, illegal cycle point offset on the right: %s => %s" % (
                     left, right))
-
-        # Check that parentheses match.
-        if left and left.count("(") != left.count(")"):
-            raise GraphParseError(
-                "ERROR, parenthesis mismatch in: \"" + left + "\"")
 
         # Split right side on AND.
         rights = right.split(self.__class__.OP_AND)


### PR DESCRIPTION
Used the same tool that ran against `isodatetime` to analyse Cylc. Found only a few places that the validation order could be done different to, hopefully, save some time from running loops or instantiating new variables. Also noticed one variable (`fname`) that was declared, never used, and re-declared later and only then used.

Cheers
Bruno