### PR TITLE
Use links to appendices' commands.

### DIFF
--- a/doc/src/custom/make-commands.sh
+++ b/doc/src/custom/make-commands.sh
@@ -46,10 +46,10 @@ END
 for CAT in $($CYLC categories); do
 	$(cat >> "$COMMAND_REF_FILE" <<END
 
+.. _command-cat-${CAT}:
+
 ${CAT}
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. _command-cat-${CAT}:
 
 .. code-block:: none
 
@@ -71,10 +71,10 @@ END
 for COM in $($CYLC commands); do
 	$(cat >> "$COMMAND_REF_FILE" <<END
 
+.. _command-${COM}:
+
 ${COM}
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. _command-${COM}:
 
 .. code-block:: none
 

--- a/doc/src/external-triggers.rst
+++ b/doc/src/external-triggers.rst
@@ -135,7 +135,7 @@ The first three arguments are compulsory; they single out the target suite name
 (``suite``) task name (``task``) and cycle point
 (``point``). The function arguments mirror the arguments and options of
 the ``cylc suite-state`` command - see
-``cylc suite-state --help`` for documentation.
+:ref:`command-suite-state` for documentation.
 
 As a simple example, consider the suites in
 ``<cylc-dir>/etc/examples/xtrigger/suite_state/``. The "upstream"

--- a/doc/src/installation.rst
+++ b/doc/src/installation.rst
@@ -207,7 +207,7 @@ Residual Tests
 
       Some test failures can be expected to result from suites timing out,
       even if nothing is wrong, if you run too many tests in parallel. See
-      ``cylc test-battery --help``.
+      :ref:`command-test-battery` for documentation.
 
 Code Style Tests
    Tests to ensure the codebase conforms to code style.

--- a/doc/src/running-suites.rst
+++ b/doc/src/running-suites.rst
@@ -72,7 +72,7 @@ not, they will be ignored.
 Restart and Suite State Checkpoints
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-At restart (see ``cylc restart --help``) a suite server program
+At restart (see :ref:`command-restart` for documentation) a suite server program
 initializes its task pool from a previously recorded checkpoint state. By
 default the latest automatic checkpoint - which is updated with every task
 state change - is loaded so that the suite can carry on exactly as it was just
@@ -285,7 +285,7 @@ Task Job Polling
 
 At any point after job submission task jobs can be *polled* to check that
 their true state conforms to what is currently recorded by the suite server
-program.  See ``cylc poll --help`` for how to poll one or more tasks
+program.  See :ref:`command-poll` for how to poll one or more tasks
 manually.
 
 Polling may be necessary if, for example, a task job gets killed by the


### PR DESCRIPTION
A few days ago there was a discussion about dropping the `cylc $COMMAND` documentation, where we decided to keep it.

Today while I was reading our [documentation for external triggers](https://cylc.github.io/doc/built-sphinx-single/index.html#built-in-suite-state-triggers), I noticed a part that says

> The function arguments mirror the arguments and options of the cylc suite-state command - see cylc suite-state --help for documentation.

And thought since we have documentation for what `cylc suite-state --help` prints, we could simply link to it? I tried a very simple `:ref:`command-suite-state`` but that did not work, giving me the error:

```
WARNING: undefined label: command-suite-state (if the link has no caption the label must precede a section header)
```

Being quite novice at Sphinx-Fu, I tried to do exactly as Sphinx's error message suggested, and moved the link before the section header in `make-commands.sh`. Not sure if the other way was intentional, or if I am breaking anything.

Tested locally generating with `cylc make-docs`.