### PR TITLE
2982.elegantly handle known errors

### DIFF
--- a/bin/cylc-broadcast
+++ b/bin/cylc-broadcast
@@ -81,6 +81,8 @@ if '--use-ssh' in sys.argv[1:]:
 import re
 from tempfile import NamedTemporaryFile
 
+from cylc.exceptions import UserInputError
+from cylc.terminal import cli_function
 from cylc.broadcast_report import (
     get_broadcast_change_report, get_broadcast_bad_options_report)
 from cylc.cfgspec.suite import SPEC, upg
@@ -114,8 +116,8 @@ def get_rdict(left, right=None):
     left can be key, [key], [key1]key2, [key1][key2], [key1][key2]key3, etc.
     """
     if left == "inherit":
-        raise ValueError(
-            "ERROR: Inheritance cannot be changed by broadcast")
+        raise UserInputError(
+            "Inheritance cannot be changed by broadcast")
     rdict = {}
     cur_dict = rdict
     tail = left
@@ -171,7 +173,7 @@ def files_to_settings(settings, setting_files, cancel_mode=False):
                     cur_setting[key] = item
 
 
-def main():
+def parse_args():
     """CLI for "cylc broadcast"."""
     parser = COP(__doc__, comms=True)
 
@@ -245,7 +247,12 @@ def main():
              "the broadcast config structure in raw Python form.",
         action="store_true", default=False, dest="raw")
 
-    options, args = parser.parse_args()
+    return parser.parse_args()
+
+
+@cli_function
+def main():
+    options, args = parse_args()
     suite = args[0]
 
     pclient = SuiteRuntimeClient(
@@ -257,7 +264,7 @@ def main():
             try:
                 TaskID.split(options.showtask)
             except ValueError:
-                parser.error("TASKID must be " + TaskID.SYNTAX)
+                raise UserInputError("TASKID must be " + TaskID.SYNTAX)
         settings = pclient('get_broadcast', {'task_id': options.showtask})
         padding = get_padding(settings) * ' '
         if options.raw:
@@ -299,8 +306,8 @@ def main():
         settings = []
         for option_item in options.cancel:
             if "=" in option_item:
-                raise ValueError(
-                    "ERROR: --cancel=[SEC]ITEM does not take a value")
+                raise UserInputError(
+                    "--cancel=[SEC]ITEM does not take a value")
             option_item = option_item.strip()
             setting = get_rdict(option_item)
             settings.append(setting)
@@ -320,8 +327,8 @@ def main():
         settings = []
         for option_item in options.settings:
             if "=" not in option_item:
-                raise ValueError(
-                    "ERROR: --set=[SEC]ITEM=VALUE requires a value")
+                raise UserInputError(
+                    "--set=[SEC]ITEM=VALUE requires a value")
             lhs, rhs = [s.strip() for s in option_item.split("=", 1)]
             setting = get_rdict(lhs, rhs)
             settings.append(setting)
@@ -338,9 +345,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -56,6 +56,7 @@ from stat import S_IRUSR
 from tempfile import mkstemp
 from subprocess import Popen, PIPE
 
+from cylc.exceptions import UserInputError
 import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.rundb import CylcSuiteDAO
@@ -64,6 +65,7 @@ from cylc.cfgspec.glbl_cfg import glbl_cfg
 from cylc.task_id import TaskID
 from cylc.task_job_logs import (
     JOB_LOG_OUT, JOB_LOG_ERR, JOB_LOG_OPTS, NN, JOB_LOGS_LOCAL)
+from cylc.terminal import cli_function
 
 
 # Immortal tail-follow processes on job hosts can be cleaned up by killing
@@ -135,7 +137,7 @@ def view_log(logpath, mode, tailer_tmpl, batchview_cmd=None, remote=False):
     elif not os.path.exists(logpath) and batchview_cmd is None:
         # Note: batchview_cmd may not need to have access to logpath, so don't
         # test for existence of path if it is set.
-        sys.stderr.write('ERROR: file not found: %s\n' % logpath)
+        sys.stderr.write('file not found: %s\n' % logpath)
         return 1
     elif mode == 'print-dir':
         print(os.path.dirname(logpath))
@@ -277,6 +279,7 @@ def tmpfile_edit(tmpfile, geditor=False):
         sys.stderr.write(err)
 
 
+@cli_function
 def main():
     """Implement cylc cat-log CLI.
 
@@ -321,7 +324,8 @@ def main():
             try:
                 logpath = logs[int(options.rotation_num)]
             except IndexError:
-                sys.exit("ERROR: max rotation %d" % (len(logs) - 1))
+                raise UserInputError(
+                    "max rotation %d" % (len(logs) - 1))
         tail_tmpl = str(glbl_cfg().get_host_item("tail command template"))
         out = view_log(logpath, mode, tail_tmpl)
         if out == 1:
@@ -333,7 +337,8 @@ def main():
     if len(args) == 2:
         # Cat task job logs, may be on suite or job host.
         if options.rotation_num is not None:
-            sys.exit("ERROR: only suite (not job) logs get rotated")
+            raise UserInputError(
+                "only suite (not job) logs get rotated")
         task_id = args[1]
         try:
             task, point = TaskID.split(task_id)

--- a/bin/cylc-cat-state
+++ b/bin/cylc-cat-state
@@ -34,16 +34,19 @@ import traceback
 
 from cylc.cfgspec.glbl_cfg import glbl_cfg
 from cylc.dump import dump_to_stdout
+from cylc.exceptions import CylcError
 import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.rundb import CylcSuiteDAO
 from cylc.task_id import TaskID
+from cylc.terminal import cli_function
 from cylc.wallclock import get_unix_time_from_time_string
 
 
 REC_BROADCAST_KEY_SECTIONS = re.compile(r"\[([^\]]+)\]")
 
 
+@cli_function
 def main():
     """CLI of "cylc cat-state"."""
     parser = COP(__doc__, argdoc=[("REG", "Suite name")])
@@ -61,7 +64,7 @@ def main():
     except sqlite3.Error:
         if cylc.flags.debug:
             traceback.print_exc()
-        sys.exit("ERROR: cannot print suite state for %s" % suite)
+        raise CylcError("cannot print suite state for %s" % suite)
 
     if options.dumpform:
         dump_to_stdout(extract_json(state))

--- a/bin/cylc-check-triggering
+++ b/bin/cylc-check-triggering
@@ -49,32 +49,40 @@ import os
 import sys
 
 from cylc.log_diagnosis import LogAnalyser
+from cylc.terminal import cli_function
 
-if len(sys.argv) == 2 and sys.argv[1] == '--help':
-    print(__doc__)
-    sys.exit(0)
 
-print("\nThis is the cylc check-triggering shutdown event handler")
+@cli_function
+def main():
+    if len(sys.argv) == 2 and sys.argv[1] == '--help':
+        print(__doc__)
+        sys.exit(0)
 
-event, suite = sys.argv[1], sys.argv[2]
+    print("\nThis is the cylc check-triggering shutdown event handler")
 
-if event != 'shutdown':
-    raise SystemExit("ERROR: run this as a shutdown event handler")
+    event, suite = sys.argv[1], sys.argv[2]
 
-try:
-    log_dir = os.path.expandvars(os.environ['CYLC_SUITE_LOG_DIR'])
-    suite_dir = os.path.expandvars(os.environ['CYLC_SUITE_DEF_PATH'])
-except KeyError as exc:
-    raise SystemExit(exc)
+    if event != 'shutdown':
+        raise SystemExit("ERROR: run this as a shutdown event handler")
 
-new_log = os.path.join(log_dir, 'log')
-ref_log = os.path.join(suite_dir, 'reference.log')
+    try:
+        log_dir = os.path.expandvars(os.environ['CYLC_SUITE_LOG_DIR'])
+        suite_dir = os.path.expandvars(os.environ['CYLC_SUITE_DEF_PATH'])
+    except KeyError as exc:
+        raise SystemExit(exc)
 
-try:
-    lanal = LogAnalyser(new_log, ref_log)
-    lanal.verify_triggering()
-except Exception as exc:
-    print(exc, file=sys.stderr)
-    raise SystemExit("ERROR: Triggering check FAILED")
-else:
-    print("Triggering check passed")
+    new_log = os.path.join(log_dir, 'log')
+    ref_log = os.path.join(suite_dir, 'reference.log')
+
+    try:
+        lanal = LogAnalyser(new_log, ref_log)
+        lanal.verify_triggering()
+    except Exception as exc:
+        print(exc, file=sys.stderr)
+        raise SystemExit("ERROR: Triggering check FAILED")
+    else:
+        print("Triggering check passed")
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/cylc-check-versions
+++ b/bin/cylc-check-versions
@@ -47,8 +47,10 @@ from cylc.subprocpool import SubProcPool
 from cylc.suite_srv_files_mgr import SuiteSrvFilesManager
 from cylc.task_remote_mgr import TaskRemoteMgr
 from cylc.templatevars import load_template_vars
+from cylc.terminal import cli_function
 
 
+@cli_function
 def main():
     parser = COP(__doc__, prep=True, jset=True)
 
@@ -143,9 +145,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-checkpoint
+++ b/bin/cylc-checkpoint
@@ -31,8 +31,10 @@ if "--use-ssh" in sys.argv[1:]:
 import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
+from cylc.terminal import cli_function
 
 
+@cli_function
 def main():
     parser = COP(__doc__, comms=True, argdoc=[
         ("REG", "Suite name"),
@@ -48,9 +50,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-client
+++ b/bin/cylc-client
@@ -33,8 +33,10 @@ if '--use-ssh' in sys.argv[1:]:
 
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
+from cylc.terminal import cli_function
 
 
+@cli_function
 def main():
     parser = COP(__doc__, comms=True, argdoc=[
         ('REG', 'Suite name'),

--- a/bin/cylc-cycle-point
+++ b/bin/cylc-cycle-point
@@ -57,11 +57,14 @@ import sys
 
 import cylc.cycling.iso8601
 from cylc.option_parsers import CylcOptionParser as COP
+from cylc.terminal import cli_function
+
 import isodatetime.data
 import isodatetime.dumpers
 import isodatetime.parsers
 
 
+@cli_function
 def main():
     parser = COP(
         __doc__,

--- a/bin/cylc-diff
+++ b/bin/cylc-diff
@@ -38,6 +38,7 @@ from cylc.option_parsers import CylcOptionParser as COP
 from cylc.config import SuiteConfig
 from cylc.suite_srv_files_mgr import SuiteSrvFilesManager
 from cylc.templatevars import load_template_vars
+from cylc.terminal import cli_function
 
 n_oone = 0
 n_otwo = 0
@@ -112,6 +113,7 @@ def prdict(dct, arrow='<', section='', level=0, diff=False, nested=False):
                 print(' ' + arrow + '  ', key, '=', dct[key])
 
 
+@cli_function
 def main():
     parser = COP(
         __doc__, jset=True, prep=True, icp=True,
@@ -174,9 +176,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-documentation
+++ b/bin/cylc-documentation
@@ -38,10 +38,13 @@ import os
 from subprocess import check_call, CalledProcessError
 
 from cylc.cfgspec.glbl_cfg import glbl_cfg
+from cylc.exceptions import UserInputError
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.run_get_stdout import run_get_stdout
+from cylc.terminal import cli_function
 
 
+@cli_function
 def main():
     parser = COP(
         __doc__, argdoc=[('[TARGET]', 'File or suite name')])
@@ -87,9 +90,10 @@ def main():
         else:
             target = glbl_cfg().get(['documentation', 'online'])
         if target is None:
-            sys.exit("ERROR: no url defined, see the [documentation][%s'] "
-                     "global configuration" % (
-                         'local' if options.local else 'online'))
+            raise UserInputError(
+                "no url defined, see the [documentation][%s'] "
+                "global configuration" % (
+                    'local' if options.local else 'online'))
 
     elif len(args) == 1:
         # Suite or task documentation.
@@ -105,13 +109,13 @@ def main():
                 "cylc get-suite-config -i [meta]URL %s" % suite)
         if not res:
             # (Illegal config item)
-            sys.exit(stdout)
+            raise UserInputError(stdout)
         elif len(stdout) == 0:
             if options.task_name is not None:
-                sys.exit("ERROR: No URL defined for %s in %s." % (
+                raise UserInputError("No URL defined for %s in %s." % (
                     options.task_name, suite))
             else:
-                sys.exit("ERROR: No URL defined for %s." % suite)
+                raise UserInputError("No URL defined for %s." % suite)
         target = stdout[0]
     else:
         parser.error("Too many arguments.")
@@ -125,7 +129,7 @@ def main():
     try:
         check_call(command, stdin=open(os.devnull))
     except CalledProcessError:
-        print('ERROR, failed to execute: %s' % command, file=sys.stderr)
+        print('failed to execute: %s' % command, file=sys.stderr)
         raise
 
 

--- a/bin/cylc-dump
+++ b/bin/cylc-dump
@@ -43,8 +43,10 @@ import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
 from cylc.dump import dump_to_stdout
+from cylc.terminal import cli_function
 
 
+@cli_function
 def main():
     parser = COP(__doc__, comms=True, noforce=True)
     parser.add_option(
@@ -81,9 +83,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-edit
+++ b/bin/cylc-edit
@@ -75,9 +75,11 @@ import cylc.flags
 from cylc.cfgspec.glbl_cfg import glbl_cfg
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.suite_srv_files_mgr import SuiteSrvFilesManager
+from cylc.terminal import cli_function
 from cylc.wallclock import get_current_time_string
 
 
+@cli_function
 def main():
     parser = COP(__doc__, prep=True)
 
@@ -118,7 +120,7 @@ def main():
 
         # edit the suite.rc file
         if not os.path.isfile(suiterc):
-            print('ERROR, file not found: ', suiterc, file=sys.stderr)
+            print('file not found: ', suiterc, file=sys.stderr)
             sys.exit(1)
 
         # in case editor has options, e.g. 'emacs -nw':
@@ -210,9 +212,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-ext-trigger
+++ b/bin/cylc-ext-trigger
@@ -39,9 +39,11 @@ import sys
 from time import sleep
 
 from cylc import LOG
+from cylc.exceptions import CylcError, ClientError
 import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
-from cylc.network.client import ClientError, SuiteRuntimeClient
+from cylc.network.client import SuiteRuntimeClient
+from cylc.terminal import cli_function
 
 
 MAX_N_TRIES = 5
@@ -52,6 +54,7 @@ MSG_SEND_RETRY = "Retrying in %s seconds, timeout is %s"
 MSG_SEND_SUCCEED = "Send message: try %s of %s succeeded"
 
 
+@cli_function
 def main():
     parser = COP(
         __doc__, comms=True,
@@ -91,7 +94,7 @@ def main():
             LOG.exception(exc)
             LOG.info(MSG_SEND_FAILED, i_try + 1, max_n_tries)
             if i_try == max_n_tries - 1:  # final attempt
-                sys.exit('ERROR: send failed')
+                raise CylcError('send failed')
             else:
                 LOG.info(MSG_SEND_RETRY, retry_intvl_secs,
                          options.comms_timeout)
@@ -103,9 +106,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-get-directory
+++ b/bin/cylc-get-directory
@@ -22,16 +22,18 @@ Retrieve and print the source directory location of suite REG.
 Here's an easy way to move to a suite source directory:
   $ cd $(cylc get-dir REG)."""
 
-import sys
-from cylc.option_parsers import CylcOptionParser as COP
-from cylc.suite_srv_files_mgr import SuiteSrvFilesManager
-import cylc.flags
-
 from cylc.remote import remrun
 if remrun():
     sys.exit(0)
 
+import sys
+from cylc.option_parsers import CylcOptionParser as COP
+from cylc.suite_srv_files_mgr import SuiteSrvFilesManager
+import cylc.flags
+from cylc.terminal import cli_function
 
+
+@cli_function
 def main():
     """Implement "cylc get-directory"."""
     options, args = COP(__doc__, prep=True).parse_args()
@@ -40,9 +42,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-get-host-metrics
+++ b/bin/cylc-get-host-metrics
@@ -48,6 +48,7 @@ from subprocess import Popen, PIPE, CalledProcessError
 import json
 
 from cylc.option_parsers import OptionParser
+from cylc.terminal import cli_function
 
 
 """Templates for extracting desired metric data via regular expression.
@@ -87,6 +88,7 @@ DISK_TEMPLATES = ['df -Pk', re.compile(
                   r'Mounted on\n\S+\s+\d+\s+\d+\s+(\d+)\s+')]
 
 
+@cli_function
 def main():
     parser = OptionParser(__doc__)
 

--- a/bin/cylc-get-site-config
+++ b/bin/cylc-get-site-config
@@ -28,8 +28,10 @@ Multiple items can be specified at once."""
 
 from cylc.cfgspec.glbl_cfg import glbl_cfg
 from cylc.option_parsers import CylcOptionParser as COP
+from cylc.terminal import cli_function
 
 
+@cli_function
 def main():
     parser = COP(__doc__, argdoc=[])
 

--- a/bin/cylc-get-suite-config
+++ b/bin/cylc-get-suite-config
@@ -61,8 +61,10 @@ import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.suite_srv_files_mgr import SuiteSrvFilesManager
 from cylc.templatevars import load_template_vars
+from cylc.terminal import cli_function
 
 
+@cli_function
 def main():
     parser = COP(__doc__, jset=True, prep=True, icp=True)
 
@@ -142,9 +144,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-get-suite-contact
+++ b/bin/cylc-get-suite-contact
@@ -25,11 +25,14 @@ from cylc.remote import remrun
 if remrun():
     sys.exit(0)
 
+from cylc.exceptions import CylcError
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.suite_srv_files_mgr import (
     SuiteSrvFilesManager, SuiteServiceFileError)
+from cylc.terminal import cli_function
 
 
+@cli_function
 def main():
     """CLI for "cylc get-suite-contact"."""
     parser = COP(__doc__, argdoc=[('REG', 'Suite name')])
@@ -37,7 +40,8 @@ def main():
     try:
         data = SuiteSrvFilesManager().load_contact_file(reg)
     except SuiteServiceFileError:
-        sys.exit("%s: cannot get contact info, suite not running?" % (reg,))
+        raise CylcError(
+            "%s: cannot get contact info, suite not running?" % (reg,))
     else:
         for key, value in sorted(data.items()):
             print("%s=%s" % (key, value))

--- a/bin/cylc-get-suite-version
+++ b/bin/cylc-get-suite-version
@@ -32,6 +32,7 @@ if '--use-ssh' in sys.argv[1:]:
 import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
+from cylc.terminal import cli_function
 
 
 def main():
@@ -46,9 +47,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-graph
+++ b/bin/cylc-graph
@@ -26,10 +26,12 @@ import sys
 
 from cylc.config import SuiteConfig
 from cylc.cycling.loader import get_point
+from cylc.exceptions import UserInputError
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.suite_srv_files_mgr import (
     SuiteSrvFilesManager, SuiteServiceFileError)
 from cylc.templatevars import load_template_vars
+from cylc.terminal import cli_function
 
 
 def sort_integer_node(item):
@@ -218,17 +220,18 @@ def parse_args():
     opts, args = parser.parse_args()
 
     if opts.ungrouped and opts.namespaces:
-        sys.exit('Cannot combine --ungrouped and --namespaces.')
+        raise UserInputError('Cannot combine --ungrouped and --namespaces.')
 
     return opts, args + [None] * (3 - len(args))
 
 
+@cli_function
 def main():
     """Implement ``cylc graph``."""
     opts, (suite, start, stop) = parse_args()
 
     if not opts.reference:
-        sys.exit('Only the --reference use cases are supported')
+        raise UserInputError('Only the --reference use cases are supported')
 
     template_vars = load_template_vars(
         opts.templatevars, opts.templatevars_file)

--- a/bin/cylc-help
+++ b/bin/cylc-help
@@ -19,15 +19,12 @@ import sys
 
 # Import cylc to initialise CYLC_DIR and the path for python (__init__.py).
 from cylc import __version__ as CYLC_VERSION
+from cylc.exceptions import CylcError
+from cylc.terminal import cli_function
 
 
-class CommandError(Exception):
-
-    def __init__(self, msg):
-        self.msg = msg
-
-    def __str__(self):
-        return repr(self.msg)
+class CommandError(CylcError):
+    pass
 
 
 class CommandNotFoundError(CommandError):
@@ -419,7 +416,8 @@ comsum['function-run'] = '(Internal) Run a function in the process pool'
 comsum['check-triggering'] = 'A suite shutdown event hook for cylc testing'
 
 
-if __name__ == "__main__":
+@cli_function
+def main():
     # no arguments: print help and exit
     if len(sys.argv) == 1:
         print(usage.replace("__CYLC_VERSION__", CYLC_VERSION))
@@ -495,3 +493,7 @@ if __name__ == "__main__":
             # cylc help CATEGORY
             category_help(category)
             sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/cylc-hold
+++ b/bin/cylc-hold
@@ -36,9 +36,10 @@ if '--use-ssh' in sys.argv[1:]:
 import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
-from cylc.terminal import prompt
+from cylc.terminal import prompt, cli_function
 
 
+@cli_function
 def main():
     parser = COP(
         __doc__, comms=True, multitask=True,
@@ -86,9 +87,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-insert
+++ b/bin/cylc-insert
@@ -40,13 +40,15 @@ if '--use-ssh' in sys.argv[1:]:
     if remrun():
         sys.exit(0)
 
+from cylc.exceptions import UserInputError
 import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
 from cylc.task_id import TaskID
-from cylc.terminal import prompt
+from cylc.terminal import prompt, cli_function
 
 
+@cli_function
 def main():
     parser = COP(
         __doc__, comms=True, multitask=True,
@@ -80,8 +82,9 @@ def main():
         items = args
         for i, item in enumerate(items):
             if not TaskID.is_valid_id_2(item):
-                sys.exit('ERROR: "%s": invalid task ID (argument %d)' % (
-                    item, i + 1))
+                raise UserInputError(
+                    '"%s": invalid task ID (argument %d)' % (
+                        item, i + 1))
         prompt('Insert %s in %s' % (items, suite), options.force)
 
     pclient = SuiteRuntimeClient(
@@ -96,9 +99,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-jobs-kill
+++ b/bin/cylc-jobs-kill
@@ -26,8 +26,10 @@ terminate the jobs.
 
 
 from cylc.remote import remrun
+from cylc.terminal import cli_function
 
 
+@cli_function
 def main():
     """CLI main."""
     parser = COP(__doc__, argdoc=[

--- a/bin/cylc-jobs-poll
+++ b/bin/cylc-jobs-poll
@@ -25,8 +25,10 @@ relevant batch system commands to ask the batch systems for more statuses.
 
 
 from cylc.remote import remrun
+from cylc.terminal import cli_function
 
 
+@cli_function
 def main():
     """CLI main."""
     parser = COP(__doc__, argdoc=[

--- a/bin/cylc-jobs-submit
+++ b/bin/cylc-jobs-submit
@@ -25,8 +25,10 @@ job files from STDIN.
 
 
 from cylc.remote import remrun
+from cylc.terminal import cli_function
 
 
+@cli_function
 def main():
     """CLI main."""
     parser = COP(__doc__, argdoc=[

--- a/bin/cylc-kill
+++ b/bin/cylc-kill
@@ -34,9 +34,10 @@ if '--use-ssh' in sys.argv[1:]:
 import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
-from cylc.terminal import prompt
+from cylc.terminal import prompt, cli_function
 
 
+@cli_function
 def main():
     """CLI of "cylc kill"."""
     parser = COP(
@@ -62,9 +63,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-list
+++ b/bin/cylc-list
@@ -38,10 +38,11 @@ import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.suite_srv_files_mgr import SuiteSrvFilesManager
 from cylc.templatevars import load_template_vars
+from cylc.terminal import cli_function
 
 
+@cli_function
 def main():
-
     parser = COP(__doc__, jset=True, prep=True, icp=True)
 
     parser.add_option(
@@ -146,9 +147,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-ls-checkpoints
+++ b/bin/cylc-ls-checkpoints
@@ -33,6 +33,7 @@ import os
 from cylc.cfgspec.glbl_cfg import glbl_cfg
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.rundb import CylcSuiteDAO
+from cylc.terminal import cli_function
 
 
 DELIM = "#" * 71
@@ -42,6 +43,7 @@ TITLE_BROADCAST_STATES = "\n# BROADCAST STATES (POINT|NAMESPACE|KEY|VALUE)\n"
 TITLE_TASK_POOL = "\n# TASK POOL (CYCLE|NAME|SPAWNED|STATUS|HOLD_SWAP)\n"
 
 
+@cli_function
 def main():
     """CLI."""
     parser = COP(__doc__, argdoc=[

--- a/bin/cylc-message
+++ b/bin/cylc-message
@@ -76,8 +76,10 @@ import sys
 import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.task_message import record_messages
+from cylc.terminal import cli_function
 
 
+@cli_function
 def main():
     """CLI."""
     parser = COP(

--- a/bin/cylc-monitor
+++ b/bin/cylc-monitor
@@ -32,15 +32,17 @@ import os
 import re
 from time import sleep, time
 
-
 from parsec.OrderedDict import OrderedDict
+
+from cylc.exceptions import ClientError
 from cylc.option_parsers import CylcOptionParser as COP
-from cylc.network.client import SuiteRuntimeClient, ClientError
+from cylc.network.client import SuiteRuntimeClient
 from cylc.cfgspec.glbl_cfg import glbl_cfg
 from cylc.task_state import (
     TASK_STATUS_RUNAHEAD, TASK_STATUSES_ORDERED,
     TASK_STATUSES_RESTRICTED)
 from cylc.task_state_prop import get_status_prop
+from cylc.terminal import cli_function
 from cylc.wallclock import get_time_string_from_unix_time
 
 
@@ -105,6 +107,7 @@ The USER_AT_HOST argument allows suite selection by 'cylc scan' output:
         self.pclient = SuiteRuntimeClient(
             suite, owner, host, port, timeout)
 
+    @cli_function
     def run(self):
         (options, args) = self.parser.parse_args()
         suite = args[0]

--- a/bin/cylc-nudge
+++ b/bin/cylc-nudge
@@ -38,8 +38,10 @@ if '--use-ssh' in sys.argv[1:]:
 import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
+from cylc.terminal import cli_function
 
 
+@cli_function
 def main():
     parser = COP(__doc__, comms=True)
 
@@ -51,16 +53,7 @@ def main():
         options.comms_timeout)
 
     success, msg = pclient('nudge')
-    if success:
-        print(msg)
-    else:
-        sys.exit(msg)
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-ping
+++ b/bin/cylc-ping
@@ -28,12 +28,15 @@ if '--use-ssh' in sys.argv[1:]:
     if remrun():
         sys.exit(0)
 
+from cylc.exceptions import UserInputError
 import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.task_id import TaskID
 from cylc.network.client import SuiteRuntimeClient
+from cylc.terminal import cli_function
 
 
+@cli_function
 def main():
     parser = COP(
         __doc__, comms=True,
@@ -58,16 +61,9 @@ def main():
     # cylc ping SUITE TASKID
     task_id = args[1]
     if not TaskID.is_valid_id(task_id):
-        sys.exit("Invalid task ID: " + task_id)
+        raise UserInputError("Invalid task ID: %s" % task_id)
     success, msg = pclient('ping_task', {'task_id': task_id})
-    if not success:
-        sys.exit('ERROR: ' + msg)
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-poll
+++ b/bin/cylc-poll
@@ -34,9 +34,10 @@ if '--use-ssh' in sys.argv[1:]:
 import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
-from cylc.terminal import prompt
+from cylc.terminal import prompt, cli_function
 
 
+@cli_function
 def main():
     parser = COP(
         __doc__, comms=True, multitask=True,
@@ -68,9 +69,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-print
+++ b/bin/cylc-print
@@ -39,6 +39,7 @@ import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.suite_srv_files_mgr import SuiteSrvFilesManager
 from cylc.print_tree import print_tree
+from cylc.terminal import cli_function
 
 
 def get_padding(reglist):
@@ -55,6 +56,7 @@ def get_padding(reglist):
     return maxlen * ' '
 
 
+@cli_function
 def main():
     parser = COP(__doc__,
                  argdoc=[('[REGEX]', 'Suite name regular expression pattern')])
@@ -153,9 +155,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-register
+++ b/bin/cylc-register
@@ -55,11 +55,13 @@ from cylc.remote import remrun
 if remrun():
     sys.exit(0)
 
+import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.suite_srv_files_mgr import SuiteSrvFilesManager
-import cylc.flags
+from cylc.terminal import cli_function
 
 
+@cli_function
 def main():
     parser = COP(
         __doc__,
@@ -83,9 +85,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-release
+++ b/bin/cylc-release
@@ -35,9 +35,10 @@ if '--use-ssh' in sys.argv[1:]:
 import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
-from cylc.terminal import prompt
+from cylc.terminal import prompt, cli_function
 
 
+@cli_function
 def main():
     parser = COP(
         __doc__, comms=True, multitask=True,
@@ -63,9 +64,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-reload
+++ b/bin/cylc-reload
@@ -49,9 +49,10 @@ if '--use-ssh' in sys.argv[1:]:
 import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
-from cylc.terminal import prompt
+from cylc.terminal import prompt, cli_function
 
 
+@cli_function
 def main():
     parser = COP(__doc__, comms=True)
     (options, args) = parser.parse_args()
@@ -65,9 +66,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-remove
+++ b/bin/cylc-remove
@@ -34,9 +34,10 @@ if '--use-ssh' in sys.argv[1:]:
 import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
-from cylc.terminal import prompt
+from cylc.terminal import prompt, cli_function
 
 
+@cli_function
 def main():
     parser = COP(
         __doc__, comms=True, multitask=True,
@@ -64,9 +65,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-report-timings
+++ b/bin/cylc-report-timings
@@ -57,10 +57,12 @@ import collections
 import contextlib
 import os
 
+from cylc.exceptions import CylcError
 import cylc.flags
 from cylc.cfgspec.glbl_cfg import glbl_cfg
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.rundb import CylcSuiteDAO
+from cylc.terminal import cli_function
 
 
 @contextlib.contextmanager
@@ -83,6 +85,7 @@ def smart_open(filename=None):
             fh.close()
 
 
+@cli_function
 def main():
     parser = COP(
         __doc__,
@@ -244,7 +247,7 @@ class TimingSummary(object):
         try:
             import pandas
         except ImportError:
-            raise Exception('Cannot import pandas - summary unavailable.')
+            raise CylcError('Cannot import pandas - summary unavailable.')
         else:
             del pandas
 
@@ -387,16 +390,11 @@ class HTMLTimingSummary(TimingSummary):
             import matplotlib
             matplotlib.use('Agg')
         except ImportError:
-            raise Exception(
+            raise CylcError(
                 'Cannot import matplotlib - HTML summary unavailable.'
             )
         super(HTMLTimingSummary, self)._check_imports()
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-reset
+++ b/bin/cylc-reset
@@ -44,9 +44,10 @@ import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
 from cylc.task_state import TASK_STATUSES_CAN_RESET_TO
-from cylc.terminal import prompt
+from cylc.terminal import prompt, cli_function
 
 
+@cli_function
 def main():
     parser = COP(
         __doc__, comms=True, multitask=True,
@@ -104,9 +105,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-scan
+++ b/bin/cylc-scan
@@ -42,6 +42,7 @@ import json
 
 from colorama import Fore, Style, init as color_init
 
+from cylc.exceptions import UserInputError
 from cylc.network.scan import (
     get_scan_items_from_fs, re_compile_filters, scan_many)
 from cylc.option_parsers import CylcOptionParser as COP
@@ -123,6 +124,7 @@ def get_parser():
     return parser
 
 
+@terminal.cli_function
 def main():
     """Implement "cylc scan"."""
     parser = get_parser()
@@ -176,7 +178,7 @@ def main():
     elif options.format == 'plain':
         formatter = format_plain
     else:
-        raise Exception('Unknown format: %s' % options.format)
+        raise UserInputError('Unknown format: %s' % options.format)
 
     # output state legend if necessary
     state_legend = ""

--- a/bin/cylc-search
+++ b/bin/cylc-search
@@ -41,6 +41,7 @@ import re
 from collections import deque
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.suite_srv_files_mgr import SuiteSrvFilesManager
+from cylc.terminal import cli_function
 from parsec.include import inline
 
 
@@ -60,126 +61,136 @@ def print_heading(heading):
     print('>>>' + '->'.join(heading))
 
 
-parser = COP(
-    __doc__, prep=True,
-    argdoc=[('SUITE', 'Suite name or path'),
-            ('PATTERN', 'Python-style regular expression'),
-            ('[PATTERN2...]', 'Additional search patterns')])
+def parse_args():
+    parser = COP(
+        __doc__, prep=True,
+        argdoc=[('SUITE', 'Suite name or path'),
+                ('PATTERN', 'Python-style regular expression'),
+                ('[PATTERN2...]', 'Additional search patterns')])
 
-parser.add_option(
-    "-x", help="Do not search in the suite bin directory",
-    action="store_false", default=True, dest="search_bin")
+    parser.add_option(
+        "-x", help="Do not search in the suite bin directory",
+        action="store_false", default=True, dest="search_bin")
 
-(options, args) = parser.parse_args()
+    return parser.parse_args()
 
-suite, suiterc = SuiteSrvFilesManager().parse_suite_arg(options, args[0])
 
-# cylc search SUITE PATTERN
-pattern = '|'.join(args[1:])
+@cli_function
+def main():
+    options, args = parse_args()
+    suite, suiterc = SuiteSrvFilesManager().parse_suite_arg(options, args[0])
 
-suitedir = os.path.dirname(suiterc)
+    # cylc search SUITE PATTERN
+    pattern = '|'.join(args[1:])
 
-if os.path.isfile(suiterc):
-    h = open(suiterc, 'r')
-    lines = h.readlines()
-    h.close()
-    lines = inline(lines, suitedir, suiterc, for_grep=True)
-else:
-    parser.error("File not found: " + suiterc)
+    suitedir = os.path.dirname(suiterc)
 
-sections = deque(['(top)'])
-
-line_count = 1
-inc_file = None
-in_include_file = False
-prev_section_key = None
-prev_file = None
-
-for line in lines:
-
-    m = re.match(r'^#\+\+\+\+ START INLINED INCLUDE FILE ([\w/.\-]+)', line)
-    if m:
-        inc_file = m.groups()[0]
-        in_include_file = True
-        inc_line_count = 0
-        continue
-
-    if not in_include_file:
-        line_count += 1
+    if os.path.isfile(suiterc):
+        h = open(suiterc, 'r')
+        lines = h.readlines()
+        h.close()
+        lines = inline(lines, suitedir, suiterc, for_grep=True)
     else:
-        inc_line_count += 1
-        m = re.match(r'^#\+\+\+\+ END INLINED INCLUDE FILE ' + inc_file, line)
+        parser.error("File not found: " + suiterc)
+
+    sections = deque(['(top)'])
+
+    line_count = 1
+    inc_file = None
+    in_include_file = False
+    prev_section_key = None
+    prev_file = None
+
+    for line in lines:
+
+        m = re.match(r'^#\+\+\+\+ START INLINED INCLUDE FILE ([\w/\.\-]+)', line)
         if m:
-            in_include_file = False
-            inc_file = None
+            inc_file = m.groups()[0]
+            in_include_file = True
+            inc_line_count = 0
             continue
 
-    m = re.match(r'\s*(\[+\s*.+\s*\]+)', line)
-    if m:
-        # new section heading detected
-        heading = m.groups()[0]
-        level = section_level(heading)
-        # unwind to the current section level
-        while len(sections) > level - 1:
-            sections.pop()
-        sections.append(heading)
-        continue
-
-    if re.search(pattern, line):
-        # Found a pattern match.
-
-        # Print the file name
-        if in_include_file:
-            curr_file = os.path.join(suitedir, inc_file)
-            line_no = inc_line_count
+        if not in_include_file:
+            line_count += 1
         else:
-            curr_file = suiterc
-            line_no = line_count
+            inc_line_count += 1
+            m = re.match(r'^#\+\+\+\+ END INLINED INCLUDE FILE ' + inc_file, line)
+            if m:
+                in_include_file = False
+                inc_file = None
+                continue
 
-        if curr_file != prev_file:
-            prev_file = curr_file
-            print("\nFILE:", curr_file)
+        m = re.match(r'\s*(\[+\s*.+\s*\]+)', line)
+        if m:
+            # new section heading detected
+            heading = m.groups()[0]
+            level = section_level(heading)
+            # unwind to the current section level
+            while len(sections) > level - 1:
+                sections.pop()
+            sections.append(heading)
+            continue
 
-        # Print the nested section headings
-        section_key = '->'.join(sections)
-        if section_key != prev_section_key:
-            prev_section_key = section_key
-            print('   SECTION:', section_key)
-
-        # Print the pattern match, with line number
-        print('      (' + str(line_no) + '):', line.rstrip('\n'))
-
-if not options.search_bin:
-    sys.exit(0)
-
-# search files in suite bin directory
-bin_ = os.path.join(suitedir, 'bin')
-if not os.path.isdir(bin_):
-    print("\nSuite " + suite + " has no bin directory", file=sys.stderr)
-    sys.exit(0)
-
-for name in os.listdir(bin_):
-    if name.startswith('.'):
-        # skip hidden dot-files
-        # (e.g. vim editor temporary files)
-        continue
-    new_file = True
-    try:
-        h = open(os.path.join(bin_, name), 'r')
-    except IOError as exc:
-        # e.g. there's a sub-directory under bin; ignore it.
-        print('Unable to open file ' + os.path.join(bin_, name), file=sys.stderr)
-        print(exc, file=sys.stderr)
-        continue
-    contents = h.readlines()
-    h.close()
-
-    count = 0
-    for line in contents:
-        line = line.rstrip('\n')
-        count += 1
         if re.search(pattern, line):
-            if new_file:
-                print('\nFILE:', os.path.join(bin_, name))
-                new_file = False
-            print('   (' + str(count) + '): ' + line)
+            # Found a pattern match.
+
+            # Print the file name
+            if in_include_file:
+                curr_file = os.path.join(suitedir, inc_file)
+                line_no = inc_line_count
+            else:
+                curr_file = suiterc
+                line_no = line_count
+
+            if curr_file != prev_file:
+                prev_file = curr_file
+                print("\nFILE:", curr_file)
+
+            # Print the nested section headings
+            section_key = '->'.join(sections)
+            if section_key != prev_section_key:
+                prev_section_key = section_key
+                print('   SECTION:', section_key)
+
+            # Print the pattern match, with line number
+            print('      (' + str(line_no) + '):', line.rstrip('\n'))
+
+    if not options.search_bin:
+        sys.exit(0)
+
+    # search files in suite bin directory
+    bin_ = os.path.join(suitedir, 'bin')
+    if not os.path.isdir(bin_):
+        print("\nSuite " + suite + " has no bin directory", file=sys.stderr)
+        sys.exit(0)
+
+    for name in os.listdir(bin_):
+        if name.startswith('.'):
+            # skip hidden dot-files
+            # (e.g. vim editor temporary files)
+            continue
+        new_file = True
+        try:
+            h = open(os.path.join(bin_, name), 'r')
+        except IOError as exc:
+            # e.g. there's a sub-directory under bin; ignore it.
+            print('Unable to open file ' + os.path.join(bin_, name),
+                  file=sys.stderr)
+            print(exc, file=sys.stderr)
+            continue
+        contents = h.readlines()
+        h.close()
+
+        count = 0
+        for line in contents:
+            line = line.rstrip('\n')
+            count += 1
+            if re.search(pattern, line):
+                if new_file:
+                    print('\nFILE:', os.path.join(bin_, name))
+                    new_file = False
+                print('   (' + str(count) + '): ' + line)
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/cylc-set-verbosity
+++ b/bin/cylc-set-verbosity
@@ -34,7 +34,7 @@ if '--use-ssh' in sys.argv[1:]:
 import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
-from cylc.terminal import prompt
+from cylc.terminal import prompt, cli_function
 
 LOGGING_LVL_OF = {
     "INFO": INFO,
@@ -46,6 +46,7 @@ LOGGING_LVL_OF = {
 }
 
 
+@cli_function
 def main():
     parser = COP(
         __doc__, comms=True,
@@ -73,9 +74,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-show
+++ b/bin/cylc-show
@@ -35,8 +35,10 @@ import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
 from cylc.task_id import TaskID
+from cylc.terminal import cli_function
 
 
+@cli_function
 def main():
     """Implement "cylc show" CLI."""
     parser = COP(
@@ -124,9 +126,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-spawn
+++ b/bin/cylc-spawn
@@ -33,9 +33,10 @@ if '--use-ssh' in sys.argv[1:]:
 import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
-from cylc.terminal import prompt
+from cylc.terminal import prompt, cli_function
 
 
+@cli_function
 def main():
     parser = COP(
         __doc__, comms=True, multitask=True,
@@ -59,9 +60,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(exc)
+    main()

--- a/bin/cylc-stop
+++ b/bin/cylc-stop
@@ -45,12 +45,13 @@ if '--use-ssh' in sys.argv[1:]:
     if remrun():
         sys.exit(0)
 
-import cylc.flags
-from cylc.task_id import TaskID
-from cylc.option_parsers import CylcOptionParser as COP
-from cylc.network.client import ClientError, ClientTimeout, SuiteRuntimeClient
 from cylc.command_polling import Poller
-from cylc.terminal import prompt
+from cylc.exceptions import ClientError, ClientTimeout
+import cylc.flags
+from cylc.network.client import SuiteRuntimeClient
+from cylc.option_parsers import CylcOptionParser as COP
+from cylc.task_id import TaskID
+from cylc.terminal import prompt, cli_function
 
 
 class StopPoller(Poller):
@@ -72,6 +73,7 @@ class StopPoller(Poller):
             return False
 
 
+@cli_function
 def main():
     parser = COP(
         __doc__, comms=True,
@@ -159,9 +161,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-submit
+++ b/bin/cylc-submit
@@ -42,6 +42,7 @@ from cylc import LOG
 from cylc.cfgspec.glbl_cfg import glbl_cfg
 from cylc.config import SuiteConfig
 from cylc.cycling.loader import get_point
+from cylc.exceptions import UserInputError
 import cylc.flags
 from cylc.subprocpool import SubProcPool
 from cylc.option_parsers import CylcOptionParser as COP
@@ -54,8 +55,10 @@ from cylc.task_events_mgr import TaskEventsManager
 from cylc.task_proxy import TaskProxy
 from cylc.task_state import TASK_STATUS_SUBMIT_FAILED
 from cylc.templatevars import load_template_vars
+from cylc.terminal import cli_function
 
 
+@cli_function
 def main():
     """cylc submit CLI.
 
@@ -80,7 +83,7 @@ def main():
     suite = args.pop(0)
     for arg in args:
         if not TaskID.is_valid_id(arg):
-            sys.exit("Invalid task ID %s" % arg)
+            raise UserInputError("Invalid task ID %s" % arg)
     suite_srv_mgr = SuiteSrvFilesManager()
     suiterc = suite_srv_mgr.get_suite_rc(suite)
     suite_dir = os.path.dirname(suiterc)
@@ -97,7 +100,7 @@ def main():
         name_str, point_str = TaskID.split(arg)
         taskdefs = config.find_taskdefs(name_str)
         if not taskdefs:
-            sys.exit("No task found for %s" % arg)
+            raise UserInputError("No task found for %s" % arg)
         for taskdef in taskdefs:
             itasks.append(TaskProxy(
                 taskdef, get_point(point_str).standardise(), is_startup=True))
@@ -138,9 +141,8 @@ def main():
             if itask.local_job_file_path:
                 print(('JOB SCRIPT=%s' % itask.local_job_file_path))
             else:
-                print((
-                    'Unable to prepare job file for %s' % itask.identity),
-                    file=sys.stderr)
+                print(('Unable to prepare job file for %s' % itask.identity),
+                      file=sys.stderr)
                 ret_code = 1
     else:
         while waiting_tasks:
@@ -161,9 +163,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-suite-state
+++ b/bin/cylc-suite-state
@@ -55,12 +55,14 @@ from cylc.remote import remrun
 if remrun():
     sys.exit(0)
 
+from cylc.exceptions import CylcError, UserInputError
 import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.dbstatecheck import CylcSuiteDBChecker
 from cylc.cfgspec.glbl_cfg import glbl_cfg
 from cylc.command_polling import Poller
 from cylc.task_state import TASK_STATUSES_ORDERED
+from cylc.terminal import cli_function
 from cylc.cycling.util import add_offset
 
 from isodatetime.parsers import TimePointParser
@@ -119,7 +121,7 @@ class SuitePoller(Poller):
             self.args['status'], self.args['message'])
 
 
-def main():
+def parse_args():
     parser = COP(__doc__)
 
     parser.add_option(
@@ -176,45 +178,47 @@ def main():
         action="store", dest="msg", default=None)
 
     SuitePoller.add_to_cmd_options(parser)
-    (options, args) = parser.parse_args(remove_opts=["--db"])
+    return parser.parse_args(remove_opts=["--db"])
 
+
+@cli_function
+def main():
+    options, args = parse_args()
     suite = args[0]
 
     if options.use_task_point and options.cycle:
-        sys.exit(
-            "ERROR: cannot specify a cycle point and use environment variable")
+        raise UserInputError(
+            "cannot specify a cycle point and use environment variable")
 
     if options.use_task_point:
         if "CYLC_TASK_CYCLE_POINT" in os.environ:
             options.cycle = os.environ["CYLC_TASK_CYCLE_POINT"]
         else:
-            sys.exit("ERROR: CYLC_TASK_CYCLE_POINT is not defined")
+            raise UserInputError("CYLC_TASK_CYCLE_POINT is not defined")
 
     if options.offset and not options.cycle:
-        sys.exit("ERROR: You must target a cycle point to use an offset")
+        raise UserInputError(
+            "You must target a cycle point to use an offset")
 
     if options.template:
         print("WARNING: ignoring --template (no longer needed)", file=sys.stderr)
 
     # Attempt to apply specified offset to the targeted cycle
     if options.offset:
-        try:
-            options.cycle = str(add_offset(options.cycle, options.offset))
-        except ValueError as exc:
-            sys.exit(exc)
+        options.cycle = str(add_offset(options.cycle, options.offset))
 
     # Exit if both task state and message are to being polled
     if options.status and options.msg:
-        sys.exit("ERROR: cannot poll both status and custom output")
+        raise UserInputError("cannot poll both status and custom output")
 
     if options.msg and not options.task and not options.cycle:
-        sys.exit("ERROR: need a taskname and cyclepoint")
+        raise UserInputError("need a taskname and cyclepoint")
 
     # Exit if an invalid status is requested
     if (options.status and
             options.status not in TASK_STATUSES_ORDERED and
             options.status not in CylcSuiteDBChecker.STATE_ALIASES):
-        sys.exit("ERROR: invalid status '" + options.status + "'")
+        raise UserInputError("invalid status '" + options.status + "'")
 
     # this only runs locally (use of --host or --user results in remote
     # re-invocation).
@@ -238,20 +242,20 @@ def main():
     connected, formatted_pt = spoller.connect()
 
     if not connected:
-        sys.exit("ERROR: cannot connect to the suite DB")
+        raise CylcError("cannot connect to the suite DB")
 
     if options.status and options.task and options.cycle:
-        """check a task status"""
+        # check a task status
         spoller.condition = options.status
         if not spoller.poll():
             sys.exit(1)
     elif options.msg:
-        """Check for a custom task output"""
+        # Check for a custom task output
         spoller.condition = "output: %s" % options.msg
         if not spoller.poll():
             sys.exit(1)
     else:
-        """just display query results"""
+        # just display query results
         spoller.checker.display_maps(
             spoller.checker.suite_state_query(
                 task=options.task,
@@ -260,9 +264,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-trigger
+++ b/bin/cylc-trigger
@@ -48,14 +48,16 @@ import shutil
 import difflib
 from subprocess import call
 
+from cylc.exceptions import CylcError, UserInputError
 import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
 from cylc.cfgspec.glbl_cfg import glbl_cfg
 from cylc.task_job_logs import JOB_LOG_DIFF
-from cylc.terminal import prompt
+from cylc.terminal import prompt, cli_function
 
 
+@cli_function
 def main():
     """CLI for "cylc trigger"."""
     parser = COP(
@@ -93,15 +95,13 @@ def main():
             'ping_task',
             {'task_id': task_id, 'exists_only': True}
         )
-        if not success:
-            sys.exit('ERROR: %s' % msg)
 
         # Get the job filename from the suite server program - the task cycle
         # point may need standardising to the suite cycle point format.
         jobfile_path = pclient(
             'get_task_jobfile_path', {'task_id': task_id})
         if not jobfile_path:
-            sys.exit('ERROR: task not found')
+            raise UserInputError('task not found')
 
         # Note: localhost time and file system time may be out of sync,
         #       so the safe way to detect whether a new file is modified
@@ -131,7 +131,8 @@ def main():
                 if old_mtime is None or mtime > old_mtime:
                     break
             if count > MAX_TRIES:
-                sys.exit('ERROR: no job file after %s seconds' % MAX_TRIES)
+                raise CylcError(
+                    'no job file after %s seconds' % MAX_TRIES)
             time.sleep(1)
 
         # Make a pre-edit copy to allow a post-edit diff.
@@ -151,10 +152,10 @@ def main():
             # Block until the editor exits.
             retcode = call(command_list)
             if retcode != 0:
-                sys.exit(
-                    'ERROR, command failed with %d:\n %s' % (retcode, command))
+                raise CylcError(
+                    'command failed with %d:\n %s' % (retcode, command))
         except OSError:
-            sys.exit('ERROR, unable to execute:\n %s' % command)
+            raise CylcError('unable to execute:\n %s' % command)
 
         # Get confirmation after editing is done.
         # Don't allow force-no-prompt in this case.
@@ -200,9 +201,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-validate
+++ b/bin/cylc-validate
@@ -30,21 +30,21 @@ from cylc.remote import remrun
 if remrun():
     sys.exit(0)
 
-from cylc import LOG
+from cylc import LOG, __version__ as CYLC_VERSION
+from cylc.config import SuiteConfig
+from cylc.exceptions import (
+    SuiteConfigError, TriggerExpressionError, TaskProxySequenceBoundsError)
 import cylc.flags
-from cylc.option_parsers import CylcOptionParser as COP
 from cylc.loggingutil import CylcLogFormatter
-from cylc import __version__ as CYLC_VERSION
-from cylc.config import SuiteConfig, SuiteConfigError
-from cylc.prerequisite import TriggerExpressionError
-from cylc.suite_srv_files_mgr import SuiteSrvFilesManager
-from cylc.task_proxy import TaskProxy, TaskProxySequenceBoundsError
-from cylc.templatevars import load_template_vars
+from cylc.option_parsers import CylcOptionParser as COP
 from cylc.profiler import Profiler
+from cylc.suite_srv_files_mgr import SuiteSrvFilesManager
+from cylc.task_proxy import TaskProxy
+from cylc.templatevars import load_template_vars
+from cylc.terminal import cli_function
 
 
-def main():
-    """cylc validate CLI."""
+def parse_args():
     parser = COP(__doc__, jset=True, prep=True, icp=True)
 
     parser.add_option(
@@ -69,7 +69,13 @@ def main():
         default="live", dest="run_mode",
         choices=['live', 'dummy', 'dummy-local', 'simulation'])
 
-    (options, args) = parser.parse_args()
+    return parser.parse_args()
+
+
+@cli_function
+def main():
+    """cylc validate CLI."""
+    options, args = parse_args()
 
     profiler = Profiler(options.profile_mode)
     profiler.start()
@@ -121,7 +127,7 @@ def main():
             continue
         except Exception as exc:
             raise SuiteConfigError(
-                'ERROR, failed to instantiate task %s: %s' % (name, exc))
+                'failed to instantiate task %s: %s' % (name, exc))
 
         # force trigger evaluation now
         try:
@@ -139,7 +145,7 @@ def main():
         except Exception as exc:
             print(str(exc), file=sys.stderr)
             raise SuiteConfigError(
-                'ERROR, %s: failed to evaluate triggers.' % name)
+                '%s: failed to evaluate triggers.' % name)
         if cylc.flags.verbose:
             print('  + %s ok' % itask.identity)
 
@@ -148,11 +154,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            import traceback
-            traceback.print_exc()
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-view
+++ b/bin/cylc-view
@@ -45,10 +45,11 @@ from cylc.cfgspec.glbl_cfg import glbl_cfg
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.suite_srv_files_mgr import SuiteSrvFilesManager
 from cylc.templatevars import load_template_vars
+from cylc.terminal import cli_function
 from parsec.fileparse import read_and_proc
 
 
-def main():
+def parse_args():
     parser = COP(__doc__, jset=True, prep=True)
 
     parser.add_option(
@@ -111,7 +112,12 @@ def main():
              "for 'cylc edit --inline'.",
         action="store_true", default=False, dest="asedit")
 
-    options, args = parser.parse_args()
+    return  parser.parse_args()
+
+
+@cli_function
+def main():
+    options, args = parse_args()
     suite, suiterc = SuiteSrvFilesManager().parse_suite_arg(options, args[0])
 
     cylc_tmpdir = glbl_cfg().get_tmpdir()
@@ -127,7 +133,8 @@ def main():
                'empy': options.empy or options.process,
                'jinja2': options.jinja2 or options.process,
                'contin': options.cat or options.process,
-               'inline': options.inline or options.jinja2 or options.empy or options.process,
+               'inline': (options.inline or options.jinja2 or options.empy
+                          or options.process),
                }
     lines = read_and_proc(
         suiterc,
@@ -184,9 +191,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/bin/cylc-warranty
+++ b/bin/cylc-warranty
@@ -24,10 +24,11 @@ Options:
 
 import sys
 import cylc.flags
+from cylc.terminal import cli_function
 
 
+@cli_function
 def main():
-
     if len(sys.argv) == 1:
         print("""GNU General Public License v3.0, Section 15:
 
@@ -48,9 +49,4 @@ ALL NECESSARY SERVICING, REPAIR OR CORRECTION.""")
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as exc:
-        if cylc.flags.debug:
-            raise
-        sys.exit(str(exc))
+    main()

--- a/doc/src/tutorial.rst
+++ b/doc/src/tutorial.rst
@@ -159,7 +159,7 @@ Suite configurations can be validated to detect syntax (and other) errors:
    0
    # fail:
    $ cylc validate my/bad/suite
-   Illegal item: [scheduling]special tusks
+   IllegalItemError: [scheduling]special tusks
    $ echo $?
    1
 

--- a/lib/cylc/broadcast_mgr.py
+++ b/lib/cylc/broadcast_mgr.py
@@ -25,8 +25,8 @@ from cylc.broadcast_report import (
     CHANGE_FMT, CHANGE_PREFIX_SET,
     get_broadcast_change_report,
     get_broadcast_bad_options_report)
-from cylc.cycling import PointParsingError
 from cylc.cycling.loader import get_point, standardise_point_string
+from cylc.exceptions import PointParsingError
 from cylc.task_id import TaskID
 
 

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -24,7 +24,7 @@ import shutil
 from tempfile import mkdtemp
 
 from parsec.config import ParsecConfig
-from parsec import ParsecError
+from parsec.exceptions import ParsecError
 from parsec.upgrade import upgrader, converter
 
 from cylc import LOG

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -30,6 +30,7 @@ from parsec.upgrade import upgrader, converter
 from cylc import LOG
 from cylc.cfgvalidate import (
     cylc_config_validate, CylcConfigValidator as VDR, DurationFloat)
+from cylc.exceptions import GlobalConfigError
 from cylc.hostuserutil import get_user_home, is_remote_user
 from cylc.network import Priv
 from cylc import __version__ as CYLC_VERSION
@@ -262,13 +263,6 @@ def upg(cfg, descr):
     u.obsolete('8.0.0', ['communication'])
 
     u.upgrade()
-
-
-class GlobalConfigError(Exception):
-    """Error in global site/user configuration."""
-
-    def __str__(self):
-        return repr(self.args[0])
 
 
 class GlobalConfig(ParsecConfig):

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -43,7 +43,8 @@ from parsec.util import replicate
 from cylc import LOG
 from cylc.c3mro import C3
 from cylc.conditional_simplifier import ConditionalSimplifier
-from cylc.exceptions import CylcError
+from cylc.exceptions import (
+    CylcError, SuiteConfigError, IntervalParsingError, TaskDefError)
 from cylc.graph_parser import GraphParser
 from cylc.param_expand import NameExpander
 from cylc.cfgspec.glbl_cfg import glbl_cfg
@@ -52,15 +53,14 @@ from cylc.cycling.loader import (
     get_point, get_point_relative, get_interval, get_interval_cls,
     get_sequence, get_sequence_cls, init_cyclers, INTEGER_CYCLING_TYPE,
     ISO8601_CYCLING_TYPE)
-from cylc.cycling import IntervalParsingError
 from cylc.cycling.iso8601 import ingest_time
 import cylc.flags
-from cylc.graphnode import GraphNodeParser, GraphNodeError
+from cylc.graphnode import GraphNodeParser
 from cylc.print_tree import print_tree
 from cylc.subprocctx import SubFuncContext
 from cylc.subprocpool import get_func
 from cylc.suite_srv_files_mgr import SuiteSrvFilesManager
-from cylc.taskdef import TaskDef, TaskDefError
+from cylc.taskdef import TaskDef
 from cylc.task_id import TaskID
 from cylc.task_outputs import TASK_OUTPUT_SUCCEEDED
 from cylc.task_trigger import TaskTrigger, Dependency
@@ -88,19 +88,6 @@ def check_varnames(env):
         if not re.match(r'^[a-zA-Z_][\w]*$', varname):
             bad.append(varname)
     return bad
-
-
-class SuiteConfigError(Exception):
-    """
-    Attributes:
-        message - what the problem is.
-        TODO - element - config element causing the problem
-    """
-    def __init__(self, msg):
-        self.msg = msg
-
-    def __str__(self):
-        return repr(self.msg)
 
 # TODO: separate config for run and non-run purposes?
 
@@ -208,17 +195,17 @@ class SuiteConfig(object):
 
         # First check for the essential scheduling section.
         if 'scheduling' not in self.cfg:
-            raise SuiteConfigError("ERROR: missing [scheduling] section.")
+            raise SuiteConfigError("missing [scheduling] section.")
         if 'dependencies' not in self.cfg['scheduling']:
             raise SuiteConfigError(
-                "ERROR: missing [scheduling][[dependencies]] section.")
+                "missing [scheduling][[dependencies]] section.")
         # (The check that 'graph' is defined is below).
         # The two runahead limiting schemes are mutually exclusive.
         rlim = self.cfg['scheduling'].get('runahead limit')
         mact = self.cfg['scheduling'].get('max active cycle points')
         if rlim and mact:
             raise SuiteConfigError(
-                "ERROR: use 'runahead limit' OR "
+                "use 'runahead limit' OR "
                 "'max active cycle points', not both")
 
         # Override the suite defn with an initial point from the CLI.
@@ -469,7 +456,7 @@ class SuiteConfig(object):
                     match = RE_EXT_TRIGGER.match(item)
                     if match is None:
                         raise SuiteConfigError(
-                            "ERROR: Illegal %s spec: %s" % (s_type, item)
+                            "Illegal %s spec: %s" % (s_type, item)
                         )
                     name, ext_trigger_msg = match.groups()
                     extn = "(" + ext_trigger_msg + ")"
@@ -478,12 +465,12 @@ class SuiteConfig(object):
                     match = RE_CLOCK_OFFSET.match(item)
                     if match is None:
                         raise SuiteConfigError(
-                            "ERROR: Illegal %s spec: %s" % (s_type, item)
+                            "Illegal %s spec: %s" % (s_type, item)
                         )
                     if (self.cfg['scheduling']['cycling mode'] !=
                             Calendar.MODE_GREGORIAN):
                         raise SuiteConfigError(
-                            "ERROR: %s tasks require "
+                            "%s tasks require "
                             "[scheduling]cycling mode=%s" % (
                                 s_type, Calendar.MODE_GREGORIAN)
                         )
@@ -500,7 +487,7 @@ class SuiteConfig(object):
                             get_interval(offset_string).standardise())
                     except IntervalParsingError:
                         raise SuiteConfigError(
-                            "ERROR: Illegal %s spec: %s" % (
+                            "Illegal %s spec: %s" % (
                                 s_type, offset_string))
                     extn = "(" + offset_string + ")"
 
@@ -532,7 +519,7 @@ class SuiteConfig(object):
         for fam in self.collapsed_families_rc:
             if fam not in self.runtime['first-parent descendants']:
                 raise SuiteConfigError(
-                    'ERROR [visualization]collapsed families: '
+                    '[visualization]collapsed families: '
                     '%s is not a first parent' % fam)
 
         if is_reload and collapsed:
@@ -583,7 +570,7 @@ class SuiteConfig(object):
                 LOG.warning(err_msg)
             if self.strict:
                 raise SuiteConfigError(
-                    'ERROR: strict validation fails naked dummy tasks')
+                    'strict validation fails naked dummy tasks')
 
         if is_validate:
             self.check_tasks()
@@ -601,7 +588,7 @@ class SuiteConfig(object):
                         "External trigger '%s'\n  used in tasks %s and %s." % (
                             msg, name, seen[msg]))
                     raise SuiteConfigError(
-                        "ERROR: external triggers must be used only once.")
+                        "external triggers must be used only once.")
 
         ngs = self.cfg['visualization']['node groups']
         # If a node group member is a family, include its descendants too.
@@ -772,7 +759,7 @@ class SuiteConfig(object):
                         TaskID.get(*lhs), TaskID.get(*rhs))
             if err_msg:
                 raise SuiteConfigError(
-                    'ERROR: circular edges detected:' + err_msg)
+                    'circular edges detected:' + err_msg)
 
     @staticmethod
     def _check_circular_helper(x2ys, y2xs):
@@ -988,11 +975,11 @@ class SuiteConfig(object):
                     continue
                 if p not in self.cfg['runtime']:
                     raise SuiteConfigError(
-                        "ERROR, undefined parent for " + name + ": " + p)
+                        "undefined parent for " + name + ": " + p)
             if pts[0] == "None":
                 if len(pts) < 2:
                     raise SuiteConfigError(
-                        "ERROR: null parentage for " + name)
+                        "null parentage for " + name)
                 demoted[name] = pts[1]
                 pts = pts[1:]
                 first_parents[name] = ['root']
@@ -1016,7 +1003,11 @@ class SuiteConfig(object):
                     c3_single.mro(name))
             except RecursionError:
                 raise SuiteConfigError(
-                    "ERROR: circular [runtime] inheritance?")
+                    "circular [runtime] inheritance?")
+            except Exception as exc:
+                # catch inheritance errors
+                # TODO - specialise MRO exceptions
+                raise SuiteConfigError(str(exc))
 
         for name in self.cfg['runtime']:
             ancestors = self.runtime['linearized ancestors'][name]
@@ -1105,7 +1096,7 @@ class SuiteConfig(object):
         max_cycles = self.cfg['scheduling']['max active cycle points']
         if max_cycles == 0:
             raise SuiteConfigError(
-                "ERROR: max cycle points must be greater than %s" %
+                "max cycle points must be greater than %s" %
                 (max_cycles)
             )
         self.max_num_active_cycle_points = self.cfg['scheduling'][
@@ -1237,7 +1228,7 @@ class SuiteConfig(object):
                 if cs:
                     # (allow explicit blanking of inherited script)
                     raise SuiteConfigError(
-                        "ERROR: script cannot be defined for automatic" +
+                        "script cannot be defined for automatic" +
                         " suite polling task '%s':\n%s" % (l_task, cs))
         # Generate the automatic scripting.
         for name, tdef in list(self.taskdefs.items()):
@@ -1398,7 +1389,7 @@ class SuiteConfig(object):
         try:
             mro = self.runtime['linearized ancestors'][ns]
         except KeyError:
-            mro = ["ERROR: no such namespace: " + ns]
+            mro = ["no such namespace: " + ns]
         return mro
 
     def print_first_parent_tree(self, pretty=False, titles=False):
@@ -1478,10 +1469,7 @@ class SuiteConfig(object):
         """
 
         for taskdef in self.taskdefs.values():
-            try:
-                taskdef.check_for_explicit_cycling()
-            except TaskDefError as exc:
-                raise SuiteConfigError(str(exc))
+            taskdef.check_for_explicit_cycling()
             # Check use of ksh in "[job]shell" setting
             job_shell = taskdef.rtconfig['job']['shell']
             if job_shell and 'ksh' in os.path.basename(job_shell):
@@ -1508,7 +1496,7 @@ class SuiteConfig(object):
                                 value % subs
                             except (KeyError, ValueError) as exc:
                                 raise SuiteConfigError(
-                                    'ERROR: bad task event handler template'
+                                    'bad task event handler template'
                                     ' %s: %s: %s' % (
                                         taskdef.name, value, repr(exc)))
         if cylc.flags.verbose:
@@ -1527,12 +1515,12 @@ class SuiteConfig(object):
                     name = name.split('(', 1)[0]
                 if not TaskID.is_valid_name(name):
                     raise SuiteConfigError(
-                        'ERROR: Illegal %s task name: %s' % (task_type, name))
+                        'Illegal %s task name: %s' % (task_type, name))
                 if (name not in self.taskdefs and
                         name not in self.cfg['runtime']):
                     msg = '%s task "%s" is not defined.' % (task_type, name)
                     if self.strict:
-                        raise SuiteConfigError("ERROR: " + msg)
+                        raise SuiteConfigError(msg)
                     else:
                         LOG.warning(msg)
 
@@ -1572,7 +1560,7 @@ class SuiteConfig(object):
                 if orig_lexpr != lexpr:
                     LOG.error("%s => %s" % (orig_lexpr, right))
                 raise SuiteConfigError(
-                    "ERROR, self-edge detected: %s => %s" % (
+                    "self-edge detected: %s => %s" % (
                         left, right))
             self.edges[seq].add((left, right, suicide, conditional))
 
@@ -1584,12 +1572,8 @@ class SuiteConfig(object):
                 # if right is None, lefts are lone nodes
                 # for which we still define the taskdefs
                 continue
-            try:
-                name, offset_is_from_icp, _, offset, _ = (
-                    GraphNodeParser.get_inst().parse(node))
-            except GraphNodeError as exc:
-                LOG.error(orig_expr)
-                raise SuiteConfigError(str(exc))
+            name, offset_is_from_icp, _, offset, _ = (
+                GraphNodeParser.get_inst().parse(node))
 
             if name not in self.cfg['runtime']:
                 # naked dummy task, implicit inheritance from root
@@ -1634,7 +1618,7 @@ class SuiteConfig(object):
                     # Check for obsolete task message offsets.
                     if BCOMPAT_MSG_RE_C6.match(item[1]):
                         raise SuiteConfigError(
-                            'ERROR: Message trigger offsets are obsolete.')
+                            'Message trigger offsets are obsolete.')
 
     def generate_triggers(self, lexpression, left_nodes, right, seq,
                           suicide, task_triggers):
@@ -1659,7 +1643,7 @@ class SuiteConfig(object):
             if left.startswith('@'):
                 xtrig_labels.add(left[1:])
                 continue
-            # (GraphNodeError checked above)
+            # (GraphParseError checked above)
             name, offset_is_from_icp, offset_is_irregular, offset, output = (
                 GraphNodeParser.get_inst().parse(left))
             ltaskdef = self.taskdefs[name]
@@ -2030,12 +2014,12 @@ class SuiteConfig(object):
             if icp:
                 section = section.replace("^", icp)
             elif "^" in section:
-                raise SuiteConfigError("ERROR: Initial cycle point referenced"
+                raise SuiteConfigError("Initial cycle point referenced"
                                        " (^) but not defined.")
             if fcp:
                 section = section.replace("$", fcp)
             elif "$" in section:
-                raise SuiteConfigError("ERROR: Final cycle point referenced"
+                raise SuiteConfigError("Final cycle point referenced"
                                        " ($) but not defined.")
             # If the section consists of more than one sequence, split it up.
             new_sections = RE_SEC_MULTI_SEQ.split(section)
@@ -2053,11 +2037,11 @@ class SuiteConfig(object):
             except (AttributeError, TypeError, ValueError, CylcError) as exc:
                 if cylc.flags.debug:
                     traceback.print_exc()
-                msg = 'ERROR: Cannot process recurrence %s' % section
+                msg = 'Cannot process recurrence %s' % section
                 msg += ' (initial cycle point=%s)' % icp
                 msg += ' (final cycle point=%s)' % fcp
                 if isinstance(exc, CylcError):
-                    msg += ' %s' % str(exc)
+                    msg += ' %s' % exc.args[0]
                 raise SuiteConfigError(msg)
             self.sequences.append(seq)
             parser = GraphParser(family_map, self.parameters)
@@ -2079,7 +2063,7 @@ class SuiteConfig(object):
                             'wall_clock', 'wall_clock', [], {})
                     else:
                         raise SuiteConfigError(
-                            "ERROR, undefined xtrigger label: %s" % label)
+                            "undefined xtrigger label: %s" % label)
                 if xtrig.func_name.startswith('wall_clock'):
                     self.xtrigger_mgr.add_clock(label, xtrig)
                     # Replace existing xclock if the new offset is larger.

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -2084,12 +2084,10 @@ class SuiteConfig(object):
                     try:
                         if not callable(get_func(xtrig.func_name, self.fdir)):
                             raise SuiteConfigError(
-                                f"ERROR, "
                                 f"xtrigger function not callable: "
                                 f"{xtrig.func_name}")
                     except ModuleNotFoundError:
                         raise SuiteConfigError(
-                            f"ERROR, "
                             f"xtrigger function not found: {xtrig.func_name}")
                     self.xtrigger_mgr.add_trig(label, xtrig)
                     self.taskdefs[task_name].xtrig_labels.add(label)

--- a/lib/cylc/cycling/__init__.py
+++ b/lib/cylc/cycling/__init__.py
@@ -20,6 +20,10 @@
 
 from abc import ABCMeta, abstractmethod
 
+from cylc.exceptions import (
+    CyclerTypeError, PointParsingError, IntervalParsingError,
+    SequenceDegenerateError)
+
 
 def parse_exclusion(expr):
     count = expr.count('!')
@@ -39,47 +43,6 @@ def parse_exclusion(expr):
         exclusions = exclusions.translate(str.maketrans('', '', ' ()'))
         exclusions = exclusions.split(',')
         return remainder.strip(), exclusions
-
-
-class CyclerTypeError(TypeError):
-
-    """An error raised when incompatible cycling types are wrongly mixed."""
-
-    ERROR_MESSAGE = "Incompatible cycling types: {0} ({1}), {2} ({3})"
-
-    def __str__(self):
-        return self.ERROR_MESSAGE.format(*self.args)
-
-
-class PointParsingError(ValueError):
-
-    """An error raised when a point has an incorrect value."""
-
-    ERROR_MESSAGE = "Incompatible value for {0}: {1}: {2}"
-
-    def __str__(self):
-        return self.ERROR_MESSAGE.format(*self.args)
-
-
-class IntervalParsingError(ValueError):
-
-    """An error raised when an interval has an incorrect value."""
-
-    ERROR_MESSAGE = "Incompatible value for {0}: {1}"
-
-    def __str__(self):
-        return self.ERROR_MESSAGE.format(*self.args)
-
-
-class SequenceDegenerateError(Exception):
-
-    """An error raised when adjacent points on a sequence are equal."""
-
-    ERROR_MESSAGE = (
-        "Sequence {0}, point format {1}: equal adjacent points: {2} => {3}.")
-
-    def __str__(self):
-        return self.ERROR_MESSAGE.format(*self.args)
 
 
 class PointBase(object, metaclass=ABCMeta):

--- a/lib/cylc/cycling/integer.py
+++ b/lib/cylc/cycling/integer.py
@@ -25,7 +25,7 @@ from cylc.cycling import (
     PointBase, IntervalBase, SequenceBase, ExclusionBase, PointParsingError,
     IntervalParsingError, parse_exclusion, cmp
 )
-from cylc.time_parser import CylcMissingContextPointError
+from cylc.exceptions import CylcMissingContextPointError
 
 CYCLER_TYPE_INTEGER = "integer"
 CYCLER_TYPE_SORT_KEY_INTEGER = "a"
@@ -329,7 +329,7 @@ class IntegerSequence(SequenceBase):
             break
 
         if not matched_recurrence:
-            raise ValueError(
+            raise ValueError(  # TODO - raise appropriate exception
                 "ERROR, bad integer cycling format: %s" % expression)
 
         self.p_start = get_point_from_expression(
@@ -389,7 +389,7 @@ class IntegerSequence(SequenceBase):
 
         if self.i_step and self.i_step < IntegerInterval.get_null():
             # (TODO - this should be easy to handle but needs testing)
-            raise ValueError(
+            raise ValueError(  # TODO - raise appropriate exception
                 "ERROR, negative intervals not supported yet: %s" %
                 self.i_step
             )

--- a/lib/cylc/cycling/util.py
+++ b/lib/cylc/cycling/util.py
@@ -41,5 +41,6 @@ def add_offset(cycle_point, offset):
         else:
             my_target_point += my_shift
     else:
+        # TODO - raise appropriate exception
         raise ValueError("ERROR, bad offset format: %s" % offset)
     return my_target_point

--- a/lib/cylc/exceptions.py
+++ b/lib/cylc/exceptions.py
@@ -15,17 +15,168 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""Common and shared exceptions in cylc."""
+"""Exceptions for "expected" errors."""
 
 
 class CylcError(Exception):
+    """Generic exception for Cylc errors.
+
+    This exception is raised in-place of "expected" errors where a short
+    message to the user is more appropriate than traceback.
+
+    CLI commands will catch this exception and exit with str(exception).
+
     """
-    Attributes:
-        message - what the problem is.
-    """
-    def __init__(self, msg):
-        Exception.__init__(self, msg)
-        self.msg = msg
 
     def __str__(self):
-        return repr(self.msg)
+        return '%s: %s' % (self.__class__.__name__, self.args[0])
+
+
+class UserInputError(CylcError):
+    """Exception covering erroneous user imput to a Cylc interface.
+
+    Ideally this would be handled in the interface (e.g. argument parser).
+    If this isn't possible raise UserInputError.
+
+    """
+
+
+class LogAnalyserError(CylcError):
+    """Exception for issues scraping Cylc suite log files."""
+
+
+class CylcConfigError(CylcError):
+    """Generic exception to handle an error in a Cylc configuration file.
+
+    TODO:
+        * reference the configuration element causing the problem
+
+    """
+
+
+class SuiteConfigError(CylcConfigError):
+    """Exception for configuration errors in a Cylc suite configuration."""
+
+
+class GlobalConfigError(CylcConfigError):
+    """Exception for configuration errors in a Cylc global configuration."""
+
+
+class GraphParseError(SuiteConfigError):
+    """Exception for errors in Cylc suite graphing."""
+
+
+class TriggerExpressionError(GraphParseError):
+    """Trigger expression syntax issue."""
+
+
+class TaskProxySequenceBoundsError(CylcError):
+    """Error on TaskProxy.__init__ with out of sequence bounds start point."""
+
+    def __init__(self, msg):
+        CylcError.__init__(
+            self, 'Not loading %s (out of sequence bounds)' % msg)
+
+
+class ParamExpandError(SuiteConfigError):
+    """Exception for errors in Cylc parameter expansion."""
+
+
+class SuiteEventError(CylcError):
+    """Exception for errors in Cylc event handlers."""
+
+
+class SuiteServiceFileError(CylcError):
+    """Exception for errors related to suite service files."""
+
+
+class TaskRemoteMgmtError(CylcError):
+    """Exceptions initialising suite run directory of remote job host."""
+
+    MSG_INIT = '%s: initialisation did not complete:\n'  # %s owner_at_host
+    MSG_SELECT = '%s: host selection failed:\n'  # %s host
+    MSG_TIDY = '%s: clean up did not complete:\n'  # %s owner_at_host
+
+    def __str__(self):
+        msg, (host, owner), cmd_str, ret_code, out, err = self.args
+        if owner:
+            owner_at_host = owner + '@' + host
+        else:
+            owner_at_host = host
+        ret = (msg + 'COMMAND FAILED (%d): %s\n') % (
+            owner_at_host, ret_code, cmd_str)
+        for label, item in ('STDOUT', out), ('STDERR', err):
+            if item:
+                for line in item.splitlines(True):  # keep newline chars
+                    ret += 'COMMAND %s: %s' % (label, line)
+        return ret
+
+
+class TaskDefError(SuiteConfigError):
+    """Exception raise for errors in TaskDef initialization."""
+
+
+class ClientError(CylcError):
+
+    def __str__(self):
+        ret = 'Request returned error: %s' % self.args[0]
+        if len(self.args) > 1 and self.args[1]:
+            # append server-side traceback if appended
+            ret += '\n' + self.args[1]
+        return ret
+
+
+class ClientTimeout(CylcError):
+    pass
+
+
+class CyclingError(CylcError):
+    pass
+
+
+class CyclerTypeError(CyclingError):
+    """An error raised when incompatible cycling types are wrongly mixed."""
+
+    def __init__(self, *args):
+        CyclingError.__init__(
+            self,
+            'Incompatible cycling types: {0} ({1}), {2} ({3})'.format(*args))
+
+
+class PointParsingError(CyclingError):
+    """An error raised when a point has an incorrect value."""
+
+    def __init__(self, *args):
+        CyclingError.__init__(
+            self, 'Incompatible value for {0}: {1}: {2}'.format(*args))
+
+
+class IntervalParsingError(CyclingError):
+    """An error raised when an interval has an incorrect value."""
+
+    def __init__(self, *args):
+        CyclingError.__init__(
+            self, 'Incompatible value for {0}: {1}'.format(*args))
+
+
+class SequenceDegenerateError(CyclingError):
+    """An error raised when adjacent points on a sequence are equal."""
+
+    def __init__(self, *args):
+        CyclingError.__init__(
+            self, (
+                '{0}, point format {1}: equal adjacent points:'
+                ' {2} => {3}.'
+            ).format(*args))
+
+
+class CylcTimeSyntaxError(CyclingError):
+    """An error denoting invalid ISO/Cylc input syntax."""
+
+
+class CylcMissingContextPointError(CyclingError):
+    """An error denoting a missing (but required) context cycle point."""
+
+
+class CylcMissingFinalCyclePointError(CyclingError):
+    """An error denoting a missing (but required) final cycle point."""

--- a/lib/cylc/exceptions.py
+++ b/lib/cylc/exceptions.py
@@ -28,9 +28,6 @@ class CylcError(Exception):
 
     """
 
-    def __str__(self):
-        return '%s: %s' % (self.__class__.__name__, self.args[0])
-
 
 class UserInputError(CylcError):
     """Exception covering erroneous user imput to a Cylc interface.

--- a/lib/cylc/graphnode.py
+++ b/lib/cylc/graphnode.py
@@ -17,14 +17,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Provide graph node parsing and caching service"""
 
-from cylc.cycling.loader import get_interval, get_interval_cls
-from cylc.task_id import TaskID
 import re
 
-
-class GraphNodeError(Exception):
-    """Graph node parsing error."""
-    pass
+from cylc.cycling.loader import get_interval, get_interval_cls
+from cylc.exceptions import GraphParseError
+from cylc.task_id import TaskID
 
 
 class GraphNodeParser(object):
@@ -97,12 +94,12 @@ class GraphNodeParser(object):
             (name, offset_is_from_icp, offset_is_irregular, offset, output)
 
         Raise:
-            GraphNodeError: on illegal syntax.
+            GraphParseError: on illegal syntax.
         """
         if node not in self._nodes:
             match = self.REC_NODE.match(node)
             if not match:
-                raise GraphNodeError('Illegal graph node: %s' % node)
+                raise GraphParseError('Illegal graph node: %s' % node)
             name, offset_is_from_icp, offset, output = match.groups()
             if offset_is_from_icp and not offset:
                 offset = self._get_offset()

--- a/lib/cylc/host_appointer.py
+++ b/lib/cylc/host_appointer.py
@@ -26,11 +26,12 @@ from time import sleep
 
 from cylc import LOG
 from cylc.cfgspec.glbl_cfg import glbl_cfg
+from cylc.exceptions import CylcError
 from cylc.hostuserutil import is_remote_host, get_fqdn_by_host
 from cylc.remote import remote_cylc_cmd, run_cmd
 
 
-class EmptyHostList(RuntimeError):
+class EmptyHostList(CylcError):
     """Exception to be raised if there are no valid run hosts.
 
     Raise if, from the global configuration settings, no hosts are listed
@@ -41,7 +42,7 @@ class EmptyHostList(RuntimeError):
     """
 
     def __str__(self):
-        msg = ("\nERROR: No hosts currently compatible with this global "
+        msg = ("\nNo hosts currently compatible with this global "
                "configuration:")
         suite_server_cfg_items = (['run hosts'], ['run host select', 'rank'],
                                   ['run host select', 'thresholds'])

--- a/lib/cylc/log_diagnosis.py
+++ b/lib/cylc/log_diagnosis.py
@@ -21,10 +21,7 @@ from difflib import unified_diff
 
 
 from cylc import LOG
-
-
-class LogAnalyserError(Exception):
-    pass
+from cylc.exceptions import LogAnalyserError
 
 
 class LogSpec(object):
@@ -79,7 +76,7 @@ class LogSpec(object):
         if found:
             return point_string
         else:
-            raise LogAnalyserError("ERROR: logged stop point not found")
+            raise LogAnalyserError("logged stop point not found")
 
 
 class LogAnalyser(object):
@@ -109,11 +106,11 @@ class LogAnalyser(object):
 
         if len(new) == 0:
             raise LogAnalyserError(
-                "ERROR: new log contains no triggering info.")
+                "new log contains no triggering info.")
 
         if len(ref) == 0:
             raise LogAnalyserError(
-                "ERROR: reference log contains no triggering info.")
+                "reference log contains no triggering info.")
 
         new.sort()
         ref.sort()
@@ -121,7 +118,7 @@ class LogAnalyser(object):
         if new != ref:
             diff = unified_diff(new, ref, 'this run', 'reference log')
             raise LogAnalyserError(
-                "ERROR: triggering is NOT consistent with the reference log:" +
+                "triggering is NOT consistent with the reference log:" +
                 '\n' + '\n'.join(diff) + '\n')
         else:
             LOG.info(

--- a/lib/cylc/network/server.py
+++ b/lib/cylc/network/server.py
@@ -223,6 +223,8 @@ def authorise(req_priv_level):
     """
     def wrapper(fcn):
         def _authorise(self, *args, user='?', meta=None, **kwargs):
+            if not meta:
+                meta = {}
             host = meta.get('host', '?')
             prog = meta.get('prog', '?')
 

--- a/lib/cylc/param_expand.py
+++ b/lib/cylc/param_expand.py
@@ -60,6 +60,7 @@ foo_m1=>bar_m1_n2
 
 import re
 
+from cylc.exceptions import ParamExpandError
 from cylc.task_id import TaskID
 from parsec.OrderedDict import OrderedDictWithDefaults
 
@@ -87,11 +88,6 @@ def item_in_iterable(item, itt):
     except ValueError:
         return False
     return int(item) in (int(i) for i in itt)
-
-
-class ParamExpandError(Exception):
-    """For parameter expansion errors."""
-    pass
 
 
 class NameExpander(object):
@@ -139,12 +135,12 @@ class NameExpander(object):
                     pname, sval = REC_P_OFFS.match(item.strip()).groups()
                     if not self.param_cfg.get(pname, None):
                         raise ParamExpandError(
-                            "ERROR, parameter %s is not defined in %s" % (
+                            "parameter %s is not defined in %s" % (
                                 pname, runtime_heading))
                     if sval:
                         if sval.startswith('+') or sval.startswith('-'):
                             raise ParamExpandError(
-                                "ERROR, parameter index offsets are not"
+                                "parameter index offsets are not"
                                 " supported in name expansion: %s%s" % (
                                     pname, sval))
                         elif sval.startswith('='):
@@ -158,7 +154,7 @@ class NameExpander(object):
                             if not item_in_iterable(
                                     nval, self.param_cfg[pname]):
                                 raise ParamExpandError(
-                                    "ERROR, parameter %s out of range: %s" % (
+                                    "parameter %s out of range: %s" % (
                                         pname, p_list_str))
                             spec_vals[pname] = nval
                     else:
@@ -199,7 +195,7 @@ class NameExpander(object):
             try:
                 results.append((tmpl % current_values, current_values))
             except KeyError as exc:
-                raise ParamExpandError('ERROR: parameter %s is not '
+                raise ParamExpandError('parameter %s is not '
                                        'defined.' % str(exc.args[0]))
         else:
             for param_val in params[0][1]:
@@ -226,7 +222,7 @@ class NameExpander(object):
         for item in (i.strip() for i in p_list_str.split(',')):
             if '-' in item or '+' in item:
                 raise ParamExpandError(
-                    "ERROR, parameter offsets illegal here: '%s'" % origin)
+                    "parameter offsets illegal here: '%s'" % origin)
             elif '=' in item:
                 # Specific value given.
                 pname, pval = [val.strip() for val in item.split('=', 1)]
@@ -236,11 +232,11 @@ class NameExpander(object):
                     pass
                 if pname not in self.param_cfg:
                     raise ParamExpandError(
-                        "ERROR, parameter '%s' undefined in '%s'" % (
+                        "parameter '%s' undefined in '%s'" % (
                             pname, origin))
                 elif pval not in self.param_cfg[pname]:
                     raise ParamExpandError(
-                        "ERROR, illegal value '%s=%s' in '%s'" % (
+                        "illegal value '%s=%s' in '%s'" % (
                             pname, pval, origin))
                 used[pname] = pval
             else:
@@ -249,7 +245,7 @@ class NameExpander(object):
                     used[item] = param_values[item]
                 except KeyError:
                     raise ParamExpandError(
-                        "ERROR, parameter '%s' undefined in '%s'" % (
+                        "parameter '%s' undefined in '%s'" % (
                             item, origin))
         if head:
             tmpl = head
@@ -313,7 +309,7 @@ class GraphExpander(object):
                 pname, offs = REC_P_OFFS.match(item).groups()
                 if not self.param_cfg.get(pname, None):
                     raise ParamExpandError(
-                        "ERROR, parameter %s is not defined in <%s>: %s" % (
+                        "parameter %s is not defined in <%s>: %s" % (
                             pname, p_group, line))
                 if offs and offs.startswith('='):
                     # Check that specific parameter values exist.
@@ -324,7 +320,7 @@ class GraphExpander(object):
                         nval = val
                     if not item_in_iterable(nval, self.param_cfg[pname]):
                         raise ParamExpandError(
-                            "ERROR, parameter %s out of range: %s" % (
+                            "parameter %s out of range: %s" % (
                                 pname, p_group))
                 if pname not in used_pnames:
                     used_pnames.append(pname)
@@ -374,7 +370,7 @@ class GraphExpander(object):
                 try:
                     repl = tmpl % param_values
                 except KeyError as exc:
-                    raise ParamExpandError('ERROR: parameter %s is not '
+                    raise ParamExpandError('parameter %s is not '
                                            'defined.' % str(exc.args[0]))
                 line = line.replace('<' + p_group + '>', repl)
                 # Remove out-of-range nodes

--- a/lib/cylc/prerequisite.py
+++ b/lib/cylc/prerequisite.py
@@ -22,11 +22,7 @@ import math
 
 from cylc.conditional_simplifier import ConditionalSimplifier
 from cylc.cycling.loader import get_point
-
-
-class TriggerExpressionError(ValueError):
-    """Trigger expression syntax issue."""
-    pass
+from cylc.exceptions import TriggerExpressionError
 
 
 class Prerequisite(object):

--- a/lib/cylc/remote.py
+++ b/lib/cylc/remote.py
@@ -200,6 +200,7 @@ def construct_ssh_cmd(raw_cmd, user=None, host=None, forward_x11=False,
         if ssh_cylc.endswith('cylc'):
             command.append(ssh_cylc)
         else:
+            # TODO - raise appropriate exception
             raise ValueError(
                 r'ERROR: bad cylc executable in global config: %s' % ssh_cylc)
 

--- a/lib/cylc/run_get_stdout.py
+++ b/lib/cylc/run_get_stdout.py
@@ -25,10 +25,10 @@ from time import sleep, time
 from cylc.cylc_subproc import procopen
 
 
-ERR_TIMEOUT = "ERROR: command timed out (>%ds), terminated by signal %d\n%s"
-ERR_SIGNAL = "ERROR: command terminated by signal %d\n%s"
-ERR_RETCODE = "ERROR: command failed %d\n%s"
-ERR_OS = "ERROR: command invocation failed"
+ERR_TIMEOUT = "command timed out (>%ds), terminated by signal %d\n%s"
+ERR_SIGNAL = "command terminated by signal %d\n%s"
+ERR_RETCODE = "command failed %d\n%s"
+ERR_OS = "command invocation failed"
 POLL_DELAY = 0.1
 
 

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -36,10 +36,10 @@ from cylc import LOG
 from cylc.broadcast_mgr import BroadcastMgr
 from cylc.cfgspec.glbl_cfg import glbl_cfg
 from cylc.config import SuiteConfig
-from cylc.cycling import PointParsingError
 from cylc.cycling.loader import get_point, standardise_point_string
 from cylc.daemonize import daemonize
-from cylc.exceptions import CylcError
+from cylc.exceptions import (
+    CylcError, PointParsingError, TaskProxySequenceBoundsError)
 import cylc.flags
 from cylc.host_appointer import HostAppointer, EmptyHostList
 from cylc.hostuserutil import get_host, get_user, get_fqdn_by_host
@@ -61,7 +61,7 @@ from cylc.task_id import TaskID
 from cylc.task_job_logs import JOB_LOG_JOB, get_task_job_log
 from cylc.task_job_mgr import TaskJobManager
 from cylc.task_pool import TaskPool
-from cylc.task_proxy import TaskProxy, TaskProxySequenceBoundsError
+from cylc.task_proxy import TaskProxy
 from cylc.task_state import (
     TASK_STATUSES_ACTIVE, TASK_STATUSES_NEVER_ACTIVE, TASK_STATUS_FAILED)
 from cylc.templatevars import load_template_vars
@@ -414,7 +414,7 @@ conditions; see `cylc conditions`.
         if reqmode:
             if reqmode != self.run_mode:
                 raise SchedulerError(
-                    'ERROR: this suite requires the %s run mode' % reqmode)
+                    'this suite requires the %s run mode' % reqmode)
 
         self.broadcast_mgr.linearized_ancestors.update(
             self.config.get_linearized_ancestors())
@@ -935,7 +935,7 @@ conditions; see `cylc conditions`.
                 break
         if ret_code or not process_str:
             raise SchedulerError(
-                'ERROR, cannot get process "args" from "ps": %s' % err)
+                'cannot get process "args" from "ps": %s' % err)
         # Write suite contact file.
         # Preserve contact data in memory, for regular health check.
         mgr = self.suite_srv_files_mgr
@@ -962,7 +962,7 @@ conditions; see `cylc conditions`.
             mgr.dump_contact_file(self.suite, contact_data)
         except IOError as exc:
             raise SchedulerError(
-                'ERROR, cannot write suite contact file: %s: %s' %
+                'cannot write suite contact file: %s: %s' %
                 (mgr.get_contact_file(self.suite), exc))
         else:
             self.contact_data = contact_data
@@ -1071,7 +1071,7 @@ conditions; see `cylc conditions`.
             req = rtc['required run mode']
             if req and req != self.run_mode:
                 raise SchedulerError(
-                    'ERROR: suite allows only ' + req + ' reference tests')
+                    'suite allows only ' + req + ' reference tests')
             handlers = self._get_events_conf('shutdown handler')
             if handlers:
                 LOG.warning('shutdown handlers replaced by reference test')
@@ -1094,7 +1094,7 @@ conditions; see `cylc conditions`.
             timeout = rtc[self.run_mode + ' mode suite timeout']
             if not timeout:
                 raise SchedulerError(
-                    'ERROR: timeout not defined for %s reference tests' % (
+                    'timeout not defined for %s reference tests' % (
                         self.run_mode))
             self.config.cfg['cylc']['events'][self.EVENT_TIMEOUT] = (
                 timeout)

--- a/lib/cylc/scheduler_cli.py
+++ b/lib/cylc/scheduler_cli.py
@@ -30,6 +30,7 @@ from cylc.remote import remrun, remote_cylc_cmd
 from cylc.scheduler import Scheduler
 from cylc.suite_srv_files_mgr import (
     SuiteSrvFilesManager, SuiteServiceFileError)
+from cylc.terminal import cli_function
 
 RUN_DOC = r"""cylc [control] run|start [OPTIONS] [ARGS]
 
@@ -77,6 +78,7 @@ START_POINT_ARG_DOC = (
     "overrides the suite definition.")
 
 
+@cli_function
 def main(is_restart=False):
     """CLI main."""
     options, args = parse_commandline(is_restart)

--- a/lib/cylc/suite_events.py
+++ b/lib/cylc/suite_events.py
@@ -23,13 +23,9 @@ from shlex import quote
 
 from cylc import LOG
 from cylc.cfgspec.glbl_cfg import glbl_cfg
+from cylc.exceptions import SuiteEventError
 from cylc.hostuserutil import get_host, get_user
 from cylc.subprocctx import SubProcContext
-
-
-class SuiteEventError(Exception):
-    """Suite event error."""
-    pass
 
 
 SuiteEventContext = namedtuple(

--- a/lib/cylc/suite_srv_files_mgr.py
+++ b/lib/cylc/suite_srv_files_mgr.py
@@ -25,14 +25,10 @@ from string import ascii_letters, digits
 
 from cylc import LOG
 from cylc.cfgspec.glbl_cfg import glbl_cfg
+from cylc.exceptions import SuiteServiceFileError
 import cylc.flags
 from cylc.hostuserutil import (
     get_host, get_user, is_remote, is_remote_host, is_remote_user)
-
-
-class SuiteServiceFileError(Exception):
-    """Raise on error related to suite service files."""
-    pass
 
 
 class SuiteSrvFilesManager(object):
@@ -170,7 +166,7 @@ class SuiteSrvFilesManager(object):
 
         raise SuiteServiceFileError(
             (
-                r"""ERROR, suite contact file exists: %(fname)s
+                r"""suite contact file exists: %(fname)s
 
 Suite "%(suite)s" is already running, and listening at "%(host)s:%(port)s".
 
@@ -335,7 +331,7 @@ To start a new run, stop the old one first with one or more of these:
                 self.register(reg=reg, source=suite_d)
                 return suite_d
             else:
-                raise SuiteServiceFileError("ERROR: Suite not found %s" % reg)
+                raise SuiteServiceFileError("Suite not found %s" % reg)
         else:
             if os.path.isabs(source):
                 return source
@@ -443,7 +439,7 @@ To start a new run, stop the old one first with one or more of these:
 
         if os.path.isabs(reg):
             raise SuiteServiceFileError(
-                "ERROR: suite name cannot be an absolute path: %s" % reg)
+                "suite name cannot be an absolute path: %s" % reg)
 
         if source is not None:
             if os.path.basename(source) == self.FILE_BASE_SUITE_RC:
@@ -454,7 +450,7 @@ To start a new run, stop the old one first with one or more of these:
         # suite.rc must exist so we can detect accidentally reversed args.
         source = os.path.abspath(source)
         if not os.path.isfile(os.path.join(source, self.FILE_BASE_SUITE_RC)):
-            raise SuiteServiceFileError("ERROR: no suite.rc in %s" % source)
+            raise SuiteServiceFileError("no suite.rc in %s" % source)
 
         # Create service dir if necessary.
         srv_d = self.get_suite_srv_dir(reg)
@@ -473,7 +469,7 @@ To start a new run, stop the old one first with one or more of these:
         if orig_source is not None and source != orig_source:
             if not redirect:
                 raise SuiteServiceFileError(
-                    "ERROR: the name '%s' already points to %s.\nUse "
+                    "the name '%s' already points to %s.\nUse "
                     "--redirect to re-use an existing name and run "
                     "directory." % (reg, orig_source))
             LOG.warning(

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -38,8 +38,8 @@ from time import time
 from parsec.OrderedDict import OrderedDict
 
 from cylc import LOG
-from cylc.config import SuiteConfigError
 from cylc.cycling.loader import get_point, standardise_point_string
+from cylc.exceptions import SuiteConfigError, PointParsingError
 from cylc.task_action_timer import TaskActionTimer
 from cylc.task_events_mgr import (
     CustomTaskEventHandlerContext, TaskEventMailContext,
@@ -125,7 +125,7 @@ class TaskPool(object):
                 continue
             try:
                 point_str = standardise_point_string(point_str)
-            except ValueError as exc:
+            except PointParsingError as exc:
                 LOG.warning(
                     self.ERR_PREFIX_TASKID_MATCH + ("%s (%s)" % (item, exc)))
                 n_warnings += 1
@@ -144,7 +144,7 @@ class TaskPool(object):
             try:
                 stop_point = get_point(
                     standardise_point_string(stop_point_str))
-            except ValueError as exc:
+            except PointParsingError as exc:
                 LOG.warning("Invalid stop point: %s (%s)" % (
                     stop_point_str, exc))
                 n_warnings += 1
@@ -1333,7 +1333,7 @@ class TaskPool(object):
                 else:
                     try:
                         point_str = standardise_point_string(point_str)
-                    except ValueError:
+                    except PointParsingError:
                         # point_str may be a glob
                         pass
                 tasks_found = False

--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -21,17 +21,11 @@
 from isodatetime.timezone import get_local_time_zone
 
 import cylc.cycling.iso8601
+from cylc.exceptions import TaskProxySequenceBoundsError
 from cylc.task_id import TaskID
 from cylc.task_state import (
     TaskState, TASK_STATUS_WAITING, TASK_STATUS_RETRYING)
 from cylc.wallclock import get_unix_time_from_time_string as str2time
-
-
-class TaskProxySequenceBoundsError(ValueError):
-    """Error on TaskProxy.__init__ with out of sequence bounds start point."""
-
-    def __str__(self):
-        return 'Not loading %s (out of sequence bounds)' % self.args[0]
 
 
 class TaskProxy(object):

--- a/lib/cylc/task_remote_mgr.py
+++ b/lib/cylc/task_remote_mgr.py
@@ -33,6 +33,7 @@ from time import time
 
 from cylc import LOG
 from cylc.cfgspec.glbl_cfg import glbl_cfg
+from cylc.exceptions import TaskRemoteMgmtError
 import cylc.flags
 from cylc.hostuserutil import is_remote, is_remote_host, is_remote_user
 from cylc.subprocctx import SubProcContext
@@ -42,28 +43,6 @@ from cylc.task_remote_cmd import (
 
 REC_COMMAND = re.compile(r'(`|\$\()\s*(.*)\s*([`)])$')
 REMOTE_INIT_FAILED = 'REMOTE INIT FAILED'
-
-
-class TaskRemoteMgmtError(Exception):
-    """Cannot initialise suite run directory of remote job host."""
-
-    MSG_INIT = '%s: initialisation did not complete:\n'  # %s owner_at_host
-    MSG_SELECT = "%s: host selection failed:\n"  # %s host
-    MSG_TIDY = '%s: clean up did not complete:\n'  # %s owner_at_host
-
-    def __str__(self):
-        msg, (host, owner), cmd_str, ret_code, out, err = self.args
-        if owner:
-            owner_at_host = owner + '@' + host
-        else:
-            owner_at_host = host
-        ret = (msg + 'COMMAND FAILED (%d): %s\n') % (
-            owner_at_host, ret_code, cmd_str)
-        for label, item in ('STDOUT', out), ('STDERR', err):
-            if item:
-                for line in item.splitlines(True):  # keep newline chars
-                    ret += 'COMMAND %s: %s' % (label, line)
-        return ret
 
 
 class TaskRemoteMgr(object):

--- a/lib/cylc/taskdef.py
+++ b/lib/cylc/taskdef.py
@@ -22,18 +22,8 @@ from collections import deque
 
 from cylc.cycling.loader import (
     get_point_relative, get_interval, is_offset_absolute)
+from cylc.exceptions import TaskDefError
 from cylc.task_id import TaskID
-
-
-class TaskDefError(Exception):
-    """Exception raise for errors in TaskDef initialization."""
-
-    def __init__(self, msg):
-        Exception.__init__(self, msg)
-        self.msg = msg
-
-    def __str__(self):
-        return "ERROR: %s" % self.msg
 
 
 class TaskDef(object):

--- a/lib/cylc/terminal.py
+++ b/lib/cylc/terminal.py
@@ -2,6 +2,8 @@
 import os
 import sys
 
+from parsec.exceptions import ParsecError
+
 from cylc.cfgspec.glbl_cfg import glbl_cfg
 
 

--- a/lib/cylc/terminal.py
+++ b/lib/cylc/terminal.py
@@ -67,7 +67,7 @@ def cli_function(function):
             if is_terminal() or not cylc.flags.debug:
                 # catch "known" CylcErrors which should have sensible short
                 # summations of the issue, full traceback not necessary
-                sys.exit(str(exc))
+                sys.exit(f'{exc.__class__.__name__}: {exc}')
             else:
                 # if command is running non-interactively just raise the full
                 # traceback

--- a/lib/cylc/tests/cycling/test_iso8601.py
+++ b/lib/cylc/tests/cycling/test_iso8601.py
@@ -26,6 +26,9 @@ from cylc.cycling.iso8601 import init, ISO8601Sequence, ISO8601Point,\
 class TestISO8601Sequence(unittest.TestCase):
     """Contains unit tests for the ISO8601Sequence class."""
 
+    def setUp(self):
+        init(time_zone='Z')
+
     def test_exclusions_simple(self):
         """Test the generation of points for sequences with exclusions."""
         init(time_zone='Z')

--- a/lib/cylc/tests/test_exceptions.py
+++ b/lib/cylc/tests/test_exceptions.py
@@ -25,8 +25,7 @@ class TestExceptions(unittest.TestCase):
 
     def test_cylc_error(self):
         error = CylcError("abcd")
-        self.assertEqual("abcd", error.msg)
-        self.assertEqual("'abcd'", str(error))
+        self.assertEqual("CylcError: abcd", str(error))
 
 
 if __name__ == '__main__':

--- a/lib/cylc/tests/test_exceptions.py
+++ b/lib/cylc/tests/test_exceptions.py
@@ -25,7 +25,7 @@ class TestExceptions(unittest.TestCase):
 
     def test_cylc_error(self):
         error = CylcError("abcd")
-        self.assertEqual("CylcError: abcd", str(error))
+        self.assertEqual("abcd", str(error))
 
 
 if __name__ == '__main__':

--- a/lib/cylc/tests/test_graph_parser.py
+++ b/lib/cylc/tests/test_graph_parser.py
@@ -18,7 +18,8 @@
 
 import unittest
 
-from cylc.graph_parser import GraphParser, GraphParseError
+from cylc.exceptions import GraphParseError, ParamExpandError
+from cylc.graph_parser import GraphParser
 
 
 class TestGraphParser(unittest.TestCase):
@@ -139,7 +140,7 @@ class TestGraphParser(unittest.TestCase):
         """Test parsing graphs with invalid parameters."""
         parameterized_parser = GraphParser(
             None, ({'city': ['la_paz']}, {'city': '_%(city)s'}))
-        with self.assertRaises(GraphParseError):
+        with self.assertRaises(ParamExpandError):
             # no state in the parameters list
             parameterized_parser.parse_graph('a => b<state>')
 

--- a/lib/cylc/tests/test_param_expand.py
+++ b/lib/cylc/tests/test_param_expand.py
@@ -18,7 +18,8 @@
 
 import unittest
 
-from cylc.param_expand import NameExpander, GraphExpander, ParamExpandError
+from cylc.exceptions import ParamExpandError
+from cylc.param_expand import NameExpander, GraphExpander
 
 
 class TestParamExpand(unittest.TestCase):

--- a/lib/cylc/time_parser.py
+++ b/lib/cylc/time_parser.py
@@ -37,25 +37,12 @@ import isodatetime.data
 import isodatetime.parsers
 
 from cylc.cycling import parse_exclusion
-from cylc.exceptions import CylcError
+from cylc.exceptions import (
+    CylcTimeSyntaxError, CylcMissingContextPointError,
+    CylcMissingFinalCyclePointError)
 
 
 UTC_UTC_OFFSET_HOURS_MINUTES = (0, 0)
-
-
-class CylcTimeSyntaxError(CylcError):
-
-    """An error denoting invalid ISO/Cylc input syntax."""
-
-
-class CylcMissingContextPointError(CylcError):
-
-    """An error denoting a missing (but required) context cycle point."""
-
-
-class CylcMissingFinalCyclePointError(CylcError):
-
-    """An error denoting a missing (but required) final cycle point."""
 
 
 class CylcTimeParser(object):

--- a/lib/parsec/__init__.py
+++ b/lib/parsec/__init__.py
@@ -20,15 +20,6 @@
 import logging
 
 
-class ParsecError(Exception):
-    def __init__(self, msg=''):
-        Exception.__init__(self, msg)
-        self.msg = self.args[0]
-
-    def __str__(self):
-        return str(self.msg)
-
-
 LOG = logging.getLogger('cylc')  # Acceptable?
 if hasattr(logging, 'NullHandler'):  # Back compat Python <2.7
     LOG.addHandler(logging.NullHandler())  # Start with a null handler

--- a/lib/parsec/config.py
+++ b/lib/parsec/config.py
@@ -17,22 +17,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
-from parsec import ParsecError
+from parsec.exceptions import (
+    ParsecError, ItemNotFoundError, NotSingleItemError)
 from parsec.fileparse import parse
 from parsec.util import printcfg
 from parsec.validate import parsec_validate
 from parsec.OrderedDict import OrderedDictWithDefaults
 from parsec.util import itemstr, m_override, replicate, un_many
-
-
-class ItemNotFoundError(ParsecError):
-    def __init__(self, msg):
-        self.msg = 'ERROR: item not found: %s' % msg
-
-
-class NotSingleItemError(ParsecError):
-    def __init__(self, msg):
-        self.msg = 'ERROR: not a singular item: %s' % msg
 
 
 class ParsecConfig(object):

--- a/lib/parsec/empysupport.py
+++ b/lib/parsec/empysupport.py
@@ -25,13 +25,7 @@ import em
 import os
 import sys
 
-
-class EmPyError(Exception):
-    """Wrapper class for EmPy exceptions."""
-
-    def __init__(self, exc, lineno):
-        Exception.__init__(self, exc)
-        self.lineno = lineno
+from parsec.exceptions import EmPyError
 
 
 def empyprocess(flines, dir_, template_vars=None):

--- a/lib/parsec/empysupport.py
+++ b/lib/parsec/empysupport.py
@@ -41,8 +41,7 @@ def empyprocess(flines, dir_, template_vars=None):
         interpreter.file(ftempl, '<template>', template_vars)
     except Exception as exc:
         lineno = interpreter.contexts[-1].identify()[1]
-        raise EmPyError(
-            interpreter.meta(exc), lineno).with_traceback(sys.exc_info()[2])
+        raise EmPyError(str(exc), lines=flines[max(lineno - 4, 0): lineno])
     finally:
         interpreter.shutdown()
         xsuite = xtempl.getvalue()

--- a/lib/parsec/empysupport.py
+++ b/lib/parsec/empysupport.py
@@ -23,7 +23,6 @@ Importing code should catch ImportError in case EmPy is not installed.
 from io import StringIO
 import em
 import os
-import sys
 
 from parsec.exceptions import EmPyError
 

--- a/lib/parsec/exceptions.py
+++ b/lib/parsec/exceptions.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from copy import copy
+import os
+
+from parsec.util import itemstr
+
+
+class ParsecError(Exception):
+    """Generic exception for Parsec errors."""
+
+    def __str__(self):
+        ret = self.__class__.__name__
+        if self.args:
+            ret += ': ' + ' '.join(self.args)
+        return ret
+
+
+class ItemNotFoundError(ParsecError, KeyError):
+    """Error raised for missing configuration items."""
+
+    def __init__(self, msg):
+        ParsecError.__init__(self, 'item not found: %s' % msg)
+
+
+class NotSingleItemError(ParsecError, TypeError):
+    """Error raised if an iterable is given where an item is expected."""
+
+    def __init__(self, msg):
+        ParsecError.__init__(self, 'not a singular item: %s' % msg)
+
+
+class FileParseError(ParsecError):
+    """Error raised when attempting to read in the config file(s)."""
+
+    def __init__(self, reason, index=None, line=None, lines=None,
+                 error_name=""):
+        msg = ''
+        if error_name:
+            msg = error_name + ":\n"
+        msg += reason
+        if index:
+            msg += " (line " + str(index + 1) + ")"
+        if line:
+            msg += ":\n   " + line.strip()
+        if lines:
+            msg += "\nContext lines:\n" + "\n".join(lines)
+            msg += "\t<-- " + error_name
+        if index:
+            # TODO - make 'view' function independent of cylc:
+            msg += "\n(line numbers match 'cylc view -p')"
+        ParsecError.__init__(self, msg)
+
+
+class IncludeFileNotFoundError(ParsecError):
+    """Error raised for missing include files."""
+
+    def __init__(self, flist):
+        """Missing include file error.
+
+        E.g. for [DIR/top.rc, DIR/inc/sub.rc, DIR/inc/gone.rc]
+        "Include-file not found: inc/gone.rc via inc/sub.rc from DIR/top.rc"
+        """
+        rflist = copy(flist)
+        top_file = rflist[0]
+        top_dir = os.path.dirname(top_file) + '/'
+        rflist.reverse()
+        msg = rflist[0].replace(top_dir, '')
+        for f in rflist[1:-1]:
+            msg += ' via %s' % f.replace(top_dir, '')
+        msg += ' from %s' % top_file
+        ParsecError.__init__(self, msg)
+
+
+class UpgradeError(ParsecError):
+    """Error raised upon fault in an upgrade operation."""
+
+
+class ValidationError(ParsecError):
+    """Generic exception for invalid configurations."""
+
+
+class IllegalValueError(ValidationError):
+    """Bad setting value."""
+
+    def __init__(self, vtype, keys, value, exc=None):
+        msg = '(type=%s) %s' % (
+            vtype, itemstr(keys[:-1], keys[-1], value=value))
+        if exc:
+            msg += " - (%s)" % exc
+        ValidationError.__init__(self, msg)
+
+
+class ListValueError(IllegalValueError):
+    """Bad setting value, for a comma separated list."""
+
+    def __init__(self, keys, value, msg='', exc=None):
+        msg = '%s\n    %s' % (
+            msg, itemstr(keys[:-1], keys[-1], value=value))
+        if exc:
+            msg += ": %s" % exc
+        ValidationError.__init__(self, msg)
+
+
+class IllegalItemError(ValidationError):
+    """Bad setting section or option name."""
+
+    def __init__(self, keys, key, msg=None):
+        if msg is not None:
+            msg = '%s - (%s)' % (itemstr(keys, key), msg)
+        else:
+            msg = '%s' % itemstr(keys, key)
+        ValidationError.__init__(self, msg)
+
+
+class EmPyError(Exception):
+    """Wrapper class for EmPy exceptions."""
+
+    def __init__(self, exc, lineno):
+        Exception.__init__(self, exc)
+        self.lineno = lineno

--- a/lib/parsec/exceptions.py
+++ b/lib/parsec/exceptions.py
@@ -26,10 +26,7 @@ class ParsecError(Exception):
     """Generic exception for Parsec errors."""
 
     def __str__(self):
-        ret = self.__class__.__name__
-        if self.args:
-            ret += ': ' + ' '.join(self.args)
-        return ret
+        return ' '.join(self.args)
 
 
 class ItemNotFoundError(ParsecError, KeyError):

--- a/lib/parsec/exceptions.py
+++ b/lib/parsec/exceptions.py
@@ -168,12 +168,12 @@ class ListValueError(IllegalValueError):
     """Bad setting value, for a comma separated list."""
 
     def __init__(self, keys, value, msg=None, exc=None):
-        ValidationError.__init__(
-            self, keys, value, msg=msg, exc=exc, vtype='list')
+        IllegalValueError.__init__(
+            self, 'list', keys, value, exc=exc, msg=msg)
 
 
 class IllegalItemError(ValidationError):
     """Bad setting section or option name."""
 
-    def __init__(self, keys, key, msg=None):
-        ValidationError.__init__(self, keys, key=key, msg=msg)
+    def __init__(self, keys, key, msg=None, exc=None):
+        ValidationError.__init__(self, keys, key=key, exc=exc, msg=msg)

--- a/lib/parsec/fileparse.py
+++ b/lib/parsec/fileparse.py
@@ -141,7 +141,7 @@ def addict(cfig, key, val, parents, index):
     if not isinstance(cfig, dict):
         # an item of this name has already been encountered at this level
         raise FileParseError(
-            'ERROR line %d: already encountered %s',
+            'line %d: already encountered %s',
             index, itemstr(parents, key, val))
 
     if key in cfig:

--- a/lib/parsec/fileparse.py
+++ b/lib/parsec/fileparse.py
@@ -40,7 +40,6 @@ from parsec import LOG
 from parsec.exceptions import ParsecError, FileParseError
 from parsec.OrderedDict import OrderedDictWithDefaults
 from parsec.include import inline
-
 from parsec.util import itemstr
 
 

--- a/lib/parsec/include.py
+++ b/lib/parsec/include.py
@@ -21,27 +21,8 @@ import os
 import re
 import sys
 from shutil import copy as shcopy
-from copy import copy
-from parsec import ParsecError
 
-
-class IncludeFileNotFoundError(ParsecError):
-
-    def __init__(self, flist):
-        """Missing include file error.
-
-        E.g. for [DIR/top.rc, DIR/inc/sub.rc, DIR/inc/gone.rc]
-        "Include-file not found: inc/gone.rc via inc/sub.rc from DIR/top.rc"
-        """
-        rflist = copy(flist)
-        top_file = rflist[0]
-        top_dir = os.path.dirname(top_file) + '/'
-        rflist.reverse()
-        self.msg = (
-            "Include-file not found: %s" % rflist[0].replace(top_dir, ''))
-        for f in rflist[1:-1]:
-            self.msg += ' via %s' % f.replace(top_dir, '')
-        self.msg += ' from %s' % top_file
+from parsec.exceptions import ParsecError, IncludeFileNotFoundError
 
 
 done = []

--- a/lib/parsec/include.py
+++ b/lib/parsec/include.py
@@ -91,7 +91,7 @@ def inline(lines, dir_, filename, for_grep=False, for_edit=False, viewcfg=None,
         if m:
             q1, match, q2 = m.groups()
             if q1 and (q1 != q2):
-                raise ParsecError("ERROR, mismatched quotes: " + line)
+                raise ParsecError("mismatched quotes: " + line)
             inc = os.path.join(dir_, match)
             if inc not in done:
                 if single or for_edit:

--- a/lib/parsec/jinja2support.py
+++ b/lib/parsec/jinja2support.py
@@ -22,15 +22,25 @@ Importing code should catch ImportError in case Jinja2 is not installed.
 
 from glob import glob
 import os
+import re
 import sys
+import traceback
+
 from jinja2 import (
     BaseLoader,
     ChoiceLoader,
     Environment,
     FileSystemLoader,
     StrictUndefined,
-    TemplateNotFound)
+    TemplateNotFound,
+    TemplateSyntaxError)
+
 from parsec import LOG
+from parsec.exceptions import Jinja2Error
+
+
+TRACEBACK_LINENO = re.compile(r'(\s+)?File "<template>", line (\d+)')
+CONTEXT_LINES = 3
 
 
 class PyModuleLoader(BaseLoader):
@@ -131,11 +141,22 @@ def jinja2environment(dir_=None):
     return env
 
 
+def get_error_location():
+    """Extract template line number from end of traceback.
+
+    Returns:
+        int: The line number or None if not found.
+
+    """
+    for line in reversed(traceback.format_exc().splitlines()):
+        match = TRACEBACK_LINENO.match(line)
+        if match:
+            return int(match.groups()[1])
+    return None
+
+
 def jinja2process(flines, dir_, template_vars=None):
     """Pass configure file through Jinja2 processor."""
-    # Set up Jinja2 environment.
-    env = jinja2environment(dir_)
-
     # Load file lines into a template, excluding '#!jinja2' so that
     # '#!cylc-x.y.z' rises to the top. Callers should handle jinja2
     # TemplateSyntaxerror and TemplateError.
@@ -153,9 +174,39 @@ def jinja2process(flines, dir_, template_vars=None):
     # AND TYPEERROR (e.g. for not using "|int" filter on number inputs.
     # Convert unicode to plain str, ToDo - still needed for parsec?)
 
+    try:
+        env = jinja2environment(dir_)
+        template = env.from_string('\n'.join(flines[1:]))
+        lines = str(template.render(template_vars)).splitlines()
+    except TemplateSyntaxError as exc:
+        filename = None
+        # extract source lines
+        if exc.lineno and exc.source and not exc.filename:
+            # error in suite.rc or cylc include file
+            lines = exc.source.splitlines()
+        elif exc.lineno and exc.filename:
+            # error in jinja2 include file
+            filename = os.path.relpath(exc.filename, dir_)
+            with open(exc.filename, 'r') as include_file:
+                include_file.seek(max(exc.lineno - CONTEXT_LINES, 0), 0)
+                lines = []
+                for _ in range(CONTEXT_LINES):
+                    lines.append(include_file.readline().splitlines()[0])
+        if lines:
+            # extract context lines from source lines
+            lines = lines[max(exc.lineno - CONTEXT_LINES, 0):exc.lineno]
+
+        raise Jinja2Error(exc, lines=lines, filename=filename)
+    except Exception as exc:
+        lineno = get_error_location()
+        lines = None
+        if lineno:
+            lineno += 1  # shebang line ignored by jinja2
+            lines = flines[max(lineno - CONTEXT_LINES, 0):lineno]
+        raise Jinja2Error(exc, lines=lines)
+
     suiterc = []
-    template = env.from_string('\n'.join(flines[1:]))
-    for line in str(template.render(template_vars)).splitlines():
+    for line in lines:
         # Jinja2 leaves blank lines where source lines contain
         # only Jinja2 code; this matters if line continuation
         # markers are involved, so we remove blank lines here.

--- a/lib/parsec/jinja2support.py
+++ b/lib/parsec/jinja2support.py
@@ -77,6 +77,7 @@ class PyModuleLoader(BaseLoader):
 
 def raise_helper(message, error_type='Error'):
     """Provides a Jinja2 function for raising exceptions."""
+    # TODO - this more nicely
     raise Exception('Jinja2 %s: %s' % (error_type, message))
 
 
@@ -106,10 +107,13 @@ def jinja2environment(dir_=None):
     # |     return str(value).rjust( int(length), str(fillchar) )
     for namespace in ['filters', 'tests', 'globals']:
         nspdir = 'Jinja2' + namespace.capitalize()
-        for fdir in [
-                os.path.join(os.environ['CYLC_DIR'], 'lib', nspdir),
-                os.path.join(dir_, nspdir),
-                os.path.join(os.environ['HOME'], '.cylc', nspdir)]:
+        fdirs = [
+            os.path.join(dir_, nspdir),
+            os.path.join(os.environ['HOME'], '.cylc', nspdir)
+        ]
+        if 'CYLC_DIR' in os.environ:
+            fdirs.append(os.path.join(os.environ['CYLC_DIR'], 'lib', nspdir))
+        for fdir in fdirs:
             if os.path.isdir(fdir):
                 sys.path.append(os.path.abspath(fdir))
                 for name in glob(os.path.join(fdir, '*.py')):

--- a/lib/parsec/tests/test_config.py
+++ b/lib/parsec/tests/test_config.py
@@ -269,11 +269,11 @@ class TestConfig(unittest.TestCase):
 
     def test_item_not_found_error(self):
         error = parsec.config.ItemNotFoundError("internal error")
-        self.assertIn('item not found: internal error', str(error))
+        self.assertEqual('item not found: internal error', str(error))
 
     def test_not_single_item_error(self):
         error = parsec.config.NotSingleItemError("internal error")
-        self.assertIn('not a singular item: internal error', str(error))
+        self.assertEqual('not a singular item: internal error', str(error))
 
 
 if __name__ == '__main__':

--- a/lib/parsec/tests/test_config.py
+++ b/lib/parsec/tests/test_config.py
@@ -20,6 +20,7 @@ import tempfile
 import unittest
 
 import parsec.config
+from parsec.exceptions import ParsecError
 import parsec.validate
 from cylc.cfgvalidate import CylcConfigValidator as VDR
 from cylc.cfgvalidate import cylc_config_validate
@@ -61,7 +62,7 @@ def get_checkspec_params():
 
     return [
         (spec1, parents1, None),
-        (spec2, parents2, parsec.config.ParsecError)
+        (spec2, parents2, ParsecError)
     ]
 
 
@@ -268,13 +269,11 @@ class TestConfig(unittest.TestCase):
 
     def test_item_not_found_error(self):
         error = parsec.config.ItemNotFoundError("internal error")
-        self.assertEqual('ERROR: item not found: internal error',
-                         error.msg)
+        self.assertIn('item not found: internal error', str(error))
 
     def test_not_single_item_error(self):
         error = parsec.config.NotSingleItemError("internal error")
-        self.assertEqual('ERROR: not a singular item: internal error',
-                         error.msg)
+        self.assertIn('not a singular item: internal error', str(error))
 
 
 if __name__ == '__main__':

--- a/lib/parsec/tests/test_empysupport.py
+++ b/lib/parsec/tests/test_empysupport.py
@@ -25,7 +25,7 @@ import tempfile
 import unittest
 
 from parsec.exceptions import EmPyError
-from parsec.fileparse import FileParseError, read_and_proc
+from parsec.fileparse import read_and_proc
 
 IS_EMPY_INSTALLED = True
 
@@ -82,7 +82,7 @@ class TestEmpysupport1(unittest.TestCase):
 
             del template_vars['name']
 
-            with self.assertRaises(EmPyError) as cm:
+            with self.assertRaises(EmPyError):
                 read_and_proc(fpath=fpath, template_vars=template_vars,
                               viewcfg=viewcfg, asedit=asedit)
             sys.stdout.getvalue = lambda: ''

--- a/lib/parsec/tests/test_empysupport.py
+++ b/lib/parsec/tests/test_empysupport.py
@@ -84,7 +84,7 @@ class TestEmpysupport1(unittest.TestCase):
             with self.assertRaises(FileParseError) as cm:
                 read_and_proc(fpath=fpath, template_vars=template_vars,
                               viewcfg=viewcfg, asedit=asedit)
-            self.assertTrue("EmPyError" in cm.exception.msg)
+            self.assertTrue("EmPyError" in str(cm.exception))
             sys.stdout.getvalue = lambda: ''
 
         sys.stdout.getvalue = lambda: ''

--- a/lib/parsec/tests/test_empysupport.py
+++ b/lib/parsec/tests/test_empysupport.py
@@ -84,7 +84,7 @@ class TestEmpysupport1(unittest.TestCase):
             with self.assertRaises(FileParseError) as cm:
                 read_and_proc(fpath=fpath, template_vars=template_vars,
                               viewcfg=viewcfg, asedit=asedit)
-            self.assertTrue("EmPyError" in str(cm.exception))
+            self.assertIn("EmPyError", str(cm.exception))
             sys.stdout.getvalue = lambda: ''
 
         sys.stdout.getvalue = lambda: ''

--- a/lib/parsec/tests/test_empysupport.py
+++ b/lib/parsec/tests/test_empysupport.py
@@ -24,6 +24,7 @@ import sys
 import tempfile
 import unittest
 
+from parsec.exceptions import EmPyError
 from parsec.fileparse import FileParseError, read_and_proc
 
 IS_EMPY_INSTALLED = True
@@ -81,17 +82,12 @@ class TestEmpysupport1(unittest.TestCase):
 
             del template_vars['name']
 
-            with self.assertRaises(FileParseError) as cm:
+            with self.assertRaises(EmPyError) as cm:
                 read_and_proc(fpath=fpath, template_vars=template_vars,
                               viewcfg=viewcfg, asedit=asedit)
-            self.assertIn("EmPyError", str(cm.exception))
             sys.stdout.getvalue = lambda: ''
 
         sys.stdout.getvalue = lambda: ''
-
-    def test_empy_error(self):
-        empy_error = parsec.empysupport.EmPyError(exc=None, lineno=13)
-        self.assertEqual(13, empy_error.lineno)
 
 
 if __name__ == '__main__':

--- a/lib/parsec/tests/test_fileparse.py
+++ b/lib/parsec/tests/test_fileparse.py
@@ -19,7 +19,7 @@
 import tempfile
 import unittest
 
-from parsec.exceptions import IncludeFileNotFoundError
+from parsec.exceptions import IncludeFileNotFoundError, Jinja2Error
 from parsec.fileparse import *
 
 
@@ -113,7 +113,7 @@ class TestFileparse(unittest.TestCase):
 
         error = FileParseError("", lines=["a", "b"])
         self.assertEqual("\nContext lines:\n"
-                         "a\nb\t<-- ", str(error))
+                         "a\nb\t<--", str(error))
 
     def test_addsect(self):
         cfg = OrderedDictWithDefaults()
@@ -323,7 +323,7 @@ class TestFileparse(unittest.TestCase):
             asedit = None
             tf.write("#!jinja2\na={{ name \n".encode())
             tf.flush()
-            with self.assertRaises(FileParseError) as cm:
+            with self.assertRaises(Jinja2Error) as cm:
                 read_and_proc(fpath=fpath, template_vars=template_vars,
                               viewcfg=viewcfg, asedit=asedit)
             self.assertIn(

--- a/lib/parsec/tests/test_fileparse.py
+++ b/lib/parsec/tests/test_fileparse.py
@@ -19,6 +19,7 @@
 import tempfile
 import unittest
 
+from parsec.exceptions import IncludeFileNotFoundError
 from parsec.fileparse import *
 
 
@@ -35,7 +36,7 @@ def get_multiline():
             0,
             0,
             FileParseError,
-            "FileParseError:\nMultiline string not closed:\n   '''single line"
+            "FileParseError: Multiline string not closed:\n   '''single line"
         ),
         (
             ["'''", "single line"],
@@ -43,7 +44,7 @@ def get_multiline():
             0,
             0,
             FileParseError,
-            "FileParseError:\nInvalid line:\n   '''"
+            "FileParseError: Invalid line:\n   '''"
         ),
         (
             ["", "another value"],  # multiline, but we forgot to close quotes
@@ -51,7 +52,7 @@ def get_multiline():
             0,
             1,
             FileParseError,
-            "FileParseError:\nMultiline string not closed"
+            "FileParseError: Multiline string not closed"
         ),
         (
             ["", "c'''"],
@@ -75,7 +76,7 @@ def get_multiline():
             0,
             3,
             FileParseError,
-            "FileParseError:\nMultiline string not closed"
+            "FileParseError: Multiline string not closed"
         ),
         (
             ["", "c", "hello", ""],
@@ -91,7 +92,7 @@ def get_multiline():
             0,
             3,
             FileParseError,
-            "FileParseError:\nInvalid line:\n   a'''c"
+            "FileParseError: Invalid line:\n   a'''c"
         )
     ]
     return r
@@ -101,18 +102,18 @@ class TestFileparse(unittest.TestCase):
 
     def test_file_parse_error(self):
         error = FileParseError(reason="No reason")
-        self.assertEqual("FileParseError:\nNo reason", error.msg)
+        self.assertEqual("FileParseError: No reason", str(error))
 
         error = FileParseError("", index=2)
-        self.assertEqual("FileParseError:\n (line 3)\n"
-                         "(line numbers match 'cylc view -p')", error.msg)
+        self.assertEqual("FileParseError:  (line 3)\n"
+                         "(line numbers match 'cylc view -p')", str(error))
 
         error = FileParseError("", line="test")
-        self.assertEqual("FileParseError:\n:\n   test", error.msg)
+        self.assertEqual("FileParseError: :\n   test", str(error))
 
         error = FileParseError("", lines=["a", "b"])
-        self.assertEqual("FileParseError:\n\nContext lines:\n"
-                         "a\nb	<-- FileParseError", error.msg)
+        self.assertEqual("FileParseError: \nContext lines:\n"
+                         "a\nb\t<-- ", str(error))
 
     def test_addsect(self):
         cfg = OrderedDictWithDefaults()
@@ -223,7 +224,7 @@ class TestFileparse(unittest.TestCase):
                 with self.assertRaises(exc) as cm:
                     multiline(flines, value, index, maxline)
                 if isinstance(cm.exception, FileParseError):
-                    self.assertEqual(expected, cm.exception.msg)
+                    self.assertIn(expected, str(cm.exception))
             else:
                 r = multiline(flines, value, index, maxline)
                 self.assertEqual(expected, r)
@@ -287,11 +288,11 @@ class TestFileparse(unittest.TestCase):
             asedit = None
             tf.write("a=b\n%include \"404.txt\"".encode())
             tf.flush()
-            with self.assertRaises(FileParseError) as cm:
+            with self.assertRaises(IncludeFileNotFoundError) as cm:
                 read_and_proc(fpath=fpath, template_vars=template_vars,
                               viewcfg=viewcfg, asedit=asedit)
-            self.assertTrue("Include-file not found: 404.txt"
-                            in cm.exception.msg)
+            self.assertTrue("Include-file not found: 404.txt",
+                            str(cm.exception))
 
     def test_read_and_proc_jinja2(self):
         with tempfile.NamedTemporaryFile() as tf:
@@ -326,9 +327,10 @@ class TestFileparse(unittest.TestCase):
             with self.assertRaises(FileParseError) as cm:
                 read_and_proc(fpath=fpath, template_vars=template_vars,
                               viewcfg=viewcfg, asedit=asedit)
-            self.assertTrue("TemplateSyntaxError: unexpected end of "
-                            "template, expected 'end of print statement'."
-                            in cm.exception.msg)
+            self.assertIn(
+                "unexpected end of template, expected "
+                "'end of print statement'.",
+                str(cm.exception))
 
     def test_read_and_proc_jinja2_error_missing_shebang(self):
         with tempfile.NamedTemporaryFile() as tf:
@@ -396,7 +398,7 @@ class TestFileparse(unittest.TestCase):
                 with self.assertRaises(FileParseError) as cm:
                     parse(fpath=fpath, output_fname=of.name,
                           template_vars=template_vars)
-                self.assertTrue("Invalid line 1: Cylc" in cm.exception.msg)
+                self.assertIn("Invalid line 1: Cylc", str(cm.exception))
 
     def test_parse_comments(self):
         with tempfile.NamedTemporaryFile() as of:
@@ -458,7 +460,7 @@ class TestFileparse(unittest.TestCase):
             with self.assertRaises(FileParseError) as cm:
                 parse(fpath=fpath, output_fname="",
                       template_vars=template_vars)
-            self.assertTrue("bracket mismatch" in cm.exception.msg)
+            self.assertIn("bracket mismatch", str(cm.exception))
 
     def test_parse_with_sections_error_wrong_level(self):
         with tempfile.NamedTemporaryFile() as of:
@@ -475,8 +477,9 @@ class TestFileparse(unittest.TestCase):
                 with self.assertRaises(FileParseError) as cm:
                     parse(fpath=fpath, output_fname=of.name,
                           template_vars=template_vars)
-                self.assertEqual("FileParseError:\nError line 4: "
-                                 "[[[subsection1]]]", cm.exception.msg)
+                self.assertIn(
+                    "FileParseError: Error line 4: [[[subsection1]]]",
+                    str(cm.exception))
 
 
 if __name__ == '__main__':

--- a/lib/parsec/tests/test_fileparse.py
+++ b/lib/parsec/tests/test_fileparse.py
@@ -36,7 +36,7 @@ def get_multiline():
             0,
             0,
             FileParseError,
-            "FileParseError: Multiline string not closed:\n   '''single line"
+            "Multiline string not closed:\n   '''single line"
         ),
         (
             ["'''", "single line"],
@@ -44,7 +44,7 @@ def get_multiline():
             0,
             0,
             FileParseError,
-            "FileParseError: Invalid line:\n   '''"
+            "Invalid line:\n   '''"
         ),
         (
             ["", "another value"],  # multiline, but we forgot to close quotes
@@ -52,7 +52,7 @@ def get_multiline():
             0,
             1,
             FileParseError,
-            "FileParseError: Multiline string not closed"
+            "Multiline string not closed"
         ),
         (
             ["", "c'''"],
@@ -76,7 +76,7 @@ def get_multiline():
             0,
             3,
             FileParseError,
-            "FileParseError: Multiline string not closed"
+            "Multiline string not closed"
         ),
         (
             ["", "c", "hello", ""],
@@ -92,7 +92,7 @@ def get_multiline():
             0,
             3,
             FileParseError,
-            "FileParseError: Invalid line:\n   a'''c"
+            "Invalid line:\n   a'''c"
         )
     ]
     return r
@@ -102,17 +102,17 @@ class TestFileparse(unittest.TestCase):
 
     def test_file_parse_error(self):
         error = FileParseError(reason="No reason")
-        self.assertEqual("FileParseError: No reason", str(error))
+        self.assertEqual("No reason", str(error))
 
         error = FileParseError("", index=2)
-        self.assertEqual("FileParseError:  (line 3)\n"
+        self.assertEqual(" (line 3)\n"
                          "(line numbers match 'cylc view -p')", str(error))
 
         error = FileParseError("", line="test")
-        self.assertEqual("FileParseError: :\n   test", str(error))
+        self.assertEqual(":\n   test", str(error))
 
         error = FileParseError("", lines=["a", "b"])
-        self.assertEqual("FileParseError: \nContext lines:\n"
+        self.assertEqual("\nContext lines:\n"
                          "a\nb\t<-- ", str(error))
 
     def test_addsect(self):
@@ -224,7 +224,7 @@ class TestFileparse(unittest.TestCase):
                 with self.assertRaises(exc) as cm:
                     multiline(flines, value, index, maxline)
                 if isinstance(cm.exception, FileParseError):
-                    self.assertIn(expected, str(cm.exception))
+                    self.assertEqual(expected, str(cm.exception))
             else:
                 r = multiline(flines, value, index, maxline)
                 self.assertEqual(expected, r)
@@ -291,8 +291,7 @@ class TestFileparse(unittest.TestCase):
             with self.assertRaises(IncludeFileNotFoundError) as cm:
                 read_and_proc(fpath=fpath, template_vars=template_vars,
                               viewcfg=viewcfg, asedit=asedit)
-            self.assertTrue("Include-file not found: 404.txt",
-                            str(cm.exception))
+            self.assertIn("404.txt", str(cm.exception))
 
     def test_read_and_proc_jinja2(self):
         with tempfile.NamedTemporaryFile() as tf:
@@ -460,7 +459,8 @@ class TestFileparse(unittest.TestCase):
             with self.assertRaises(FileParseError) as cm:
                 parse(fpath=fpath, output_fname="",
                       template_vars=template_vars)
-            self.assertIn("bracket mismatch", str(cm.exception))
+            self.assertEqual("bracket mismatch:\n   [[section1]",
+                             str(cm.exception))
 
     def test_parse_with_sections_error_wrong_level(self):
         with tempfile.NamedTemporaryFile() as of:
@@ -477,8 +477,8 @@ class TestFileparse(unittest.TestCase):
                 with self.assertRaises(FileParseError) as cm:
                     parse(fpath=fpath, output_fname=of.name,
                           template_vars=template_vars)
-                self.assertIn(
-                    "FileParseError: Error line 4: [[[subsection1]]]",
+                self.assertEqual(
+                    "Error line 4: [[[subsection1]]]",
                     str(cm.exception))
 
 

--- a/lib/parsec/tests/test_include.py
+++ b/lib/parsec/tests/test_include.py
@@ -24,6 +24,7 @@ tests. So this suite of unit tests should not cover all the module features.
 import tempfile
 import unittest
 
+from parsec.exceptions import ParsecError
 from parsec.include import *
 
 
@@ -34,8 +35,7 @@ class TestInclude(unittest.TestCase):
         with tempfile.NamedTemporaryFile(dir=dir_temp) as tf:
             file_list = [tf.name, tf.name, tf.name]
             error = IncludeFileNotFoundError(file_list)
-            self.assertTrue("Include-file not found:" in error.msg)
-            self.assertTrue(" via " in error.msg)
+            self.assertTrue(" via " in str(error))
 
     def test_inline_error_empty_lines_1(self):
         """The inline function throws an error when you have the following

--- a/lib/parsec/tests/test_jinja2support.py
+++ b/lib/parsec/tests/test_jinja2support.py
@@ -20,6 +20,7 @@ import tempfile
 import unittest
 
 import jinja2
+
 from parsec.jinja2support import *
 
 
@@ -80,8 +81,9 @@ class TestJinja2support(unittest.TestCase):
         lines = ["skipped", "My name is {{ name }}", ""]
         template_dir = tempfile.gettempdir()
 
-        with self.assertRaises(jinja2.UndefinedError):
+        with self.assertRaises(Jinja2Error) as exc:
             jinja2process(lines, template_dir, template_vars=None)
+            self.assertIn('jinja2.UndefinedError', str(exc))
 
     def test_pymoduleloader(self):
         temp_directory = tempfile.mkdtemp(prefix='cylc', suffix='test_jinja2')

--- a/lib/parsec/tests/test_parsec.py
+++ b/lib/parsec/tests/test_parsec.py
@@ -25,12 +25,16 @@ class TestParsec(unittest.TestCase):
 
     def test_parsec_error_msg(self):
         parsec_error = ParsecError()
-        self.assertEqual('ParsecError', str(parsec_error))
+        self.assertEqual('', str(parsec_error))
+        parsec_error = ParsecError('foo')
+        self.assertEqual('foo', str(parsec_error))
+        parsec_error = ParsecError('foo', 'bar', 'baz')
+        self.assertEqual('foo bar baz', str(parsec_error))
 
     def test_parsec_error_str(self):
         msg = 'Turbulence!'
         parsec_error = ParsecError(msg)
-        self.assertIn(msg, str(parsec_error))
+        self.assertEqual(msg, str(parsec_error))
 
 
 if __name__ == '__main__':

--- a/lib/parsec/tests/test_parsec.py
+++ b/lib/parsec/tests/test_parsec.py
@@ -18,21 +18,19 @@
 
 import unittest
 
-import parsec
+from parsec.exceptions import ParsecError
 
 
 class TestParsec(unittest.TestCase):
 
     def test_parsec_error_msg(self):
-        parsec_error = parsec.ParsecError()
-        self.assertEqual('', parsec_error.msg)
-        # TBD: why do we have msg if the Exception class provides message?
-        self.assertEqual(parsec_error.msg, str(parsec_error))
+        parsec_error = ParsecError()
+        self.assertEqual('ParsecError', str(parsec_error))
 
     def test_parsec_error_str(self):
         msg = 'Turbulence!'
-        parsec_error = parsec.ParsecError(msg)
-        self.assertEqual(msg, str(parsec_error))
+        parsec_error = ParsecError(msg)
+        self.assertIn(msg, str(parsec_error))
 
 
 if __name__ == '__main__':

--- a/lib/parsec/tests/test_upgrade.py
+++ b/lib/parsec/tests/test_upgrade.py
@@ -140,7 +140,7 @@ class TestUpgrade(unittest.TestCase):
         }
         with self.assertRaises(UpgradeError) as cm:
             self.u.expand(upg)
-        self.assertIn('__MANY__ mismatch', str(cm.exception))
+        self.assertEqual('__MANY__ mismatch', str(cm.exception))
 
     def test_expand_deprecate(self):
 

--- a/lib/parsec/tests/test_upgrade.py
+++ b/lib/parsec/tests/test_upgrade.py
@@ -140,7 +140,7 @@ class TestUpgrade(unittest.TestCase):
         }
         with self.assertRaises(UpgradeError) as cm:
             self.u.expand(upg)
-        self.assertEqual('ERROR: __MANY__ mismatch', str(cm.exception))
+        self.assertIn('__MANY__ mismatch', str(cm.exception))
 
     def test_expand_deprecate(self):
 

--- a/lib/parsec/tests/test_validate.py
+++ b/lib/parsec/tests/test_validate.py
@@ -111,18 +111,18 @@ class TestValidate(unittest.TestCase):
     def test_list_value_error(self):
         keys = ['a,', 'b', 'c']
         value = 'a sample value'
-        error = ListValueError(keys, value, "who cares:")
+        error = ListValueError(keys, value, "who cares")
         output = str(error)
-        expected = 'who cares:\n    [a,][b]c = a sample value'
+        expected = '(type=list) [a,][b]c = a sample value - (who cares)'
         self.assertEqual(expected, output)
 
     def test_list_value_error_with_exception(self):
         keys = ['a,', 'b', 'c']
         value = 'a sample value'
         exc = Exception('test')
-        error = ListValueError(keys, value, "who cares:", exc)
+        error = ListValueError(keys, value, "who cares", exc)
         output = str(error)
-        expected = 'who cares:\n    [a,][b]c = a sample value: test'
+        expected = '(type=list) [a,][b]c = a sample value - (test: who cares)'
         self.assertEqual(expected, output)
 
     def test_illegal_value_error(self):

--- a/lib/parsec/tests/test_validate.py
+++ b/lib/parsec/tests/test_validate.py
@@ -81,7 +81,7 @@ def get_parsec_validator_invalid_values():
     }
     cfg = OrderedDictWithDefaults()
     cfg['value'] = "1, 2, 5"
-    msg = 'value = [1, 2, 5]'
+    msg = '(type=option) value = [1, 2, 5]'
     values.append((spec, cfg, msg))
 
     # set 3 (f, f, t, f)
@@ -99,7 +99,7 @@ def get_parsec_validator_invalid_values():
     }
     cfg = OrderedDictWithDefaults()
     cfg['value'] = "5"
-    msg = 'value = 5'
+    msg = '(type=option) value = 5'
     values.append((spec, cfg, msg))
 
     return values
@@ -113,10 +113,7 @@ class TestValidate(unittest.TestCase):
         value = 'a sample value'
         error = ListValueError(keys, value, "who cares:")
         output = str(error)
-        expected = (
-            "ListValueError: who cares:\n"
-            "    [a,][b]c = a sample value"
-        )
+        expected = 'who cares:\n    [a,][b]c = a sample value'
         self.assertEqual(expected, output)
 
     def test_list_value_error_with_exception(self):
@@ -125,10 +122,7 @@ class TestValidate(unittest.TestCase):
         exc = Exception('test')
         error = ListValueError(keys, value, "who cares:", exc)
         output = str(error)
-        expected = (
-            'ListValueError: who cares:\n'
-            '    [a,][b]c = a sample value: test'
-        )
+        expected = 'who cares:\n    [a,][b]c = a sample value: test'
         self.assertEqual(expected, output)
 
     def test_illegal_value_error(self):
@@ -137,8 +131,8 @@ class TestValidate(unittest.TestCase):
         value = 'a sample value'
         error = IllegalValueError(value_type, keys, value)
         output = str(error)
-        expected = "[a,][b]c = a sample value"
-        self.assertIn(expected, output)
+        expected = "(type=ClassA) [a,][b]c = a sample value"
+        self.assertEqual(expected, output)
 
     def test_illegal_value_error_with_exception(self):
         value_type = 'ClassA'
@@ -148,7 +142,7 @@ class TestValidate(unittest.TestCase):
         error = IllegalValueError(value_type, keys, value, exc)
         output = str(error)
         expected = "(type=ClassA) [a,][b]c = a sample value - (test)"
-        self.assertIn(expected, output)
+        self.assertEqual(expected, output)
 
     def test_illegal_item_error(self):
         keys = ['a,', 'b', 'c']
@@ -156,7 +150,7 @@ class TestValidate(unittest.TestCase):
         error = IllegalItemError(keys, key)
         output = str(error)
         expected = "[a,][b][c]a sample value"
-        self.assertIn(expected, output)
+        self.assertEqual(expected, output)
 
     def test_illegal_item_error_message(self):
         keys = ['a,', 'b', 'c']
@@ -164,8 +158,8 @@ class TestValidate(unittest.TestCase):
         message = "invalid"
         error = IllegalItemError(keys, key, message)
         output = str(error)
-        expected = "[a,][b][c]a sample value"
-        self.assertIn(expected, output)
+        expected = "[a,][b][c]a sample value - (invalid)"
+        self.assertEqual(expected, output)
 
     def test_parsec_validator_invalid_key(self):
         parsec_validator = ParsecValidator()
@@ -198,7 +192,7 @@ class TestValidate(unittest.TestCase):
         cfg['section  3000000'] = 'test'
         with self.assertRaises(IllegalItemError) as cm:
             parsec_validator.validate(cfg, SAMPLE_SPEC_1)
-        self.assertIn(
+        self.assertEqual(
             "section  3000000 - (consecutive spaces)",
             str(cm.exception))
 
@@ -208,7 +202,7 @@ class TestValidate(unittest.TestCase):
             if msg is not None:
                 with self.assertRaises(IllegalValueError) as cm:
                     parsec_validator.validate(cfg, spec)
-                self.assertIn(msg, str(cm.exception))
+                self.assertEqual(msg, str(cm.exception))
             else:
                 # parsec_validator.validate(cfg, spec)
                 # let's use the alias `parsec_validate` here

--- a/lib/parsec/upgrade.py
+++ b/lib/parsec/upgrade.py
@@ -136,7 +136,7 @@ class upgrader(object):
                     npre = nkeys[:i]
                     npost = nkeys[i + 1:]
             if not npre or not npost:
-                raise UpgradeError('ERROR: __MANY__ mismatch')
+                raise UpgradeError('__MANY__ mismatch')
             for m in many:
                 exp_upgs.append({
                     'old': pre + [m] + post,

--- a/lib/parsec/upgrade.py
+++ b/lib/parsec/upgrade.py
@@ -19,12 +19,9 @@
 
 from logging import DEBUG, WARNING
 
-from parsec import LOG, ParsecError
+from parsec import LOG
+from parsec.exceptions import UpgradeError
 from parsec.OrderedDict import OrderedDict
-
-
-class UpgradeError(ParsecError):
-    pass
 
 
 class converter(object):

--- a/lib/parsec/validate.py
+++ b/lib/parsec/validate.py
@@ -227,7 +227,7 @@ class ParsecValidator(object):
             >>> ParsecValidator.coerce_spaceless_str_list(
             ...     'a, b c, d', ['foo'])  # doctest: +NORMALIZE_WHITESPACE
             Traceback (most recent call last):
-            parsec.exceptions.ListValueError: ListValueError: \
+            parsec.exceptions.ListValueError:\
             list item "b c" cannot contain a space character:
                 foo = a, b c, d
 
@@ -250,7 +250,7 @@ class ParsecValidator(object):
             ...     'foo, bar, 127.0.0.1:8080, baz', ['pub']
             ... )  # doctest: +NORMALIZE_WHITESPACE
             Traceback (most recent call last):
-            parsec.exceptions.ListValueError: ListValueError: \
+            parsec.exceptions.ListValueError: \
             ambiguous host "127.0.0.1:8080"
                 pub = foo, bar, 127.0.0.1:8080, baz
 

--- a/lib/parsec/validate.py
+++ b/lib/parsec/validate.py
@@ -227,9 +227,9 @@ class ParsecValidator(object):
             >>> ParsecValidator.coerce_spaceless_str_list(
             ...     'a, b c, d', ['foo'])  # doctest: +NORMALIZE_WHITESPACE
             Traceback (most recent call last):
-            parsec.exceptions.ListValueError:\
-            list item "b c" cannot contain a space character:
-                foo = a, b c, d
+            parsec.exceptions.ListValueError: \
+            (type=list) foo = a, b c, d - \
+            (list item "b c" cannot contain a space character)
 
         """
         lst = cls.strip_and_unquote_list(keys, value)
@@ -237,7 +237,7 @@ class ParsecValidator(object):
             if ' ' in item:
                 raise ListValueError(
                     keys, value,
-                    msg='list item "%s" cannot contain a space character:' %
+                    msg='list item "%s" cannot contain a space character' %
                     item)
         return lst
 
@@ -251,8 +251,8 @@ class ParsecValidator(object):
             ... )  # doctest: +NORMALIZE_WHITESPACE
             Traceback (most recent call last):
             parsec.exceptions.ListValueError: \
-            ambiguous host "127.0.0.1:8080"
-                pub = foo, bar, 127.0.0.1:8080, baz
+                (type=list) pub = foo, bar, 127.0.0.1:8080, baz - \
+                (ambiguous host "127.0.0.1:8080")
 
         """
         hosts = cls.coerce_spaceless_str_list(value, keys)
@@ -275,13 +275,13 @@ class ParsecValidator(object):
                 try:
                     lvalues.append(type_(item))
                 except ValueError as exc:
-                    raise IllegalValueError('list', keys, item, exc)
+                    raise IllegalValueError('list', keys, item, exc=exc)
             else:
                 # mult * val
                 try:
                     lvalues += int(mult) * [type_(val)]
                 except ValueError as exc:
-                    raise IllegalValueError('list', keys, item, exc)
+                    raise IllegalValueError('list', keys, item, exc=exc)
         return lvalues
 
     @classmethod
@@ -388,8 +388,8 @@ class ParsecValidator(object):
         if cls._REC_MULTI_PARAM.search(value):
             raise ListValueError(
                 keys, value,
-                msg="names containing commas must be quoted "
-                "(e.g. 'foo<m,n>'):")
+                msg="names containing commas must be quoted"
+                "(e.g. 'foo<m,n>')")
         pos = 0
         while True:
             match = cls._REC_UQLP.search(value, pos)

--- a/lib/parsec/validate.py
+++ b/lib/parsec/validate.py
@@ -27,43 +27,8 @@ from collections import deque
 import re
 from textwrap import dedent
 
-from parsec import ParsecError
-from parsec.util import itemstr
-
-
-class ValidationError(ParsecError):
-    """Base class for bad setting errors."""
-    pass
-
-
-class ListValueError(ValidationError):
-    """Bad setting value, for a comma separated list."""
-    def __init__(self, keys, value, msg='', exc=None):
-        ValidationError.__init__(self)
-        self.msg = '%s\n    %s' % (
-            msg, itemstr(keys[:-1], keys[-1], value=value))
-        if exc:
-            self.msg += ": %s" % exc
-
-
-class IllegalValueError(ValidationError):
-    """Bad setting value."""
-    def __init__(self, vtype, keys, value, exc=None):
-        ValidationError.__init__(self)
-        self.msg = 'Illegal %s value: %s' % (
-            vtype, itemstr(keys[:-1], keys[-1], value=value))
-        if exc:
-            self.msg += ": %s" % exc
-
-
-class IllegalItemError(ValidationError):
-    """Bad setting section or option name."""
-    def __init__(self, keys, key, msg=None):
-        ValidationError.__init__(self)
-        if msg is not None:
-            self.msg = 'Illegal item (%s): %s' % (msg, itemstr(keys, key))
-        else:
-            self.msg = 'Illegal item: %s' % itemstr(keys, key)
+from parsec.exceptions import (
+    ListValueError, IllegalValueError, IllegalItemError)
 
 
 class ParsecValidator(object):
@@ -262,9 +227,10 @@ class ParsecValidator(object):
             >>> ParsecValidator.coerce_spaceless_str_list(
             ...     'a, b c, d', ['foo'])  # doctest: +NORMALIZE_WHITESPACE
             Traceback (most recent call last):
-            parsec.validate.ListValueError: list item "b c" cannot contain a \
-            space character:
+            parsec.exceptions.ListValueError: ListValueError: \
+            list item "b c" cannot contain a space character:
                 foo = a, b c, d
+
         """
         lst = cls.strip_and_unquote_list(keys, value)
         for item in lst:
@@ -281,10 +247,13 @@ class ParsecValidator(object):
 
         Example:
             >>> ParsecValidator.coerce_absolute_host_list(
-            ...     'foo, bar, 127.0.0.1:8080, baz', ['pub'])
+            ...     'foo, bar, 127.0.0.1:8080, baz', ['pub']
+            ... )  # doctest: +NORMALIZE_WHITESPACE
             Traceback (most recent call last):
-            parsec.validate.ListValueError: ambiguous host "127.0.0.1:8080"
+            parsec.exceptions.ListValueError: ListValueError: \
+            ambiguous host "127.0.0.1:8080"
                 pub = foo, bar, 127.0.0.1:8080, baz
+
         """
         hosts = cls.coerce_spaceless_str_list(value, keys)
         for host in hosts:

--- a/tests/cyclers/28-implicit-disallowed.t
+++ b/tests/cyclers/28-implicit-disallowed.t
@@ -27,7 +27,7 @@ run_fail $TEST_NAME cylc validate $SUITE_NAME
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-cmp
 cmp_ok $TEST_NAME_BASE-validate.stderr <<__ERR__
-'ERROR: No cycling sequences defined for foo'
+TaskDefError: No cycling sequences defined for foo
 __ERR__
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/cylc-cat-log/03-bad-suite.t
+++ b/tests/cylc-cat-log/03-bad-suite.t
@@ -24,12 +24,12 @@ BAD_NAME="$(basename "$(mktemp -u "${CYLC_RUN_DIR}/XXXXXXXX")")"
 
 run_fail "${TEST_NAME_BASE}-suite" cylc cat-log -f l "${BAD_NAME}"
 cmp_ok "${TEST_NAME_BASE}-suite.stderr" <<__ERR__
-ERROR: file not found: ${CYLC_RUN_DIR}/${BAD_NAME}/log/suite/log
+file not found: ${CYLC_RUN_DIR}/${BAD_NAME}/log/suite/log
 __ERR__
 
 run_fail "${TEST_NAME_BASE}-suite" cylc cat-log -f j "${BAD_NAME}" "garbage.1"
 cmp_ok "${TEST_NAME_BASE}-suite.stderr" <<__ERR__
-ERROR: file not found: ${CYLC_RUN_DIR}/${BAD_NAME}/log/job/1/garbage/NN/job
+file not found: ${CYLC_RUN_DIR}/${BAD_NAME}/log/job/1/garbage/NN/job
 __ERR__
 
 exit

--- a/tests/cylc-get-suite-contact/00-basic.t
+++ b/tests/cylc-get-suite-contact/00-basic.t
@@ -35,7 +35,7 @@ run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
 run_fail "${TEST_NAME_BASE}-get-suite-contact-1" \
     cylc get-suite-contact "${SUITE_NAME}"
 cmp_ok "${TEST_NAME_BASE}-get-suite-contact-1.stderr" <<__ERR__
-${SUITE_NAME}: cannot get contact info, suite not running?
+CylcError: ${SUITE_NAME}: cannot get contact info, suite not running?
 __ERR__
 run_ok "${TEST_NAME_BASE}-run-hold" cylc run --hold "${SUITE_NAME}"
 run_ok "${TEST_NAME_BASE}-get-suite-contact-2" \

--- a/tests/cylc-insert/09-insert-no-cycle-point.t
+++ b/tests/cylc-insert/09-insert-no-cycle-point.t
@@ -23,10 +23,10 @@ install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
 suite_run_fail "${TEST_NAME_BASE}" \
-    cylc run -v -v --reference-test --debug --no-detach "${SUITE_NAME}"
+    cylc run -v -v --reference-test --no-detach "${SUITE_NAME}"
 JOB_LOG_D="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/log/job"
 contains_ok "${JOB_LOG_D}/20140101T0000+01/prep/NN/job.err" \
-    <<<'ERROR: "foo": invalid task ID (argument 1)'
+    <<<'UserInputError: "foo": invalid task ID (argument 1)'
 
 purge_suite "${SUITE_NAME}"
 exit

--- a/tests/events/36-task-event-bad-custom-template.t
+++ b/tests/events/36-task-event-bad-custom-template.t
@@ -26,7 +26,7 @@ fi
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 run_fail "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
 cmp_ok "${TEST_NAME_BASE}-validate.stderr" <<'__ERR__'
-"ERROR: bad task event handler template t1: echo %(rubbish)s: KeyError('rubbish')"
+SuiteConfigError: bad task event handler template t1: echo %(rubbish)s: KeyError('rubbish')
 __ERR__
 suite_run_ok "${TEST_NAME_BASE}-run" \
     cylc run --reference-test --debug --no-detach "${SUITE_NAME}"

--- a/tests/inheritance/01-circular.t
+++ b/tests/inheritance/01-circular.t
@@ -27,7 +27,7 @@ run_fail $TEST_NAME cylc validate $SUITE_NAME
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-cmp
 cmp_ok $TEST_NAME_BASE-validate.stderr <<__ERR__
-'ERROR: circular [runtime] inheritance?'
+SuiteConfigError: circular [runtime] inheritance?
 __ERR__
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/inheritance/02-bad-reinherit.t
+++ b/tests/inheritance/02-bad-reinherit.t
@@ -27,7 +27,7 @@ run_fail $TEST_NAME cylc validate $SUITE_NAME
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-cmp
 cmp_ok $TEST_NAME_BASE-validate.stderr <<__ERR__
-ERROR: foo: bad runtime namespace inheritance hierarchy.
+SuiteConfigError: ERROR: foo: bad runtime namespace inheritance hierarchy.
 See the cylc documentation on multiple inheritance.
 __ERR__
 #-------------------------------------------------------------------------------

--- a/tests/lib/bash/test_header
+++ b/tests/lib/bash/test_header
@@ -262,6 +262,8 @@ contains_ok() {
         mkdir -p "${TEST_LOG_DIR}"
         echo "Missing lines:" >>"${TEST_NAME}.stderr"
         cat "${TEST_NAME}.stdout" >>"${TEST_NAME}.stderr"
+        echo 'Test File:' >>"${TEST_NAME}.stderr"
+        cat "${FILE_TEST}" >>"${TEST_NAME}.stderr"
         cp -p "${TEST_NAME}.stderr" "${TEST_LOG_DIR}/${TEST_NAME}.stderr"
         fail "${TEST_NAME}"
         return
@@ -294,7 +296,13 @@ grep_ok() {
         return
     fi
     mkdir -p "${TEST_LOG_DIR}"
-    echo "Can't find ${BRE} in ${FILE}" >"${TEST_LOG_DIR}/${TEST_NAME}.stderr"
+    echo "Can't find:
+===========
+${BRE}
+===========
+in:
+===========
+$(cat ${FILE})" >"${TEST_LOG_DIR}/${TEST_NAME}.stderr"
     fail "${TEST_NAME}"
 }
 

--- a/tests/param_expand/01-basic.t
+++ b/tests/param_expand/01-basic.t
@@ -117,7 +117,7 @@ foo<i> => bar<i>
 __SUITE__
 run_fail "${TEST_NAME_BASE}-05" cylc validate "suite.rc"
 cmp_ok "${TEST_NAME_BASE}-05.stderr" <<'__ERR__'
-Illegal parameter value: [cylc][parameters]i = space is dangerous: space is dangerous: bad value
+IllegalValueError: (type=parameter) [cylc][parameters]i = space is dangerous - (space is dangerous: bad value)
 __ERR__
 
 cat >'suite.rc' <<'__SUITE__'
@@ -137,7 +137,7 @@ foo<i> => bar<i>
 __SUITE__
 run_fail "${TEST_NAME_BASE}-06" cylc validate "suite.rc"
 cmp_ok "${TEST_NAME_BASE}-06.stderr" <<'__ERR__'
-Illegal parameter value: [cylc][parameters]i = mix, 1..10: mixing int range and str
+IllegalValueError: (type=parameter) [cylc][parameters]i = mix, 1..10 - (mixing int range and str)
 __ERR__
 
 cat >'suite.rc' <<'__SUITE__'
@@ -176,7 +176,7 @@ foo<i> => bar<i>
 __SUITE__
 run_fail "${TEST_NAME_BASE}-08" cylc validate "suite.rc"
 cmp_ok "${TEST_NAME_BASE}-08.stderr" <<'__ERR__'
-Illegal parameter value: [cylc][parameters]i = 1..2 3..4: 1..2 3..4: bad value
+IllegalValueError: (type=parameter) [cylc][parameters]i = 1..2 3..4 - (1..2 3..4: bad value)
 __ERR__
 
 cat >'suite.rc' <<'__SUITE__'
@@ -196,7 +196,7 @@ foo<i> => bar<i>
 __SUITE__
 run_fail "${TEST_NAME_BASE}-09" cylc validate "suite.rc"
 cmp_ok "${TEST_NAME_BASE}-09.stderr" <<'__ERR__'
-ERROR, parameter i is not defined in foo<i>
+ParamExpandError: parameter i is not defined in foo<i>
 __ERR__
 
 cat >'suite.rc' <<'__SUITE__'
@@ -213,7 +213,7 @@ foo<i> => bar<i>
 __SUITE__
 run_fail "${TEST_NAME_BASE}-10" cylc validate "suite.rc"
 cmp_ok "${TEST_NAME_BASE}-10.stderr" <<'__ERR__'
-ERROR, parameter i is not defined in <i>: foo<i> => bar<i>
+ParamExpandError: parameter i is not defined in <i>: foo<i>=>bar<i>
 __ERR__
 
 cat >'suite.rc' <<'__SUITE__'

--- a/tests/param_expand/02-param_val.t
+++ b/tests/param_expand/02-param_val.t
@@ -222,7 +222,7 @@ __SUITE__
 TNAME=${TEST_NAME_BASE}-err-1
 run_fail "${TNAME}" cylc validate "suite.rc"
 cmp_ok "${TNAME}.stderr" - << __ERR__
-ERROR, illegal value 'i=frog' in 'inherit = FAM<i=frog,j>'
+ParamExpandError: illegal value 'i=frog' in 'inherit = FAM<i=frog,j>'
 __ERR__
 
 #------------------------------------------------------------------------------
@@ -250,5 +250,5 @@ __SUITE__
 TNAME="${TEST_NAME_BASE}-err-2"
 run_fail "${TNAME}" cylc validate "suite.rc"
 cmp_ok "${TNAME}.stderr" - << __ERR__
-ERROR, parameter 'i' undefined in 'inherit = FAM<i,j=1>'
+ParamExpandError: parameter 'i' undefined in 'inherit = FAM<i,j=1>'
 __ERR__

--- a/tests/registration/00-simple.t
+++ b/tests/registration/00-simple.t
@@ -39,7 +39,7 @@ CYLC_RUN_DIR=$(cylc get-global --print-run-dir)
 TEST_NAME="${TEST_NAME_BASE}-noreg"
 run_fail "${TEST_NAME}" cylc register "${SUITE_NAME}" "${PWD}/zilch"
 contains_ok "${TEST_NAME}.stderr" <<__ERR__
-ERROR: no suite.rc in ${PWD}/zilch
+SuiteServiceFileError: no suite.rc in ${PWD}/zilch
 __ERR__
 
 CHEESE=${PRE}-cheese
@@ -103,7 +103,7 @@ run_ok "${TEST_NAME}" cylc register $CHEESE $CHEESE
 TEST_NAME="${TEST_NAME_BASE}-repurpose1"
 run_fail "${TEST_NAME}" cylc register $CHEESE $YOGHURT
 contains_ok "${TEST_NAME}.stderr" <<__ERR__
-ERROR: the name '$CHEESE' already points to ${PWD}/$CHEESE.
+SuiteServiceFileError: the name '$CHEESE' already points to ${PWD}/$CHEESE.
 Use --redirect to re-use an existing name and run directory.
 __ERR__
 

--- a/tests/registration/02-on-the-fly.t
+++ b/tests/registration/02-on-the-fly.t
@@ -91,7 +91,7 @@ contains_ok "${TEST_NAME}-validate.stdout" <<__OUT__
 REGISTERED ${TESTD} -> ${CYLC_RUN_DIR}/${TESTD}
 __OUT__
 contains_ok "${TEST_NAME}-validate.stderr" <<__ERR__
-Illegal item: sched
+IllegalItemError: sched
 __ERR__
 
 purge_suite $TESTD

--- a/tests/shutdown/11-bad-port-file.t
+++ b/tests/shutdown/11-bad-port-file.t
@@ -32,7 +32,7 @@ PORT="$(awk -F= '$1 ~ /CYLC_SUITE_PORT/ {print $2}' "${SRVD}/contact")"
 echo 'garbage' >"${SRVD}/contact"
 run_fail "${TEST_NAME_BASE}-stop-1" cylc stop "${SUITE_NAME}"
 contains_ok "${TEST_NAME_BASE}-stop-1.stderr" <<__ERR__
-not enough values to unpack (expected 2, got 1)
+ValueError: not enough values to unpack (expected 2, got 1)
 __ERR__
 # ^ the error raised by SuiteServierFileManager.load_contact_file as it
 #   attempts to parse "garbage"

--- a/tests/shutdown/18-client-on-dead-suite.t
+++ b/tests/shutdown/18-client-on-dead-suite.t
@@ -36,7 +36,7 @@ kill "${MYPID}"  # Should leave behind the contact file
 wait "${MYPID}" 1>'/dev/null' 2>&1 || true
 run_fail "${TEST_NAME_BASE}-1" cylc ping "${SUITE_NAME}"
 contains_ok "${TEST_NAME_BASE}-1.stderr" <<__ERR__
-Request returned error: Suite "$SUITE_NAME" already stopped
+ClientError: Request returned error: Suite "$SUITE_NAME" already stopped
 __ERR__
 run_fail "${TEST_NAME_BASE}-2" cylc ping "${SUITE_NAME}"
 contains_ok "${TEST_NAME_BASE}-2.stderr" <<__ERR__

--- a/tests/special/07-clock-triggered-360.t
+++ b/tests/special/07-clock-triggered-360.t
@@ -24,7 +24,7 @@ install_suite $TEST_NAME_BASE clock-360
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-validate
 run_fail $TEST_NAME cylc validate $SUITE_NAME
-grep_ok "ERROR: clock-trigger tasks require \[scheduling\]cycling mode=" \
+grep_ok "SuiteConfigError: clock-trigger tasks require \[scheduling\]cycling mode=" \
     $TEST_NAME.stderr
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/validate/07-null-parentage.t
+++ b/tests/validate/07-null-parentage.t
@@ -24,6 +24,6 @@ install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-val
 run_fail $TEST_NAME cylc validate $SUITE_NAME
-grep_ok 'ERROR: null parentage for foo' "$TEST_NAME.stderr"
+grep_ok 'SuiteConfigError: null parentage for foo' "$TEST_NAME.stderr"
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/validate/08-whitespace.t
+++ b/tests/validate/08-whitespace.t
@@ -25,7 +25,7 @@ set_test_number 1
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE
-run_ok $TEST_NAME cylc validate --debug -v $SUITE_NAME
+run_ok $TEST_NAME cylc validate -v $SUITE_NAME
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME
 exit

--- a/tests/validate/09-include-missing.t
+++ b/tests/validate/09-include-missing.t
@@ -23,8 +23,7 @@ echo '%include foo.rc' >suite.rc
 echo '%include bar.rc' >foo.rc
 run_fail "$TEST_NAME_BASE" cylc validate suite.rc
 cmp_ok "$TEST_NAME_BASE.stderr" <<__ERR__
-FileParseError:
-Include-file not found: bar.rc via foo.rc from $PWD/suite.rc
+IncludeFileNotFoundError: bar.rc via foo.rc from $PWD/suite.rc
 __ERR__
 #-------------------------------------------------------------------------------
 exit

--- a/tests/validate/10-bad-recurrence.t
+++ b/tests/validate/10-bad-recurrence.t
@@ -36,7 +36,7 @@ cat >'suite.rc' <<'__SUITE__'
 __SUITE__
 run_fail "${TEST_NAME}" cylc validate 'suite.rc'
 cmp_ok "${TEST_NAME}.stderr" <<'__ERR__'
-'ERROR: Cannot process recurrence R/T00/PT5D (initial cycle point=20140101T0000+01) (final cycle point=20140201T0000+01)'
+SuiteConfigError: Cannot process recurrence R/T00/PT5D (initial cycle point=20140101T0000+01) (final cycle point=20140201T0000+01)
 __ERR__
 
 TEST_NAME="${TEST_NAME_BASE}-old-icp"
@@ -54,7 +54,7 @@ cat >'suite.rc' <<'__SUITE__'
 __SUITE__
 run_fail "${TEST_NAME}" cylc validate 'suite.rc'
 cmp_ok "${TEST_NAME}.stderr" <<'__ERR__'
-"ERROR: Cannot process recurrence R1/P0D (initial cycle point=20140101T0000Z) (final cycle point=None) 'This suite requires a final cycle point.'"
+SuiteConfigError: Cannot process recurrence R1/P0D (initial cycle point=20140101T0000Z) (final cycle point=None) This suite requires a final cycle point.
 __ERR__
 
 TEST_NAME="${TEST_NAME_BASE}-2-digit-century"
@@ -75,7 +75,7 @@ cat >'suite.rc' <<'__SUITE__'
 __SUITE__
 run_fail "${TEST_NAME}" cylc validate 'suite.rc'
 cmp_ok "${TEST_NAME}.stderr" <<'__ERR__'
-'ERROR: Cannot process recurrence R/00/P5D (initial cycle point=20140101T0000+01) (final cycle point=20140201T0000+01) "\'00\': 2 digit centuries not allowed. Did you mean T-digit-digit e.g. \'T00\'?"'
+SuiteConfigError: Cannot process recurrence R/00/P5D (initial cycle point=20140101T0000+01) (final cycle point=20140201T0000+01) '00': 2 digit centuries not allowed. Did you mean T-digit-digit e.g. 'T00'?
 __ERR__
 
 TEST_NAME="${TEST_NAME_BASE}-old-recurrences"
@@ -90,7 +90,7 @@ cat >'suite.rc' <<'__SUITE__'
 __SUITE__
 run_fail "${TEST_NAME}" cylc validate 'suite.rc'
 cmp_ok "${TEST_NAME}.stderr" <<'__ERR__'
-'ERROR: Cannot process recurrence 0 (initial cycle point=20100101T0000+01) (final cycle point=None) "\'0\': not a valid cylc-shorthand or full ISO 8601 date representation"'
+SuiteConfigError: Cannot process recurrence 0 (initial cycle point=20100101T0000+01) (final cycle point=None) '0': not a valid cylc-shorthand or full ISO 8601 date representation
 __ERR__
 
 TEST_NAME="${TEST_NAME_BASE}-old-cycle-point-format"
@@ -105,7 +105,7 @@ cat >'suite.rc' <<'__SUITE__'
 __SUITE__
 run_fail "${TEST_NAME}" cylc validate 'suite.rc'
 cmp_ok "${TEST_NAME}.stderr" <<'__ERR__'
-'ERROR: Cannot process recurrence R1 (initial cycle point=2010010101) (final cycle point=None) "\'2010010101\': not a valid cylc-shorthand or full ISO 8601 date representation"'
+SuiteConfigError: Cannot process recurrence R1 (initial cycle point=2010010101) (final cycle point=None) '2010010101': not a valid cylc-shorthand or full ISO 8601 date representation
 __ERR__
 
 exit

--- a/tests/validate/13-fail-old-syntax-2.t
+++ b/tests/validate/13-fail-old-syntax-2.t
@@ -23,7 +23,7 @@ set_test_number 2
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE
-run_fail $TEST_NAME cylc validate --debug -v $SUITE_NAME
+run_fail $TEST_NAME cylc validate -v $SUITE_NAME
 grep_ok 'Illegal graph node: foo\[T\-24\]:succeed' "${TEST_NAME}.stderr"
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/validate/14-fail-old-syntax-3.t
+++ b/tests/validate/14-fail-old-syntax-3.t
@@ -23,9 +23,8 @@ set_test_number 2
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE
-run_fail $TEST_NAME cylc validate --debug -v $SUITE_NAME
-grep_ok "Illegal ISO 8601 interval value: \
-\[runtime\]\[root\]\[events\]execution timeout = 3" $TEST_NAME.stderr
+run_fail $TEST_NAME cylc validate -v $SUITE_NAME
+grep_ok "IllegalValueError: (type=ISO 8601 interval) \[runtime\]\[root\]\[events\]execution timeout = 3" $TEST_NAME.stderr
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME
 exit

--- a/tests/validate/14-fail-old-syntax-3.t
+++ b/tests/validate/14-fail-old-syntax-3.t
@@ -23,8 +23,10 @@ set_test_number 2
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE
-run_fail $TEST_NAME cylc validate -v $SUITE_NAME
-grep_ok "IllegalValueError: (type=ISO 8601 interval) \[runtime\]\[root\]\[events\]execution timeout = 3" $TEST_NAME.stderr
+run_fail $TEST_NAME cylc validate $SUITE_NAME
+cmp_ok "$TEST_NAME.stderr" <<__END__
+IllegalValueError: (type=ISO 8601 interval) [runtime][root][events]execution timeout = 3
+__END__
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME
 exit

--- a/tests/validate/15-fail-old-syntax-4.t
+++ b/tests/validate/15-fail-old-syntax-4.t
@@ -23,7 +23,7 @@ set_test_number 2
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE
-run_fail $TEST_NAME cylc validate --debug -v $SUITE_NAME
+run_fail $TEST_NAME cylc validate -v $SUITE_NAME
 grep_ok "Incompatible value for <class 'cylc.cycling.iso8601.ISO8601Point'>: \
 2010010100: Invalid ISO 8601 date representation: 2010010100" $TEST_NAME.stderr
 #-------------------------------------------------------------------------------

--- a/tests/validate/16-fail-old-syntax-5.t
+++ b/tests/validate/16-fail-old-syntax-5.t
@@ -23,8 +23,9 @@ set_test_number 2
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE
-run_fail $TEST_NAME cylc validate --debug -v $SUITE_NAME
-grep_ok "Illegal item: \[scheduling\]\[special tasks\]start-up" $TEST_NAME.stderr
+run_fail $TEST_NAME cylc validate -v $SUITE_NAME
+grep_ok "IllegalItemError: \[scheduling\]\[special tasks\]start-up" \
+    $TEST_NAME.stderr
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME
 exit

--- a/tests/validate/16-fail-old-syntax-5.t
+++ b/tests/validate/16-fail-old-syntax-5.t
@@ -23,9 +23,10 @@ set_test_number 2
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE
-run_fail $TEST_NAME cylc validate -v $SUITE_NAME
-grep_ok "IllegalItemError: \[scheduling\]\[special tasks\]start-up" \
-    $TEST_NAME.stderr
+run_fail $TEST_NAME cylc validate $SUITE_NAME
+cmp_ok "$TEST_NAME.stderr" <<__END__
+IllegalItemError: [scheduling][special tasks]start-up
+__END__
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME
 exit

--- a/tests/validate/17-fail-old-syntax-6.t
+++ b/tests/validate/17-fail-old-syntax-6.t
@@ -23,9 +23,9 @@ set_test_number 2
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE
-run_fail $TEST_NAME cylc validate --debug -v $SUITE_NAME
-grep_ok "'Obsolete syntax: mixed integer \[dependencies\]graph with cycling \
-\[dependencies\]\[12\]'" $TEST_NAME.stderr
+run_fail $TEST_NAME cylc validate -v $SUITE_NAME
+grep_ok "SuiteConfigError: Obsolete syntax: mixed integer \[dependencies\]graph with cycling \
+\[dependencies\]\[12\]" $TEST_NAME.stderr
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME
 exit

--- a/tests/validate/18-fail-no-scheduling.t
+++ b/tests/validate/18-fail-no-scheduling.t
@@ -23,7 +23,7 @@ set_test_number 2
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE
-run_fail $TEST_NAME cylc validate --debug -v $SUITE_NAME
+run_fail $TEST_NAME cylc validate -v $SUITE_NAME
 grep_ok "missing \[scheduling\] section" $TEST_NAME.stderr
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/validate/19-fail-no-dependencies.t
+++ b/tests/validate/19-fail-no-dependencies.t
@@ -23,7 +23,7 @@ set_test_number 2
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE
-run_fail $TEST_NAME cylc validate --debug -v $SUITE_NAME
+run_fail $TEST_NAME cylc validate -v $SUITE_NAME
 grep_ok "No suite dependency graph defined\." $TEST_NAME.stderr
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/validate/20-fail-no-graph-async.t
+++ b/tests/validate/20-fail-no-graph-async.t
@@ -23,7 +23,7 @@ set_test_number 2
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE
-run_fail $TEST_NAME cylc validate --debug -v $SUITE_NAME
+run_fail $TEST_NAME cylc validate -v $SUITE_NAME
 grep_ok "No suite dependency graph defined\." $TEST_NAME.stderr
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/validate/21-fail-no-graph-sequence.t
+++ b/tests/validate/21-fail-no-graph-sequence.t
@@ -23,7 +23,7 @@ set_test_number 2
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE
-run_fail $TEST_NAME cylc validate --debug -v $SUITE_NAME
+run_fail $TEST_NAME cylc validate -v $SUITE_NAME
 grep_ok "No suite dependency graph defined\." $TEST_NAME.stderr
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/validate/22-fail-year-bounds.t
+++ b/tests/validate/22-fail-year-bounds.t
@@ -23,7 +23,7 @@ set_test_number 2
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE
-run_fail $TEST_NAME cylc validate --debug -v $SUITE_NAME
+run_fail $TEST_NAME cylc validate -v $SUITE_NAME
 grep_ok "incompatible with \[cylc\]cycle point num expanded year digits = 0" \
     $TEST_NAME.stderr
 #-------------------------------------------------------------------------------

--- a/tests/validate/23-fail-old-syntax-7.t
+++ b/tests/validate/23-fail-old-syntax-7.t
@@ -24,7 +24,7 @@ install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}"
 run_fail "${TEST_NAME}" cylc validate -v "${SUITE_NAME}"
-contains_ok "${TEST_NAME}.stderr" <<<'Illegal item: [scheduling]initial cycle time'
+contains_ok "${TEST_NAME}.stderr" <<<'IllegalItemError: [scheduling]initial cycle time'
 #-------------------------------------------------------------------------------
 purge_suite "${SUITE_NAME}"
 exit

--- a/tests/validate/23-fail-old-syntax-7.t
+++ b/tests/validate/23-fail-old-syntax-7.t
@@ -23,8 +23,10 @@ set_test_number 2
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}"
-run_fail "${TEST_NAME}" cylc validate -v "${SUITE_NAME}"
-contains_ok "${TEST_NAME}.stderr" <<<'IllegalItemError: [scheduling]initial cycle time'
+run_fail "${TEST_NAME}" cylc validate "${SUITE_NAME}"
+cmp_ok "${TEST_NAME}.stderr" <<__END__
+IllegalItemError: [scheduling]initial cycle time
+__END__
 #-------------------------------------------------------------------------------
 purge_suite "${SUITE_NAME}"
 exit

--- a/tests/validate/24-fail-initial-greater-final.t
+++ b/tests/validate/24-fail-initial-greater-final.t
@@ -23,7 +23,7 @@ set_test_number 2
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE
-run_fail $TEST_NAME cylc validate --debug -v $SUITE_NAME
+run_fail $TEST_NAME cylc validate -v $SUITE_NAME
 grep_ok "The initial cycle point:20141208T0000Z is after the final cycle \
 point:20141207T0000Z."    $TEST_NAME.stderr
 #-------------------------------------------------------------------------------

--- a/tests/validate/26-fail-graph-double-conditionals.t
+++ b/tests/validate/26-fail-graph-double-conditionals.t
@@ -27,13 +27,13 @@ cat > suite.rc <<__END__
 __END__
 #-------------------------------------------------------------------------------
 TEST_NAME=${TEST_NAME_BASE}-async-and
-run_fail $TEST_NAME cylc validate --debug -v suite.rc
-grep_ok "ERROR, the graph AND operator is '&': " $TEST_NAME.stderr
+run_fail $TEST_NAME cylc validate -v suite.rc
+grep_ok "GraphParseError: the graph AND operator is '&': " $TEST_NAME.stderr
 #-------------------------------------------------------------------------------
 TEST_NAME=${TEST_NAME_BASE}-async-or
 sed -i -e 's/&&/||/' suite.rc
-run_fail $TEST_NAME cylc validate --debug -v suite.rc
-grep_ok "ERROR, the graph OR operator is '|': " $TEST_NAME.stderr
+run_fail $TEST_NAME cylc validate -v suite.rc
+grep_ok "GraphParseError: the graph OR operator is '|': " $TEST_NAME.stderr
 #-------------------------------------------------------------------------------
 cat > suite.rc <<__END__
 [scheduling]
@@ -44,11 +44,10 @@ cat > suite.rc <<__END__
 __END__
 #-------------------------------------------------------------------------------
 TEST_NAME=${TEST_NAME_BASE}-cycling-and
-run_fail $TEST_NAME cylc validate --debug -v suite.rc
-grep_ok "ERROR, the graph AND operator is '&': " $TEST_NAME.stderr
+run_fail $TEST_NAME cylc validate -v suite.rc
+grep_ok "GraphParseError: the graph AND operator is '&': " $TEST_NAME.stderr
 #-------------------------------------------------------------------------------
 TEST_NAME=${TEST_NAME_BASE}-cycling-or
 sed -i -e 's/&&/||/' suite.rc
-run_fail $TEST_NAME cylc validate --debug -v suite.rc
-grep_ok "ERROR, the graph OR operator is '|': " $TEST_NAME.stderr
-
+run_fail $TEST_NAME cylc validate -v suite.rc
+grep_ok "GraphParseError: the graph OR operator is '|': " $TEST_NAME.stderr

--- a/tests/validate/28-fail-max-active-cycle-points-zero.t
+++ b/tests/validate/28-fail-max-active-cycle-points-zero.t
@@ -23,8 +23,9 @@ set_test_number 2
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE
-run_fail $TEST_NAME cylc validate --debug -v $SUITE_NAME
-grep_ok "ERROR: max cycle points must be greater than 0" $TEST_NAME.stderr
+run_fail $TEST_NAME cylc validate -v $SUITE_NAME
+grep_ok "SuiteConfigError: max cycle points must be greater than 0" \
+    $TEST_NAME.stderr
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME
 exit

--- a/tests/validate/31-fail-not-integer.t
+++ b/tests/validate/31-fail-not-integer.t
@@ -23,7 +23,7 @@ set_test_number 2
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE
-run_fail $TEST_NAME cylc validate --debug -v $SUITE_NAME
+run_fail $TEST_NAME cylc validate -v $SUITE_NAME
 grep_ok "Conflicting syntax: integer vs cycling suite" $TEST_NAME.stderr
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/validate/32-fail-graph-bracket-missing.t
+++ b/tests/validate/32-fail-graph-bracket-missing.t
@@ -24,8 +24,9 @@ set_test_number 2
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE
-run_fail $TEST_NAME cylc validate --debug -v $SUITE_NAME
-grep_ok "ERROR, parenthesis mismatch in: " $TEST_NAME.stderr
+run_fail $TEST_NAME cylc validate -v $SUITE_NAME
+cat $TEST_NAME.stderr >&2
+grep_ok "GraphParseError: parenthesis mismatch in: " $TEST_NAME.stderr
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME
 exit

--- a/tests/validate/36-fail-double-runahead.t
+++ b/tests/validate/36-fail-double-runahead.t
@@ -24,8 +24,8 @@ set_test_number 2
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE
-run_fail $TEST_NAME cylc validate --debug -v $SUITE_NAME
-grep_ok "ERROR: use 'runahead limit' OR 'max active cycle points', not both" \
+run_fail $TEST_NAME cylc validate -v $SUITE_NAME
+grep_ok "SuiteConfigError: use 'runahead limit' OR 'max active cycle points', not both" \
   $TEST_NAME.stderr
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/validate/37-clock-trigger-task-not-defined.t
+++ b/tests/validate/37-clock-trigger-task-not-defined.t
@@ -32,6 +32,6 @@ cat >'suite.rc' <<'__SUITE_RC__'
 __SUITE_RC__
 run_fail "${TEST_NAME_BASE}" cylc validate --strict "${PWD}/suite.rc"
 cmp_ok "${TEST_NAME_BASE}.stderr" <<'__ERR__'
-'ERROR: clock-trigger task "foo" is not defined.'
+SuiteConfigError: clock-trigger task "foo" is not defined.
 __ERR__
 exit

--- a/tests/validate/38-degenerate-point-format.t
+++ b/tests/validate/38-degenerate-point-format.t
@@ -23,8 +23,8 @@ set_test_number 2
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE
-run_fail $TEST_NAME cylc validate --debug -v $SUITE_NAME
-grep_ok "Sequence R/2015-08/P1D, point format %Y-%m: equal adjacent points: 2015-08 => 2015-08." \
+run_fail $TEST_NAME cylc validate -v $SUITE_NAME
+grep_ok "SequenceDegenerateError: R/2015-08/P1D, point format %Y-%m: equal adjacent points: 2015-08 => 2015-08." \
     $TEST_NAME.stderr
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/validate/39-fail-suicide-left.t
+++ b/tests/validate/39-fail-suicide-left.t
@@ -29,6 +29,6 @@ __SUITE_RC__
 
 run_fail "${TEST_NAME_BASE}" cylc validate 'suite.rc'
 cmp_ok "${TEST_NAME_BASE}.stderr" <<'__ERR__'
-ERROR, suicide markers must be on the right of a trigger: !dont-kill-me
+GraphParseError: suicide markers must be on the right of a trigger: !dont-kill-me
 __ERR__
 exit

--- a/tests/validate/40-jinja2-template-syntax-error-main.t
+++ b/tests/validate/40-jinja2-template-syntax-error-main.t
@@ -24,7 +24,7 @@ install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 TEST_NAME=$TEST_NAME_BASE-val
 run_fail "$TEST_NAME" cylc validate suite.rc
 contains_ok "$TEST_NAME.stderr" <<'__ERROR__'
-Jinja2Error:
+FileParseError: Jinja2Error:
 jinja2.exceptions.TemplateSyntaxError: Encountered unknown tag 'end'. Jinja was looking for the following tags: 'elif' or 'else' or 'endif'. The innermost block that needs to be closed is 'if'.
 Context lines:
     [[dependencies]]

--- a/tests/validate/40-jinja2-template-syntax-error-main.t
+++ b/tests/validate/40-jinja2-template-syntax-error-main.t
@@ -23,14 +23,14 @@ install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-val
 run_fail "$TEST_NAME" cylc validate suite.rc
-contains_ok "$TEST_NAME.stderr" <<'__ERROR__'
-FileParseError: Jinja2Error:
-jinja2.exceptions.TemplateSyntaxError: Encountered unknown tag 'end'. Jinja was looking for the following tags: 'elif' or 'else' or 'endif'. The innermost block that needs to be closed is 'if'.
+cmp_ok "$TEST_NAME.stderr" <<'__ERROR__'
+Jinja2Error: Encountered unknown tag 'end'.
+Jinja was looking for the following tags: 'elif' or 'else' or 'endif'.
+The innermost block that needs to be closed is 'if'.
 Context lines:
-    [[dependencies]]
         {% if true %}
         graph = foo
-        {% end if %	<-- Jinja2Error
+        {% end if %	<-- TemplateSyntaxError
 __ERROR__
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/validate/41-jinja2-template-syntax-error-cylc-include.t
+++ b/tests/validate/41-jinja2-template-syntax-error-cylc-include.t
@@ -24,7 +24,7 @@ install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 TEST_NAME=$TEST_NAME_BASE-val
 run_fail "$TEST_NAME" cylc validate suite.rc
 contains_ok "$TEST_NAME.stderr" <<'__ERROR__'
-Jinja2Error:
+FileParseError: Jinja2Error:
 jinja2.exceptions.TemplateSyntaxError: Encountered unknown tag 'end'. Jinja was looking for the following tags: 'elif' or 'else' or 'endif'. The innermost block that needs to be closed is 'if'.
 Context lines:
 # This is a bit of graph configuration.

--- a/tests/validate/41-jinja2-template-syntax-error-cylc-include.t
+++ b/tests/validate/41-jinja2-template-syntax-error-cylc-include.t
@@ -23,14 +23,14 @@ install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-val
 run_fail "$TEST_NAME" cylc validate suite.rc
-contains_ok "$TEST_NAME.stderr" <<'__ERROR__'
-FileParseError: Jinja2Error:
-jinja2.exceptions.TemplateSyntaxError: Encountered unknown tag 'end'. Jinja was looking for the following tags: 'elif' or 'else' or 'endif'. The innermost block that needs to be closed is 'if'.
+cmp_ok "$TEST_NAME.stderr" <<'__ERROR__'
+Jinja2Error: Encountered unknown tag 'end'.
+Jinja was looking for the following tags: 'elif' or 'else' or 'endif'.
+The innermost block that needs to be closed is 'if'.
 Context lines:
-# This is a bit of graph configuration.
         {% if true %}
         graph = foo
-        {% end if %	<-- Jinja2Error
+        {% end if %	<-- TemplateSyntaxError
 __ERROR__
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/validate/42-jinja2-template-syntax-error-jinja-include.t
+++ b/tests/validate/42-jinja2-template-syntax-error-jinja-include.t
@@ -25,7 +25,7 @@ TEST_NAME=$TEST_NAME_BASE-val
 run_fail "$TEST_NAME" cylc validate suite.rc
 sed -i 's/^  File ".*", line/  File "FILE", line/g' "$TEST_NAME.stderr"
 cmp_ok "$TEST_NAME.stderr" <<'__ERROR__'
-Jinja2Error:
+FileParseError: Jinja2Error:
   File "FILE", line 59, in fail
     raise exc(msg, lineno, self.name, self.filename)
 jinja2.exceptions.TemplateSyntaxError: Encountered unknown tag 'end'. Jinja was looking for the following tags: 'elif' or 'else' or 'endif'. The innermost block that needs to be closed is 'if'.

--- a/tests/validate/42-jinja2-template-syntax-error-jinja-include.t
+++ b/tests/validate/42-jinja2-template-syntax-error-jinja-include.t
@@ -23,12 +23,15 @@ install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-val
 run_fail "$TEST_NAME" cylc validate suite.rc
-sed -i 's/^  File ".*", line/  File "FILE", line/g' "$TEST_NAME.stderr"
 cmp_ok "$TEST_NAME.stderr" <<'__ERROR__'
-FileParseError: Jinja2Error:
-  File "FILE", line 59, in fail
-    raise exc(msg, lineno, self.name, self.filename)
-jinja2.exceptions.TemplateSyntaxError: Encountered unknown tag 'end'. Jinja was looking for the following tags: 'elif' or 'else' or 'endif'. The innermost block that needs to be closed is 'if'.
+Jinja2Error: Encountered unknown tag 'end'.
+Error in file "suite-includeme.rc"
+Jinja was looking for the following tags: 'elif' or 'else' or 'endif'.
+The innermost block that needs to be closed is 'if'.
+Context lines:
+        {% if true %}
+        graph = foo
+        {% end if %	<-- TemplateSyntaxError
 __ERROR__
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/validate/43-jinja2-template-error-main.t
+++ b/tests/validate/43-jinja2-template-error-main.t
@@ -32,7 +32,7 @@ cat >'suite.rc' <<'__SUITERC__'
 __SUITERC__
 run_fail "${TEST_NAME_BASE}" cylc validate 'suite.rc'
 contains_ok "${TEST_NAME_BASE}.stderr" <<'__ERROR__'
-Jinja2Error:
+FileParseError: Jinja2Error:
     'You can only sort by either "key" or "value"'
 jinja2.exceptions.FilterArgumentError: You can only sort by either "key" or "value"
 __ERROR__

--- a/tests/validate/43-jinja2-template-error-main.t
+++ b/tests/validate/43-jinja2-template-error-main.t
@@ -31,10 +31,12 @@ cat >'suite.rc' <<'__SUITERC__'
         script = sleep 1
 __SUITERC__
 run_fail "${TEST_NAME_BASE}" cylc validate 'suite.rc'
-contains_ok "${TEST_NAME_BASE}.stderr" <<'__ERROR__'
-FileParseError: Jinja2Error:
-    'You can only sort by either "key" or "value"'
-jinja2.exceptions.FilterArgumentError: You can only sort by either "key" or "value"
+cmp_ok "${TEST_NAME_BASE}.stderr" <<'__ERROR__'
+Jinja2Error: You can only sort by either "key" or "value"
+Context lines:
+[scheduling]
+    [[dependencies]]
+        graph = {{ foo|dictsort(by='by') }}	<-- FilterArgumentError
 __ERROR__
 
 exit

--- a/tests/validate/44-jinja2-template-not-found.t
+++ b/tests/validate/44-jinja2-template-not-found.t
@@ -25,7 +25,7 @@ TEST_NAME=$TEST_NAME_BASE-val
 run_fail "$TEST_NAME" cylc validate suite.rc
 sed -i 's/^  File ".*/  File "FILE", line NN, in ROUTINE/g' "$TEST_NAME.stderr"
 cmp_ok "$TEST_NAME.stderr" <<'__ERROR__'
-Jinja2Error:
+FileParseError: Jinja2Error:
   File "FILE", line NN, in ROUTINE
 jinja2.exceptions.TemplateNotFound: suite-foo.rc
 Context lines:

--- a/tests/validate/44-jinja2-template-not-found.t
+++ b/tests/validate/44-jinja2-template-not-found.t
@@ -23,16 +23,12 @@ install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-val
 run_fail "$TEST_NAME" cylc validate suite.rc
-sed -i 's/^  File ".*/  File "FILE", line NN, in ROUTINE/g' "$TEST_NAME.stderr"
 cmp_ok "$TEST_NAME.stderr" <<'__ERROR__'
-FileParseError: Jinja2Error:
-  File "FILE", line NN, in ROUTINE
-jinja2.exceptions.TemplateNotFound: suite-foo.rc
+Jinja2Error: suite-foo.rc
 Context lines:
-    [[dependencies]]
         graph = foo
 [runtime]
-{% include 'suite-foo.rc' %}	<-- Jinja2Error
+{% include 'suite-foo.rc' %}	<-- TemplateNotFound
 __ERROR__
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/validate/45-jinja2-type-error.t
+++ b/tests/validate/45-jinja2-type-error.t
@@ -31,7 +31,7 @@ cat >'suite.rc' <<'__SUITERC__'
 __SUITERC__
 run_fail "${TEST_NAME}" cylc validate 'suite.rc'
 cmp_ok "${TEST_NAME}.stderr" <<'__ERROR__'
-Jinja2Error:
+FileParseError: Jinja2Error:
   File "<template>", line 5, in top-level template code
 TypeError: unsupported operand type(s) for /: 'int' and 'str'
 Context lines:
@@ -49,7 +49,7 @@ cat >'suite.rc' <<'__SUITERC__'
 __SUITERC__
 run_fail "${TEST_NAME}" cylc validate 'suite.rc'
 cmp_ok "${TEST_NAME}.stderr" <<'__ERROR__'
-Jinja2Error:
+FileParseError: Jinja2Error:
   File "<template>", line 2, in top-level template code
 ValueError: not enough values to unpack (expected 3, got 2)
 Context lines:

--- a/tests/validate/45-jinja2-type-error.t
+++ b/tests/validate/45-jinja2-type-error.t
@@ -31,14 +31,11 @@ cat >'suite.rc' <<'__SUITERC__'
 __SUITERC__
 run_fail "${TEST_NAME}" cylc validate 'suite.rc'
 cmp_ok "${TEST_NAME}.stderr" <<'__ERROR__'
-FileParseError: Jinja2Error:
-  File "<template>", line 5, in top-level template code
-TypeError: unsupported operand type(s) for /: 'int' and 'str'
+Jinja2Error: unsupported operand type(s) for /: 'int' and 'str'
 Context lines:
-[scheduling]
     [[dependencies]]
         graph = foo
-{{ 1 / 'foo' }}	<-- Jinja2Error
+{{ 1 / 'foo' }}	<-- TypeError
 __ERROR__
 
 TEST_NAME="${TEST_NAME}-value-error"
@@ -49,12 +46,11 @@ cat >'suite.rc' <<'__SUITERC__'
 __SUITERC__
 run_fail "${TEST_NAME}" cylc validate 'suite.rc'
 cmp_ok "${TEST_NAME}.stderr" <<'__ERROR__'
-FileParseError: Jinja2Error:
-  File "<template>", line 2, in top-level template code
-ValueError: not enough values to unpack (expected 3, got 2)
+Jinja2Error: not enough values to unpack (expected 3, got 2)
 Context lines:
+#!Jinja2
 {% set foo = [1, 2] %}
-{% set a, b, c = foo %}	<-- Jinja2Error
+{% set a, b, c = foo %}	<-- ValueError
 __ERROR__
 
 exit

--- a/tests/validate/46-fail-bad-vis-nod-attrs.t
+++ b/tests/validate/46-fail-bad-vis-nod-attrs.t
@@ -23,7 +23,7 @@ set_test_number 2
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE
-run_fail $TEST_NAME cylc validate --debug -v $SUITE_NAME
+run_fail $TEST_NAME cylc validate -v $SUITE_NAME
 grep_ok \
     "Node attributes must be of the form 'key1=value1', 'key2=value2', etc." \
     $TEST_NAME.stderr

--- a/tests/validate/47-fail-no-graph.t
+++ b/tests/validate/47-fail-no-graph.t
@@ -26,7 +26,7 @@ cat > suite.rc <<__END__
     [[dependencies]]
         graph = ""
 __END__
-run_fail $TEST_NAME cylc validate --debug -v suite.rc
+run_fail $TEST_NAME cylc validate -v suite.rc
 grep_ok "No suite dependency graph defined." $TEST_NAME.stderr
 #-------------------------------------------------------------------------------
 TEST_NAME=${TEST_NAME_BASE}-no-graph
@@ -36,5 +36,5 @@ cat > suite.rc <<__END__
     [[dependencies]]
         [[[R1]]]
 __END__
-run_fail $TEST_NAME cylc validate --debug -v suite.rc
+run_fail $TEST_NAME cylc validate -v suite.rc
 grep_ok "No suite dependency graph defined." $TEST_NAME.stderr

--- a/tests/validate/49-jinja2-undefined-error.t
+++ b/tests/validate/49-jinja2-undefined-error.t
@@ -24,7 +24,7 @@ install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 TEST_NAME=$TEST_NAME_BASE-val
 run_fail "$TEST_NAME" cylc validate suite.rc
 cmp_ok "$TEST_NAME.stderr" <<'__ERROR__'
-Jinja2Error:
+FileParseError: Jinja2Error:
   File "<template>", line 5, in top-level template code
 jinja2.exceptions.UndefinedError: 'UNDEFINED_WHATEVER' is undefined
 Context lines:

--- a/tests/validate/49-jinja2-undefined-error.t
+++ b/tests/validate/49-jinja2-undefined-error.t
@@ -24,14 +24,11 @@ install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 TEST_NAME=$TEST_NAME_BASE-val
 run_fail "$TEST_NAME" cylc validate suite.rc
 cmp_ok "$TEST_NAME.stderr" <<'__ERROR__'
-FileParseError: Jinja2Error:
-  File "<template>", line 5, in top-level template code
-jinja2.exceptions.UndefinedError: 'UNDEFINED_WHATEVER' is undefined
+Jinja2Error: 'UNDEFINED_WHATEVER' is undefined
 Context lines:
-[scheduling]
     [[dependencies]]
         graph = foo
-    [[[{{ UNDEFINED_WHATEVER }}]]]	<-- Jinja2Error
+    [[[{{ UNDEFINED_WHATEVER }}]]]	<-- UndefinedError
 __ERROR__
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/validate/51-zero-interval.t
+++ b/tests/validate/51-zero-interval.t
@@ -35,7 +35,7 @@ __SUITE_RC__
 
 run_fail "${TEST_NAME_BASE}" cylc validate 'suite.rc'
 cmp_ok "${TEST_NAME_BASE}.stderr" <<'__ERR__'
-Sequence R/20100101T0000Z/P0Y, point format CCYYMMDDThhmmZ: equal adjacent points: 20100101T0000Z => 20100101T0000Z.
+SequenceDegenerateError: R/20100101T0000Z/P0Y, point format CCYYMMDDThhmmZ: equal adjacent points: 20100101T0000Z => 20100101T0000Z.
 __ERR__
 
 exit

--- a/tests/validate/53-missing-parentage.t
+++ b/tests/validate/53-missing-parentage.t
@@ -24,6 +24,6 @@ install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-val
 run_fail $TEST_NAME cylc validate $SUITE_NAME
-grep_ok 'ERROR: null parentage for foo' "$TEST_NAME.stderr"
+grep_ok 'SuiteConfigError: null parentage for foo' "$TEST_NAME.stderr"
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/validate/61-include-missing-quote.t
+++ b/tests/validate/61-include-missing-quote.t
@@ -27,7 +27,7 @@ __SUITE_RC__
 
 run_fail "${TEST_NAME_BASE}" cylc validate 'suite.rc'
 cmp_ok "${TEST_NAME_BASE}.stderr" <<'__ERR__'
-ERROR, mismatched quotes: %include 'foo.rc
+ParsecError: mismatched quotes: %include 'foo.rc
 __ERR__
 
 exit

--- a/tests/validate/62-null-task-name.t
+++ b/tests/validate/62-null-task-name.t
@@ -29,7 +29,8 @@ do
         graph = ${GRAPH}
 __SUITE_RC__
     run_fail "${TEST_NAME_BASE}" cylc validate 'suite.rc'
-    grep_ok 'ERROR, null task name in graph: ' "${TEST_NAME_BASE}.stderr"
+    grep_ok 'GraphParseError: null task name in graph: ' \
+        "${TEST_NAME_BASE}.stderr"
 done
 
 exit

--- a/tests/validate/63-collapse-secondary-parent.t
+++ b/tests/validate/63-collapse-secondary-parent.t
@@ -39,7 +39,7 @@ __SUITE_RC__
 
 run_fail "${TEST_NAME_BASE}" cylc validate 'suite.rc'
 
-ERR='ERROR \[visualization\]collapsed families: BAR is not a first parent'
+ERR='SuiteConfigError: \[visualization\]collapsed families: BAR is not a first parent'
 grep_ok "$ERR" "${TEST_NAME_BASE}.stderr"
 
 exit

--- a/tests/validate/64-circular.t
+++ b/tests/validate/64-circular.t
@@ -28,7 +28,7 @@ __SUITE_RC__
 
 run_fail "${TEST_NAME_BASE}-simple-1" cylc validate 'suite.rc'
 contains_ok "${TEST_NAME_BASE}-simple-1.stderr" <<'__ERR__'
-'ERROR, self-edge detected: a:succeed => a'
+SuiteConfigError: self-edge detected: a:succeed => a
 __ERR__
 
 cat >'suite.rc' <<'__SUITE_RC__'
@@ -39,7 +39,7 @@ __SUITE_RC__
 
 run_fail "${TEST_NAME_BASE}-simple-2" cylc validate 'suite.rc'
 contains_ok "${TEST_NAME_BASE}-simple-2.stderr" <<'__ERR__'
-'ERROR: circular edges detected:  d.1 => a.1  a.1 => b.1  b.1 => c.1  c.1 => d.1'
+SuiteConfigError: circular edges detected:  d.1 => a.1  a.1 => b.1  b.1 => c.1  c.1 => d.1
 __ERR__
 
 cat >'suite.rc' <<'__SUITE_RC__'
@@ -54,7 +54,7 @@ __SUITE_RC__
 
 run_fail "${TEST_NAME_BASE}-simple-fam" cylc validate 'suite.rc'
 contains_ok "${TEST_NAME_BASE}-simple-fam.stderr" <<'__ERR__'
-'ERROR, self-edge detected: f:succeed => f'
+SuiteConfigError: self-edge detected: f:succeed => f
 __ERR__
 
 cat >'suite.rc' <<'__SUITE_RC__'
@@ -73,7 +73,7 @@ __SUITE_RC__
 
 run_fail "${TEST_NAME_BASE}-intercycle-1" cylc validate 'suite.rc'
 contains_ok "${TEST_NAME_BASE}-intercycle-1.stderr" <<'__ERR__'
-'ERROR: circular edges detected:  a.2002 => a.2001  a.2001 => a.2002  a.2003 => a.2002  a.2002 => a.2003'
+SuiteConfigError: circular edges detected:  a.2002 => a.2001  a.2001 => a.2002  a.2003 => a.2002  a.2002 => a.2003
 __ERR__
 
 cat >'suite.rc' <<'__SUITE_RC__'
@@ -89,7 +89,7 @@ __SUITE_RC__
 
 run_fail "${TEST_NAME_BASE}-intercycle-2" cylc validate 'suite.rc'
 contains_ok "${TEST_NAME_BASE}-intercycle-2.stderr" <<'__ERR__'
-'ERROR: circular edges detected:  foo.8 => bar.8  bar.8 => baz.8  baz.8 => foo.8'
+SuiteConfigError: circular edges detected:  foo.8 => bar.8  bar.8 => baz.8  baz.8 => foo.8
 __ERR__
 
 cat >'suite.rc' <<'__SUITE_RC__'
@@ -106,7 +106,7 @@ __SUITE_RC__
 
 run_fail "${TEST_NAME_BASE}-param-1" cylc validate 'suite.rc'
 contains_ok "${TEST_NAME_BASE}-param-1.stderr" <<'__ERR__'
-'ERROR: circular edges detected:  fool_foo2.1 => fool_foo1.1  fool_foo1.1 => fool_foo2.1'
+SuiteConfigError: circular edges detected:  fool_foo2.1 => fool_foo1.1  fool_foo1.1 => fool_foo2.1
 __ERR__
 
 cat >'suite.rc' <<'__SUITE_RC__'

--- a/tests/validate/65-bad-task-event-handler-tmpl.t
+++ b/tests/validate/65-bad-task-event-handler-tmpl.t
@@ -33,7 +33,7 @@ cat >'suite.rc' <<'__SUITE_RC__'
 __SUITE_RC__
 run_fail "${TEST_NAME}" cylc validate 'suite.rc'
 cmp_ok "${TEST_NAME}.stderr" <<'__ERR__'
-"ERROR: bad task event handler template t1: echo %(rubbish)s: KeyError('rubbish')"
+SuiteConfigError: bad task event handler template t1: echo %(rubbish)s: KeyError('rubbish')
 __ERR__
 
 TEST_NAME="${TEST_NAME_BASE}-bad-value"
@@ -49,7 +49,7 @@ cat >'suite.rc' <<'__SUITE_RC__'
 __SUITE_RC__
 run_fail "${TEST_NAME}" cylc validate 'suite.rc'
 cmp_ok "${TEST_NAME}.stderr" <<'__ERR__'
-"ERROR: bad task event handler template t1: echo %(ids: ValueError('incomplete format key')"
+SuiteConfigError: bad task event handler template t1: echo %(ids: ValueError('incomplete format key')
 __ERR__
 
 exit

--- a/tests/validate/66-fail-consec-spaces.t
+++ b/tests/validate/66-fail-consec-spaces.t
@@ -36,6 +36,5 @@ cat > suite.rc <<__END__
         [[[directives]]]
             -l  select=1:ncpus=24:mem=20GB  # ERROR!
 __END__
-run_fail $TEST_NAME cylc validate --debug -v suite.rc
-grep_ok "Illegal item (consecutive spaces):\
- \[runtime\]\[task1\]\[directives\]-l  select" $TEST_NAME.stderr
+run_fail $TEST_NAME cylc validate -v suite.rc
+grep_ok "IllegalItemError: \[runtime\]\[task1\]\[directives\]-l  select - (consecutive spaces)" $TEST_NAME.stderr

--- a/tests/validate/66-fail-consec-spaces.t
+++ b/tests/validate/66-fail-consec-spaces.t
@@ -36,5 +36,7 @@ cat > suite.rc <<__END__
         [[[directives]]]
             -l  select=1:ncpus=24:mem=20GB  # ERROR!
 __END__
-run_fail $TEST_NAME cylc validate -v suite.rc
-grep_ok "IllegalItemError: \[runtime\]\[task1\]\[directives\]-l  select - (consecutive spaces)" $TEST_NAME.stderr
+run_fail $TEST_NAME cylc validate suite.rc
+cmp_ok "$TEST_NAME.stderr" <<__END__
+IllegalItemError: [runtime][task1][directives]-l  select - (consecutive spaces)
+__END__

--- a/tests/validate/68-trailing_whitespace.t
+++ b/tests/validate/68-trailing_whitespace.t
@@ -41,8 +41,7 @@ __SUITE_RC__
 
 run_fail "${TEST_NAME_BASE}-simple-fail" cylc validate 'suite.rc'
 cmp_ok "${TEST_NAME_BASE}-simple-fail.stderr" <<'__ERR__'
-FileParseError:
-Syntax error line 7: Whitespace after the line continuation character (\).
+FileParseError: Syntax error line 7: Whitespace after the line continuation character (\).
 __ERR__
 
 # Test example with correct syntax


### PR DESCRIPTION
### ~For Discussion~

~**I've made a quick start at #2982, raising as a PR now to discuss approach before committing to it.**~

### ~WIP~

~I've got the `tests/validate` tests to pass, these changes should give a flavour for what this would look like if fully implemented.~

closes #2982

#### Highlights:

* Cylc / Parsec exceptions inherit from `CylcError` and `ParsecError` respectively.
* Jinja2 becomes an optional extra to Parsec (like EmPy).
* Add `UserImputError` for CLI input.
* Merge `GraphNodeError` in with `GraphParseError`
* CLI commands catch `CylcError`, `ParsecError` errors elegantly but allow anything else to materialise in traceback.
* Use (minimal) inheritance for exceptions:
  * Excessive nesting causes performance and maintenance issues.
  * Don't catch `CylcError` exceptions in order to re-raise as a more generic type e.g. `GraphParseError` being re-raised as a `SuiteConfigError`
* Simplify & standardise exceptions.
  * No more `def __str__(self): return repr(self.msg)`.
* Move exceptions into their own module.
* Replace inconsistent `ERROR` prefix with the more informative error class name.
* Remove redundant information (stuff like this: `ItemError: ERROR: error in item`).

#### Example:

*before*: catch specific exception and re-raise as a generic exception
```
FileParseError:
Include-file not found: bar.rc via foo.rc from $PWD/suite.rc
```
*after*: remove un-necessary `Include-file not found` text, exception title should suffice
```
IncludeFileNotFoundError: bar.rc via foo.rc from $PWD/suite.rc
```

#### TODO:

* Isodatetime exceptions should inherit from `ISODateTimeError`.

#### Questions

@cylc/core Are we happy with this approach?

Should exceptions multiple-inherit for context (`see lib/parsec/exceptions.py` for example):
```
class ItemNotFoundError(ParsecError, KeyError):
```