### PR TITLE
docs: fix jinja2 variable setting example suites

### DIFF
--- a/doc/src/suite-config.rst
+++ b/doc/src/suite-config.rst
@@ -3465,37 +3465,8 @@ The values of Jinja2 variables can be passed in from the cylc command
 line rather than hardwired in the suite configuration.
 Here's an example, from ``<cylc-dir>/etc/examples/jinja2/defaults``:
 
-.. code-block:: cylc
-
-   #!Jinja2
-
-   [meta]
-
-       title = "Jinja2 example: use of defaults and external input"
-
-       description = """
-   The template variable FIRST_TASK must be given on the cylc command line
-   using --set or --set-file=FILE; two other variables, LAST_TASK and
-   N_MEMBERS can be set similarly, but if not they have default values."""
-
-   {% set LAST_TASK = LAST_TASK | default( 'baz' ) %}
-   {% set N_MEMBERS = N_MEMBERS | default( 3 ) | int %}
-
-   {# input of FIRST_TASK is required - no default #}
-
-   [scheduling]
-       initial cycle point = 20100808T00
-       final cycle point   = 20100816T00
-       [[dependencies]]
-           [[[0]]]
-               graph = """{{ FIRST_TASK }} => ENS
-                    ENS:succeed-all => {{ LAST_TASK }}"""
-   [runtime]
-       [[ENS]]
-   {% for I in range( 0, N_MEMBERS ) %}
-       [[ mem_{{ I }} ]]
-           inherit = ENS
-   {% endfor %}
+.. literalinclude:: ../../etc/examples/jinja2/defaults/suite.rc
+   :language: cylc
 
 Here's the result:
 
@@ -3504,23 +3475,23 @@ Here's the result:
    $ cylc list SUITE
    Jinja2 Template Error
    'FIRST_TASK' is undefined
-   cylc-list foo  failed:  1
+   cylc-list SUITE  failed:  1
 
-   $ cylc list --set FIRST_TASK=bob foo
+   $ cylc list --set FIRST_TASK=bob SUITE
    bob
    baz
    mem_2
    mem_1
    mem_0
 
-   $ cylc list --set FIRST_TASK=bob --set LAST_TASK=alice foo
+   $ cylc list --set FIRST_TASK=bob --set LAST_TASK=alice SUITE
    bob
    alice
    mem_2
    mem_1
    mem_0
 
-   $ cylc list --set FIRST_TASK=bob --set N_MEMBERS=10 foo
+   $ cylc list --set FIRST_TASK=bob --set N_MEMBERS=10 SUITE
    mem_9
    mem_8
    mem_7

--- a/doc/src/tutorial.rst
+++ b/doc/src/tutorial.rst
@@ -1269,11 +1269,12 @@ configuration for groups of related tasks:
    :language: cylc
 
 To view the result of Jinja2 processing with the Jinja2 flag
-``MULTI`` set to ``False``:
+``MULTI`` set to an empty variable, so the ``{% if MULTI %}`` statement
+evaluates to ``False``:
 
 .. code-block:: bash
 
-   $ cylc view --jinja2 --stdout tut/oneoff/jinja2
+   $ cylc view --set=MULTI= --jinja2 --stdout tut/oneoff/jinja2
 
 .. code-block:: cylc
 
@@ -1286,7 +1287,8 @@ To view the result of Jinja2 processing with the Jinja2 flag
        [[hello]]
            script = "sleep 10; echo Hello World!"
 
-And with ``MULTI`` set to ``True``:
+
+And without setting ``MULTI``, so it assumes the default value of ``True``:
 
 .. code-block:: bash
 

--- a/etc/examples/tutorial/oneoff/jinja2/suite.rc
+++ b/etc/examples/tutorial/oneoff/jinja2/suite.rc
@@ -1,6 +1,6 @@
 #!jinja2
 
-{% set MULTI = True %}
+{% set MULTI = MULTI | default( 'True' ) %}
 {% set N_GOODBYES = 3 %}
 
 [meta]


### PR DESCRIPTION
Close #2953 & fix numerous long-term errors in that section (``7.26.``) & a similar section (``9.6.4.``) of the docs.

Most of the context is explained in https://github.com/cylc/cylc/issues/2953#issuecomment-463327389, but for further clarification on changes to the ``9.6.4.`` example suite, it:

* was at some point (not during the Sphinx conversion!) hard-coded into the docs instead of included from the ``etc/`` directory as with other example suites, & had not been updated in line with changes, so notably contained an obsolete ``[[[0]]]`` recurrence expression;
* was referred to as ``foo`` despite not being assigned that name.