### PR TITLE
Add tests for quoting of tilde expressions in environment section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ requests_).
  - Tim Whitcomb
  - (Scott Wales)
  - Tomek Trzeciak
- - (Thomas Coleman)
+ - Thomas Coleman
  - Bruno Kinoshita
  - (Annette Osprey)
  - (Jonathan Thomas)

--- a/lib/cylc/tests/test_job_file.py
+++ b/lib/cylc/tests/test_job_file.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from cylc.job_file import JobFileWriter
+
+
+# List of tilde variable inputs
+# input value, expected output value
+TILDE_IN_OUT = [('~foo/bar bar', '~foo/"bar bar"'),
+                ('~/bar bar', '~/"bar bar"'),
+                ('~/a', '~/"a"'),
+                ('test', '"test"'),
+                ('~', '~'),
+                ('~a', '~a')]
+
+
+class TestJobFile(unittest.TestCase):
+    def test_get_variable_value_definition(self):
+        """Test the value for single/tilde variables are correctly quoted"""
+        for in_value, out_value in TILDE_IN_OUT:
+            res = JobFileWriter._get_variable_value_definition(in_value)
+            self.assertEqual(out_value, res)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Tests for part of job_file.py. It's failing in my build environment because pycodestyle is looking in the .git directory (perhaps there is a bug in the travis pycodestyle setup?) because my branch name was originally `<...>.py`, as per below. So I'm going to rely on the output from the official tests in the pull request.

```
./.git/logs/refs/remotes/origin/add_test_for_job_file.py:1:80: E501 line too long (156 > 79 characters)
./.git/logs/refs/remotes/origin/add_test_for_job_file.py:1:99: E225 missing whitespace around operator
./.git/logs/refs/remotes/origin/add_test_for_job_file.py:1:124: E225 missing whitespace around operator
./.git/logs/refs/remotes/origin/add_test_for_job_file.py:1:138: E225 missing whitespace around operator
./.git/logs/refs/remotes/origin/add_test_for_job_file.py:2:80: E501 line too long (156 > 79 characters)
```

