### PR TITLE
Remove latex refs 7

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -43,8 +43,10 @@ if grep 'functional-tests' <<< "${args[@]}"; then
       --install-option="--library-path=/usr/lib/graphviz/"
 fi
 
-# install dependencies required for building documentation, only when instructed to do so
+# install dependencies required for building documentation
 if grep 'docs' <<< "${args[@]}$"; then
+    pip install sphinx
+    # for PDF output via LaTeX builder
     sudo apt-get install texlive-latex-base
 fi
 

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -46,8 +46,6 @@ fi
 # install dependencies required for building documentation
 if grep 'docs' <<< "${args[@]}$"; then
     pip install sphinx
-    # for PDF output via LaTeX builder
-    sudo apt-get install texlive-latex-base
 fi
 
 # configure local SSH for Cylc jobs

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,6 +6,17 @@ more detailed information.**
 Cylc must be installed on suite and task job hosts. Third-party dependencies
 (below) are not required on job hosts.
 
+### Python 2 or Python 3 ?
+
+Currently in the source code repository:
+- **master branch:** Python 3, ZeroMQ network layer, **no GUI** - Cylc-8 Work In Progress
+- **7.8.x branch:** Python 2, Cherrypy network layer, PyGTK GUI - Cylc-7 Maintenance
+
+The first official Cylc-8 release (with a new web UI) is not expected until late 2019.
+Until then we recommend the latest cylc-7.8 release for production use.
+
+**THIS IS THE 7.8.x (PYTHON 2) INSTALL.md**
+
 ### Third-party Software Packages
 
 Install the packages listed in the **Installation** section of the User Guide.
@@ -21,24 +32,20 @@ such as `/opt`:
 
 ```bash
 cd /opt
-tar xzf cylc-7.7.0.tar.gz
+tar xzf cylc-7.8.1.tar.gz
 # DO NOT CHANGE THE NAME OF THE UNPACKED CYLC SOURCE DIRECTORY.
-cd cylc-7.7.0
+cd cylc-7.8.1
 export PATH=$PWD/bin:$PATH
 make
 ```
 
 Then make (or update) a symlink to the latest installed version:
 ```bash
-ln -s /opt/cylc-7.7.0 /opt/cylc
+ln -s /opt/cylc-7.8.1 /opt/cylc
 ```
 
 When you type `make`:
-  * A file called VERSION is created, containing the Cylc version number
-    * The version number is taken from the name of the parent directory. DO
-      NOT CHANGE THE NAME OF THE UNPACKED CYLC SOURCE DIRECTORY
-  * The Cylc documentation is generated from source and put in doc/install/
-    (if you have pdflatex, tex4ht, and several other LateX packages installed).
+  * The Cylc User Guide is generated from source (if you have sphinx-doc installed).
 
 If this is the first installed version of Cylc, copy the wrapper script
 `usr/bin/cylc` to a location in the system executable path, such as
@@ -46,7 +53,7 @@ If this is the first installed version of Cylc, copy the wrapper script
 instructions - to point to the Cylc install location:
 
 ```bash
-cp /opt/cylc-7.7.0/usr/bin/cylc /usr/local/bin/
+cp /opt/cylc-7.8.1/usr/bin/cylc /usr/local/bin/
 # (and EDIT /usr/local/bin/cylc as instructed)
 ```
 
@@ -61,44 +68,4 @@ version.
 ```
 $ cylc check-software
 Checking your software...
-
-Individual results:
-===============================================================================
-Package (version requirements)                          Outcome (version found)
-===============================================================================
-                              *REQUIRED SOFTWARE*                              
-Python (2.6+, <3).....................FOUND & min. version MET (2.7.12.final.0)
-
-       *OPTIONAL SOFTWARE for the GUI & dependency graph visualisation*       
-Python:pygtk (2.0+)...........................FOUND & min. version MET (2.24.0)
-graphviz (any)...................................................FOUND (2.38.0)
-Python:pygraphviz (any)...........................................FOUND (1.3.1)
-
-                  *OPTIONAL SOFTWARE for the HTML User Guide*                  
-ImageMagick (any)...............................................FOUND (6.8.9-9)
-
-            *OPTIONAL SOFTWARE for the HTTPS communications layer*            
-Python:urllib3 (any).............................................FOUND (1.13.1)
-Python:OpenSSL (any).............................................FOUND (17.2.0)
-Python:requests (2.4.2+).......................FOUND & min. version MET (2.9.1)
-
-                 *OPTIONAL SOFTWARE for the LaTeX User Guide*                 
-TeX:framed (any)....................................................FOUND (n/a)
-TeX (3.0+)................................FOUND & min. version MET (3.14159265)
-TeX:preprint (any)..................................................FOUND (n/a)
-TeX:tex4ht (any)....................................................FOUND (n/a)
-TeX:tocloft (any)...................................................FOUND (n/a)
-TeX:texlive (any)...................................................FOUND (n/a)
-===============================================================================
-
-Summary:
-                         ****************************                         
-                             Core requirements: ok                             
-                            Full-functionality: ok                            
-                         ****************************  
-```
-
-### Installing The Documentation
-
-After running `make`, copy the `doc/install` directory to a location such as
-`/var/www/html/` and update your Cylc site config file to point to it.
+...

--- a/bin/cylc-check-software
+++ b/bin/cylc-check-software
@@ -197,10 +197,9 @@ def cmd_find_ver(
             res = [NOTFOUND_MSG, False]
         else:
             try:
-                output = procopen([cmd, ver_opt], stdoutpipe=True,
-                                  stdin=open(os.devnull),
-                                  stderrpipe=True).communicate()
-                [outfile - 1].strip()
+                output = procopen(
+                    [cmd, ver_opt], stdoutpipe=True, stdin=open(os.devnull),
+                    stderrpipe=True).communicate()[outfile - 1].strip()
                 version = re.search(ver_extr, output).groups()[0]
                 try_next_cmd = False
                 if min_ver is None:

--- a/bin/cylc-check-software
+++ b/bin/cylc-check-software
@@ -35,8 +35,6 @@ Arguments:
 import os
 import re
 import sys
-from subprocess import PIPE, CalledProcessError, check_call
-
 from cylc.cylc_subproc import procopen
 
 # Standardised output messages

--- a/bin/cylc-check-software
+++ b/bin/cylc-check-software
@@ -47,7 +47,7 @@ FOUND_UNKNOWNVER_MSG = 'FOUND but could not determine version (?)'
 NOTFOUND_MSG = 'NOT FOUND (-)'
 
 """Specification of cylc core & full-functionality module requirements, the
-latter grouped as Python, TeX or 'other' (neither). 'opt_spec' item format:
+latter grouped as Python or 'other'. 'opt_spec' item format:
 <MODULE>: [<MIN VER OR 'None'>, <FUNC TAG>, <GROUP>, <'OTHER' TUPLE>] with
 <'OTHER' TUPLE> = ([<BASE CMD(S)>], <VER OPT>, <REGEX>, <OUTFILE ARG>).
 """
@@ -184,27 +184,8 @@ def check_py_module_ver(module, min_ver, write=True):
     return res[1]
 
 
-def tex_module_search(tex_module, write=True):
-    """Print outcome of local TeX module search using 'kpsewhich' command."""
-    msg = 'TeX:%s (any)' % tex_module
-    cmd = ['kpsewhich', '%s.sty' % tex_module]
-    # This is less intensive & quicker than searching via 'find' or 'locate'.
-    try:
-        process = procopen(cmd, stdin=open(os.devnull), stdoutpipe=True)
-        check_call(['test', '-n', process.communicate()[0].strip()],
-                   stdin=open(os.devnull), stdout=PIPE, stderr=PIPE)
-    except (CalledProcessError, OSError):
-        if write:
-            shell_align_write('.', msg, NOTFOUND_MSG)
-        return False
-    else:
-        if write:
-            shell_align_write('.', msg, FOUND_NOVER_MSG + ' (n/a)')
-        return True
-
-
-def cmd_find_ver(module, min_ver, cmd_base, ver_opt, ver_extr, outfile=1,
-                 write=True):
+def cmd_find_ver(
+        module, min_ver, cmd_base, ver_opt, ver_extr, outfile=1, write=True):
     """Print outcome & return Boolean (True for pass) of local module version
     requirement test using relevant custom command base keyword(s),
     version-checking option(s) & version-extraction regex.
@@ -246,8 +227,6 @@ def functionality_print(func):
         if func_dep == func:
             if tag == 'PY':
                 opt_result[module] = check_py_module_ver(module, ver_req)
-            elif tag == 'TEX':
-                opt_result[module] = tex_module_search(module)
             elif tag == 'OTHER':
                 opt_result[module] = cmd_find_ver(module, ver_req, *items[3])
     return
@@ -261,8 +240,6 @@ def individual_status_print(module):
         ver_req, _, tag = opt_spec[module][:3]
         if tag == 'PY':
             return int(not check_py_module_ver(module, ver_req, write=False))
-        elif tag == 'TEX':
-            return int(not tex_module_search(module, write=False))
         elif tag == 'OTHER':
             other_args = opt_spec[module][3]
             return int(

--- a/doc/src/global-site-user-conf.rst
+++ b/doc/src/global-site-user-conf.rst
@@ -19,7 +19,7 @@ can be overridden by users,
 .. code-block:: bash
 
    # cylc user global config file
-   ~/.cylc/$(cylc --version)/global.rc  # e.g. ~/.cylc/7.7.0/global.rc
+   ~/.cylc/$(cylc --version)/global.rc  # e.g. ~/.cylc/7.8.2/global.rc
 
 The file ``<cylc-dir>/etc/global.rc.eg`` contains instructions on how
 to generate and install site and user global config files:

--- a/doc/src/installation.rst
+++ b/doc/src/installation.rst
@@ -151,15 +151,15 @@ modified slightly to point to a location such as ``/opt`` where
 successive Cylc releases will be unpacked side by side.
 
 To install Cylc, unpack the release tarball in the right location, e.g.
-``/opt/cylc-7.7.0``, type ``make`` inside the release
+``/opt/cylc-7.8.2``, type ``make`` inside the release
 directory, and set site defaults - if necessary - in a site global config file
 (below).
 
 Make a symbolic link from ``cylc`` to the latest installed version:
-``ln -s /opt/cylc-7.7.0 /opt/cylc``. This will be invoked by the
+``ln -s /opt/cylc-7.8.2 /opt/cylc``. This will be invoked by the
 central wrapper if a specific version is not requested. Otherwise, the
 wrapper will attempt to invoke the Cylc version specified in
-``$CYLC_VERSION``, e.g. ``CYLC_VERSION=7.7.0``. This variable
+``$CYLC_VERSION``, e.g. ``CYLC_VERSION=7.8.2``. This variable
 is automatically set in task job scripts to ensure that jobs use the same Cylc
 version as their parent suite server program.  It can also be set by users,
 manually or in login scripts, to fix the Cylc version in their environment.

--- a/etc/global.rc.eg
+++ b/etc/global.rc.eg
@@ -17,7 +17,7 @@
 # you may unwittingly override future changes to system defaults).
 #
 # The SITE FILE LOCATION is [cylc-dir]/etc/global.rc, where [cylc-dir] is your
-# install location, e.g. /opt/cylc/cylc-7.7.0.
+# install location, e.g. /opt/cylc/cylc-7.8.2.
 #
 # FORWARD COMPATIBILITY: The site global.rc file must be kept in the source
 # installation (i.e. it is version specific) because older versions of Cylc
@@ -29,7 +29,7 @@
 # you may unwittingly override future changes to site or system defaults).
 #
 # The USER FILE LOCATIONS are:
-#   1) ~/.cylc/<CYLC-VERSION>/global.rc  # e.g. ~/.cylc/7.7.0/global.rc
+#   1) ~/.cylc/<CYLC-VERSION>/global.rc  # e.g. ~/.cylc/7.8.2/global.rc
 #   2) ~/.cylc/global.rc
 # If the first lcoation is not found, the second will be checked.
 # 

--- a/usr/bin/cylc
+++ b/usr/bin/cylc
@@ -28,13 +28,13 @@
 #
 #  2. Install cylc versions as described in the INSTALL file, e.g.:
 #     /opt/cylc-7.6.1/
-#     /opt/cylc-7.7.0/
-#     /opt/cylc -> cylc-7.7.0/  # symlink DEFAULT version
+#     /opt/cylc-7.8.2/
+#     /opt/cylc -> cylc-7.8.2/  # symlink DEFAULT version
 #
 # Environment variables:
 #  $CYLC_HOME_ROOT: top installation directory, e.g. /opt/
-#  $CYLC_HOME:   a specific version, e.g. /opt/cylc-7.7.0/
-#  $CYLC_VERSION: a specific version string, e.g. 7.7.0
+#  $CYLC_HOME:   a specific version, e.g. /opt/cylc-7.8.2/
+#  $CYLC_VERSION: a specific version string, e.g. 7.8.2
 #
 #  3. Set $CYLC_HOME_ROOT for your site - see "!!! EDIT ME !!! below.
 


### PR DESCRIPTION
I found a few remaining references to the old User Guide build.

Very simple - see the commit logs for specifics.  Also updated INSTALL.md to look like the one on master (removing actual `cylc check-sofware` output, as that is prone to getting out of date).