### PR TITLE
Make suite context available before config parsing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,7 @@ requests_).
  - (Martin Dix)
  - (Ivor Blockley)
  - Alexander Paulsell
+ - David Sutherland
 
 (All contributors are identifiable with email addresses in the git version
 control logs or otherwise.)

--- a/doc/src/suite-config.rst
+++ b/doc/src/suite-config.rst
@@ -3241,9 +3241,35 @@ automatically imports the user environment to template's global namespace
            [[[environment]]]
                SUITE_OWNER_HOME_DIR_ON_SUITE_HOST = {{environ['HOME']}}
 
-This example is emphasizes that *the environment is read on the suite
-host at the time the suite configuration is parsed* - it is not, for
-instance, read at task run time on the task host.
+In addition, the following variables are exported to this environment
+prior to configuration parsing to provide suite context:
+
+.. code-block:: bash
+
+   CYLC_DEBUG                      # Debug mode, true or not defined
+   CYLC_DIR                        # Location of cylc installation used
+   CYLC_VERBOSE                    # Verbose mode, True or False
+   CYLC_VERSION                    # Version of cylc installation used
+
+   CYLC_SUITE_NAME                 # Suite name
+
+   CYLC_SUITE_DEF_PATH             # Location of the suite source
+                                   # configuration path on suite host, 
+                                   # e.g. ~/cylc-run/foo
+   CYLC_SUITE_LOG_DIR              # Suite log directory.
+   CYLC_SUITE_RUN_DIR              # Location of the suite run directory in
+                                   # suite host, e.g. ~/cylc-run/foo
+   CYLC_SUITE_SHARE_DIR            # Suite (or task post parsing!)
+                                   # shared directory.
+   CYLC_SUITE_WORK_DIR             # Suite work directory.
+
+
+.. note::
+
+    The above example is emphasizes that *the environment is read on the suite
+    host at the time the suite configuration is parsed* - it is not, for
+    instance, read at task run time on the task host. This also pertains to some
+    of the above-listed suite context.
 
 
 .. _CustomJinja2Filters:

--- a/doc/src/suite-config.rst
+++ b/doc/src/suite-config.rst
@@ -3266,11 +3266,9 @@ prior to configuration parsing to provide suite context:
 
 .. note::
 
-    The above example gives emphasis that *the environment is read on the
-    suite host at the time the suite configuration is parsed* - it is not, for
-    instance, read at task run time on the task host. This also pertains to
-    some of the above-listed suite context.
-
+    The example above emphasizes that *the environment - including the suite
+    context variables - is read on the suite host when the suite configuration
+    is parsed*, not at task run time on job hosts.
 
 .. _CustomJinja2Filters:
 

--- a/doc/src/suite-config.rst
+++ b/doc/src/suite-config.rst
@@ -3253,8 +3253,8 @@ prior to configuration parsing to provide suite context:
 
    CYLC_SUITE_NAME                 # Suite name
 
-   CYLC_SUITE_DEF_PATH             # Location of the suite source
-                                   # configuration path on suite host, 
+   CYLC_SUITE_DEF_PATH             # Location of the suite configuration
+                                   # source path on suite host,
                                    # e.g. ~/cylc-run/foo
    CYLC_SUITE_LOG_DIR              # Suite log directory.
    CYLC_SUITE_RUN_DIR              # Location of the suite run directory in
@@ -3266,10 +3266,10 @@ prior to configuration parsing to provide suite context:
 
 .. note::
 
-    The above example is emphasizes that *the environment is read on the suite
-    host at the time the suite configuration is parsed* - it is not, for
-    instance, read at task run time on the task host. This also pertains to some
-    of the above-listed suite context.
+    The above example gives emphasis that *the environment is read on the
+    suite host at the time the suite configuration is parsed* - it is not, for
+    instance, read at task run time on the task host. This also pertains to
+    some of the above-listed suite context.
 
 
 .. _CustomJinja2Filters:

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -17,9 +17,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Parse and validate the suite definition file
 
-Suite context is exported to the environment, which may be used in
-configuration parsing (as this has utility for both running and
-non-running suites).
+Set local values of variables to give suite context before parsing
+config, i.e for template filters (Jinja2, python ...etc) and possibly
+needed locally by event handlers. This is needed for both running and
+non-running suite parsing (obtaining config/graph info). Potentially
+task-specific due to different directory paths on different task hosts,
+however, they are overridden by tasks prior to job submission.
 
 Do some consistency checking, then construct task proxy objects and graph
 structures.
@@ -190,6 +193,7 @@ class SuiteConfig(object):
         # one up from root
         self.feet = []
 
+        # Export local environmental suite context before config parsing.
         self.process_suite_env()
 
         # parse, upgrade, validate the suite, but don't expand with default
@@ -1425,11 +1429,7 @@ class SuiteConfig(object):
         print_tree(tree, padding=padding, use_unicode=pretty)
 
     def process_suite_env(self):
-        # Set local values of variables to give suite context before parsing
-        # config, i.e for template filters (Jinja2, python ...etc) and possibly
-        # needed locally by event handlers. Potentially task-specific due to
-        # different directory paths on different task hosts, however, they are
-        # overridden by tasks prior to job submission:
+        """Suite context is exported to the local environment."""
         for var, val in [
                 ('CYLC_SUITE_NAME', self.suite),
                 ('CYLC_DEBUG', str(cylc.flags.debug).lower()),
@@ -1442,7 +1442,7 @@ class SuiteConfig(object):
             os.environ[var] = val
 
     def process_config_env(self):
-        # Set local runtime environment
+        """Set local config derived environment."""
         os.environ['CYLC_UTC'] = str(get_utc_mode())
         os.environ['CYLC_SUITE_INITIAL_CYCLE_POINT'] = str(self.initial_point)
         os.environ['CYLC_SUITE_FINAL_CYCLE_POINT'] = str(self.final_point)

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -398,10 +398,7 @@ class SuiteConfig(object):
                     self.cfg['scheduling']['initial cycle point constraints'])
                 raise SuiteConfigError(
                     ("Initial cycle point %s does not meet the constraints " +
-                     "%s") % (
-                         str(self.initial_point),
-                         constraints_str
-                         )
+                     "%s") % (str(self.initial_point), constraints_str)
                 )
 
         if (self.cfg['scheduling']['final cycle point'] is not None and
@@ -738,7 +735,6 @@ class SuiteConfig(object):
                 self.suite, cfg['meta']['URL'])
             cfg['meta']['URL'] = RE_TASK_NAME_VAR.sub(
                 name, cfg['meta']['URL'])
-
 
         if is_validate:
             self.mem_log("config.py: before _check_circular()")
@@ -1450,7 +1446,8 @@ class SuiteConfig(object):
         os.environ['CYLC_UTC'] = str(get_utc_mode())
         os.environ['CYLC_SUITE_INITIAL_CYCLE_POINT'] = str(self.initial_point)
         os.environ['CYLC_SUITE_FINAL_CYCLE_POINT'] = str(self.final_point)
-        os.environ['CYLC_CYCLING_MODE'] = self.cfg['scheduling']['cycling mode']
+        os.environ['CYLC_CYCLING_MODE'] = self.cfg['scheduling'][
+            'cycling mode']
         #     (global config auto expands environment variables in local paths)
         cenv = self.cfg['cylc']['environment'].copy()
         for var, val in cenv.items():

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -1879,8 +1879,7 @@ conditions; see `cylc conditions`.
                 self.stop_clock_time))
             self.stop_clock_time = None
             return True
-        else:
-            return False
+        return False
 
     def _update_profile_info(self, category, amount, amount_format="%s"):
         """Update the 1, 5, 15 minute dt averages for a given category."""

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -971,11 +971,9 @@ conditions; see `cylc conditions`.
 
     def load_suiterc(self, is_reload=False):
         """Load, and log the suite definition."""
-        # Suite context is exported to the environment therein.
+        # Local suite environment set therein.
         self.config = SuiteConfig(
-            self.suite, self.suiterc, self.suite_dir, self.suite_run_dir,
-            self.suite_log_dir, self.suite_work_dir, self.suite_share_dir,
-            template_vars=self.template_vars,
+            self.suite, self.suiterc, self.template_vars,
             run_mode=self.run_mode,
             cli_initial_point_string=self.cli_initial_point_string,
             cli_start_point_string=self.cli_start_point_string,
@@ -986,6 +984,10 @@ conditions; see `cylc conditions`.
             output_fname=os.path.join(
                 self.suite_run_dir,
                 self.suite_srv_files_mgr.FILE_BASE_SUITE_RC + '.processed'),
+            run_dir=self.suite_run_dir,
+            log_dir=self.suite_log_dir,
+            work_dir=self.suite_work_dir,
+            share_dir=self.suite_share_dir,
         )
         self.suiterc_update_time = time()
         # Dump the loaded suiterc for future reference.

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -450,7 +450,6 @@ conditions; see `cylc conditions`.
         self.suite_db_mgr.put_suite_params(self)
         self.suite_db_mgr.put_suite_template_vars(self.template_vars)
         self.suite_db_mgr.put_runtime_inheritance(self.config)
-        self.configure_suite_environment()
 
         # Copy local python modules from source to run directory
         for sub_dir in ["python", os.path.join("lib", "python")]:
@@ -891,7 +890,6 @@ conditions; see `cylc conditions`.
         for task in add:
             LOG.warning("Added task: '%s'" % (task,))
 
-        self.configure_suite_environment()
         if self.options.genref or self.options.reftest:
             self.configure_reftest(recon=True)
         self.suite_db_mgr.put_suite_params(self)
@@ -972,9 +970,12 @@ conditions; see `cylc conditions`.
             self.contact_data = contact_data
 
     def load_suiterc(self, is_reload=False):
-        """Load and log the suite definition."""
+        """Load, and log the suite definition."""
+        # Suite context is exported to the environment therein.
         self.config = SuiteConfig(
-            self.suite, self.suiterc, self.template_vars,
+            self.suite, self.suiterc, self.suite_dir, self.suite_run_dir,
+            self.suite_log_dir, self.suite_work_dir, self.suite_share_dir,
+            template_vars=self.template_vars,
             run_mode=self.run_mode,
             cli_initial_point_string=self.cli_initial_point_string,
             cli_start_point_string=self.cli_start_point_string,
@@ -1013,12 +1014,7 @@ conditions; see `cylc conditions`.
         # self.config already alters the 'initial cycle point' for CLI.
         self.initial_point = self.config.initial_point
         self.start_point = self.config.start_point
-        self.final_point = get_point(
-            self.options.final_point_string or
-            self.config.cfg['scheduling']['final cycle point']
-        )
-        if self.final_point is not None:
-            self.final_point.standardise()
+        self.final_point = self.config.final_point
 
         if not self.initial_point and not self.is_restart:
             LOG.warning('No initial cycle point provided - no cycling tasks '
@@ -1026,6 +1022,19 @@ conditions; see `cylc conditions`.
 
         if self.run_mode != self.config.run_mode:
             self.run_mode = self.config.run_mode
+
+        # Pass static cylc and suite variables to job script generation code
+        self.task_job_mgr.job_file_writer.set_suite_env({
+            'CYLC_UTC': str(get_utc_mode()),
+            'CYLC_DEBUG': str(cylc.flags.debug).lower(),
+            'CYLC_VERBOSE': str(cylc.flags.verbose).lower(),
+            'CYLC_SUITE_NAME': self.suite,
+            'CYLC_CYCLING_MODE': str(
+                self.config.cfg['scheduling']['cycling mode']),
+            'CYLC_SUITE_INITIAL_CYCLE_POINT': str(self.initial_point),
+            'CYLC_SUITE_FINAL_CYCLE_POINT': str(self.final_point),
+        })
+
 
     def _load_suite_params_1(self, _, row):
         """Load previous initial cycle point or (warm) start cycle point.
@@ -1050,47 +1059,6 @@ conditions; see `cylc conditions`.
         # Command line argument takes precedence
         if key not in self.template_vars:
             self.template_vars[key] = value
-
-    def configure_suite_environment(self):
-        """Configure suite environment."""
-        # Pass static cylc and suite variables to job script generation code
-        self.task_job_mgr.job_file_writer.set_suite_env({
-            'CYLC_UTC': str(get_utc_mode()),
-            'CYLC_DEBUG': str(cylc.flags.debug).lower(),
-            'CYLC_VERBOSE': str(cylc.flags.verbose).lower(),
-            'CYLC_SUITE_NAME': self.suite,
-            'CYLC_CYCLING_MODE': str(
-                self.config.cfg['scheduling']['cycling mode']),
-            'CYLC_SUITE_INITIAL_CYCLE_POINT': str(self.initial_point),
-            'CYLC_SUITE_FINAL_CYCLE_POINT': str(self.final_point),
-        })
-
-        # Make suite vars available to [cylc][environment]:
-        for var, val in self.task_job_mgr.job_file_writer.suite_env.items():
-            os.environ[var] = val
-        # Set local values of variables that are potentially task-specific
-        # due to different directory paths on different task hosts. These
-        # are overridden by tasks prior to job submission, but in
-        # principle they could be needed locally by event handlers:
-        for var, val in [
-                ('CYLC_SUITE_RUN_DIR', self.suite_run_dir),
-                ('CYLC_SUITE_LOG_DIR', self.suite_log_dir),
-                ('CYLC_SUITE_WORK_DIR', self.suite_work_dir),
-                ('CYLC_SUITE_SHARE_DIR', self.suite_share_dir),
-                ('CYLC_SUITE_DEF_PATH', self.suite_dir)]:
-            os.environ[var] = val
-
-        # (global config auto expands environment variables in local paths)
-        cenv = self.config.cfg['cylc']['environment'].copy()
-        for var, val in cenv.items():
-            cenv[var] = os.path.expandvars(val)
-        # path to suite bin directory for suite and event handlers
-        cenv['PATH'] = os.pathsep.join([
-            os.path.join(self.suite_dir, 'bin'), os.environ['PATH']])
-
-        # and to suite event handlers in this process.
-        for var, val in cenv.items():
-            os.environ[var] = val
 
     def configure_reftest(self, recon=False):
         """Configure the reference test."""
@@ -1137,8 +1105,8 @@ conditions; see `cylc conditions`.
         """
         try:
             if (self.run_mode in ['simulation', 'dummy'] and
-                self.config.cfg['cylc']['simulation'][
-                    'disable suite event handlers']):
+                    self.config.cfg['cylc']['simulation'][
+                        'disable suite event handlers']):
                 return
         except KeyError:
             pass
@@ -1299,7 +1267,7 @@ conditions; see `cylc conditions`.
             else:
                 raise SchedulerStop(self.stop_mode)
         elif (self.time_next_kill is not None and
-                time() > self.time_next_kill):
+              time() > self.time_next_kill):
             self.command_poll_tasks()
             self.command_kill_tasks()
             self.time_next_kill = time() + self.INTERVAL_STOP_KILL
@@ -1314,12 +1282,10 @@ conditions; see `cylc conditions`.
             #           * Ensure the host can be safely taken down once the
             #             suite has stopped running.
             for itask in self.pool.get_tasks():
-                if (
-                    itask.state.status in TASK_STATUSES_ACTIVE
-                    and itask.summary['batch_sys_name']
-                    and self.task_job_mgr.batch_sys_mgr.is_job_local_to_host(
-                        itask.summary['batch_sys_name'])
-                ):
+                if (itask.state.status in TASK_STATUSES_ACTIVE and
+                        itask.summary['batch_sys_name'] and
+                        self.task_job_mgr.batch_sys_mgr.is_job_local_to_host(
+                            itask.summary['batch_sys_name'])):
                     LOG.info('Waiting for jobs running on localhost to '
                              'complete before attempting restart')
                     break
@@ -1504,10 +1470,8 @@ conditions; see `cylc conditions`.
                                 '    $ cylc restart %s', self.suite)
                             if self.set_auto_restart(mode=mode):
                                 return  # skip remaining health checks
-                        elif (
-                            self.set_auto_restart(current_glbl_cfg.get(
-                                ['suite servers', 'auto restart delay']))
-                        ):
+                        elif (self.set_auto_restart(current_glbl_cfg.get(
+                                ['suite servers', 'auto restart delay']))):
                             # server is condemned -> configure the suite to
                             # auto stop-restart if possible, else, report the
                             # issue preventing this

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -1037,12 +1037,12 @@ conditions; see `cylc conditions`.
             'CYLC_SUITE_FINAL_CYCLE_POINT': str(self.final_point),
         })
 
-
     def _load_suite_params_1(self, _, row):
         """Load previous initial cycle point or (warm) start cycle point.
 
         For restart, these may be missing from "suite.rc", but was specified as
         a command line argument on cold/warm start.
+
         """
         key, value = row
         if key == 'initial_point':


### PR DESCRIPTION
**Problem**
In order to have information available in the environment for template filters (Jinja2 ...etc), it needs to be exported before parsing/processing the suite.rc. For example I may want to reference the installed or source directory:
```
#!/usr/bin/env python

# Get items from suite run-dir file to create tasks...

import os

def get_file_items(ITEMS):
    suiterun = os.environ['CYLC_SUITE_RUN_DIR']
    infile = open(os.path.join(suiterun,'dat','items.dat'))
    ITEMS = [line.rstrip('\n') for line in infile]
    return ITEMS.sort()
```

With the run path not always being the same as the def/source path, and PWD not being consistent anyway, the alternative is to hard code this somewhere before running (or create some awkward workaround?).

The suite context is available locally after startup (on reload).

A test suite with the above (and below) filter might be:
```
#!/usr/bin/env python

# Get the current environment (maybe os module available in jinja?)

import os

def test_func(ENV_DIC):
    return ENV_DIC.update(os.environ)
```
```
#!Jinja2

[meta]
    title = Suite Env Jinja

{% set FROM_FILE = true %}

{% if FROM_FILE %}
    {% set ITEMS=[] | get_file_items %}
{% else %}
    {% set ITEMS = ['baz'] %}
{% endif %}

{% set ENV_DIC={} | test_func %}
{% for ITEM, VALUE in ENV_DIC.items() %}
# {{ITEM}} = {{VALUE}}
{% endfor %}

[cylc]
    cycle point format = CCYY
[scheduling]
    initial cycle point = 1
    final cycle point = 1
    [[dependencies]]
        graph = """
{% for ITEM in ITEMS %}
{{ ITEM }}
{% endfor %}
"""
[runtime]
    [[root]]
        [[[environment]]]
{% if FROM_FILE %}
            KEYS = small_key
            VALS = chest-padlock
{% else %}
            KEYS = big_key,mediam_key
            VALS = house,garage
{% endif %}

{% for ITEM in ITEMS %}
    [[{{ ITEM }}]]
        script = """

IFS=', ' read -r -a k_ray <<< "$KEYS"
IFS=', ' read -r -a v_ray <<< "$VALS"

for index in "${!k_ray[@]}"; do
    echo "unlocking {{ ITEM }} ${v_ray[index]} with ${k_ray[index]}"
    if [[ "${v_ray[index]}" == *"chest"* ]]; then
        echo 'You Struck Gold!!! $$$'
    fi
done
echo
"""
{% endfor %}
```


**Solution**
There doesn't appear to be a reason why the suite context can't be set in the local environment before parsing the suite config. So this is what I've done.
However, to make the same functionality work for getting config and graph information via the CLI, I had to shift the exports out of the `schedular.py` and into the `config.py` (rather than just exporting before the SuiteConfig instantiation).

(remote host might need tested, as I didn't set that up, even though the other tests passed)

Note: if this passes standard, I'll make a branch for pull request to `7.8.x`...