### PR TITLE
Fix syntax for array access in cylc check-software

### DIFF
--- a/bin/cylc-check-software
+++ b/bin/cylc-check-software
@@ -186,10 +186,11 @@ def cmd_find_ver(module, min_ver, cmd_base, ver_opt, ver_extr, outfile=1,
             res = [NOTFOUND_MSG, False]
         else:
             try:
-                output = procopen([cmd, ver_opt], stdoutpipe=True,
-                                  stdin=open(os.devnull),
-                                  stderrpipe=True).communicate()
-                [outfile - 1].decode().strip()
+                output = procopen(
+                    [cmd, ver_opt], stdoutpipe=True,
+                    stdin=open(os.devnull),
+                    stderrpipe=True).communicate()[outfile - 1].decode()\
+                    .strip()
                 version = re.search(ver_extr, output).groups()[0]
                 try_next_cmd = False
                 if min_ver is None:


### PR DESCRIPTION
Not happening any time soon, as we don't have a dependency to `OTHER` tool in `check-software`, but only to `PY` tools for now.

But if we had one, then it would crash due to an array access moved to next line. The code is still perfectly fine, so in theory no syntax error. Except that our intention here is to access one of the elements of the tuple returned by process `communicate()` method.

Tested locally by adding

```diff
diff --git a/bin/cylc-check-software b/bin/cylc-check-software
index 4d8843d43..ff2bfb878 100755
--- a/bin/cylc-check-software
+++ b/bin/cylc-check-software
@@ -54,6 +54,8 @@ req_py_ver_range = ((3,6),)
 opt_spec = {
     'EmPy': [None, 'TEMPLATING', 'PY'],
     'sphinx': [(1, 5, 3), 'HTMLDOCS', 'PY'],
+    'graphviz': [None, 'TEMPLATING', 'OTHER',
+            (['dot'], '-V', r'graphviz version ([^\s]+)', 2)]
 }
```

And debugging in the IDE. Not applicable to the 7.8.x branches.