### PR TITLE
host appointer: improve handling of unexpected out

### DIFF
--- a/lib/cylc/host_appointer.py
+++ b/lib/cylc/host_appointer.py
@@ -18,6 +18,7 @@
 """Functionality for selecting Cylc suite hosts."""
 
 import json
+from itertools import dropwhile
 from pipes import quote
 from random import choice
 import socket
@@ -198,6 +199,13 @@ class HostAppointer(object):
                         proc.returncode, err)
                 else:
                     # Command OK
+                    # Users may have profile scripts that write to STDOUT.
+                    # Drop all output lines until the the first character of a
+                    # line is '{'. Hopefully this is enough to find us the
+                    # first line that denotes the beginning of the expected
+                    # JSON data structure.
+                    out = ''.join(dropwhile(
+                        lambda s: not s.startswith('{'), out.splitlines(True)))
                     host_stats[host] = json.loads(out)
             sleep(0.01)
         return host_stats


### PR DESCRIPTION
On SSH call with login shell, sites/users may have logic in profile
scripts writing to STDOUT. This causes the logic that expects JSON to
fail to load the output. This change attempts to drop all lines before
it finds the first open curly bracket `{`, which should be good enough
to denote the start of JSON content in most cases.

Close #2897. (Need to back port to to 7.8.2.)