### PR TITLE
Remove unused imports

### DIFF
--- a/bin/cylc-check-versions
+++ b/bin/cylc-check-versions
@@ -35,12 +35,10 @@ Use -v/--verbose to see the command invoked to determine the remote version
 site dependent -- see cylc global config documentation."""
 
 import os
-import shlex
 import sys
 from time import sleep
 
 import cylc.flags
-from cylc.config import SuiteConfig
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.cylc_subproc import procopen
 from cylc import __version__ as CYLC_VERSION

--- a/lib/parsec/fileparse.py
+++ b/lib/parsec/fileparse.py
@@ -37,7 +37,6 @@ import sys
 import re
 import traceback
 
-from jinja2 import TemplateError, UndefinedError
 from parsec import LOG, ParsecError
 from parsec.OrderedDict import OrderedDictWithDefaults
 from parsec.include import inline, IncludeFileNotFoundError

--- a/lib/parsec/tests/test_util.py
+++ b/lib/parsec/tests/test_util.py
@@ -17,7 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
-from io import StringIO
 
 from parsec.util import *
 

--- a/tests/cylc-cat-state/basic/state-check.py
+++ b/tests/cylc-cat-state/basic/state-check.py
@@ -19,7 +19,6 @@ import os
 import sqlite3
 import sys
 from cylc.cylc_subproc import procopen
-import shlex
 
 
 def main(argv):


### PR DESCRIPTION
Few imports that can be removed after latest changes :+1: 

No 7.8.x backport.