### PR TITLE
gui: fix recursive traceback w/ argument-free launch

### DIFF
--- a/lib/cylc/gui/dbchooser.py
+++ b/lib/cylc/gui/dbchooser.py
@@ -105,8 +105,11 @@ class db_updater(threading.Thread):
 
         # Scan for running suites
         choices = []
-        for host, port, suite_identity in scan_many(
-                get_scan_items_from_fs(), timeout=self.timeout):
+        scan_results = scan_many(
+            get_scan_items_from_fs(), timeout=self.timeout)
+        if scan_results is None:
+            return
+        for host, port, suite_identity in scan_results:
             name = suite_identity[KEY_NAME]
             owner = suite_identity[KEY_OWNER]
             if is_remote_user(owner):


### PR DESCRIPTION
I ran into another (see #2844) bug for running a bare ``gcylc`` command. This one is worse as it spawns ``python2`` processes & produces recursive traceback dialogues. In light of this, I couldn't (& won't re-attempt to) copy & paste the traceback text, but from a screen-shot captured it is:

![bare_gcylc_traceback](https://user-images.githubusercontent.com/30274190/51327689-c164ae80-1a69-11e9-90e9-fdeec4d29ebb.png)

Add a simple fix for this.

#### To recreate :asterisk: (note: be prepared to quickly ``killall python2``)

[:asterisk: ...possibly, it may only occur under specific set-up conditions]

Launch the GUI with no suite(s) as argument(s) i.e. ``gcylc &`` (I advise leaving in the ``&`` as without it, it may be impossible to re-gain control of the terminal to halt the spawning) & then click 'File -> Open Another Suite'.