### PR TITLE
Fix dev-suites reference in docs (now in examples)

### DIFF
--- a/doc/src/external-triggers.rst
+++ b/doc/src/external-triggers.rst
@@ -138,16 +138,16 @@ the ``cylc suite-state`` command - see
 ``cylc suite-state --help`` for documentation.
 
 As a simple example, consider the suites in
-``<cylc-dir>/etc/dev-suites/xtrigger/suite_state/``. The "upstream"
+``<cylc-dir>/etc/examples/xtrigger/suite_state/``. The "upstream"
 suite (which we want to trigger off of) looks like this:
 
-.. literalinclude:: ../../etc/dev-suites/xtrigger/suite_state/upstream/suite.rc
+.. literalinclude:: ../../etc/examples/xtrigger/suite_state/upstream/suite.rc
    :language: cylc
 
 It must be registered and run under the name *up*, as referenced in the
 "downstream" suite that depends on it:
 
-.. literalinclude:: ../../etc/dev-suites/xtrigger/suite_state/downstream/suite.rc
+.. literalinclude:: ../../etc/examples/xtrigger/suite_state/downstream/suite.rc
    :language: cylc
 
 Try starting the downstream suite first, then the upstream, and
@@ -355,7 +355,7 @@ to (for example) task name, task ID, or cycle point (just use the appropriate
 string templates in the suite configuration for this).
 
 An example xrandom trigger suite is
-``<cylc-dir>/etc/dev-suites/xtriggers/xrandom/``.
+``<cylc-dir>/etc/examples/xtriggers/xrandom/``.
 
 
 .. _Current Trigger Function Limitations:


### PR DESCRIPTION
Hi,

I removed the `dev-suites` in https://github.com/cylc/cylc/pull/3006/commits/479eaa27c38ae333d02becfbf39326d50ac30625, but forgot to properly search for other occurrences.

While following up some discussion on Riot about issues in the External Triggers documentation, found this one while running `cylc make-docs` from `master`.

I do not believe it should be backported to 7.8. And it is a simple find-replace for `dev-suites` by `examples`.