### PR TITLE
config: more helpful error message on cli misuse

### DIFF
--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -83,16 +83,9 @@ def check_varnames(env):
 
 
 class SuiteConfigError(Exception):
-    """
-    Attributes:
-        message - what the problem is.
-        TODO - element - config element causing the problem
-    """
-    def __init__(self, msg):
-        self.msg = msg
+    """Catch all exception for suite configuration errors."""
+    pass
 
-    def __str__(self):
-        return repr(self.msg)
 
 # TODO: separate config for run and non-run purposes?
 
@@ -228,10 +221,15 @@ class SuiteConfig(object):
                 fcp = self.cfg['scheduling'].get('final cycle point')
                 if just_has_async_graph and not (
                         icp in [None, "1"] and fcp in [None, icp]):
-                    raise SuiteConfigError(
-                        'Conflicting syntax: integer vs ' +
-                        'cycling suite: ' +
-                        'are you missing a [dependencies][[[R1]]] section?')
+                    msg = (
+                        'Conflicting syntax: integer vs cycling suite:'
+                        '\n* Are you missing a [dependencies][R1] section?')
+                    if cli_initial_point_string:
+                        msg += (
+                            '\n* Did you mean to provide "%s" as the initial '
+                            'cycle point?' % cli_initial_point_string)
+                    raise SuiteConfigError(msg)
+
                 if just_has_async_graph:
                     # There aren't any other graphs, so set integer cycling.
                     self.cfg['scheduling']['cycling mode'] = (

--- a/tests/cli/00-cycle-points.t
+++ b/tests/cli/00-cycle-points.t
@@ -20,7 +20,7 @@
 
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
-set_test_number 4
+set_test_number 6
 #-------------------------------------------------------------------------------
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
@@ -37,5 +37,12 @@ suite_run_ok $TEST_NAME cylc run --until=2015-04 --debug --no-detach $SUITE_NAME
 TEST_NAME=$TEST_NAME_BASE-run-fail
 # This should fail as the final cycle point  is < the initial one.
 suite_run_fail $TEST_NAME cylc run --until=2015-03 --debug --no-detach $SUITE_NAME 2015-04
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-invalid-syntax-conflict
+# This should fail as the final cycle point  is < the initial one.
+suite_run_fail $TEST_NAME cylc run --debug --no-detach $SUITE_NAME invalid \
+    -s 'INTEGER=True'
+grep_ok 'Did you mean to provide "invalid" as the initial cycle point?' \
+    "${TEST_NAME}.stderr"
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/cli/00-cycle-points/suite.rc
+++ b/tests/cli/00-cycle-points/suite.rc
@@ -1,13 +1,18 @@
+#!Jinja2
 [cylc]
     UTC mode = true
     [[events]]
         abort on timeout = true
         timeout = PT20S
 [scheduling]
+{% if INTEGER is not defined %}
     initial cycle point = 2015-01
     final cycle point = 2015-01
+{% endif %}
     [[dependencies]]
+{% if INTEGER is not defined %}
         [[[P1D]]]
+{% endif %}
             graph = foo
 [runtime]
     [[foo]]

--- a/tests/cyclers/28-implicit-disallowed.t
+++ b/tests/cyclers/28-implicit-disallowed.t
@@ -27,7 +27,7 @@ run_fail $TEST_NAME cylc validate $SUITE_NAME
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-cmp
 cmp_ok $TEST_NAME_BASE-validate.stderr <<__ERR__
-'ERROR: No cycling sequences defined for foo'
+ERROR: No cycling sequences defined for foo
 __ERR__
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/events/36-task-event-bad-custom-template.t
+++ b/tests/events/36-task-event-bad-custom-template.t
@@ -26,7 +26,7 @@ fi
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 run_fail "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
 cmp_ok "${TEST_NAME_BASE}-validate.stderr" <<'__ERR__'
-"ERROR: bad task event handler template t1: echo %(rubbish)s: KeyError('rubbish',)"
+ERROR: bad task event handler template t1: echo %(rubbish)s: KeyError('rubbish',)
 __ERR__
 suite_run_ok "${TEST_NAME_BASE}-run" \
     cylc run --reference-test --debug --no-detach "${SUITE_NAME}"

--- a/tests/inheritance/01-circular.t
+++ b/tests/inheritance/01-circular.t
@@ -27,7 +27,7 @@ run_fail $TEST_NAME cylc validate $SUITE_NAME
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-cmp
 cmp_ok $TEST_NAME_BASE-validate.stderr <<__ERR__
-'ERROR: circular [runtime] inheritance?'
+ERROR: circular [runtime] inheritance?
 __ERR__
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/validate/10-bad-recurrence.t
+++ b/tests/validate/10-bad-recurrence.t
@@ -36,7 +36,7 @@ cat >'suite.rc' <<'__SUITE__'
 __SUITE__
 run_fail "${TEST_NAME}" cylc validate 'suite.rc'
 cmp_ok "${TEST_NAME}.stderr" <<'__ERR__'
-'ERROR: Cannot process recurrence R/T00/PT5D (initial cycle point=20140101T0000+01) (final cycle point=20140201T0000+01)'
+ERROR: Cannot process recurrence R/T00/PT5D (initial cycle point=20140101T0000+01) (final cycle point=20140201T0000+01)
 __ERR__
 
 TEST_NAME="${TEST_NAME_BASE}-old-icp"
@@ -54,7 +54,7 @@ cat >'suite.rc' <<'__SUITE__'
 __SUITE__
 run_fail "${TEST_NAME}" cylc validate 'suite.rc'
 cmp_ok "${TEST_NAME}.stderr" <<'__ERR__'
-"ERROR: Cannot process recurrence R1/P0D (initial cycle point=20140101T0000Z) (final cycle point=None) 'This suite requires a final cycle point.'"
+ERROR: Cannot process recurrence R1/P0D (initial cycle point=20140101T0000Z) (final cycle point=None) 'This suite requires a final cycle point.'
 __ERR__
 
 TEST_NAME="${TEST_NAME_BASE}-2-digit-century"
@@ -75,7 +75,7 @@ cat >'suite.rc' <<'__SUITE__'
 __SUITE__
 run_fail "${TEST_NAME}" cylc validate 'suite.rc'
 cmp_ok "${TEST_NAME}.stderr" <<'__ERR__'
-'ERROR: Cannot process recurrence R/00/P5D (initial cycle point=20140101T0000+01) (final cycle point=20140201T0000+01) "\'00\': 2 digit centuries not allowed. Did you mean T-digit-digit e.g. \'T00\'?"'
+ERROR: Cannot process recurrence R/00/P5D (initial cycle point=20140101T0000+01) (final cycle point=20140201T0000+01) "'00': 2 digit centuries not allowed. Did you mean T-digit-digit e.g. 'T00'?"
 __ERR__
 
 TEST_NAME="${TEST_NAME_BASE}-old-recurrences"
@@ -90,7 +90,7 @@ cat >'suite.rc' <<'__SUITE__'
 __SUITE__
 run_fail "${TEST_NAME}" cylc validate 'suite.rc'
 cmp_ok "${TEST_NAME}.stderr" <<'__ERR__'
-'ERROR: Cannot process recurrence 0 (initial cycle point=20100101T0000+01) (final cycle point=None) "\'0\': not a valid cylc-shorthand or full ISO 8601 date representation"'
+ERROR: Cannot process recurrence 0 (initial cycle point=20100101T0000+01) (final cycle point=None) "'0': not a valid cylc-shorthand or full ISO 8601 date representation"
 __ERR__
 
 TEST_NAME="${TEST_NAME_BASE}-old-cycle-point-format"
@@ -105,7 +105,7 @@ cat >'suite.rc' <<'__SUITE__'
 __SUITE__
 run_fail "${TEST_NAME}" cylc validate 'suite.rc'
 cmp_ok "${TEST_NAME}.stderr" <<'__ERR__'
-'ERROR: Cannot process recurrence R1 (initial cycle point=2010010101) (final cycle point=None) "\'2010010101\': not a valid cylc-shorthand or full ISO 8601 date representation"'
+ERROR: Cannot process recurrence R1 (initial cycle point=2010010101) (final cycle point=None) "'2010010101': not a valid cylc-shorthand or full ISO 8601 date representation"
 __ERR__
 
 exit

--- a/tests/validate/17-fail-old-syntax-6.t
+++ b/tests/validate/17-fail-old-syntax-6.t
@@ -24,8 +24,8 @@ install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE
 run_fail $TEST_NAME cylc validate --debug -v $SUITE_NAME
-grep_ok "'Obsolete syntax: mixed integer \[dependencies\]graph with cycling \
-\[dependencies\]\[12\]'" $TEST_NAME.stderr
+grep_ok "Obsolete syntax: mixed integer \[dependencies\]graph with cycling \
+\[dependencies\]\[12\]" $TEST_NAME.stderr
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME
 exit

--- a/tests/validate/37-clock-trigger-task-not-defined.t
+++ b/tests/validate/37-clock-trigger-task-not-defined.t
@@ -32,6 +32,6 @@ cat >'suite.rc' <<'__SUITE_RC__'
 __SUITE_RC__
 run_fail "${TEST_NAME_BASE}" cylc validate --strict "${PWD}/suite.rc"
 cmp_ok "${TEST_NAME_BASE}.stderr" <<'__ERR__'
-'ERROR: clock-trigger task "foo" is not defined.'
+ERROR: clock-trigger task "foo" is not defined.
 __ERR__
 exit

--- a/tests/validate/64-circular.t
+++ b/tests/validate/64-circular.t
@@ -28,7 +28,7 @@ __SUITE_RC__
 
 run_fail "${TEST_NAME_BASE}-simple-1" cylc validate 'suite.rc'
 contains_ok "${TEST_NAME_BASE}-simple-1.stderr" <<'__ERR__'
-'ERROR, self-edge detected: a:succeed => a'
+ERROR, self-edge detected: a:succeed => a
 __ERR__
 
 cat >'suite.rc' <<'__SUITE_RC__'
@@ -39,7 +39,7 @@ __SUITE_RC__
 
 run_fail "${TEST_NAME_BASE}-simple-2" cylc validate 'suite.rc'
 contains_ok "${TEST_NAME_BASE}-simple-2.stderr" <<'__ERR__'
-'ERROR: circular edges detected:  d.1 => a.1  a.1 => b.1  b.1 => c.1  c.1 => d.1'
+ERROR: circular edges detected:  d.1 => a.1  a.1 => b.1  b.1 => c.1  c.1 => d.1
 __ERR__
 
 cat >'suite.rc' <<'__SUITE_RC__'
@@ -54,7 +54,7 @@ __SUITE_RC__
 
 run_fail "${TEST_NAME_BASE}-simple-fam" cylc validate 'suite.rc'
 contains_ok "${TEST_NAME_BASE}-simple-fam.stderr" <<'__ERR__'
-'ERROR, self-edge detected: g:succeed => g'
+ERROR, self-edge detected: g:succeed => g
 __ERR__
 
 cat >'suite.rc' <<'__SUITE_RC__'
@@ -73,7 +73,7 @@ __SUITE_RC__
 
 run_fail "${TEST_NAME_BASE}-intercycle-1" cylc validate 'suite.rc'
 contains_ok "${TEST_NAME_BASE}-intercycle-1.stderr" <<'__ERR__'
-'ERROR: circular edges detected:  a.2002 => a.2001  a.2001 => a.2002  a.2003 => a.2002  a.2002 => a.2003'
+ERROR: circular edges detected:  a.2002 => a.2001  a.2001 => a.2002  a.2003 => a.2002  a.2002 => a.2003
 __ERR__
 
 cat >'suite.rc' <<'__SUITE_RC__'
@@ -89,7 +89,7 @@ __SUITE_RC__
 
 run_fail "${TEST_NAME_BASE}-intercycle-2" cylc validate 'suite.rc'
 contains_ok "${TEST_NAME_BASE}-intercycle-2.stderr" <<'__ERR__'
-'ERROR: circular edges detected:  foo.8 => bar.8  bar.8 => baz.8  baz.8 => foo.8'
+ERROR: circular edges detected:  foo.8 => bar.8  bar.8 => baz.8  baz.8 => foo.8
 __ERR__
 
 cat >'suite.rc' <<'__SUITE_RC__'
@@ -106,7 +106,7 @@ __SUITE_RC__
 
 run_fail "${TEST_NAME_BASE}-param-1" cylc validate 'suite.rc'
 contains_ok "${TEST_NAME_BASE}-param-1.stderr" <<'__ERR__'
-'ERROR: circular edges detected:  fool_foo2.1 => fool_foo1.1  fool_foo1.1 => fool_foo2.1'
+ERROR: circular edges detected:  fool_foo2.1 => fool_foo1.1  fool_foo1.1 => fool_foo2.1
 __ERR__
 
 cat >'suite.rc' <<'__SUITE_RC__'

--- a/tests/validate/65-bad-task-event-handler-tmpl.t
+++ b/tests/validate/65-bad-task-event-handler-tmpl.t
@@ -33,7 +33,7 @@ cat >'suite.rc' <<'__SUITE_RC__'
 __SUITE_RC__
 run_fail "${TEST_NAME}" cylc validate 'suite.rc'
 cmp_ok "${TEST_NAME}.stderr" <<'__ERR__'
-"ERROR: bad task event handler template t1: echo %(rubbish)s: KeyError('rubbish',)"
+ERROR: bad task event handler template t1: echo %(rubbish)s: KeyError('rubbish',)
 __ERR__
 
 TEST_NAME="${TEST_NAME_BASE}-bad-value"
@@ -49,7 +49,7 @@ cat >'suite.rc' <<'__SUITE_RC__'
 __SUITE_RC__
 run_fail "${TEST_NAME}" cylc validate 'suite.rc'
 cmp_ok "${TEST_NAME}.stderr" <<'__ERR__'
-"ERROR: bad task event handler template t1: echo %(ids: ValueError('incomplete format key',)"
+ERROR: bad task event handler template t1: echo %(ids: ValueError('incomplete format key',)
 __ERR__
 
 exit


### PR DESCRIPTION
Response to user request for more informative feedback in the event that a user misses a `-s` flag when attempting to run a non-cycling suite e.g:

```console
$ cylc run mysuite FOO=BAR
...
Conflicting syntax: 'integer vs cycling suite: are you missing a [dependencies][[[R1]]] section?'
```

It's difficult to provide suggestive feedback as it is not clear what the user's intent was. Also there are other ways we could end up with a malformed `=` separated pair on the CLI.

```console
$ cylc run mysuite mode=simulation
```