### PR TITLE
Give logger a null handler on start up

### DIFF
--- a/bin/cylc-cycle-point
+++ b/bin/cylc-cycle-point
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""cylc [util] cycle-point [OPTIONS] [POINT]
+"""cylc [util] cycle-point [OPTIONS] ARGS
 
 Cycle point date-time offset computation, and filename templating.
 
@@ -50,25 +50,23 @@ Other examples:
   % export CYLC_TASK_CYCLE_POINT=2010-08
   % export MYTEMPLATE=foo-CCYY-MM.nc
   % cylc cycle-point --offset-years=2 --template=MYTEMPLATE
-  foo-2012-08.nc
-
-Arguments:
-   [POINT]  ISO 8601 date-time, e.g. 20140201T0000Z, default
-      $CYLC_TASK_CYCLE_POINT"""
+  foo-2012-08.nc"""
 
 import os
 import sys
-from optparse import OptionParser
 
-import cylc.flags
 import cylc.cycling.iso8601
+from cylc.option_parsers import CylcOptionParser as COP
 import isodatetime.data
 import isodatetime.dumpers
 import isodatetime.parsers
 
 
 def main():
-    parser = OptionParser(__doc__)
+    parser = COP(
+        __doc__,
+        argdoc=[
+            ('[POINT]', 'ISO8601 date-time, default=$CYLC_TASK_CYCLE_POINT')])
 
     parser.add_option(
         "--offset-hours", metavar="HOURS",
@@ -132,7 +130,7 @@ def main():
         "--print-hour", help="Print only hh of result",
         action="store_true", default=False, dest="print_hour")
 
-    (options, args) = parser.parse_args()
+    options, args = parser.parse_args(remove_opts=['--host', '--user'])
 
     if len(args) == 0:
         # input cycle point must be defined in the environment.
@@ -266,9 +264,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-documentation
+++ b/bin/cylc-documentation
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""cylc [info] documentation|browse [OPTIONS] [SUITE]
+"""cylc [info] documentation|browse [OPTIONS] ARGS
 
 View documentation in the browser, as per Cylc global config.
 
@@ -25,10 +25,7 @@ View documentation in the browser, as per Cylc global config.
 % cylc doc [-t TASK] SUITE
     View suite or task documentation, if URLs are specified in the suite. This
     parses the suite definition to extract the requested URL. Note that suite
-    server programs also hold suite URLs for access from the Cylc GUI.
-
-Arguments:
-   [TARGET]    File or suite name"""
+    server programs also hold suite URLs for access from the Cylc GUI."""
 
 import sys
 
@@ -40,15 +37,15 @@ for arg in sys.argv[1:]:
 
 import os
 from subprocess import check_call, CalledProcessError
-from optparse import OptionParser
 
-import cylc.flags
 from cylc.cfgspec.glbl_cfg import glbl_cfg
+from cylc.option_parsers import CylcOptionParser as COP
 from cylc.run_get_stdout import run_get_stdout
 
 
 def main():
-    parser = OptionParser(__doc__)
+    parser = COP(
+        __doc__, argdoc=[('[TARGET]', 'File or suite name')])
 
     parser.add_option(
         "--local",
@@ -81,8 +78,7 @@ def main():
         help="Print exception traceback on error.",
         action="store_true", default=False, dest="debug")
 
-    (options, args) = parser.parse_args()
-    cylc.flags.debug = options.debug
+    options, args = parser.parse_args(remove_opts=['--host', '--user'])
 
     viewer = glbl_cfg().get(['document viewers', 'html'])
     if len(args) == 0:
@@ -135,9 +131,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-get-gui-config
+++ b/bin/cylc-get-gui-config
@@ -25,23 +25,13 @@ use -i/--item and wrap parent sections in square brackets:
    cylc get-gui-config --item '[themes][default]succeeded'
 Multiple items can be specified at once."""
 
-import sys
-from optparse import OptionParser
 
 from cylc.cfgspec.gcylc import GcylcConfig
-import cylc.flags
+from cylc.option_parsers import CylcOptionParser as COP
 
 
 def main():
-    parser = OptionParser(__doc__)
-
-    parser.add_option(
-        "-v", "--verbose", help="Print extra information.",
-        action="store_true", default=False, dest="verbose")
-
-    parser.add_option(
-        "--debug", help="Show exception tracebacks.",
-        action="store_true", default=False, dest="debug")
+    parser = COP(__doc__, argdoc=[])
 
     parser.add_option(
         "-i", "--item", metavar="[SEC...]ITEM",
@@ -57,12 +47,7 @@ def main():
         "-p", "--python", help="Print native Python format.",
         action="store_true", default=False, dest="pnative")
 
-    (options, args) = parser.parse_args()
-    cylc.flags.verbose = options.verbose
-    cylc.flags.debug = options.debug
-
-    if len(args) != 0:
-        parser.error("ERROR: wrong number of arguments")
+    options = parser.parse_args(remove_opts=['--host', '--user'])[0]
 
     # Import gcfg here to avoid aborting before command help is printed.
     GcylcConfig.get_inst().idump(
@@ -70,9 +55,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-get-site-config
+++ b/bin/cylc-get-site-config
@@ -25,13 +25,13 @@ use -i/--item and wrap parent sections in square brackets:
    cylc get-site-config --item '[editors]terminal'
 Multiple items can be specified at once."""
 
-import sys
-from optparse import OptionParser
-import cylc.flags
+
+from cylc.cfgspec.glbl_cfg import glbl_cfg
+from cylc.option_parsers import CylcOptionParser as COP
 
 
 def main():
-    parser = OptionParser(__doc__)
+    parser = COP(__doc__, argdoc=[])
 
     parser.add_option(
         "-i", "--item", metavar="[SEC...]ITEM",
@@ -58,24 +58,8 @@ def main():
         help="Print the cylc site configuration directory location.",
         action="store_true", default=False, dest="site_dir")
 
-    parser.add_option(
-        "-v", "--verbose", help="Print extra information.",
-        action="store_true", default=False, dest="verbose")
+    options = parser.parse_args(remove_opts=['--host', '--user'])[0]
 
-    parser.add_option(
-        "--debug",
-        help="Show exception tracebacks.",
-        action="store_true", default=False, dest="debug")
-
-    (options, args) = parser.parse_args()
-    cylc.flags.verbose = options.verbose
-    cylc.flags.debug = options.debug
-
-    if len(args) != 0:
-        parser.error("ERROR: wrong number of arguments")
-
-    # import glbl_cfg here to avoid aborting before command help is printed
-    from cylc.cfgspec.glbl_cfg import glbl_cfg
     if options.run_dir:
         print glbl_cfg().get_host_item('run directory')
     elif options.site_dir:
@@ -86,9 +70,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/lib/cylc/option_parsers.py
+++ b/lib/cylc/option_parsers.py
@@ -67,9 +67,6 @@ avoid this, use the '--no-multitask-compat' option, or use the new syntax
 
         if multitask:
             usage += self.MULTITASK_USAGE
-        usage += """
-
-Arguments:"""
         args = ""
         self.n_compulsory_args = 0
         self.n_optional_args = 0
@@ -87,20 +84,21 @@ Arguments:"""
             if len(arg[0]) > maxlen:
                 maxlen = len(arg[0])
 
-        for arg in argdoc:
-            if arg[0].startswith('['):
-                self.n_optional_args += 1
-            else:
-                self.n_compulsory_args += 1
-            if arg[0].endswith('...]'):
-                self.unlimited_args = True
+        if argdoc:
+            usage += "\n\nArguments:"
+            for arg in argdoc:
+                if arg[0].startswith('['):
+                    self.n_optional_args += 1
+                else:
+                    self.n_compulsory_args += 1
+                if arg[0].endswith('...]'):
+                    self.unlimited_args = True
 
-            args += arg[0] + " "
+                args += arg[0] + " "
 
-            pad = (maxlen - len(arg[0])) * ' ' + '               '
-            usage += "\n   " + arg[0] + pad + arg[1]
-
-        usage = usage.replace('ARGS', args)
+                pad = (maxlen - len(arg[0])) * ' ' + '               '
+                usage += "\n   " + arg[0] + pad + arg[1]
+            usage = usage.replace('ARGS', args)
 
         OptionParser.__init__(self, usage)
 
@@ -295,6 +293,10 @@ Arguments:"""
             LOG.setLevel(logging.DEBUG)
         else:
             LOG.setLevel(logging.INFO)
+        # Remove NullHandler before add the StreamHandler
+        while LOG.handlers:
+            LOG.handlers[0].close()
+            LOG.removeHandler(LOG.handlers[0])
         errhandler = logging.StreamHandler(sys.stderr)
         errhandler.setFormatter(CylcLogFormatter())
         LOG.addHandler(errhandler)

--- a/lib/parsec/__init__.py
+++ b/lib/parsec/__init__.py
@@ -30,3 +30,5 @@ class ParsecError(Exception):
 
 
 LOG = logging.getLogger('cylc')  # Acceptable?
+if hasattr(logging, 'NullHandler'):  # Back compat Python <2.7
+    LOG.addHandler(logging.NullHandler())  # Start with a null handler


### PR DESCRIPTION
So, cylc logger will always have a handler. CylcOptionParser will ensure
that commands will have a valid logging handler. Scheduler will do
likewise for daemonized suites.

Use CylcOptionParser for all remaining user commands:
* cylc cycle-point
* cylc documentation
* cylc get-gui-config
* cylc get-site-config

This ensures that these commands will have logging handlers set.

Fix #2940.