### PR TITLE
Fix subprocpool pipe polling

### DIFF
--- a/lib/cylc/option_parsers.py
+++ b/lib/cylc/option_parsers.py
@@ -285,7 +285,12 @@ Arguments:"""
         cylc.flags.verbose = options.verbose
         cylc.flags.debug = options.debug
 
-        # Set up stream logging
+        # Set up stream logging for CLI. Note:
+        # 1. On choosing STDERR: Log messages are diagnostics, so STDERR is the
+        #    better choice for the logging stream. This allows us to use STDOUT
+        #    for verbosity agnostic outputs.
+        # 2. Suite server programs will remove this handler when it becomes a
+        #    daemon.
         if options.debug or options.verbose:
             LOG.setLevel(logging.DEBUG)
         else:

--- a/lib/cylc/subprocpool.py
+++ b/lib/cylc/subprocpool.py
@@ -102,7 +102,7 @@ class SuiteProcPool(object):
     using a cylc.subprocctx.SubProcContext object. The caller will add the
     context object using the SuiteProcPool.put_command method. A callback can
     be specified to notify the caller on exit of the subprocess.
-    
+
     A command launched by the pool is expected to write to STDOUT and STDERR.
     These are captured while the command runs and/or when the command exits.
     The contents are appended to the `.out` and `.err` attributes of the
@@ -114,7 +114,7 @@ class SuiteProcPool(object):
     Therefore, log messages will only be written to the suite log by the
     callback function when the command exits (and only if the callback function
     has the logic to do so).
-            
+
     """
 
     ERR_SUITE_STOPPING = 'suite stopping, command not run'
@@ -285,9 +285,9 @@ class SuiteProcPool(object):
                 # Nothing readable
                 break
             for fileno in fileno_list:
-                # If a file handle is readable, read something from it, add results
-                # into the command context object's `.out` or `.err`, whichever
-                # is relevant. To avoid blocking:
+                # If a file handle is readable, read something from it, add
+                # results into the command context object's `.out` or `.err`,
+                # whichever is relevant. To avoid blocking:
                 # 1. Use `os.read` here instead of `file.read` to avoid any
                 #    buffering that may cause the file handle to block.
                 # 2. Call os.read only once after a poll. Poll again before

--- a/lib/cylc/subprocpool.py
+++ b/lib/cylc/subprocpool.py
@@ -271,15 +271,13 @@ class SuiteProcPool(object):
                 # Nothing readable
                 break
             for fileno in fileno_list:
-                data = ''
-                while True:
-                    # Use the low level `os.read` here instead of
-                    # `file.read` to avoid any buffering that may cause
-                    # the file handle to block.
-                    res = os.read(fileno, 65536)  # 64K
-                    if not res:
-                        break
-                    data += res
+                # Use the low level `os.read` here instead of
+                # `file.read` to avoid any buffering that may cause
+                # the file handle to block.
+                try:
+                    data = os.read(fileno, 65536)  # 64K
+                except OSError:
+                    continue
                 if fileno == proc.stdout.fileno():
                     if ctx.out is None:
                         ctx.out = ''

--- a/lib/cylc/task_job_mgr.py
+++ b/lib/cylc/task_job_mgr.py
@@ -513,6 +513,8 @@ class TaskJobManager(object):
                         LOG.warning(
                             'Unhandled %s output: %s', ctx.cmd_key, line)
                         LOG.exception(exc)
+        # Task jobs that are in the original command but did not get a status
+        # in the output. Handle as failures.
         for key, itask in sorted(bad_tasks.items()):
             line = (
                 "|".join([ctx.timestamp, os.sep.join(key), "1"]) + "\n")

--- a/lib/cylc/task_job_mgr.py
+++ b/lib/cylc/task_job_mgr.py
@@ -513,9 +513,8 @@ class TaskJobManager(object):
                         LOG.warning(
                             'Unhandled %s output: %s', ctx.cmd_key, line)
                         LOG.exception(exc)
-        for key, itask in bad_tasks.items():
+        for key, itask in sorted(bad_tasks.items()):
             line = (
-                self.batch_sys_mgr.OUT_PREFIX_SUMMARY +
                 "|".join([ctx.timestamp, os.sep.join(key), "1"]) + "\n")
             summary_callback(suite, itask, ctx, line)
 

--- a/tests/job-submission/19-chatty.t
+++ b/tests/job-submission/19-chatty.t
@@ -1,0 +1,90 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test job submission with a very chatty command.
+# + Simulate "cylc jobs-submit" getting killed half way through.
+
+. "$(dirname "$0")/test_header"
+
+set_test_number 14
+
+create_test_globalrc "
+process pool timeout = PT10S" ""
+
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+
+suite_run_ok "${TEST_NAME_BASE}-suite-run" \
+    cylc run --debug --no-detach "${SUITE_NAME}"
+
+# Logged killed jobs-submit command
+cylc cat-log "${SUITE_NAME}" | sed -n '
+/\[jobs-submit \(cmd\|ret_code\|out\|err\)\]/,+2{
+    s/^.*\(\[jobs-submit\)/\1/p
+}' >'log'
+contains_ok 'log' <<'__OUT__'
+[jobs-submit ret_code] -9
+[jobs-submit err] killed on timeout (PT10S)
+__OUT__
+
+# Logged jobs that called talkingnonsense
+sed -n 's/\(\[jobs-submit out\]\) .*\(|1\/\)/\1 \2/p' 'log' >'log2'
+N=0
+while read; do
+    TAIL="${REPLY#${SUITE_RUN_DIR}/log/job/}"
+    TASK_JOB="${TAIL%/job}"
+    contains_ok 'log2' <<<"[jobs-submit out] |${TASK_JOB}|1|None"
+    ((N += 1))
+done <"${SUITE_RUN_DIR}/talkingnonsense.out"
+# Logged jobs that did not call talkingnonsense
+for I in `eval echo {$N..9}`; do
+    contains_ok 'log2' <<<"[jobs-submit out] |1/nh${I}/01|1"
+done
+
+# Task pool in database contains the correct states
+cylc ls-checkpoints "${SUITE_NAME}" '0' | sed -n '/^# TASK POOL/,$p' | sort \
+    >'cylc-ls-checkpoints.out'
+
+cmp_ok 'cylc-ls-checkpoints.out' <<'__OUT__'
+1|h0|1|succeeded|
+1|h1|1|succeeded|
+1|h2|1|succeeded|
+1|h3|1|succeeded|
+1|h4|1|succeeded|
+1|h5|1|succeeded|
+1|h6|1|succeeded|
+1|h7|1|succeeded|
+1|h8|1|succeeded|
+1|h9|1|succeeded|
+1|nh0|0|submit-failed|
+1|nh1|0|submit-failed|
+1|nh2|0|submit-failed|
+1|nh3|0|submit-failed|
+1|nh4|0|submit-failed|
+1|nh5|0|submit-failed|
+1|nh6|0|submit-failed|
+1|nh7|0|submit-failed|
+1|nh8|0|submit-failed|
+1|nh9|0|submit-failed|
+1|starter|1|succeeded|
+1|stopper|1|succeeded|
+# TASK POOL (CYCLE|NAME|SPAWNED|STATUS|HOLD_SWAP)
+__OUT__
+
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/job-submission/19-chatty.t
+++ b/tests/job-submission/19-chatty.t
@@ -57,10 +57,13 @@ for I in `eval echo {$N..9}`; do
 done
 
 # Task pool in database contains the correct states
-cylc ls-checkpoints "${SUITE_NAME}" '0' | sed -n '/^# TASK POOL/,$p' | sort \
+# Use LANG=C sort to put # on top
+cylc ls-checkpoints "${SUITE_NAME}" '0' | sed -n '/^# TASK POOL/,$p' \
+    | env LANG=C sort \
     >'cylc-ls-checkpoints.out'
 
 cmp_ok 'cylc-ls-checkpoints.out' <<'__OUT__'
+# TASK POOL (CYCLE|NAME|SPAWNED|STATUS|HOLD_SWAP)
 1|h0|1|succeeded|
 1|h1|1|succeeded|
 1|h2|1|succeeded|
@@ -83,7 +86,6 @@ cmp_ok 'cylc-ls-checkpoints.out' <<'__OUT__'
 1|nh9|0|submit-failed|
 1|starter|1|succeeded|
 1|stopper|1|succeeded|
-# TASK POOL (CYCLE|NAME|SPAWNED|STATUS|HOLD_SWAP)
 __OUT__
 
 purge_suite "${SUITE_NAME}"

--- a/tests/job-submission/19-chatty.t
+++ b/tests/job-submission/19-chatty.t
@@ -58,12 +58,12 @@ done
 
 # Task pool in database contains the correct states
 # Use LANG=C sort to put # on top
-cylc ls-checkpoints "${SUITE_NAME}" '0' | sed -n '/^# TASK POOL/,$p' \
-    | env LANG=C sort \
-    >'cylc-ls-checkpoints.out'
+cylc ls-checkpoints "${SUITE_NAME}" '0' \
+    | sed -n '/^# TASK POOL/,$p' \
+    | sed '/^# TASK POOL/d' \
+    | sort >'cylc-ls-checkpoints.out'
 
 cmp_ok 'cylc-ls-checkpoints.out' <<'__OUT__'
-# TASK POOL (CYCLE|NAME|SPAWNED|STATUS|HOLD_SWAP)
 1|h0|1|succeeded|
 1|h1|1|succeeded|
 1|h2|1|succeeded|

--- a/tests/job-submission/19-chatty/bin/talkingnonsense
+++ b/tests/job-submission/19-chatty/bin/talkingnonsense
@@ -1,0 +1,8 @@
+#!/bin/bash
+sleep 1
+cat "${CYLC_DIR}/COPYING"
+sleep 1
+tac "${CYLC_DIR}/COPYING" >&2
+sleep 1
+echo "$@" >>"${CYLC_SUITE_RUN_DIR}/talkingnonsense.out"
+exit 1

--- a/tests/job-submission/19-chatty/suite.rc
+++ b/tests/job-submission/19-chatty/suite.rc
@@ -1,0 +1,37 @@
+[cylc]
+   [[events]]
+      abort on timeout = True
+      timeout = PT20S
+[scheduling]
+    [[dependencies]]
+        # The "starter" task sleeps 5 seconds between start and complete.
+        # NOHOPE family should start first, so we'll have a "cylc jobs-submit"
+        # starting to run the talkingnonsense command (which sleeps and talks
+        # nonsense!) in serial.
+        # While the above "cylc jobs-submit" is still on going, we start
+        # another "cylc jobs-submit" command doing normal job submissions of
+        # HOPEFUL tasks.
+        # The first job submission command should never finish before getting
+        # killed (see global configuration in ".t" file causing the NOHOPE
+        # family to go into submission failure and triggering the stopper task.
+        # The idea is that the NOHOPE job submission nonsense should not block
+        # the HOPEFUL tasks from launching normally.
+        graph = "starter:start => NOHOPE"
+        graph = "starter => HOPEFUL"
+        graph = HOPEFUL:succeeded-all
+        graph = "NOHOPE:submit-fail-all => stopper"
+[runtime]
+    [[starter]]
+        script = wait && sleep 5
+    [[HOPEFUL]]
+        script = true
+    [[NOHOPE]]
+        [[[job]]]
+            batch system = at
+            batch submit command template = talkingnonsense %(job)s
+    [[nh0, nh1, nh2, nh3, nh4, nh5, nh6, nh7, nh8, nh9]]
+        inherit = NOHOPE
+    [[h0, h1, h2, h3, h4, h5, h6, h7, h8, h9]]
+        inherit = HOPEFUL
+    [[stopper]]
+        script = cylc stop "${CYLC_SUITE_NAME}"


### PR DESCRIPTION
Most likely :bug: introduced by #2876. Sorry.

Read each ready pipe once after each poll. Poll again after read.

If `cylc jobs-submit` returns with incomplete summary for all expected
tasks, report tasks that do not have a summary line as submission
failed.

Fix #2929.