### PR TITLE
task remote init: fix strange tempfile issue

### DIFF
--- a/bin/cylc-check-versions
+++ b/bin/cylc-check-versions
@@ -43,7 +43,7 @@ import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc import __version__ as CYLC_VERSION
 from cylc.config import SuiteConfig
-from cylc.subprocpool import SuiteProcPool
+from cylc.subprocpool import SubProcPool
 from cylc.suite_srv_files_mgr import SuiteSrvFilesManager
 from cylc.task_remote_mgr import TaskRemoteMgr
 from cylc.templatevars import load_template_vars
@@ -73,7 +73,7 @@ def main():
             config.get_config(['runtime', name, 'remote', 'owner']),
             config.get_config(['runtime', name, 'remote', 'host'])))
     task_remote_mgr = TaskRemoteMgr(
-        suite, SuiteProcPool(), suite_srv_files_mgr)
+        suite, SubProcPool(), suite_srv_files_mgr)
     for _, host_str in account_set:
         task_remote_mgr.remote_host_select(host_str)
     accounts = []

--- a/bin/cylc-submit
+++ b/bin/cylc-submit
@@ -43,7 +43,7 @@ from cylc.cfgspec.glbl_cfg import glbl_cfg
 from cylc.config import SuiteConfig
 from cylc.cycling.loader import get_point
 import cylc.flags
-from cylc.subprocpool import SuiteProcPool
+from cylc.subprocpool import SubProcPool
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.suite_db_mgr import SuiteDatabaseManager
 from cylc.broadcast_mgr import BroadcastMgr
@@ -104,7 +104,7 @@ def main():
 
     # Initialise job submit environment
     glbl_cfg().create_cylc_run_tree(suite)
-    pool = SuiteProcPool()
+    pool = SubProcPool()
     db_mgr = SuiteDatabaseManager()
     task_job_mgr = TaskJobManager(
         suite, pool, db_mgr, suite_srv_mgr,

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -48,7 +48,7 @@ from cylc.log_diagnosis import LogSpec
 from cylc.network.server import SuiteRuntimeServer
 from cylc.profiler import Profiler
 from cylc.state_summary_mgr import StateSummaryMgr
-from cylc.subprocpool import SuiteProcPool
+from cylc.subprocpool import SubProcPool
 from cylc.suite_db_mgr import SuiteDatabaseManager
 from cylc.suite_events import (
     SuiteEventContext, SuiteEventError, SuiteEventHandler)
@@ -351,7 +351,7 @@ conditions; see `cylc conditions`.
         self.profiler.log_memory("scheduler.py: start configure")
 
         # Start up essential services
-        self.proc_pool = SuiteProcPool()
+        self.proc_pool = SubProcPool()
         self.state_summary_mgr = StateSummaryMgr()
         self.command_queue = Queue()
         self.message_queue = Queue()

--- a/lib/cylc/subprocctx.py
+++ b/lib/cylc/subprocctx.py
@@ -47,8 +47,9 @@ class SubProcContext(object):
                     Default return code.
                 shell (boolean):
                     Launch command with "/bin/sh"?
-                stdin_file_paths (list):
+                stdin_files (list):
                     Files with content to send to command's STDIN.
+                    Can be file paths or opened file handles.
                 stdin_str (str):
                     Content to send to command's STDIN.
         .err (str):
@@ -84,9 +85,9 @@ class SubProcContext(object):
             value = getattr(self, attr, None)
             if value is not None and str(value).strip():
                 mesg = ''
-                if attr == 'cmd' and self.cmd_kwargs.get('stdin_file_paths'):
+                if attr == 'cmd' and self.cmd_kwargs.get('stdin_files'):
                     mesg += 'cat'
-                    for file_path in self.cmd_kwargs.get('stdin_file_paths'):
+                    for file_path in self.cmd_kwargs.get('stdin_files'):
                         mesg += ' ' + quote(file_path)
                     mesg += ' | '
                 if attr == 'cmd' and isinstance(value, list):

--- a/lib/cylc/subprocpool.py
+++ b/lib/cylc/subprocpool.py
@@ -91,16 +91,16 @@ def run_function(func_name, json_args, json_kwargs, src_dir):
     sys.stdout.write(json.dumps(res))
 
 
-class SuiteProcPool(object):
+class SubProcPool(object):
     """Manage queueing and pooling of subprocesses.
 
     This is mainly used by the main loop of the suite server program, although
-    the SuiteProcPool.run_command can be used as a standalone utility function
+    the SubProcPool.run_command can be used as a standalone utility function
     to run the command in a cylc.subprocctx.SubProcContext.
 
     A command to run under a subprocess in the pool is expected to be wrapped
     using a cylc.subprocctx.SubProcContext object. The caller will add the
-    context object using the SuiteProcPool.put_command method. A callback can
+    context object using the SubProcPool.put_command method. A callback can
     be specified to notify the caller on exit of the subprocess.
 
     A command launched by the pool is expected to write to STDOUT and STDERR.
@@ -311,15 +311,20 @@ class SuiteProcPool(object):
     def _run_command_init(cls, ctx, callback=None, callback_args=None):
         """Prepare and launch shell command in ctx."""
         try:
-            if ctx.cmd_kwargs.get('stdin_file_paths'):
-                if len(ctx.cmd_kwargs['stdin_file_paths']) > 1:
+            if ctx.cmd_kwargs.get('stdin_files'):
+                if len(ctx.cmd_kwargs['stdin_files']) > 1:
                     stdin_file = TemporaryFile()
-                    for file_path in ctx.cmd_kwargs['stdin_file_paths']:
-                        stdin_file.write(open(file_path, 'rb').read())
+                    for file_ in ctx.cmd_kwargs['stdin_files']:
+                        if hasattr(file_, 'read'):
+                            stdin_file.write(file_.read())
+                        else:
+                            stdin_file.write(open(file_, 'rb').read())
                     stdin_file.seek(0)
+                elif hasattr(ctx.cmd_kwargs['stdin_files'][0], 'read'):
+                    stdin_file = ctx.cmd_kwargs['stdin_files'][0]
                 else:
                     stdin_file = open(
-                        ctx.cmd_kwargs['stdin_file_paths'][0], 'rb')
+                        ctx.cmd_kwargs['stdin_files'][0], 'rb')
             elif ctx.cmd_kwargs.get('stdin_str'):
                 stdin_file = TemporaryFile('bw+')
                 stdin_file.write(ctx.cmd_kwargs.get('stdin_str').encode())

--- a/lib/cylc/task_job_mgr.py
+++ b/lib/cylc/task_job_mgr.py
@@ -43,7 +43,7 @@ from cylc.job_file import JobFileWriter
 from cylc.task_job_logs import (
     JOB_LOG_JOB, get_task_job_log, get_task_job_job_log,
     get_task_job_activity_log, get_task_job_id, NN)
-from cylc.subprocpool import SuiteProcPool
+from cylc.subprocpool import SubProcPool
 from cylc.subprocctx import SubProcContext
 from cylc.task_action_timer import TaskActionTimer
 from cylc.task_events_mgr import TaskEventsManager, log_task_job_activity
@@ -74,7 +74,7 @@ class TaskJobManager(object):
 
     JOBS_KILL = 'jobs-kill'
     JOBS_POLL = 'jobs-poll'
-    JOBS_SUBMIT = SuiteProcPool.JOBS_SUBMIT
+    JOBS_SUBMIT = SubProcPool.JOBS_SUBMIT
     POLL_FAIL = 'poll failed'
     REMOTE_SELECT_MSG = 'waiting for remote host selection'
     REMOTE_INIT_MSG = 'remote host initialising'
@@ -296,11 +296,11 @@ class TaskJobManager(object):
                 '%s ... # will invoke in batches, sizes=%s',
                 cmd, [len(b) for b in itasks_batches])
             for i, itasks_batch in enumerate(itasks_batches):
-                stdin_file_paths = []
+                stdin_files = []
                 job_log_dirs = []
                 for itask in itasks_batch:
                     if remote_mode:
-                        stdin_file_paths.append(
+                        stdin_files.append(
                             get_task_job_job_log(
                                 suite, itask.point, itask.tdef.name,
                                 itask.submit_num))
@@ -317,7 +317,7 @@ class TaskJobManager(object):
                     SubProcContext(
                         self.JOBS_SUBMIT,
                         cmd + job_log_dirs,
-                        stdin_file_paths=stdin_file_paths,
+                        stdin_files=stdin_files,
                         job_log_dirs=job_log_dirs,
                         **kwargs
                     ),
@@ -713,7 +713,7 @@ class TaskJobManager(object):
                 ctx.cmd = cmd_ctx.cmd  # print original command on failure
         log_task_job_activity(ctx, suite, itask.point, itask.tdef.name)
 
-        if ctx.ret_code == SuiteProcPool.RET_CODE_SUITE_STOPPING:
+        if ctx.ret_code == SubProcPool.RET_CODE_SUITE_STOPPING:
             return
 
         try:

--- a/lib/cylc/task_remote_mgr.py
+++ b/lib/cylc/task_remote_mgr.py
@@ -29,7 +29,7 @@ from shlex import quote
 import re
 from subprocess import Popen, PIPE
 import tarfile
-from tempfile import NamedTemporaryFile
+from tempfile import TemporaryFile
 from time import time
 
 from cylc import LOG
@@ -195,8 +195,9 @@ class TaskRemoteMgr(object):
             self.remote_init_map[(host, owner)] = REMOTE_INIT_NOT_REQUIRED
             return self.remote_init_map[(host, owner)]
 
-        # Create "stdin_file_paths" file, with "items" in it.
-        tmphandle = NamedTemporaryFile()
+        # Create a TAR archive with the service files,
+        # so they can be sent later via SSH's STDIN to the task remote.
+        tmphandle = TemporaryFile()
         tarhandle = tarfile.open(fileobj=tmphandle, mode='w')
         for path, arcname in items:
             tarhandle.add(path, arcname=arcname)
@@ -222,8 +223,7 @@ class TaskRemoteMgr(object):
         cmd.append(glbl_cfg().get_derived_host_item(
             self.suite, 'suite run directory', host, owner))
         self.proc_pool.put_command(
-            SubProcContext(
-                'remote-init', cmd, stdin_file_paths=[tmphandle.name]),
+            SubProcContext('remote-init', cmd, stdin_files=[tmphandle]),
             self._remote_init_callback,
             [host, owner, tmphandle])
         # None status: Waiting for command to finish

--- a/lib/cylc/tests/test_subprocpool.py
+++ b/lib/cylc/tests/test_subprocpool.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python2
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from tempfile import NamedTemporaryFile, TemporaryFile
+import unittest
+
+from cylc.subprocctx import SubProcContext
+from cylc.subprocpool import SubProcPool
+
+
+class TestSubProcPool(unittest.TestCase):
+
+    def test_run_command_returns_0(self):
+        """Test basic usage, command returns 0"""
+        ctx = SubProcContext('truth', ['true'])
+        SubProcPool.run_command(ctx)
+        self.assertEqual(ctx.err, '')
+        self.assertEqual(ctx.out, '')
+        self.assertEqual(ctx.ret_code, 0)
+
+    def test_run_command_returns_1(self):
+        """Test basic usage, command returns 1"""
+        ctx = SubProcContext('lies', ['false'])
+        SubProcPool.run_command(ctx)
+        self.assertEqual(ctx.err, '')
+        self.assertEqual(ctx.out, '')
+        self.assertEqual(ctx.ret_code, 1)
+
+    def test_run_command_writes_to_out(self):
+        """Test basic usage, command writes to STDOUT"""
+        ctx = SubProcContext('parrot', ['echo', 'pirate', 'urrrr'])
+        SubProcPool.run_command(ctx)
+        self.assertEqual(ctx.err, '')
+        self.assertEqual(ctx.out, 'pirate urrrr\n')
+        self.assertEqual(ctx.ret_code, 0)
+
+    def test_run_command_writes_to_err(self):
+        """Test basic usage, command writes to STDERR"""
+        ctx = SubProcContext(
+            'parrot2', ['bash', '-c', 'echo pirate errrr >&2'])
+        SubProcPool.run_command(ctx)
+        self.assertEqual(ctx.err, 'pirate errrr\n')
+        self.assertEqual(ctx.out, '')
+        self.assertEqual(ctx.ret_code, 0)
+
+    def test_run_command_with_stdin_from_str(self):
+        """Test STDIN from string"""
+        ctx = SubProcContext('meow', ['cat'], stdin_str='catches mice.\n')
+        SubProcPool.run_command(ctx)
+        self.assertEqual(ctx.err, '')
+        self.assertEqual(ctx.out, 'catches mice.\n')
+        self.assertEqual(ctx.ret_code, 0)
+
+    def test_run_command_with_stdin_from_handle(self):
+        """Test STDIN from a single opened file handle"""
+        handle = TemporaryFile()
+        handle.write('catches mice.\n'.encode('UTF-8'))
+        handle.seek(0)
+        ctx = SubProcContext('meow', ['cat'], stdin_files=[handle])
+        SubProcPool.run_command(ctx)
+        self.assertEqual(ctx.err, '')
+        self.assertEqual(ctx.out, 'catches mice.\n')
+        self.assertEqual(ctx.ret_code, 0)
+        handle.close()
+
+    def test_run_command_with_stdin_from_path(self):
+        """Test STDIN from a single file path"""
+        handle = NamedTemporaryFile()
+        handle.write('catches mice.\n'.encode('UTF-8'))
+        handle.seek(0)
+        ctx = SubProcContext('meow', ['cat'], stdin_files=[handle.name])
+        SubProcPool.run_command(ctx)
+        self.assertEqual(ctx.err, '')
+        self.assertEqual(ctx.out, 'catches mice.\n')
+        self.assertEqual(ctx.ret_code, 0)
+        handle.close()
+
+    def test_run_command_with_stdin_from_handles(self):
+        """Test STDIN from multiple file handles"""
+        handles = []
+        for txt in ['catches mice.\n', 'eat fish.\n']:
+            handle = TemporaryFile()
+            handle.write(txt.encode('UTF-8'))
+            handle.seek(0)
+            handles.append(handle)
+        ctx = SubProcContext('meow', ['cat'], stdin_files=handles)
+        SubProcPool.run_command(ctx)
+        self.assertEqual(ctx.err, '')
+        self.assertEqual(ctx.out, 'catches mice.\neat fish.\n')
+        self.assertEqual(ctx.ret_code, 0)
+        for handle in handles:
+            handle.close()
+
+    def test_run_command_with_stdin_from_paths(self):
+        """Test STDIN from multiple file paths"""
+        handles = []
+        for txt in ['catches mice.\n', 'eat fish.\n']:
+            handle = NamedTemporaryFile()
+            handle.write(txt.encode('UTF-8'))
+            handle.seek(0)
+            handles.append(handle)
+        ctx = SubProcContext(
+            'meow', ['cat'], stdin_files=[handle.name for handle in handles])
+        SubProcPool.run_command(ctx)
+        self.assertEqual(ctx.err, '')
+        self.assertEqual(ctx.out, 'catches mice.\neat fish.\n')
+        self.assertEqual(ctx.ret_code, 0)
+        for handle in handles:
+            handle.close()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Users are experiencing issues on one of the platforms we deploy Cylc
where remote submission fails intermittently with a file not found error
complaining that a temporary file cannot be found. (The file is used for
piping service files as a tar archive via STDIN (to the SSH) command.) This should not
be the case, as the temporary file handle should still be referenced,
but clearly there was an issue.

In this change, we pass the temporary file handle directly instead of
passing the name of the temporary file to the process pool. This appears
to fix the issue. (Note: Before #2590, we were unable to pass the file
handle because the context needs to be serialised for the
multiprocessing.Pool. This is no longer a requirement in our own
subprocess pool, so it is now safe to pass the handle.)

Previously flow of logic roughly looks like this:
```python
# In cylc.task_remote_mgr.TaskRemoteMgr.remote_init:
handle = NamedTemporaryFile()
# ... write to handle, and seek to position 0
# ... pass the "tmphandle" to the subprocess pool by file name
self.proc_pool.put_command(SubProcContext(..., [tmphandle.name], ...))
# ... time passes
# ... cylc.subprocpool.SubProcPool._run_command_init opens the the file
stdin_file = open(ctx.cmd_kwargs['stdin_file_paths'][0], 'rb')  # <= FAILED HERE
# ... SubProcPool done with command
# In cylc.task_remote_mgr.TaskRemoteMgr._remote_init_callback:
tmphandle.close()  # Should delete tmphandle.name as well
```

The new flow of logic roughly looks like this:
```python
# In cylc.task_remote_mgr.TaskRemoteMgr.remote_init:
handle = NamedTemporaryFile()
# ... write to handle, and seek to position 0
# ... pass the "tmphandle" to the subprocess pool by file handle
self.proc_pool.put_command(SubProcContext(..., [tmphandle], ...))
# ... time passes
# ... cylc.subprocpool.SubProcPool._run_command_init opens the the file
if hasattr(ctx.cmd_kwargs['stdin_file_paths'][0], 'read'):
    stdin_file = ctx.cmd_kwargs['stdin_file_paths'][0]
else:
    # as before
# ... SubProcPool done with command
# In cylc.task_remote_mgr.TaskRemoteMgr._remote_init_callback:
tmphandle.close()  # Should delete tmphandle.name as well
```

Also renamed `SuiteProcPool` to `SubProcPool` to match module name and `SubProcContext`.