### PR TITLE
Fix issue #2898: close app nicely on CTRL+C

### DIFF
--- a/bin/cylc-gui
+++ b/bin/cylc-gui
@@ -107,12 +107,15 @@ def main():
             print >> sys.stderr, ('USER_AT_HOST must take the form '
                                   '"user@host:port"')
             sys.exit(1)
-    ControlApp(
+    app = ControlApp(
         suite, options.owner, options.host,
         options.port, options.comms_timeout,
         load_template_vars(options.templatevars, options.templatevars_file),
         options.restricted)
-    gtk.main()
+    try:
+        gtk.main()
+    except KeyboardInterrupt:
+        app.quit()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix for #2898 , in the 7.8.x branch (see [previous pull request for more](https://github.com/cylc/cylc/pull/2985)).

Encloses GTK main loop in a try/catch, to wait for `KeyboardInterrupt` and quit nicely.

Another workaround is to use `CTRL + \`, which sends `SIGKILL`, but not a well known short-cut (nor really nice/polite to go `SIGKILL`ing processes around :grimacing: 

Tested locally from `master` branch, but alas going with no unit/functional tests, so Codecov won't be happy.

Bruno