### PR TITLE
Subprocpool: use SpooledTemporaryFile instead of TemporaryFile

### DIFF
--- a/lib/cylc/subprocpool.py
+++ b/lib/cylc/subprocpool.py
@@ -17,13 +17,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Manage queueing and pooling of subprocesses for the suite server program."""
 
+from collections import deque
 import json
 import os
 import select
-import sys
-from collections import deque
 from signal import SIGKILL
-from tempfile import TemporaryFile
+import sys
+from tempfile import SpooledTemporaryFile
 from threading import RLock
 from time import time
 
@@ -138,6 +138,11 @@ class SubProcPool(object):
         """Close pool."""
         self.set_stopping()
         self.closed = True
+
+    @staticmethod
+    def get_temporary_file():
+        """Return a SpooledTemporaryFile for feeding data to command STDIN."""
+        return SpooledTemporaryFile()
 
     def is_not_done(self):
         """Return True if queuings or runnings not empty."""
@@ -311,7 +316,7 @@ class SubProcPool(object):
         try:
             if ctx.cmd_kwargs.get('stdin_files'):
                 if len(ctx.cmd_kwargs['stdin_files']) > 1:
-                    stdin_file = TemporaryFile()
+                    stdin_file = cls.get_temporary_file()
                     for file_ in ctx.cmd_kwargs['stdin_files']:
                         if hasattr(file_, 'read'):
                             stdin_file.write(file_.read())
@@ -324,7 +329,7 @@ class SubProcPool(object):
                     stdin_file = open(
                         ctx.cmd_kwargs['stdin_files'][0], 'rb')
             elif ctx.cmd_kwargs.get('stdin_str'):
-                stdin_file = TemporaryFile('bw+')
+                stdin_file = cls.get_temporary_file()
                 stdin_file.write(ctx.cmd_kwargs.get('stdin_str').encode())
                 stdin_file.seek(0)
             else:

--- a/lib/cylc/task_remote_mgr.py
+++ b/lib/cylc/task_remote_mgr.py
@@ -29,7 +29,6 @@ from shlex import quote
 import re
 from subprocess import Popen, PIPE
 import tarfile
-from tempfile import TemporaryFile
 from time import time
 
 from cylc import LOG
@@ -197,7 +196,7 @@ class TaskRemoteMgr(object):
 
         # Create a TAR archive with the service files,
         # so they can be sent later via SSH's STDIN to the task remote.
-        tmphandle = TemporaryFile()
+        tmphandle = self.proc_pool.get_temporary_file()
         tarhandle = tarfile.open(fileobj=tmphandle, mode='w')
         for path, arcname in items:
             tarhandle.add(path, arcname=arcname)

--- a/lib/cylc/tests/test_subprocpool.py
+++ b/lib/cylc/tests/test_subprocpool.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from tempfile import NamedTemporaryFile, TemporaryFile
+from tempfile import NamedTemporaryFile, SpooledTemporaryFile, TemporaryFile
 import unittest
 
 from cylc.subprocctx import SubProcContext
@@ -24,6 +24,11 @@ from cylc.subprocpool import SubProcPool
 
 
 class TestSubProcPool(unittest.TestCase):
+
+    def test_get_temporary_file(self):
+        """Test SubProcPool.get_temporary_file."""
+        self.assertIsInstance(
+            SubProcPool.get_temporary_file(), SpooledTemporaryFile)
 
     def test_run_command_returns_0(self):
         """Test basic usage, command returns 0"""

--- a/lib/cylc/tests/test_subprocpool.py
+++ b/lib/cylc/tests/test_subprocpool.py
@@ -71,6 +71,14 @@ class TestSubProcPool(unittest.TestCase):
         self.assertEqual(ctx.out, 'catches mice.\n')
         self.assertEqual(ctx.ret_code, 0)
 
+    def test_run_command_with_stdin_from_unicode(self):
+        """Test STDIN from string with Unicode"""
+        ctx = SubProcContext('meow', ['cat'], stdin_str='喵\n')
+        SubProcPool.run_command(ctx)
+        self.assertEqual(ctx.err, '')
+        self.assertEqual(ctx.out, '喵\n')
+        self.assertEqual(ctx.ret_code, 0)
+
     def test_run_command_with_stdin_from_handle(self):
         """Test STDIN from a single opened file handle"""
         handle = TemporaryFile()


### PR DESCRIPTION
Use SpooledTemporaryFile to avoid using the file system - should in theory eliminate the reliance on TMPDIR.

Note: The biggest usage of this is remote job submission - with up to 100 job files being sent via STDIN to the remote host per command. A job file is typically about 1-2K in size, so even 100 of them should only be ~200K. In the default configuration where we have a pool of 4 sub-processes, this should still be less than 1M. Unlikely to be a big issue for a modern computing host?

Fix #2999.