### PR TITLE
Allow environment section to define multiple variables by a command

### DIFF
--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -66,6 +66,9 @@ RE_SEC_MULTI_SEQ = re.compile(r'(?![^(]+\)),')
 RE_SUITE_NAME_VAR = re.compile(r'\${?CYLC_SUITE_(REG_)?NAME}?')
 RE_TASK_NAME_VAR = re.compile(r'\${?CYLC_TASK_NAME}?')
 
+# Variable name, including comma separated list of variables
+RE_VAR_NAME = re.compile(r'^[a-zA-Z_]\w*(?:\s*,\s*[a-zA-Z_]\w*)*$')
+
 # Message trigger offset regex.
 BCOMPAT_MSG_RE_C6 = re.compile(r'^(.*)\[\s*(([+-])?\s*(.*))?\s*\](.*)$')
 
@@ -77,7 +80,7 @@ def check_varnames(env):
     """
     bad = []
     for varname in env:
-        if not re.match(r'^[a-zA-Z_][\w]*$', varname):
+        if not RE_VAR_NAME.match(varname):
             bad.append(varname)
     return bad
 

--- a/lib/cylc/tests/test_config.py
+++ b/lib/cylc/tests/test_config.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import unittest
+
+from cylc.config import check_varnames
+
+
+GOOD_VARNAMES = ['aaa', 'BBB', 'C_a', '_']
+GOOD_MULTI_VARNAMES = ['a,b,c', 'a, _', '_ , d']
+BAD_VARNAMES = ['0a', '@f', 'f-g']
+BAD_MULTI_VARNAMES = ['a,', ',b', 'a,03df, f', 'a, , b']
+
+
+class TestConfig(unittest.TestCase):
+    def test_check_varnames_good_singles(self):
+        """Test that good variable names are accepted"""
+        results = check_varnames(GOOD_VARNAMES)
+        self.assertEqual(results, [])
+
+    def test_check_varnames_good_multi(self):
+        """Test that good multi-variable lines are accepted"""
+        results = check_varnames(GOOD_MULTI_VARNAMES)
+        self.assertEqual(results, [])
+
+    def test_check_varnames_bad_varnames(self):
+        """Test that bad variable names are caught"""
+        results = check_varnames(BAD_VARNAMES)
+        self.assertEqual(results, BAD_VARNAMES)
+
+    def test_check_varnames_bad_multi(self):
+        """Test that bad multi-variables lines are caught"""
+        results = check_varnames(BAD_MULTI_VARNAMES)
+        self.assertEqual(results, BAD_MULTI_VARNAMES)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/cylc/tests/test_job_file.py
+++ b/lib/cylc/tests/test_job_file.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from cylc.job_file import JobFileWriter
+
+
+EXPECTED_READ = 'read -r %s <<< %s'
+
+# List of multiple variable inputs
+# input variables, input values, expected variables
+MULTI = [("A,B", "$(echo test test)", "A B"),
+         ("A, BC", "`echo test test`", "A BC")]
+
+# List of single variable inputs
+# input value, expected output value
+SINGLES = [('~foo/bar bar', '~foo/"bar bar"'),
+           ('~/bar bar', '~/"bar bar"'),
+           ('~/a', '~/"a"'),
+           ('test', '"test"'),
+           ('~', '~'),
+           ('~a', '~a')]
+
+
+class TestJobFile(unittest.TestCase):
+    def test_get_variable_value_definition(self):
+        """Test the value for single variables are correctly quoted"""
+        for in_value, out_value in SINGLES:
+            res = JobFileWriter._get_variable_value_definition(in_value)
+            self.assertEqual(out_value, res)
+
+    def test_get_multi_variable_command(self):
+        """Test that the multi-variables values are returned correctly"""
+        for variable, value, expected_variable in MULTI:
+            res = JobFileWriter._get_multi_variable_command(variable, value)
+            self.assertEqual(EXPECTED_READ % (expected_variable, value),
+                             res)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/jobscript/20-multi-variables.t
+++ b/tests/jobscript/20-multi-variables.t
@@ -1,0 +1,45 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# job script torture test and check jobscript is generated correctly
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 8
+#-------------------------------------------------------------------------------
+install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-validate
+run_ok $TEST_NAME cylc validate $SUITE_NAME
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-run
+suite_run_ok $TEST_NAME cylc run --reference-test --debug --no-detach $SUITE_NAME
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-jobscript-match
+run_ok $TEST_NAME cylc jobscript $SUITE_NAME a.1
+sed 's/\(export CYLC_.*=\).*/\1/g' $TEST_NAME.stdout >jobfile
+sed "s?##suitename##?${SUITE_NAME}?" \
+    $TEST_SOURCE_DIR/$TEST_NAME_BASE/a.ref-jobfile >reffile
+cmp_ok jobfile reffile
+
+TEST_NAME=$TEST_NAME_BASE-job.out-match
+outfile="${SUITE_RUN_DIR}/log/job/1/a/01/job.out"
+grep_ok "A is '1'" "$outfile"
+grep_ok "B is '2'" "$outfile"
+grep_ok "C is '3'" "$outfile"
+grep_ok "D is '4 5'" "$outfile"
+
+purge_suite $SUITE_NAME

--- a/tests/jobscript/20-multi-variables/a.ref-jobfile
+++ b/tests/jobscript/20-multi-variables/a.ref-jobfile
@@ -1,0 +1,50 @@
+#!/bin/bash -l
+#
+# ++++ THIS IS A CYLC TASK JOB SCRIPT ++++
+# Suite: ##suitename##
+# Task: a.1
+# Job log directory: 1/a/01
+# Job submit method: background
+export CYLC_DIR=
+export CYLC_VERSION=
+CYLC_FAIL_SIGNALS='EXIT ERR TERM XCPU'
+
+cylc__job__inst__cylc_env() {
+    # CYLC SUITE ENVIRONMENT:
+    export CYLC_CYCLING_MODE=
+    export CYLC_SUITE_FINAL_CYCLE_POINT=
+    export CYLC_SUITE_INITIAL_CYCLE_POINT=
+    export CYLC_SUITE_NAME=
+    export CYLC_UTC=
+    export CYLC_VERBOSE=
+
+    export CYLC_SUITE_RUN_DIR=
+    export CYLC_SUITE_DEF_PATH=
+    export CYLC_SUITE_DEF_PATH_ON_SUITE_HOST=
+    export CYLC_SUITE_UUID=
+
+    # CYLC TASK ENVIRONMENT:
+    export CYLC_TASK_JOB=
+    export CYLC_TASK_NAMESPACE_HIERARCHY=
+    export CYLC_TASK_DEPENDENCIES=
+    export CYLC_TASK_TRY_NUMBER=
+}
+
+cylc__job__inst__user_env() {
+    # TASK RUNTIME ENVIRONMENT:
+    export A B C D
+    read -r A B C D <<< $(echo 1 2 3 4 5)
+}
+
+cylc__job__inst__script() {
+# SCRIPT:
+echo "A is '$A'"
+echo "B is '$B'"
+echo "C is '$C'"
+echo "D is '$D'"
+}
+
+. "${CYLC_DIR}/lib/cylc/job.sh"
+cylc__job__main
+
+#EOF: 1/a/01

--- a/tests/jobscript/20-multi-variables/reference.log
+++ b/tests/jobscript/20-multi-variables/reference.log
@@ -1,0 +1,3 @@
+2017-02-09T16:45:37Z INFO - Initial point: 1
+2017-02-09T16:45:37Z INFO - Final point: 1
+2017-02-09T16:45:37Z INFO - [a.1] -triggered off []

--- a/tests/jobscript/20-multi-variables/suite.rc
+++ b/tests/jobscript/20-multi-variables/suite.rc
@@ -1,0 +1,21 @@
+[cylc]
+    [[reference test]]
+        live mode suite timeout = PT30S
+        dummy mode suite timeout = PT30S
+        simulation mode suite timeout = PT30S
+    [[events]]
+        abort on stalled = True
+[scheduling]
+    [[dependencies]]
+        graph = a
+[runtime]
+    [[root]]
+        script = """
+echo "A is '$A'"
+echo "B is '$B'"
+echo "C is '$C'"
+echo "D is '$D'"
+"""
+    [[a]]
+        [[[environment]]]
+            A,B ,C , D = $(echo 1 2 3 4 5)


### PR DESCRIPTION
I thought this might be a useful feature. I often seem to have a pre-script along the lines of `read -r DATE YYYY MM DD HH <<< $(date -d "${CYLC_TASK_CYCLE_POINT//[TZ]/ }" "+%Y%m%d %Y %m %d %H")`, and it would be nice to be able to just do that in the environment section. 

I've only run it in the python3 Cylc, but it should work in the python2 version too.

I need to update docs still, but don't want to do that unless its agreed to proceed. I also wondered about putting in a validation of the RHS, but I wasn't entirely sure where/how to do that yet... The logic I wanted to put in would be at suite validation time, checking the RHS either is ``` `...` ``` or `$(...)`, and if neither, make it `$(...)`. If I can be pointed to where that should be done, I'm happy to add that sort of functionality too.