### PR TITLE
Fix missing import in gcylc cfgspec.

### DIFF
--- a/lib/cylc/cfgspec/gcylc.py
+++ b/lib/cylc/cfgspec/gcylc.py
@@ -25,6 +25,7 @@ from parsec import ParsecError
 from parsec.config import ParsecConfig, ItemNotFoundError, itemstr
 from parsec.upgrade import upgrader
 from parsec.util import printcfg
+from cylc import LOG
 from cylc.cfgvalidate import (
     cylc_config_validate, CylcConfigValidator as VDR, DurationFloat)
 from cylc.task_state import (


### PR DESCRIPTION
Bug causing failure at GUI start-up if `gcylc.rc` has illegal config items, on attempt to log the error message.

PR to 7.8.x only, as the GUI is getting nuked on master.

(Should be a quick review!)