### PR TITLE
Convert range to list so that we can use reduce

### DIFF
--- a/lib/cylc/conditional_simplifier.py
+++ b/lib/cylc/conditional_simplifier.py
@@ -95,7 +95,7 @@ class ConditionalSimplifier(object):
         """Nest a list according to any brackets in it"""
         start = 0
         finish = len(nest_me)
-        indices = range(0, len(nest_me))
+        indices = list(range(0, len(nest_me)))
         for i in indices:
             if nest_me[i] == "(":
                 start = i

--- a/lib/cylc/tests/test_conditional_simplifier.py
+++ b/lib/cylc/tests/test_conditional_simplifier.py
@@ -73,6 +73,12 @@ class TestConditionalSimplifier(unittest.TestCase):
             self.assertEqual(expected,
                              ConditionalSimplifier.clean_expr(expr, criterion))
 
+    def test_flatten_nested_expr_with_brackets(self):
+        """Test expressions with brackets"""
+        bracketed = ConditionalSimplifier.get_bracketed(
+            ['(', 'a', '&', 'b', ')'])
+        self.assertEqual(['(', ['a', '&', 'b'], ')'], bracketed)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I think this one slipped in during the Python3 conversion. The real issue was in the lack of a test to cover this code.

Added a test that fails with previous code, as calling `reverse()` on the result of `range` (some view/iterator, not a list) results in an error. This could cause parsing suites to fail.

Should not be backported to 7.x, as this happens only with Py3.
