### PR TITLE
document suite runtime interface

### DIFF
--- a/bin/cylc-checkpoint
+++ b/bin/cylc-checkpoint
@@ -46,7 +46,7 @@ def main():
     pclient = SuiteRuntimeClient(
         suite, options.owner, options.host, options.port,
         options.comms_timeout)
-    pclient('take_checkpoints', {'items': [name]})
+    pclient('take_checkpoints', {'name': name})
 
 
 if __name__ == "__main__":

--- a/bin/cylc-hold
+++ b/bin/cylc-hold
@@ -70,7 +70,7 @@ def main():
         items = parser.parse_multitask_compat(options, args)
         pclient(
             'hold_tasks',
-            {'items': items},
+            {'task_globs': items},
             timeout=options.comms_timeout
         )
     elif options.hold_point_string:

--- a/bin/cylc-hold
+++ b/bin/cylc-hold
@@ -52,11 +52,10 @@ def main():
         help="Hold whole suite AFTER this cycle point.",
         metavar="CYCLE_POINT", action="store", dest="hold_point_string")
 
-    options, args = parser.parse_args()
+    options, (suite, *task_globs) = parser.parse_args()
 
-    suite = args.pop(0)
-    if args:
-        prompt('Hold task(s) %s in %s' % (args, suite), options.force)
+    if task_globs:
+        prompt('Hold task(s) %s in %s' % (task_globs, suite), options.force)
     elif options.hold_point_string:
         prompt(
             'Hold suite after %s' % options.hold_point_string, options.force)
@@ -66,8 +65,7 @@ def main():
     pclient = SuiteRuntimeClient(
         suite, options.owner, options.host, options.port)
 
-    if args:
-        task_globs = parser.parse_multitask_compat(options, args)
+    if task_globs:
         pclient(
             'hold_tasks',
             {'task_globs': task_globs},

--- a/bin/cylc-hold
+++ b/bin/cylc-hold
@@ -18,7 +18,7 @@
 
 """cylc [control] hold [OPTIONS] ARGS
 
-Hold one or more waiting tasks (cylc hold REG TASKID ...), or
+Hold one or more waiting tasks (cylc hold REG TASK_GLOB ...), or
 a whole suite (cylc hold REG).
 
 Held tasks do not submit even if they are ready to run.
@@ -45,7 +45,7 @@ def main():
         __doc__, comms=True, multitask=True,
         argdoc=[
             ("REG", "Suite name"),
-            ('[TASKID ...]', 'Task identifiers')])
+            ('[TASK_GLOB ...]', 'Task matching patterns')])
 
     parser.add_option(
         "--after",
@@ -67,10 +67,10 @@ def main():
         suite, options.owner, options.host, options.port)
 
     if args:
-        items = parser.parse_multitask_compat(options, args)
+        task_globs = parser.parse_multitask_compat(options, args)
         pclient(
             'hold_tasks',
-            {'task_globs': items},
+            {'task_globs': task_globs},
             timeout=options.comms_timeout
         )
     elif options.hold_point_string:

--- a/bin/cylc-insert
+++ b/bin/cylc-insert
@@ -64,25 +64,13 @@ def main():
         "--no-check", help="Add task even if the provided cycle point is not "
         "valid for the given task.", action="store_true", default=False)
 
-    options, args = parser.parse_args()
-    suite = args.pop(0)
+    options, (suite, *items) = parser.parse_args()
 
-    if (len(args) in [2, 3]
-            and all("/" not in arg for arg in args)
-            and all("." not in arg for arg in args[1:])):
-        items = [(args[0] + "." + args[1])]
-        if len(args) == 3:
-            options.stop_point_string = args[2]
-        prompt(
-            'Insert %s in %s' % (items, suite), options.force)
-    else:
-        items = args
-        for i, item in enumerate(items):
-            if not TaskID.is_valid_id_2(item):
-                raise UserInputError(
-                    '"%s": invalid task ID (argument %d)' % (
-                        item, i + 1))
-        prompt('Insert %s in %s' % (items, suite), options.force)
+    for i, item in enumerate(items):
+        if not TaskID.is_valid_id_2(item):
+            raise UserInputError(
+                '"%s": invalid task ID (argument %d)' % (item, i + 1))
+    prompt('Insert %s in %s' % (items, suite), options.force)
 
     pclient = SuiteRuntimeClient(
         suite, options.owner, options.host, options.port)

--- a/bin/cylc-insert
+++ b/bin/cylc-insert
@@ -67,12 +67,9 @@ def main():
     options, args = parser.parse_args()
     suite = args.pop(0)
 
-    # See "cop.parse_multitask_compat" for back compat discussion
-    # "cop.parse_multitask_compat" cannot be used here because argument 3
-    # (after suite argument) used to be "options.stop_point_string".
-    if (options.multitask_compat and len(args) in [2, 3] and
-            all("/" not in arg for arg in args) and
-            all("." not in arg for arg in args[1:])):
+    if (len(args) in [2, 3]
+            and all("/" not in arg for arg in args)
+            and all("." not in arg for arg in args[1:])):
         items = [(args[0] + "." + args[1])]
         if len(args) == 3:
             options.stop_point_string = args[2]

--- a/bin/cylc-kill
+++ b/bin/cylc-kill
@@ -57,7 +57,7 @@ def main():
         suite, options.owner, options.host, options.port)
     pclient(
         'kill_tasks',
-        {'items': parser.parse_multitask_compat(options, args)},
+        {'task_globs': parser.parse_multitask_compat(options, args)},
         timeout=options.comms_timeout
     )
 

--- a/bin/cylc-kill
+++ b/bin/cylc-kill
@@ -46,18 +46,17 @@ def main():
             ('REG', 'Suite name'),
             ('[TASK_GLOB ...]', 'Task matching patterns')])
 
-    options, args = parser.parse_args()
+    options, (suite, *task_globs) = parser.parse_args()
 
-    suite = args.pop(0)
-    if args:
-        prompt('Kill task %s in %s' % (args, suite), options.force)
+    if task_globs:
+        prompt('Kill task %s in %s' % (task_globs, suite), options.force)
     else:
         prompt('Kill ALL tasks in %s' % (suite), options.force)
     pclient = SuiteRuntimeClient(
         suite, options.owner, options.host, options.port)
     pclient(
         'kill_tasks',
-        {'task_globs': parser.parse_multitask_compat(options, args)},
+        {'task_globs': task_globs},
         timeout=options.comms_timeout
     )
 

--- a/bin/cylc-kill
+++ b/bin/cylc-kill
@@ -20,7 +20,7 @@
 
 Kill jobs of active tasks and update their statuses accordingly.
 
-To kill one or more tasks, "cylc kill REG TASKID ..."; to kill all active
+To kill one or more tasks, "cylc kill REG TASK_GLOB ..."; to kill all active
 tasks: "cylc kill REG".
 """
 
@@ -44,7 +44,7 @@ def main():
         __doc__, comms=True, multitask=True,
         argdoc=[
             ('REG', 'Suite name'),
-            ('[TASKID ...]', 'Task identifiers')])
+            ('[TASK_GLOB ...]', 'Task matching patterns')])
 
     options, args = parser.parse_args()
 

--- a/bin/cylc-make-docs
+++ b/bin/cylc-make-docs
@@ -38,7 +38,7 @@ echo "Building the HTML Cylc Documentation with Sphinx:"
 echo >&2
 cd "$CYLC_DIR"/doc/
 echo "... Generating the command reference ..."
-./src/custom/make-commands.sh
+#./src/custom/make-commands.sh
 echo >&2
 
 echo "... Generating multi-page User Guide..."

--- a/bin/cylc-make-docs
+++ b/bin/cylc-make-docs
@@ -38,7 +38,7 @@ echo "Building the HTML Cylc Documentation with Sphinx:"
 echo >&2
 cd "$CYLC_DIR"/doc/
 echo "... Generating the command reference ..."
-#./src/custom/make-commands.sh
+./src/custom/make-commands.sh
 echo >&2
 
 echo "... Generating multi-page User Guide..."

--- a/bin/cylc-poll
+++ b/bin/cylc-poll
@@ -49,19 +49,19 @@ def main():
         "-s", "--succeeded", help="Allow polling of succeeded tasks.",
         action="store_true", default=False, dest="poll_succ")
 
-    options, args = parser.parse_args()
+    options, (suite, *task_globs) = parser.parse_args()
 
-    suite = args.pop(0)
-    if args:
-        prompt('Poll task %s in %s' % (args, suite), options.force)
+    if task_globs:
+        prompt('Poll task %s in %s' % (task_globs, suite), options.force)
     else:
         prompt('Poll ALL tasks in %s' % (suite), options.force)
     pclient = SuiteRuntimeClient(
         suite, options.owner, options.host, options.port,
         options.comms_timeout)
-    task_globs = parser.parse_multitask_compat(options, args)
-    pclient('poll_tasks',
-            {'task_globs': task_globs, 'poll_succ': options.poll_succ})
+    pclient(
+        'poll_tasks',
+        {'task_globs': task_globs, 'poll_succ': options.poll_succ}
+    )
 
 
 if __name__ == "__main__":

--- a/bin/cylc-poll
+++ b/bin/cylc-poll
@@ -63,9 +63,10 @@ def main():
     # Back compat: back_out introduced >7.5.0
     # So don't call with "poll_succ" if not necessary to avoid breakage.
     if options.poll_succ:
-        pclient('poll_tasks', {'items': items, 'poll_succ': options.poll_succ})
+        pclient('poll_tasks',
+                {'task_globs': items, 'poll_succ': options.poll_succ})
     else:
-        pclient('poll_tasks', {'items': items})
+        pclient('poll_tasks', {'task_globs': items})
 
 
 if __name__ == "__main__":

--- a/bin/cylc-poll
+++ b/bin/cylc-poll
@@ -20,8 +20,8 @@
 
 Poll (query) task jobs to verify and update their statuses.
 
-Use "cylc poll REG" to poll all active tasks, or "cylc poll REG TASKID" to poll
-individual tasks or families, or groups of them.
+Use "cylc poll REG" to poll all active tasks, or "cylc poll REG TASK_GLOB"
+to poll individual tasks or families, or groups of them.
 """
 
 import sys
@@ -43,7 +43,7 @@ def main():
         __doc__, comms=True, multitask=True,
         argdoc=[
             ('REG', 'Suite name'),
-            ('[TASKID ...]', 'Task identifiers')])
+            ('[TASK_GLOB ...]', 'Task matching patterns')])
 
     parser.add_option(
         "-s", "--succeeded", help="Allow polling of succeeded tasks.",
@@ -59,14 +59,9 @@ def main():
     pclient = SuiteRuntimeClient(
         suite, options.owner, options.host, options.port,
         options.comms_timeout)
-    items = parser.parse_multitask_compat(options, args)
-    # Back compat: back_out introduced >7.5.0
-    # So don't call with "poll_succ" if not necessary to avoid breakage.
-    if options.poll_succ:
-        pclient('poll_tasks',
-                {'task_globs': items, 'poll_succ': options.poll_succ})
-    else:
-        pclient('poll_tasks', {'task_globs': items})
+    task_globs = parser.parse_multitask_compat(options, args)
+    pclient('poll_tasks',
+            {'task_globs': task_globs, 'poll_succ': options.poll_succ})
 
 
 if __name__ == "__main__":

--- a/bin/cylc-release
+++ b/bin/cylc-release
@@ -58,7 +58,7 @@ def main():
         options.comms_timeout)
     if args:
         items = parser.parse_multitask_compat(options, args)
-        pclient('release_tasks', {'items': items})
+        pclient('release_tasks', {'task_globs': items})
     else:
         pclient('release_suite')
 

--- a/bin/cylc-release
+++ b/bin/cylc-release
@@ -18,7 +18,7 @@
 
 """cylc [control] release|unhold [OPTIONS] ARGS
 
-Release one or more held tasks (cylc release REG TASKID)
+Release one or more held tasks (cylc release REG TASK_GLOB)
 or the whole suite (cylc release REG). Held tasks do not
 submit even if they are ready to run.
 
@@ -44,7 +44,7 @@ def main():
         __doc__, comms=True, multitask=True,
         argdoc=[
             ("REG", 'Suite name'),
-            ('[TASKID ...]', 'Task identifiers')])
+            ('[TASK_GLOB ...]', 'Task matching patterns')])
 
     options, args = parser.parse_args()
     suite = args.pop(0)
@@ -57,8 +57,8 @@ def main():
         suite, options.owner, options.host, options.port,
         options.comms_timeout)
     if args:
-        items = parser.parse_multitask_compat(options, args)
-        pclient('release_tasks', {'task_globs': items})
+        task_globs = parser.parse_multitask_compat(options, args)
+        pclient('release_tasks', {'task_globs': task_globs})
     else:
         pclient('release_suite')
 

--- a/bin/cylc-release
+++ b/bin/cylc-release
@@ -46,19 +46,20 @@ def main():
             ("REG", 'Suite name'),
             ('[TASK_GLOB ...]', 'Task matching patterns')])
 
-    options, args = parser.parse_args()
-    suite = args.pop(0)
+    options, (suite, *task_globs) = parser.parse_args()
 
-    if args:
-        prompt('Release task(s) %s in %s' % (args, suite), options.force)
+    if task_globs:
+        prompt('Release task(s) %s in %s' % (task_globs, suite), options.force)
     else:
         prompt('Release suite %s' % suite, options.force)
     pclient = SuiteRuntimeClient(
         suite, options.owner, options.host, options.port,
         options.comms_timeout)
-    if args:
-        task_globs = parser.parse_multitask_compat(options, args)
-        pclient('release_tasks', {'task_globs': task_globs})
+    if task_globs:
+        pclient(
+            'release_tasks',
+            {'task_globs': task_globs}
+        )
     else:
         pclient('release_suite')
 

--- a/bin/cylc-remove
+++ b/bin/cylc-remove
@@ -50,14 +50,12 @@ def main():
         help="Do not spawn successors before removal.",
         action="store_true", default=False, dest="no_spawn")
 
-    options, args = parser.parse_args()
+    options, (suite, *task_globs) = parser.parse_args()
 
-    suite = args.pop(0)
-    prompt('remove task(s) %s in %s' % (args, suite), options.force)
+    prompt('remove task(s) %s in %s' % (task_globs, suite), options.force)
     pclient = SuiteRuntimeClient(
         suite, options.owner, options.host, options.port,
         options.comms_timeout)
-    task_globs = parser.parse_multitask_compat(options, args)
     pclient(
         'remove_tasks',
         {'task_globs': task_globs, 'spawn': (not options.no_spawn)}

--- a/bin/cylc-remove
+++ b/bin/cylc-remove
@@ -60,7 +60,7 @@ def main():
     items = parser.parse_multitask_compat(options, args)
     pclient(
         'remove_tasks',
-        {'items': items, 'spawn': (not options.no_spawn)}
+        {'task_globs': items, 'spawn': (not options.no_spawn)}
     )
 
 

--- a/bin/cylc-remove
+++ b/bin/cylc-remove
@@ -18,7 +18,7 @@
 
 """cylc [control] remove [OPTIONS] ARGS
 
-Remove one or more tasks (cylc remove REG TASKID), or all tasks with a
+Remove one or more tasks (cylc remove REG TASK_GLOB), or all tasks with a
 given cycle point (cylc remove REG *.POINT) from a running suite.
 
 Tasks will spawn successors first if they have not done so already.
@@ -43,7 +43,7 @@ def main():
         __doc__, comms=True, multitask=True,
         argdoc=[
             ("REG", "Suite name"),
-            ('TASKID [...]', 'Task identifiers')])
+            ('TASK_GLOB [...]', 'Task matching patterns')])
 
     parser.add_option(
         "--no-spawn",
@@ -57,10 +57,10 @@ def main():
     pclient = SuiteRuntimeClient(
         suite, options.owner, options.host, options.port,
         options.comms_timeout)
-    items = parser.parse_multitask_compat(options, args)
+    task_globs = parser.parse_multitask_compat(options, args)
     pclient(
         'remove_tasks',
-        {'task_globs': items, 'spawn': (not options.no_spawn)}
+        {'task_globs': task_globs, 'spawn': (not options.no_spawn)}
     )
 
 

--- a/bin/cylc-reset
+++ b/bin/cylc-reset
@@ -100,7 +100,8 @@ def main():
     items = parser.parse_multitask_compat(options, args)
     pclient(
         'reset_task_states',
-        {'items': items, 'state': options.state, 'outputs': options.outputs}
+        {'task_globs': items, 'state': options.state,
+         'outputs': options.outputs}
     )
 
 

--- a/bin/cylc-reset
+++ b/bin/cylc-reset
@@ -71,9 +71,7 @@ def main():
               "Can be used more than once to reset multiple task outputs."),
         action="append", default=[], dest="outputs")
 
-    options, args = parser.parse_args()
-
-    suite = args.pop(0)
+    options, (suite, *task_globs) = parser.parse_args()
 
     if not options.state and not options.outputs:
         parser.error("Neither --state=STATE nor --output=OUTPUT is set")
@@ -84,7 +82,7 @@ def main():
             "'cylc reset -s spawn' is deprecated; calling 'cylc spawn'\n")
         cmd = sys.argv[0].replace('reset', 'spawn')
         try:
-            os.execvp(cmd, [cmd] + args)
+            os.execvp(cmd, [cmd] + task_globs)
         except OSError as exc:
             if exc.filename is None:
                 exc.filename = cmd
@@ -93,11 +91,10 @@ def main():
     if not options.state:
         options.state = ''
 
-    prompt('Reset task(s) %s in %s' % (args, suite), options.force)
+    prompt('Reset task(s) %s in %s' % (task_globs, suite), options.force)
     pclient = SuiteRuntimeClient(
         suite, options.owner, options.host, options.port,
         options.comms_timeout)
-    task_globs = parser.parse_multitask_compat(options, args)
     pclient(
         'reset_task_states',
         {'task_globs': task_globs, 'state': options.state,

--- a/bin/cylc-reset
+++ b/bin/cylc-reset
@@ -53,7 +53,7 @@ def main():
         __doc__, comms=True, multitask=True,
         argdoc=[
             ('REG', 'Suite name'),
-            ('[TASKID ...]', 'Task identifiers')])
+            ('[TASK_GLOB ...]', 'Task matching patterns')])
 
     parser.add_option(
         "-s", "--state", metavar="STATE",
@@ -97,10 +97,10 @@ def main():
     pclient = SuiteRuntimeClient(
         suite, options.owner, options.host, options.port,
         options.comms_timeout)
-    items = parser.parse_multitask_compat(options, args)
+    task_globs = parser.parse_multitask_compat(options, args)
     pclient(
         'reset_task_states',
-        {'task_globs': items, 'state': options.state,
+        {'task_globs': task_globs, 'state': options.state,
          'outputs': options.outputs}
     )
 

--- a/bin/cylc-show
+++ b/bin/cylc-show
@@ -86,7 +86,7 @@ def main():
 
     if task_ids:
         results, bad_items = pclient('get_task_requisites', {
-            'items': task_ids, 'list_prereqs': options.list_prereqs})
+            'task_globs': task_ids, 'list_prereqs': options.list_prereqs})
         if options.json:
             json_filter.append(results)
         else:

--- a/bin/cylc-show
+++ b/bin/cylc-show
@@ -45,7 +45,7 @@ def main():
         __doc__, comms=True, noforce=True, multitask=True,
         argdoc=[
             ('REG', 'Suite name'),
-            ('[TASK_GLOB ...]', 'Task matching patterns')])
+            ('[TASKS ...]', 'Task names or ids (name.cycle)')])
 
     parser.add_option('--list-prereqs', action="store_true", default=False,
                       help="Print a task's pre-requisites as a list.")
@@ -53,9 +53,8 @@ def main():
     parser.add_option('--json', action="store_true", default=False,
                       help="Print output in JSON format.")
 
-    options, args = parser.parse_args()
-    suite = args[0]
-    task_args = args[1:]
+    options, (suite, *task_args) = parser.parse_args()
+
     pclient = SuiteRuntimeClient(
         suite, options.owner, options.host, options.port,
         options.comms_timeout)
@@ -85,8 +84,10 @@ def main():
                     print("%s: %s" % (key, value or "(not given)"))
 
     if task_ids:
-        results, bad_items = pclient('get_task_requisites', {
-            'task_globs': task_ids, 'list_prereqs': options.list_prereqs})
+        results, bad_items = pclient(
+            'get_task_requisites',
+            {'task_globs': task_ids, 'list_prereqs': options.list_prereqs}
+        )
         if options.json:
             json_filter.append(results)
         else:

--- a/bin/cylc-show
+++ b/bin/cylc-show
@@ -45,7 +45,7 @@ def main():
         __doc__, comms=True, noforce=True, multitask=True,
         argdoc=[
             ('REG', 'Suite name'),
-            ('[TASKID ...]', 'Task names or identifiers')])
+            ('[TASK_GLOB ...]', 'Task matching patterns')])
 
     parser.add_option('--list-prereqs', action="store_true", default=False,
                       help="Print a task's pre-requisites as a list.")

--- a/bin/cylc-spawn
+++ b/bin/cylc-spawn
@@ -42,7 +42,7 @@ def main():
         __doc__, comms=True, multitask=True,
         argdoc=[
             ('REG', 'Suite name'),
-            ('[TASKID ...]', 'Task identifiers')])
+            ('[TASK_GLOB ...]', 'Task matching patterns')])
 
     options, args = parser.parse_args()
 

--- a/bin/cylc-spawn
+++ b/bin/cylc-spawn
@@ -44,18 +44,16 @@ def main():
             ('REG', 'Suite name'),
             ('[TASK_GLOB ...]', 'Task matching patterns')])
 
-    options, args = parser.parse_args()
+    options, (suite, *task_globs) = parser.parse_args()
 
-    suite = args.pop(0)
-
-    prompt('Spawn task(s) %s in %s' % (args, suite), options.force)
+    prompt('Spawn task(s) %s in %s' % (task_globs, suite), options.force)
     pclient = SuiteRuntimeClient(
         suite, options.owner, options.host, options.port,
         options.comms_timeout)
 
     pclient(
         'spawn_tasks',
-        {'task_globs': parser.parse_multitask_compat(options, args)}
+        {'task_globs': task_globs}
     )
 
 

--- a/bin/cylc-spawn
+++ b/bin/cylc-spawn
@@ -55,7 +55,7 @@ def main():
 
     pclient(
         'spawn_tasks',
-        {'items': parser.parse_multitask_compat(options, args)}
+        {'task_globs': parser.parse_multitask_compat(options, args)}
     )
 
 

--- a/bin/cylc-trigger
+++ b/bin/cylc-trigger
@@ -76,10 +76,9 @@ def main():
         help="(with --edit) force use of the configured GUI editor.",
         action="store_true", default=False, dest="geditor")
 
-    options, args = parser.parse_args()
-    suite = args.pop(0)
+    options, (suite, *task_globs) = parser.parse_args()
 
-    msg = 'Trigger task(s) %s in %s' % (args, suite)
+    msg = 'Trigger task(s) %s in %s' % (task_globs, suite)
     prompt(msg, options.force)
 
     pclient = SuiteRuntimeClient(
@@ -88,7 +87,6 @@ def main():
 
     aborted = False
     if options.edit_run:
-        task_globs = parser.parse_multitask_compat(options, args)
         task_id = task_globs[0]
         # Check that TASK is a unique task.
         success, msg = pclient(
@@ -192,10 +190,10 @@ def main():
             aborted = True
 
     # Trigger the task proxy(s).
-    pclient('trigger_tasks', {
-        'task_globs': parser.parse_multitask_compat(options, args),
-        'back_out': aborted
-    })
+    pclient(
+        'trigger_tasks',
+        {'task_globs': task_globs, 'back_out': aborted}
+    )
 
 
 if __name__ == "__main__":

--- a/bin/cylc-trigger
+++ b/bin/cylc-trigger
@@ -115,7 +115,8 @@ def main():
             old_mtime = None
 
         # Tell the suite server program to generate the job file.
-        pclient('dry_run_tasks', {'items': [task_id], 'check_syntax': False})
+        pclient('dry_run_tasks', {
+                'task_globs': [task_id], 'check_syntax': False})
 
         # Wait for the new job file to be written. Use mtime because the same
         # file could potentially exist already, left from a previous run.
@@ -195,9 +196,9 @@ def main():
     # Back compat: back_out introduced >7.5.0
     # So don't call with "back_out" if not necessary to avoid breakage.
     if aborted:
-        pclient('trigger_tasks', {'items': items, 'back_out': aborted})
+        pclient('trigger_tasks', {'task_globs': items, 'back_out': aborted})
     else:
-        pclient('trigger_tasks', {'items': items})
+        pclient('trigger_tasks', {'task_globs': items})
 
 
 if __name__ == "__main__":

--- a/bin/cylc-trigger
+++ b/bin/cylc-trigger
@@ -64,7 +64,7 @@ def main():
         __doc__, comms=True, multitask=True,
         argdoc=[
             ('REG', 'Suite name'),
-            ('[TASKID ...]', 'Task identifiers')])
+            ('[TASK_GLOB ...]', 'Task matching patterns')])
 
     parser.add_option(
         "-e", "--edit",
@@ -88,8 +88,8 @@ def main():
 
     aborted = False
     if options.edit_run:
-        items = parser.parse_multitask_compat(options, args)
-        task_id = items[0]
+        task_globs = parser.parse_multitask_compat(options, args)
+        task_id = task_globs[0]
         # Check that TASK is a unique task.
         success, msg = pclient(
             'ping_task',
@@ -192,13 +192,10 @@ def main():
             aborted = True
 
     # Trigger the task proxy(s).
-    items = parser.parse_multitask_compat(options, args)
-    # Back compat: back_out introduced >7.5.0
-    # So don't call with "back_out" if not necessary to avoid breakage.
-    if aborted:
-        pclient('trigger_tasks', {'task_globs': items, 'back_out': aborted})
-    else:
-        pclient('trigger_tasks', {'task_globs': items})
+    pclient('trigger_tasks', {
+        'task_globs': parser.parse_multitask_compat(options, args),
+        'back_out': aborted
+    })
 
 
 if __name__ == "__main__":

--- a/doc/src/api/index.rst
+++ b/doc/src/api/index.rst
@@ -1,0 +1,7 @@
+Cylc API
+========
+
+
+.. toctree::
+
+   zmq

--- a/doc/src/api/zmq.rst
+++ b/doc/src/api/zmq.rst
@@ -1,0 +1,40 @@
+Suite Runtime Interface
+=======================
+
+
+Cylc suites are TCP servers which use the ZeroMQ protocol to communicate with
+clients and jobs.
+
+Cylc provides a Python client to communicate with this server
+:py:class:`cylc.network.client.SuiteRuntimeClient`
+
+.. code-block:: python
+
+   >>> from cylc.network.client import SuiteRuntimeClient
+   >>> client = SuiteRuntimeClient('my-suite')
+   >>> client('ping_suite')
+   True
+
+Cylc also provides sub-command called ``cylc client`` which is a simple
+wrapper of the Python client.
+
+.. code-block:: console
+
+   $ cylc client generic ping_suite -n
+   true
+
+The available "commands" or ("endpoints") are contained in
+:py:class:`cylc.network.server.SuiteRuntimeServer` class.
+
+
+Client
+------
+
+.. autoclass:: cylc.network.client.SuiteRuntimeClient
+
+
+Server
+------
+
+.. autoclass:: cylc.network.server.SuiteRuntimeServer
+   :members:

--- a/doc/src/api/zmq.rst
+++ b/doc/src/api/zmq.rst
@@ -27,6 +27,16 @@ The available "commands" or ("endpoints") are contained in
 :py:class:`cylc.network.server.SuiteRuntimeServer` class.
 
 
+Privilege Levels
+----------------
+
+Cylc protects its network interface with configurable privilege levels which
+can be used to allocate different levels of control to different users.
+
+.. autoclass:: cylc.network.Priv
+   :members:
+
+
 Client
 ------
 

--- a/doc/src/appendices/site-user-config-ref.rst
+++ b/doc/src/appendices/site-user-config-ref.rst
@@ -1095,23 +1095,7 @@ password.
 This sets the client privilege level for public access - i.e. no
 suite passphrase required.
 
-- *type*: string (must be one of the following options)
-- *options*:
+- *type*: string (must be one of the following options).
+- *options*: A Cylc privilege level: :py:obj:`cylc.network.Priv`.
 
-  none
-     Permit no public suite access.
-  identity
-     Only suite and owner names revealed.
-  description
-     Identity plus suite title and description.
-  state-totals
-     Identity, description, and task state totals.
-  read
-     Full read-only access.
-  shutdown
-     *Not yet implemented*
-     Full read access plus shutdown, but no other control.
-  control
-     Permit full control (not recommended).
-
-- *default*: state-totals
+- *default*: :py:obj:`cylc.network.Priv.STATE_TOTALS`

--- a/doc/src/index.rst
+++ b/doc/src/index.rst
@@ -1,5 +1,3 @@
-.. cylc documentation master file.
-
 Cylc documentation
 ==================
 
@@ -41,6 +39,8 @@ indefinitely.
    external-triggers
    running-suites
    suite-storage-etc
+
+   api/index
 
    appendices/appendices-master
 

--- a/doc/src/running-suites.rst
+++ b/doc/src/running-suites.rst
@@ -504,23 +504,9 @@ server program is determined by the public access privilege level set in global
 site/user config (:ref:`GlobalAuth`) and optionally overridden in suites
 (:ref:`SuiteAuth`):
 
-none
-   Permit no public suite access.
-identity
-   Only suite and owner names revealed.
-description
-   Identity plus suite title and description.
-state-totals
-   Identity, description, and task state totals.
-read
-   Full read-only access.
-shutdown
-   *Not yet implemented*
-   Full read access plus shutdown, but no other control.
-control
-   Permit full control (not recommended).
+See Cylc privilege levels: :py:obj:`cylc.network.Priv`.
 
-The default public access level is *state-totals*.
+The default public access level is :py:obj:`cylc.network.Priv.STATE_TOTALS`.
 
 The ``cylc scan`` command can print
 descriptions and task state totals in addition to basic suite identity, if the

--- a/lib/cylc/network/__init__.py
+++ b/lib/cylc/network/__init__.py
@@ -33,7 +33,7 @@ class Priv(IntEnum):
     """Cylc privilege levels.
 
     In Cylc configurations use the lower-case form of each privilege level
-    e.g. ``control`` for ``Priv.CONTORL``.
+    e.g. ``control`` for ``Priv.CONTROL``.
 
     These levels are ordered (by the integer associated with each) from 0.
     Each privilege level grants access to the levels below it.

--- a/lib/cylc/network/__init__.py
+++ b/lib/cylc/network/__init__.py
@@ -30,18 +30,36 @@ HASH = 'HS256'  # Encoding for JWT
 
 
 class Priv(IntEnum):
-    """Cylc privilege level."""
+    """Cylc privilege levels.
 
-    # TODO - autodocument from this class.
-    # TODO - revert name changes?
+    In Cylc configurations use the lower-case form of each privilege level
+    e.g. ``control`` for ``Priv.CONTORL``.
+
+    These levels are ordered (by the integer associated with each) from 0.
+    Each privilege level grants access to the levels below it.
+
+    """
 
     CONTROL = 6
+    """Provides full control of a suite."""
+
     SHUTDOWN = 5  # (Not used yet - for the post-passphrase era.)
+    """Allows issuing of the shutdown command."""
+
     READ = 4
+    """Permits read access to the suite's state."""
+
     STATE_TOTALS = 3
+    """Provides access to the count of tasks in each state."""
+
     DESCRIPTION = 2
+    """Permits reading of suite metadata."""
+
     IDENTITY = 1
+    """Provides read access to the suite name, owner and Cylc version."""
+
     NONE = 0
+    """No access."""
 
     @classmethod
     def parse(cls, key):

--- a/lib/cylc/network/client.py
+++ b/lib/cylc/network/client.py
@@ -108,23 +108,9 @@ class ZMQClient(object):
             self.header = dict(header)
 
     async def async_request(self, command, args=None, timeout=None):
-        """Send a request.
+        """Send an asynchronous request using asyncio.
 
-        For convenience use __call__ to call this method.
-
-        Args:
-            command (str): The name of the endpoint to call.
-            args (dict): Arguments to pass to the endpoint function.
-            timeout (float): Override the default timeout (seconds).
-
-        Raises:
-            ClientTimeout: If a response takes longer than timeout to arrive.
-            ClientError: Coverall for all other issues including failed
-                authentication.
-
-        Returns:
-            object: The data exactly as returned from the endpoint function,
-                nothing more, nothing less.
+        Has the same arguments and return values as ``serial_request``.
 
         """
         if timeout:
@@ -169,6 +155,24 @@ class ZMQClient(object):
             raise ClientError(error['message'], error.get('traceback'))
 
     def serial_request(self, command, args=None, timeout=None):
+        """Send a request.
+
+        For convenience use ``__call__`` to call this method.
+
+        Args:
+            command (str): The name of the endpoint to call.
+            args (dict): Arguments to pass to the endpoint function.
+            timeout (float): Override the default timeout (seconds).
+
+        Raises:
+            ClientTimeout: If a response takes longer than timeout to arrive.
+            ClientError: Coverall for all other issues including failed auth.
+
+        Returns:
+            object: The data exactly as returned from the endpoint function,
+                nothing more, nothing less.
+
+        """
         return asyncio.run(
             self.async_request(command, args, timeout))
 
@@ -197,6 +201,16 @@ class SuiteRuntimeClient:
 
     If there is no socket bound to the specified host/port the client will
     bail after ``timeout`` seconds.
+
+    Call server "endpoints" using:
+
+    ``__call__``, ``serial_request``
+
+       .. automethod:: cylc.network.client.ZMQClient.serial_request
+
+    ``async_request``
+
+       .. automethod:: cylc.network.client.ZMQClient.async_request
 
     """
 

--- a/lib/cylc/network/server.py
+++ b/lib/cylc/network/server.py
@@ -155,8 +155,9 @@ class ZMQServer(object):
             except Exception as exc:  # purposefully catch generic exception
                 # failed to decode message, possibly resulting from failed
                 # authentication
-                response = self.encode(
-                    {'error': {'message': str(exc)}}, self.secret())
+                import traceback
+                return {'error': {
+                    'message': str(exc), 'traceback': traceback.format_exc()}}
             else:
                 # success case - serve the request
                 LOG.debug('zmq:recv %s', message)
@@ -224,7 +225,6 @@ def authorise(req_priv_level):
 
     """
     def wrapper(fcn):
-        """Warp"""
         @wraps(fcn)  # preserve args and docstrings
         def _authorise(self, *args, user='?', meta=None, **kwargs):
             if not meta:

--- a/lib/cylc/network/server.py
+++ b/lib/cylc/network/server.py
@@ -397,7 +397,7 @@ class SuiteRuntimeServer(ZMQServer):
                 Information about outcome.
 
         """
-        self.schd.command_queue.put(('dry_run_tasks', (task_glob,),
+        self.schd.command_queue.put(('dry_run_tasks', (task_globs,),
                                     {'check_syntax': check_syntax}))
         return (True, 'Command queued')
 

--- a/lib/cylc/network/server.py
+++ b/lib/cylc/network/server.py
@@ -83,7 +83,7 @@ class ZMQServer(object):
         self.decode = decode_method
         self.secret = secret_method
 
-    def start(self, ports):
+    def start(self, min_port, max_port):
         """Start the server running
 
         Args:
@@ -96,17 +96,8 @@ class ZMQServer(object):
         self.socket = self.context.socket(zmq.REP)
         self.socket.RCVTIMEO = int(self.RECV_TIMEOUT) * 1000
 
-        # pick port
-        for port in ports:
-            try:
-                self.socket.bind('tcp://*:%d' % port)
-            except zmq.error.ZMQError:
-                pass
-            else:
-                self.port = port
-                break
-        else:
-            raise IOError('No room at the inn, all ports occupied.')
+        self.port = self.socket.bind_to_random_port(
+            'tcp://*', min_port, max_port)
 
         # start accepting requests
         self.register_endpoints()

--- a/lib/cylc/network/server.py
+++ b/lib/cylc/network/server.py
@@ -241,6 +241,9 @@ def authorise(req_priv_level):
             LOG.info(
                 '[client-command] %s %s@%s:%s', fcn.__name__, user, host, prog)
             return fcn(self, *args, **kwargs)
+        _authorise.__doc__ += (  # add auth level to docstring
+            'Authentication:\n%s:py:obj:`cylc.network.%s`\n' % (
+                ' ' * 12, req_priv_level))
         return _authorise
     return wrapper
 

--- a/lib/cylc/option_parsers.py
+++ b/lib/cylc/option_parsers.py
@@ -46,11 +46,7 @@ For example, to match:
   '*0000Z/foo*:retrying'
 * retrying tasks in 'BAR' family: '*/BAR:retrying' or 'BAR.*:retrying'
 * retrying tasks in 'BAR' or 'BAZ' families: '*/BA[RZ]:retrying' or
-  'BA[RZ].*:retrying'
-
-The old 'MATCH POINT' syntax will be automatically detected and supported. To
-avoid this, use the '--no-multitask-compat' option, or use the new syntax
-(with a '/' or a '.') when specifying 2 TASK_GLOB arguments."""
+  'BA[RZ].*:retrying'"""
 
     def __init__(self, usage, argdoc=None, comms=False, noforce=False,
                  jset=False, multitask=False, prep=False, auto_add=True,
@@ -75,7 +71,6 @@ avoid this, use the '--no-multitask-compat' option, or use the new syntax
         self.comms = comms
         self.jset = jset
         self.noforce = noforce
-        self.multitask = multitask
         self.prep = prep
         self.icp = icp
         self.suite_info = []
@@ -212,13 +207,6 @@ avoid this, use the '--no-multitask-compat' option, or use the new syntax
                 ),
                 action="store", default=None, dest="templatevars_file")
 
-        if self.multitask:
-            self.add_std_option(
-                "--no-multitask-compat",
-                help="Disallow backward compatible multitask interface.",
-                action="store_false", default=True,
-                dest="multitask_compat")
-
         if self.icp:
             self.add_option(
                 "--icp",
@@ -276,26 +264,3 @@ avoid this, use the '--no-multitask-compat' option, or use the new syntax
         LOG.addHandler(errhandler)
 
         return (options, args)
-
-    @classmethod
-    def parse_multitask_compat(cls, options, mtask_args):
-        """Parse argument items for multitask backward compatibility.
-
-        If options.multitask_compat is False, return (mtask_args, None).
-
-        If options.multitask_compat is True, it checks if mtask_args is a
-        2-element array and if the 1st and 2nd arguments look like the old
-        "MATCH" "POINT" CLI arguments.
-        If so, it returns (mtask_args[0], mtask_args[1]).
-        Otherwise, it return (mtask_args, None).
-
-        """
-        if (options.multitask_compat and len(mtask_args) == 2 and
-                not any("/" in mtask_arg for mtask_arg in mtask_args) and
-                "." not in mtask_args[1]):
-            # For backward compat, argument list should have 2 elements.
-            # Element 1 may be a regular expression, so it may contain "." but
-            # should not contain a "/".
-            # All other elements should contain no "." and "/".
-            return (mtask_args[0] + "." + mtask_args[1],)
-        return mtask_args

--- a/lib/cylc/option_parsers.py
+++ b/lib/cylc/option_parsers.py
@@ -32,7 +32,8 @@ class CylcOptionParser(OptionParser):
     """Common options for all cylc CLI commands."""
 
     MULTITASK_USAGE = """
-TASKID is a pattern to match task proxies or task families, or groups of them:
+TASK_GLOB is a pattern to match task proxies or task families,
+or groups of them:
 * [CYCLE-POINT-GLOB/]TASK-NAME-GLOB[:TASK-STATE]
 * [CYCLE-POINT-GLOB/]FAMILY-NAME-GLOB[:TASK-STATE]
 * TASK-NAME-GLOB[.CYCLE-POINT-GLOB][:TASK-STATE]
@@ -49,7 +50,7 @@ For example, to match:
 
 The old 'MATCH POINT' syntax will be automatically detected and supported. To
 avoid this, use the '--no-multitask-compat' option, or use the new syntax
-(with a '/' or a '.') when specifying 2 TASKID arguments."""
+(with a '/' or a '.') when specifying 2 TASK_GLOB arguments."""
 
     def __init__(self, usage, argdoc=None, comms=False, noforce=False,
                  jset=False, multitask=False, prep=False, auto_add=True,
@@ -212,15 +213,6 @@ avoid this, use the '--no-multitask-compat' option, or use the new syntax
                 action="store", default=None, dest="templatevars_file")
 
         if self.multitask:
-            self.add_std_option(
-                "-m", "--family",
-                help=(
-                    "(Obsolete) This option is now ignored "
-                    "and is retained for backward compatibility only. "
-                    "TASKID in the argument list can be used to match "
-                    "task and family names regardless of this option."),
-                action="store_true", default=False, dest="is_family")
-
             self.add_std_option(
                 "--no-multitask-compat",
                 help="Disallow backward compatible multitask interface.",

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -1838,9 +1838,9 @@ conditions; see `cylc conditions`.
         """Force spawn task successors."""
         return self.pool.spawn_tasks(items)
 
-    def command_take_checkpoints(self, items):
+    def command_take_checkpoints(self, name):
         """Insert current task_pool, etc to checkpoints tables."""
-        return self.suite_db_mgr.checkpoint(items[0])
+        return self.suite_db_mgr.checkpoint(name)
 
     def filter_initial_task_list(self, inlist):
         """Return list of initial tasks after applying a filter."""

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -248,7 +248,8 @@ class Scheduler(object):
                 daemonize(self)
             self._setup_suite_logger()
             self.server = SuiteRuntimeServer(self)
-            self.server.start(glbl_cfg().get(['suite servers', 'run ports']))
+            port_range = glbl_cfg().get(['suite servers', 'run ports'])
+            self.server.start(port_range[0], port_range[-1])
             self.port = self.server.port
             self.configure()
             self.profiler.start()

--- a/tests/cylc-insert/05-insert-compat/suite.rc
+++ b/tests/cylc-insert/05-insert-compat/suite.rc
@@ -29,6 +29,7 @@ duration of the suite; and the other is set to stop after two cycles."""
         script = "sleep 1" # quick
     [[prep]]
         script = """
-cylc insert $CYLC_SUITE_NAME bar 20140101T00
-cylc insert $CYLC_SUITE_NAME baz 20140101T00 20140102T00
-"""
+            cylc insert $CYLC_SUITE_NAME 'bar.20140101T00'
+            cylc insert $CYLC_SUITE_NAME 'baz.20140101T00' \
+                --stop-point 20140102T00
+        """

--- a/tests/cylc-insert/06-insert-bad-cycle-point-compat/suite.rc
+++ b/tests/cylc-insert/06-insert-bad-cycle-point-compat/suite.rc
@@ -24,4 +24,4 @@
         script = "sleep 1" # quick
     [[prep]]
         # Insert the task with a bad cycle point
-        script = cylc insert $CYLC_SUITE_NAME foo teatime
+        script = cylc insert "$CYLC_SUITE_NAME" 'foo.teatime'

--- a/tests/cylc-insert/07-insert-bad-stop-cycle-point/suite.rc
+++ b/tests/cylc-insert/07-insert-bad-stop-cycle-point/suite.rc
@@ -24,4 +24,6 @@
         script = "sleep 1" # quick
     [[prep]]
         # Insert the task with a bad cycle point
-        script = cylc insert $CYLC_SUITE_NAME foo 20140101T00 soon
+        script = """
+            cylc insert $CYLC_SUITE_NAME 'foo.20140101T00' --stop-point=soon
+        """

--- a/tests/cylc-insert/08-insert-family-compat/suite.rc
+++ b/tests/cylc-insert/08-insert-family-compat/suite.rc
@@ -26,9 +26,7 @@ cylc remove --no-spawn "$CYLC_SUITE_NAME" "FAM-?.$CYLC_TASK_CYCLE_POINT"
 """
     [[inserter]]
         # Re-insert one family.
-        script = """
-cylc insert -m $CYLC_SUITE_NAME FAM-A $CYLC_TASK_CYCLE_POINT
-"""
+        script = cylc insert $CYLC_SUITE_NAME FAM-A $CYLC_TASK_CYCLE_POINT
     [[FAM-A, FAM-B]]
     [[a1, a2]]
         inherit = FAM-A

--- a/tests/cylc-insert/08-insert-family-compat/suite.rc
+++ b/tests/cylc-insert/08-insert-family-compat/suite.rc
@@ -26,7 +26,7 @@ cylc remove --no-spawn "$CYLC_SUITE_NAME" "FAM-?.$CYLC_TASK_CYCLE_POINT"
 """
     [[inserter]]
         # Re-insert one family.
-        script = cylc insert $CYLC_SUITE_NAME FAM-A $CYLC_TASK_CYCLE_POINT
+        script = cylc insert "$CYLC_SUITE_NAME" "FAM-A.$CYLC_TASK_CYCLE_POINT"
     [[FAM-A, FAM-B]]
     [[a1, a2]]
         inherit = FAM-A

--- a/tests/cylc-kill/00-multi-hosts-compat/suite.rc
+++ b/tests/cylc-kill/00-multi-hosts-compat/suite.rc
@@ -21,6 +21,6 @@ KILLABLE:start-all => killer
             host={{CYLC_TEST_HOST}}
     [[killer]]
         script="""
-cylc kill -m "${CYLC_SUITE_NAME}" KILLABLE 1
+cylc kill "${CYLC_SUITE_NAME}" KILLABLE 1
 cylc stop "${CYLC_SUITE_NAME}"
 """

--- a/tests/cylc-kill/01-multi-hosts/suite.rc
+++ b/tests/cylc-kill/01-multi-hosts/suite.rc
@@ -21,6 +21,6 @@ KILLABLE:start-all => killer
             host={{CYLC_TEST_HOST}}
     [[killer]]
         script="""
-cylc kill -m "${CYLC_SUITE_NAME}" KILLABLE.1
+cylc kill "${CYLC_SUITE_NAME}" KILLABLE.1
 cylc stop "${CYLC_SUITE_NAME}"
 """

--- a/tests/cylc-kill/02-submitted/suite.rc
+++ b/tests/cylc-kill/02-submitted/suite.rc
@@ -24,7 +24,7 @@ sleep 60
         script="""
 wait "${CYLC_TASK_MESSAGE_STARTED_PID}" 2>/dev/null || true
 sleep 5
-cylc kill -m "${CYLC_SUITE_NAME}" '*:submitted'
+cylc kill "${CYLC_SUITE_NAME}" '*:submitted'
 """
     [[sleeper]]
         script=sleep 20

--- a/tests/cylc-take-checkpoints/00-basic/suite.rc
+++ b/tests/cylc-take-checkpoints/00-basic/suite.rc
@@ -20,7 +20,7 @@ if [[ "${CYLC_TASK_CYCLE_POINT}" == '2017' ]]; then
     sleep 2  # state of current task should be recorded after 2 seconds
     cylc checkpoint "${CYLC_SUITE_NAME}" 'snappy'
     LOG="${CYLC_SUITE_LOG_DIR}/log"
-    while ! grep -qF "INFO - Command succeeded: take_checkpoints(['snappy'])" \
+    while ! grep -qF "INFO - Command succeeded: take_checkpoints(snappy)" \
         "${LOG}"
     do
         sleep 1  # make sure take_checkpoints command completes

--- a/tests/cylc-trigger/03-edit-run/suite.rc
+++ b/tests/cylc-trigger/03-edit-run/suite.rc
@@ -18,13 +18,13 @@ second task fixes and retriggers it with an edit-run."""
         script = /bin/false
     [[fixer-task]]
         script = """
-cylc trigger --edit $CYLC_SUITE_NAME broken-task 1 << __END__
+cylc trigger --edit $CYLC_SUITE_NAME 'broken-task.1' << __END__
 y
 __END__"""
     [[syntax_errored_task]]
         script = $(
     [[syntax_fixer_task]]
         script = """
-cylc trigger --edit $CYLC_SUITE_NAME syntax_errored_task 1 << __END__
+cylc trigger --edit $CYLC_SUITE_NAME 'syntax_errored_task.1' << __END__
 y
 __END__"""

--- a/tests/cylc-trigger/08-edit-run-host-select/suite.rc
+++ b/tests/cylc-trigger/08-edit-run-host-select/suite.rc
@@ -17,6 +17,6 @@ second task fixes and retriggers it with an edit-run."""
             host = $(echo localhost)
     [[fixer-task]]
         script = """
-cylc trigger --edit $CYLC_SUITE_NAME broken-task 1 << __END__
+cylc trigger --edit $CYLC_SUITE_NAME 'broken-task.1' << __END__
 y
 __END__"""

--- a/tests/restart/25-hold-suite/suite.rc
+++ b/tests/restart/25-hold-suite/suite.rc
@@ -12,15 +12,15 @@
     [[dependencies]]
         [[[P1Y]]]
             graph = """
-t1[-P1Y] => t1 => t2
-"""
+                t1[-P1Y] => t1 => t2
+            """
 [runtime]
     [[t1]]
         script = """
-if [[ "${CYLC_TASK_CYCLE_POINT}" == '2016' ]]; then
-    cylc hold "${CYLC_SUITE_NAME}"
-    cylc stop "${CYLC_SUITE_NAME}"
-fi
-"""
+            if [[ "${CYLC_TASK_CYCLE_POINT}" == '2016' ]]; then
+                cylc hold "${CYLC_SUITE_NAME}"
+                cylc stop "${CYLC_SUITE_NAME}"
+            fi
+        """
     [[t2]]
         script = true


### PR DESCRIPTION
Follow on from #2966 
Closes #3048 

Write up the network stuff whilst it's still fresh in my head:

* Add new `api` section to the user guide
  * We can migrate other reference material there when we auto-document it.
* Document the `SuiteRuntimeServer` endpoints.
* Document the suite privilege levels.