### PR TITLE
Ignore sphinx built-sphinx-single directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,9 @@
 # Generated documentation files (from 'cylc make-docs')
 # - Command reference from called script 'custom/make-commands.sh'.
 doc/src/appendices/command-ref.rst
-# - Main directory of generated sphinx docs (guides) files.
+# - Main directories of generated sphinx docs (guides) files.
 doc/built-sphinx/
+doc/built-sphinx-single/
 # - Installed docs
 doc/install/
 


### PR DESCRIPTION
I think we need to ignore the directory with the generated single page for sphinx? It appeared in my git changes are `cylc make-docs`.