### PR TITLE
Use calculated event_time instead of new current_time call

### DIFF
--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -693,7 +693,7 @@ class TaskEventsManager(object):
         if event_time is None:
             event_time = get_current_time_string()
         self.suite_db_mgr.put_update_task_jobs(itask, {
-            "time_submit_exit": get_current_time_string(),
+            "time_submit_exit": event_time,
             "submit_status": 1,
         })
         itask.summary['submit_method_id'] = None


### PR DESCRIPTION
Fix #2977 