### PR TITLE
Use higher contrast link colours.

### DIFF
--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -72,17 +72,16 @@ html_theme = "classic"
 html_theme_options = {
     "stickysidebar": True,
     "sidebarwidth": 250,
-
     "relbarbgcolor": "black",
     "footerbgcolor": "black",
     "sidebarbgcolor": "white",
     "sidebartextcolor": "black",
-    "sidebarlinkcolor": "#00B3FD",
+    "sidebarlinkcolor": "#0000EE;",
     "headbgcolor":  "white",
     "headtextcolor":  "#FF5966",
-    "linkcolor": "#00C697",
-    "visitedlinkcolor": "#00C697",
-    "headlinkcolor": "#00C697",
+    "linkcolor": "#0000EE;",
+    "visitedlinkcolor": "#551A8B;",
+    "headlinkcolor": "#0000EE;",
     "codebgcolor": "#ebf9f6",
 }
 


### PR DESCRIPTION
Adjust the link colours to be higher contrast to aid with visibility.

Just deleting the colour settings results in using the values from the "classic" theme which are hard to read on the white background of the nav bar. As such have explicitly used colours based on what appears to once have been the "default" values for links and visited links. 

Built in my homespace and readable in my Firefox browser.