### PR TITLE
Remove dev-suites from tests

### DIFF
--- a/tests/validate/04-builtin-suites.t
+++ b/tests/validate/04-builtin-suites.t
@@ -18,7 +18,7 @@
 . "$(dirname "$0")/test_header"
 #-------------------------------------------------------------------------------
 # Generate a list of suites.
-SUITES=($(find "${CYLC_DIR}/"{etc/examples,etc/dev-suites} -name 'suite.rc' \
+SUITES=($(find "${CYLC_DIR}/etc/examples" -name 'suite.rc' \
     | grep -v 'empy' ))  # TODO - don't validate empy suites see: #2958
 ABS_PATH_LENGTH=${#CYLC_DIR}
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Sorry, missed this one after removing `dev-suites`. Checked the source directory, but not the tests. Found it as it raises a warning, without failing the test, complaining about not being able to locate the `dev-suites` folder.

Did a `grep` and found no more `dev-suites`, so this should be the last one. Executed the test locally with `cylc test-battery tests/validate/04-builtin-suites.t` with no errors.

Probably 1 review should be enough?