### PR TITLE
docs: amend makefile command; address warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ version:
 	etc/dev-bin/create-version-file
 
 documentation:
-	cd doc && $(MAKE)
+	cylc make-docs
 
 clean:
 	cd doc && $(MAKE) clean

--- a/doc/src/appendices/site-user-config-ref.rst
+++ b/doc/src/appendices/site-user-config-ref.rst
@@ -180,14 +180,14 @@ Documentation locations for the ``cylc doc`` command and gcylc
 Help menus.
 
 [documentation] ``->`` [[online]]
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 URL of the online cylc documentation.
 
 [documentation] ``->`` [[local]]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Path where the Cylc documentation will appear if built locally.
+Path where the cylc documentation will appear if built locally.
 
 [documentation] ``->`` [[cylc homepage]]
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Close #2950 & also amend an RST format title underline which is a character too short, introducing a ``sphinx-build`` warning [``.../site-user-config-ref.rst:183: WARNING: Title underline too short.``].

With this PR, running both the explicit ``cylc make-docs`` command & ``make`` (in the overarching i.e. ``$CYLC_DIR``directory) will build the docs cleanly.