### PR TITLE
Fix pycodestyle exclusion list (add from their default)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,5 +7,8 @@ ignore=
     ; line break after binary operator
     W504
 exclude=
+    .git,
+    __pycache__,
+    .tox,
     ./lib/jinja2,
     ./lib/markupsafe


### PR DESCRIPTION
In #3007, @ColemanTom reported that running `pycodestyle` against his branch reported false positives for files within the `.git` directory.

I thought that was funny, and decided to try, and indeed creating a branch with `git checkout -b delete.py` and running `pycodestyle` results in some 4 or so lines with incorrect values.

The reason for that is that [pycodestyle contains a list of default exclusions](https://github.com/PyCQA/pycodestyle/blob/96d2db0fa17cc41ae45bcc6fa5ca72e6f712d1bf/pycodestyle.py#L83), which includes `.git`.

But in our `tox.ini` file, we specify the list of exclusions to cover only `jinja2` and `markupsafe` folders (as they are imported modules, it makes sense to exclude them).

The issue happens as we have replaced the `.git` by our values. The original exclusion list includes CSV and Subversion files, which are not necessary for us IMO.

So I've added `.git`, `__pycache`, and `.tox` from their default list back, plus our two entries for `jinja2` and `markupsafe`. Tested, and the issue did not happen again.

@ColemanTom hopefully this explains what happened in your pull request. Interesting problem to distract for a while in such a strange Friday afternoon around here.

Cheers
Bruno