### PR TITLE
task_job_mgr: except KeyError

### DIFF
--- a/lib/cylc/task_job_mgr.py
+++ b/lib/cylc/task_job_mgr.py
@@ -509,7 +509,7 @@ class TaskJobManager(object):
                             del bad_tasks[(point, name, submit_num)]
                         itask = tasks[(point, name, submit_num)]
                         callback(suite, itask, ctx, line)
-                    except (LookupError, ValueError) as exc:
+                    except (LookupError, ValueError, KeyError) as exc:
                         LOG.warning(
                             'Unhandled %s output: %s', ctx.cmd_key, line)
                         LOG.exception(exc)


### PR DESCRIPTION
This addresses traceback we have seen (on 7.8.1), probably resulting from a sickly system.

```python
	Traceback (most recent call last):
	  File "/net/home/h03/fcm/cylc-7.8.1/lib/cylc/task_job_mgr.py", line 509, in _manip_task_jobs_callback
	    del bad_tasks[(point, name, submit_num)]
	KeyError: ...
```