### PR TITLE
Set location of coverage file in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,12 @@ env:
 install: .travis/install.sh functional-tests docs
 script:
 - export PYTHONPATH="${TRAVIS_BUILD_DIR}/.travis"
+# As we fork processes, we need to make sure to point where each forked process
+# will put its .coverage... files. Otherwise they may be created under directories
+# that `coverage combine` isn't expecting, causing the report to omit tests.
+# On the other hand, changing .coveragerc directly affects developers running
+# coverage locally. Therefore, we have this sed line here only for Travis.
+- sed -i -e "s|data_file=.coverage|data_file=${TRAVIS_BUILD_DIR}/.coverage|g" .coveragerc
 - coverage run .travis/cover.py
 - unset PYTHONPATH
 after_script: .travis/after_script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,8 @@ env:
   - CYLC_TEST_RUN_PLATFORM=false
   # Custom diff command to ignore Xlib errors (xvfb has not RANDR extension).
   - CYLC_TEST_DIFF_CMD="diff -I Xlib -u"
-  - COVERAGE_PROCESS_START="${TRAVIS_BUILD_DIR}/.coveragerc"
+  # This coverage RC file is created under the script task
+  - COVERAGE_PROCESS_START="/tmp/.coveragerc"
   matrix:
   - CHUNK="1/4"
   - CHUNK="2/4"
@@ -58,12 +59,14 @@ env:
 install: .travis/install.sh functional-tests docs
 script:
 - export PYTHONPATH="${TRAVIS_BUILD_DIR}/.travis"
-# As we fork processes, we need to make sure to point where each forked process
-# will put its .coverage... files. Otherwise they may be created under directories
-# that `coverage combine` isn't expecting, causing the report to omit tests.
-# On the other hand, changing .coveragerc directly affects developers running
-# coverage locally. Therefore, we have this sed line here only for Travis.
-- sed -i -e "s|data_file=.coverage|data_file=${TRAVIS_BUILD_DIR}/.coverage|g" .coveragerc
+# When we run cylc commands, there are processes being forked, that get a
+# new working directory. As .coveragerc contains relatives paths, it fails
+# to produce the correct coverage, unless we use absolute paths. The `sed`
+# call below tries to define the data_file, and sources locations for Travis.
+- sed -e "s|data_file=.coverage|data_file=${TRAVIS_BUILD_DIR}/.coverage|g; s|./bin|${TRAVIS_BUILD_DIR}/bin|g; s|./lib|${TRAVIS_BUILD_DIR}/lib|g" .coveragerc > /tmp/.coveragerc
+# And some tests fail if we touch files in the git working directory, due
+# to Cylc's version appearing with the "dirty" suffix. To avoid this, we
+# are using a new coveragerc created under the temporary directory.
 - coverage run .travis/cover.py
 - unset PYTHONPATH
 after_script: .travis/after_script.sh


### PR DESCRIPTION
Adding a `sed` command to our `.travis.yml` to use an absolute directory for the coverage data file. This way when processes are forked, they will use the same location, instead of a location relative to their working directory.

This should increase the coverage of the project, and cover files such as `daemonize.py`.

Bruno