### PR TITLE
docs: amend makefile command; address warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ version:
 	etc/dev-bin/create-version-file
 
 documentation:
-	cd doc && $(MAKE)
+	cylc make-docs
 
 clean:
 	cd doc && $(MAKE) clean


### PR DESCRIPTION
Duplicate for the feature branch of #2951, to close #2950, where changes to ``site-user-config-ref.rst`` are omitted to copy as they apply to amended text that has is not (yet, depending on merge order of another PR) been changed as required in ``7.8.x``.