### PR TITLE
Minor improvements for docstrings

### DIFF
--- a/lib/cylc/batch_sys_handlers/loadleveler.py
+++ b/lib/cylc/batch_sys_handlers/loadleveler.py
@@ -15,14 +15,14 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"Loadleveler job submission"
+"""Loadleveler job submission"""
 
 import re
 
 
 class LoadlevelerHandler(object):
 
-    "Loadleveler job submission"
+    """Loadleveler job submission"""
 
     DIRECTIVE_PREFIX = "# @ "
     KILL_CMD_TMPL = "llcancel '%(job_id)s'"

--- a/lib/cylc/batch_sys_handlers/lsf.py
+++ b/lib/cylc/batch_sys_handlers/lsf.py
@@ -15,13 +15,13 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"IBM Platform LSF bsub job submission"
+"""IBM Platform LSF bsub job submission"""
 
 import re
 
 
 class LSFHandler(object):
-    "IBM Platform LSF bsub job submission"
+    """IBM Platform LSF bsub job submission"""
 
     DIRECTIVE_PREFIX = "#BSUB "
     KILL_CMD_TMPL = "bkill '%(job_id)s'"

--- a/lib/cylc/batch_sys_handlers/moab.py
+++ b/lib/cylc/batch_sys_handlers/moab.py
@@ -15,14 +15,14 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"Moab batch system job submission and manipulation."
+"""Moab batch system job submission and manipulation."""
 
 import re
 
 
 class MoabHandler(object):
 
-    "Moab batch system job submission and manipulation."
+    """Moab batch system job submission and manipulation."""
 
     DIRECTIVE_PREFIX = "#PBS "
     KILL_CMD_TMPL = "mjobctl -c '%(job_id)s'"

--- a/lib/cylc/batch_sys_handlers/pbs.py
+++ b/lib/cylc/batch_sys_handlers/pbs.py
@@ -15,14 +15,14 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"PBS batch system job submission and manipulation."
+"""PBS batch system job submission and manipulation."""
 
 import re
 
 
 class PBSHandler(object):
 
-    "PBS batch system job submission and manipulation."
+    """PBS batch system job submission and manipulation."""
 
     DIRECTIVE_PREFIX = "#PBS "
     # PBS fails a job submit if job "name" in "-N name" is too long.

--- a/lib/cylc/batch_sys_handlers/sge.py
+++ b/lib/cylc/batch_sys_handlers/sge.py
@@ -15,14 +15,14 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"SGE qsub job submission"
+"""SGE qsub job submission"""
 
 import re
 
 
 class SGEHandler(object):
 
-    "SGE qsub job submission"
+    """SGE qsub job submission"""
 
     DIRECTIVE_PREFIX = "#$ "
     KILL_CMD_TMPL = "qdel '%(job_id)s'"

--- a/lib/cylc/cfgspec/suite.py
+++ b/lib/cylc/cfgspec/suite.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"Define all legal items and values for cylc suite definition files."
+"""Define all legal items and values for cylc suite definition files."""
 
 from isodatetime.data import Calendar
 

--- a/lib/cylc/cfgvalidate.py
+++ b/lib/cylc/cfgvalidate.py
@@ -195,6 +195,8 @@ class CylcConfigValidator(ParsecValidator):
                 This can be a list of str values. Each str value must conform
                 to the same restriction as a task name.
                 Otherwise, this can be a mixture of int ranges and int values.
+            keys (list):
+                Keys in nested dict that represents the raw configuration.
 
         Return (list):
             A list of strings or a list of sorted integers.

--- a/lib/cylc/network/__init__.py
+++ b/lib/cylc/network/__init__.py
@@ -85,7 +85,7 @@ def encrypt(message, secret):
     """Make a message unreadable.
 
     Args:
-        message (str): The message to send, must be serialiseable .
+        message (dict): The message to send, must be serialiseable .
         secret (str): The encrypt key.
 
     Return:

--- a/lib/cylc/network/scan.py
+++ b/lib/cylc/network/scan.py
@@ -123,7 +123,9 @@ def scan_many(items, methods=None, timeout=None, ordered=False):
 
     Args:
         items (list): list of 'host' string or ('host', port) tuple to scan.
+        methods (list): list of 'method' string to be executed when scanning.
         timeout (float): connection timeout, default is CONNECT_TIMEOUT.
+        ordered (bool): whether to scan items in order or not (default).
 
     Return:
         list: [(host, port, identify_result), ...]

--- a/lib/parsec/fileparse.py
+++ b/lib/parsec/fileparse.py
@@ -329,7 +329,7 @@ def read_and_proc(fpath, template_vars=None, viewcfg=None, asedit=False):
 
 
 def parse(fpath, output_fname=None, template_vars=None):
-    "Parse file items line-by-line into a corresponding nested dict."
+    """Parse file items line-by-line into a corresponding nested dict."""
 
     # read and process the file (jinja2, include-files, line continuation)
     flines = read_and_proc(fpath, template_vars)

--- a/lib/parsec/validate.py
+++ b/lib/parsec/validate.py
@@ -209,7 +209,7 @@ class ParsecValidator(object):
 
     @classmethod
     def coerce_float_list(cls, value, keys):
-        "Coerce list values with optional multipliers to float."
+        """Coerce list values with optional multipliers to float."""
         values = cls.strip_and_unquote_list(keys, value)
         return cls.expand_list(values, keys, float)
 
@@ -226,7 +226,7 @@ class ParsecValidator(object):
 
     @classmethod
     def coerce_int_list(cls, value, keys):
-        "Coerce list values with optional multipliers to integer."
+        """Coerce list values with optional multipliers to integer."""
         items = []
         for item in cls.strip_and_unquote_list(keys, value):
             values = cls.parse_int_range(item)


### PR DESCRIPTION
Fixing docstrings where single double or single quotes were used instead of triple quotes, and also added some parameters that were missing from methods documentation.

I do not thing we need this for Cylc 7.8.x.