### PR TITLE
Fix missing python2 hash-bang lines.

### DIFF
--- a/bin/cylc-get-host-metrics
+++ b/bin/cylc-get-host-metrics
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
 # Copyright (C) 2008-2019 NIWA

--- a/etc/dev-suites/xtrigger/kafka/consumer/lib/python/cylc_kafka_consumer.py
+++ b/etc/dev-suites/xtrigger/kafka/consumer/lib/python/cylc_kafka_consumer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """
 A generic Kakfa consumer for use as a Cylc external trigger function.
 

--- a/etc/dev-suites/xtrigger/kafka/producer/bin/cylc_kafka_producer.py
+++ b/etc/dev-suites/xtrigger/kafka/producer/bin/cylc_kafka_producer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """
 A generic Kafka producer for use as a Cylc event handler.
 

--- a/lib/cylc/cycling/util.py
+++ b/lib/cylc/cycling/util.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
 # Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.

--- a/lib/cylc/review.py
+++ b/lib/cylc/review.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
 # Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.

--- a/lib/cylc/ws.py
+++ b/lib/cylc/ws.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
 # Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.

--- a/lib/cylc/xtrigger_mgr.py
+++ b/lib/cylc/xtrigger_mgr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
 # Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.

--- a/lib/cylc/xtriggers/echo.py
+++ b/lib/cylc/xtriggers/echo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
 # Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.

--- a/lib/cylc/xtriggers/suite_state.py
+++ b/lib/cylc/xtriggers/suite_state.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
 # Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.

--- a/lib/cylc/xtriggers/wall_clock.py
+++ b/lib/cylc/xtriggers/wall_clock.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
 # Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.

--- a/lib/cylc/xtriggers/xrandom.py
+++ b/lib/cylc/xtriggers/xrandom.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
 # Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.

--- a/lib/parsec/empysupport.py
+++ b/lib/parsec/empysupport.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
 # Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.

--- a/tests/xtriggers/02-persistence/faker_fail.py
+++ b/tests/xtriggers/02-persistence/faker_fail.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 def faker(name, debug=False):
     print "%s: failing" % name

--- a/tests/xtriggers/02-persistence/faker_succ.py
+++ b/tests/xtriggers/02-persistence/faker_succ.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 def faker(name, debug=False):
     print "%s: succeeding" % name


### PR DESCRIPTION
Fix a few `#!/usr/bin/env python(2)` lines.  For 7.8.x.

One review should do.

(My own env currently defaults to Python 3).