### PR TITLE
review: fix waiting tasks

### DIFF
--- a/lib/cylc/cylc-review/static/js/cylc-review.js
+++ b/lib/cylc/cylc-review/static/js/cylc-review.js
@@ -128,16 +128,13 @@ $(function() {
     $("#uncheck_task_statuses").click(function() {
         $("input.task_status").prop("checked", false);
     });
-    $("#all_task_statuses").change(function() {
-        if ($(this).prop("checked")) {
-            $("#uncheck_task_statuses").prop("disabled", true);
-            $("input.task_status").prop("checked", true);
-            $("input.task_status").prop("disabled", true);
-        }
-        else {
-            $("#uncheck_task_statuses").prop("disabled", false);
-            $("input.task_status").prop("disabled", false);
-        }
+    $("#check_task_statuses").click(function() {
+        $("input.task_status").prop("checked", true);
     });
-    $("#all_task_statuses").change();
+    $("#reset_task_statuses").click(function() {
+        // default task statuses - if updating please also change the
+        // def taskjobs function in review.py
+        $("input.task_status").prop("checked", true);
+        $("input.task_status[value=waiting]").prop("checked", false);
+    });
 });

--- a/lib/cylc/cylc-review/template/job-entry.html
+++ b/lib/cylc/cylc-review/template/job-entry.html
@@ -107,16 +107,18 @@
   <td>
     <!-- entry: submi_num -->
     <small>
+    {% if entry.submit_num > 0 %}
       <a
       href="{{taskjobs_link}}&amp;cycles={{cycle_str}}&amp;tasks={{entry.name}}"
       >{{entry.submit_num}} of {{entry.submit_num_max}}</a>
+    {% endif %}
     </small>
   </td>
   <td>
     <!-- entry: submit time -->
     <small>
       <abbr class="t_submit livestamp"
-      title="{{entry.events[0]}}">{{entry.events[0]}}</abbr>
+      title="{{entry.events[0]}}">{{entry.events[0] or ''}}</abbr>
     </small>
   </td>
   <td class="text-right">

--- a/lib/cylc/cylc-review/template/pager.html
+++ b/lib/cylc/cylc-review/template/pager.html
@@ -42,9 +42,6 @@
               <input type="hidden" name="task_status" value="{{key}}" />
               {% endif -%}
             {% endfor -%}
-            {% if all_task_statuses -%}
-              <input type="hidden" name="task_status" value="" />
-            {% endif -%}
             {% if job_status -%}
               <input type="hidden" name="job_status" value="{{job_status}}" />
             {% endif -%}

--- a/lib/cylc/cylc-review/template/taskjobs.html
+++ b/lib/cylc/cylc-review/template/taskjobs.html
@@ -43,17 +43,8 @@
             <div class="col-sm-12 col-md-12">
               <strong>Select by Task Statuses</strong>
               <br/>
-              <label class="checkbox-inline" for="all_task_statuses">
-                <input id="all_task_statuses" type="checkbox"
-                name="task_status"
-                value=""
-                title="Display jobs of all tasks"
-{% if all_task_statuses -%}
-                checked="checked"
-{% endif -%}
-                />
-                select all
-              </label>
+              <button id="check_task_statuses" type="button"
+              class="btn btn-default btn-xs">check all</button>
               <button id="uncheck_task_statuses" type="button"
               class="btn btn-default btn-xs">uncheck all</button>
             </div>
@@ -169,8 +160,8 @@
             </div>
             <div class="form-group col-sm-4 col-md-2 btn-toolbar">
               <div class="btn-group pull-right">
-                <input type="reset" class="btn btn-default" value="reset"
-                title="Reset Display Options"/>
+                <input type="button" class="btn btn-default" value="reset"
+                title="Reset Display Options" id="reset_task_statuses"/>
                 <input type="submit" class="btn btn-primary" value="update"
                 title="Update Display Options"/>
               </div>

--- a/lib/cylc/review.py
+++ b/lib/cylc/review.py
@@ -44,7 +44,7 @@ import urllib
 from cylc.hostuserutil import get_host
 from cylc.review_dao import CylcReviewDAO
 from cylc.task_state import (
-    TASK_STATUSES_ORDERED, TASK_STATUS_GROUPS)
+    TASK_STATUSES_ORDERED, TASK_STATUS_GROUPS, TASK_STATUS_WAITING)
 from cylc.version import CYLC_VERSION
 from cylc.ws import get_util_home
 from cylc.suite_srv_files_mgr import SuiteSrvFilesManager
@@ -288,17 +288,20 @@ class CylcReviewService(object):
             page = int(page)
         else:
             page = 1
-        task_statuses = (
-            [[item, ""] for item in TASK_STATUSES_ORDERED])
-        if task_status:
-            if not isinstance(task_status, list):
-                task_status = [task_status]
-        for item in task_statuses:
-            if not task_status or item[0] in task_status:
-                item[1] = "1"
-        all_task_statuses = all([status[1] == "1" for status in task_statuses])
-        if all_task_statuses:
-            task_status = []
+
+        # get selected task states
+        if not task_status:
+            # default task statuses - if updating please also change the
+            # $("#reset_task_statuses").click function in cylc-review.js
+            task_status = [state for state in TASK_STATUSES_ORDERED
+                           if state != TASK_STATUS_WAITING]
+        elif not isinstance(task_status, list):
+            task_status = [task_status]
+
+        # generate list of all task states [(state, "0" or "1"), ...]
+        task_statuses = [(status, "1" if status in task_status else "0")
+                         for status in TASK_STATUSES_ORDERED]
+
         data = {
             "cycles": cycles,
             "host": self.host_name,
@@ -306,7 +309,6 @@ class CylcReviewService(object):
             "logo": self.logo,
             "method": "taskjobs",
             "no_fuzzy_time": no_fuzzy_time,
-            "all_task_statuses": all_task_statuses,
             "task_statuses": task_statuses,
             "job_status": job_status,
             "order": order,

--- a/lib/cylc/review_dao.py
+++ b/lib/cylc/review_dao.py
@@ -193,7 +193,7 @@ class CylcReviewDAO(object):
         # Get number of entries
         of_n_entries = 0
         stmt = ("SELECT COUNT(*)" +
-                " FROM task_jobs JOIN task_states USING (name, cycle)" +
+                " FROM task_states LEFT JOIN task_jobs USING (name, cycle)" +
                 where_expr)
         try:
             for row in self._db_exec(user_name, suite_name, stmt, where_args):
@@ -217,7 +217,7 @@ class CylcReviewDAO(object):
                 " time_submit, submit_status," +
                 " time_run, time_run_exit, run_signal, run_status," +
                 " user_at_host, batch_sys_name, batch_sys_job_id" +
-                " FROM task_jobs JOIN task_states USING (cycle, name)" +
+                " FROM task_states LEFT JOIN task_jobs USING (cycle, name)" +
                 where_expr +
                 " ORDER BY " +
                 self.JOB_ORDERS.get(order, self.JOB_ORDERS["time_desc"]))
@@ -236,7 +236,7 @@ class CylcReviewDAO(object):
             entry = {
                 "cycle": cycle,
                 "name": name,
-                "submit_num": submit_num,
+                "submit_num": submit_num or 0,
                 "submit_num_max": submit_num_max,
                 "events": [time_submit, time_run, time_run_exit],
                 "task_status": task_status,

--- a/tests/cylc-review/00-basic.t
+++ b/tests/cylc-review/00-basic.t
@@ -117,6 +117,10 @@ FOO0="{'cycle': '20000101T0000Z', 'name': 'foo0', 'submit_num': 1}"
 FOO0_JOB='log/job/20000101T0000Z/foo0/01/job'
 FOO1="{'cycle': '20000101T0000Z', 'name': 'foo1', 'submit_num': 1}"
 FOO1_JOB='log/job/20000101T0000Z/foo1/01/job'
+# foo0 in the next cycle
+FOO2="{'cycle': '20010101T0000Z', 'name': 'foo0', 'submit_num': 0}"
+# foo1 in the next cycle
+FOO3="{'cycle': '20010101T0000Z', 'name': 'foo1', 'submit_num': 0}"
 
 cylc_ws_json_greps "${TEST_NAME}.stdout" "${TEST_NAME}.stdout" \
     "[('cylc_version',), '$(cylc version | cut -d' ' -f 2)']" \
@@ -134,7 +138,7 @@ cylc_ws_json_greps "${TEST_NAME}.stdout" "${TEST_NAME}.stdout" \
     "[('order',), None]" \
     "[('states', 'is_running',), False]" \
     "[('states', 'is_failed',), False]" \
-    "[('of_n_entries',), 2]" \
+    "[('of_n_entries',), 4]" \
     "[('entries', ${FOO0}, 'task_status',), 'succeeded']" \
     "[('entries', ${FOO0}, 'host',), '$(hostname -f)']" \
     "[('entries', ${FOO0}, 'submit_method',), 'background']" \
@@ -182,7 +186,9 @@ cylc_ws_json_greps "${TEST_NAME}.stdout" "${TEST_NAME}.stdout" \
     "[('entries', ${FOO1}, 'logs', 'job.trace.256.html', 'seq_key'), 'job.trace.*.html']" \
     "[('entries', ${FOO1}, 'seq_logs_indexes', 'job.trace.*.html', '2'), 'job.trace.2.html']" \
     "[('entries', ${FOO1}, 'seq_logs_indexes', 'job.trace.*.html', '32'), 'job.trace.32.html']" \
-    "[('entries', ${FOO1}, 'seq_logs_indexes', 'job.trace.*.html', '256'), 'job.trace.256.html']"
+    "[('entries', ${FOO1}, 'seq_logs_indexes', 'job.trace.*.html', '256'), 'job.trace.256.html']" \
+    "[('entries', ${FOO2}, 'events',), [None, None, None]]" \
+    "[('entries', ${FOO3}, 'events',), [None, None, None]]" \
 
 #-------------------------------------------------------------------------------
 # Data transfer output check for a suite run directory with only a "log/db"

--- a/tests/cylc-review/10-jobs-task-status.t
+++ b/tests/cylc-review/10-jobs-task-status.t
@@ -89,9 +89,8 @@ BAR2="{'cycle': '20000101T0000Z', 'name': 'bar', 'submit_num': 2}"
 BAR3="{'cycle': '20000101T0000Z', 'name': 'bar', 'submit_num': 3}"
 BAZ1="{'cycle': '20000101T0000Z', 'name': 'baz', 'submit_num': 1}"
 BAZ2="{'cycle': '20000101T0000Z', 'name': 'baz', 'submit_num': 2}"
-BAZ3="{'cycle': '20010101T0000Z', 'name': 'baz', 'submit_num': 0}"
 cylc_ws_json_greps "${TEST_NAME}.stdout" "${TEST_NAME}.stdout" \
-    "[('of_n_entries',), 12]" \
+    "[('of_n_entries',), 9]" \
     "[('job_status',), None]" \
     "[('entries', ${FOO1}, 'task_status',), 'succeeded']" \
     "[('entries', ${FOO1}, 'run_status',), 1]" \
@@ -117,13 +116,7 @@ cylc_ws_json_greps "${TEST_NAME}.stdout" "${TEST_NAME}.stdout" \
     "[('entries', ${BAZ2}, 'task_status',), 'succeeded']" \
     "[('entries', ${BAZ2}, 'submit_status',), 0]" \
     "[('entries', ${BAZ2}, 'run_status',), 0]" \
-    "[('entries', ${BAZ2}, 'run_signal',), None]" \
-    "[('entries', ${BAZ3}, 'submit_status',), None]" \
-    "[('entries', ${BAZ3}, 'run_signal',), None]" \
-    "[('entries', ${BAZ3}, 'host',), None]" \
-    "[('entries', ${BAZ3}, 'submit_method',), None]" \
-    "[('entries', ${BAZ3}, 'submit_method_id',), None]" \
-    "[('entries', ${BAZ3}, 'events',), [None, None, None]]"
+    "[('entries', ${BAZ2}, 'run_signal',), None]"
 
 #-------------------------------------------------------------------------------
 # Data transfer output check for suite's job page, job status filters

--- a/tests/cylc-review/10-jobs-task-status.t
+++ b/tests/cylc-review/10-jobs-task-status.t
@@ -89,8 +89,9 @@ BAR2="{'cycle': '20000101T0000Z', 'name': 'bar', 'submit_num': 2}"
 BAR3="{'cycle': '20000101T0000Z', 'name': 'bar', 'submit_num': 3}"
 BAZ1="{'cycle': '20000101T0000Z', 'name': 'baz', 'submit_num': 1}"
 BAZ2="{'cycle': '20000101T0000Z', 'name': 'baz', 'submit_num': 2}"
+BAZ3="{'cycle': '20010101T0000Z', 'name': 'baz', 'submit_num': 0}"
 cylc_ws_json_greps "${TEST_NAME}.stdout" "${TEST_NAME}.stdout" \
-    "[('of_n_entries',), 9]" \
+    "[('of_n_entries',), 12]" \
     "[('job_status',), None]" \
     "[('entries', ${FOO1}, 'task_status',), 'succeeded']" \
     "[('entries', ${FOO1}, 'run_status',), 1]" \
@@ -116,7 +117,13 @@ cylc_ws_json_greps "${TEST_NAME}.stdout" "${TEST_NAME}.stdout" \
     "[('entries', ${BAZ2}, 'task_status',), 'succeeded']" \
     "[('entries', ${BAZ2}, 'submit_status',), 0]" \
     "[('entries', ${BAZ2}, 'run_status',), 0]" \
-    "[('entries', ${BAZ2}, 'run_signal',), None]"
+    "[('entries', ${BAZ2}, 'run_signal',), None]" \
+    "[('entries', ${BAZ3}, 'submit_status',), None]" \
+    "[('entries', ${BAZ3}, 'run_signal',), None]" \
+    "[('entries', ${BAZ3}, 'host',), None]" \
+    "[('entries', ${BAZ3}, 'submit_method',), None]" \
+    "[('entries', ${BAZ3}, 'submit_method_id',), None]" \
+    "[('entries', ${BAZ3}, 'events',), [None, None, None]]"
 
 #-------------------------------------------------------------------------------
 # Data transfer output check for suite's job page, job status filters


### PR DESCRIPTION
#### At present waiting tasks do not appear in Cylc Review due to a SQL query error.

We were [joining](https://www.w3schools.com/sql/sql_join.asp) the tasks and jobs tables. In SQL terms `JOIN` means intersection. As waiting tasks do not have jobs they were excluded in the intersection. I've changed the `JOIN` to `LEFT JOIN` to include tasks with out jobs.