### PR TITLE
Graph color fixes

### DIFF
--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -664,14 +664,6 @@ class SuiteConfig(object):
             raise SuiteConfigError("Node attributes must be of the form "
                                    "'key1=value1', 'key2=value2', etc.")
 
-        # (Note that we're retaining 'default node attributes' even
-        # though this could now be achieved by styling the root family,
-        # because putting default attributes for root in the suite.rc spec
-        # results in root appearing last in the ordered dict of node
-        # names, so it overrides the styling for lesser groups and
-        # nodes, whereas the reverse is needed - fixing this would
-        # require reordering task_attr in lib/cylc/graphing.py).
-
         self.leaves = self.get_task_name_list()
         for ancestors in self.runtime['first-parent ancestors'].values():
             try:

--- a/lib/cylc/graphing.py
+++ b/lib/cylc/graphing.py
@@ -277,8 +277,7 @@ class CGraphPlain(pygraphviz.AGraph):
         Node fill color: destkop theme background.
         """
 
-        # Transparent graph bg - let the desktop theme bg shine through.
-        self.graph_attr['bgcolor'] = '#ffffff00'
+        self.graph_attr['bgcolor'] = bgcolor
         self.graph_attr['color'] = fgcolor
         self.graph_attr['fontcolor'] = fgcolor
 
@@ -360,6 +359,11 @@ class CGraph(CGraphPlain):
             attr, value = [val.strip() for val in item.split('=', 1)]
             attrs[attr] = value
             node.attr[attr] = value
+        # For "style=filled", ensure labels are readable (inverse lightness)
+        if node.attr['style'] == 'filled' and not (
+            any(attribute.startswith('fontcolor') for
+                attribute in self.vizconfig['default node attributes'])):
+            node.attr['fontcolor'] = self.graph_attr['bgcolor']
         if node.attr['style'] != 'filled' and (
                 'color' in attrs and 'fontcolor' not in attrs):
             node.attr['fontcolor'] = node.attr['color']

--- a/lib/cylc/graphing.py
+++ b/lib/cylc/graphing.py
@@ -273,7 +273,8 @@ class CGraphPlain(pygraphviz.AGraph):
     def set_def_style(self, fgcolor, bgcolor, def_node_attr=None):
         """Set default graph styles.
 
-        Depending on light/dark desktop color theme.
+        Node, edge, and font color: desktop theme foreground.
+        Node fill color: destkop theme background.
         """
 
         if def_node_attr is None:
@@ -282,18 +283,11 @@ class CGraphPlain(pygraphviz.AGraph):
         # Transparent graph bg - let the desktop theme bg shine through.
         self.graph_attr['bgcolor'] = '#ffffff00'
 
-        # graph and cluster:
         self.graph_attr['color'] = fgcolor
         self.graph_attr['fontcolor'] = fgcolor
-        # node outlines (or node fill if fillcolor is not defined):
         self.node_attr['color'] = fgcolor
-        # edges:
+        self.node_attr['fontcolor'] = fgcolor  # node labels
         self.edge_attr['color'] = fgcolor  # edges
-        # node labels:
-        if def_node_attr.get('style', '') == "filled":
-            self.node_attr['fontcolor'] = bgcolor  # node labels
-        else:
-            self.node_attr['fontcolor'] = fgcolor  # node labels
 
 
 class CGraph(CGraphPlain):

--- a/lib/cylc/graphing.py
+++ b/lib/cylc/graphing.py
@@ -298,6 +298,7 @@ class CGraph(CGraphPlain):
 
         # suite.rc visualization config section
         CGraphPlain.__init__(self, title, suite_polling_tasks)
+        self.task_attr = {}
         if vizconfig is None:
             vizconfig = {
                 'default node attributes': [],
@@ -320,7 +321,6 @@ class CGraph(CGraphPlain):
 
         # non-default node attributes by task name
         # TODO - ERROR CHECKING FOR INVALID TASK NAME
-        self.task_attr = {}
 
         for item in self.vizconfig['node attributes']:
             if item in self.vizconfig['node groups']:

--- a/lib/cylc/graphing.py
+++ b/lib/cylc/graphing.py
@@ -279,12 +279,13 @@ class CGraphPlain(pygraphviz.AGraph):
 
         # Transparent graph bg - let the desktop theme bg shine through.
         self.graph_attr['bgcolor'] = '#ffffff00'
-
         self.graph_attr['color'] = fgcolor
         self.graph_attr['fontcolor'] = fgcolor
+
         self.node_attr['color'] = fgcolor
-        self.node_attr['fontcolor'] = fgcolor  # node labels
-        self.edge_attr['color'] = fgcolor  # edges
+        self.node_attr['fontcolor'] = fgcolor
+
+        self.edge_attr['color'] = fgcolor
 
 
 class CGraph(CGraphPlain):
@@ -307,13 +308,14 @@ class CGraph(CGraphPlain):
             }
         self.vizconfig = vizconfig
 
+    def set_attributes(self):
         # graph attributes
         # - default node attributes
-        for item in vizconfig['default node attributes']:
+        for item in self.vizconfig['default node attributes']:
             attr, value = [val.strip() for val in item.split('=', 1)]
             self.node_attr[attr] = value
         # - default edge attributes
-        for item in vizconfig['default edge attributes']:
+        for item in self.vizconfig['default edge attributes']:
             attr, value = [val.strip() for val in item.split('=', 1)]
             self.edge_attr[attr] = value
 
@@ -414,6 +416,7 @@ class CGraph(CGraphPlain):
             suiterc.cfg['visualization'])
 
         graph.set_def_style(fgcolor, bgcolor)
+        graph.set_attributes()
 
         gr_edges = suiterc.get_graph_raw(
             start_point_string, stop_point_string,

--- a/lib/cylc/graphing.py
+++ b/lib/cylc/graphing.py
@@ -270,15 +270,12 @@ class CGraphPlain(pygraphviz.AGraph):
 
         return subgraph
 
-    def set_def_style(self, fgcolor, bgcolor, def_node_attr=None):
+    def set_def_style(self, fgcolor, bgcolor):
         """Set default graph styles.
 
         Node, edge, and font color: desktop theme foreground.
         Node fill color: destkop theme background.
         """
-
-        if def_node_attr is None:
-            def_node_attr = {}
 
         # Transparent graph bg - let the desktop theme bg shine through.
         self.graph_attr['bgcolor'] = '#ffffff00'
@@ -416,7 +413,7 @@ class CGraph(CGraphPlain):
             suiterc.suite_polling_tasks,
             suiterc.cfg['visualization'])
 
-        graph.set_def_style(fgcolor, bgcolor, graph.node_attr)
+        graph.set_def_style(fgcolor, bgcolor)
 
         gr_edges = suiterc.get_graph_raw(
             start_point_string, stop_point_string,

--- a/lib/cylc/tests/test_graphing.py
+++ b/lib/cylc/tests/test_graphing.py
@@ -82,6 +82,8 @@ class TestGraphParser(unittest.TestCase):
                  ('baz.3', 'qux.3', False, False, False)
                  ]
         self.cgraph.add_edges(edges)
+        self.cgraph.set_def_style('white', 'black')
+        self.cgraph.set_attributes()
 
     def test_gtk_rgb_to_hex(self):
         self.assertEqual(gtk_rgb_to_hex(fake_gtk_color()), '#ffffff')
@@ -99,7 +101,9 @@ class TestGraphParser(unittest.TestCase):
         self.assertEqual(
             node.attr.items(),
             [(u'URL', u'foo.1'),
+             (u'color', u'white'),
              (u'fillcolor', u'yellow'),
+             (u'fontcolor', u'black'),
              (u'label', u'foo\\n1'),
              (u'penwidth', u'2')]
         )
@@ -109,9 +113,9 @@ class TestGraphParser(unittest.TestCase):
         bgcolor = 'blue'
         def_node_attr = {}
         def_node_attr['style'] = 'filled'
-        self.cgraph.set_def_style(fgcolor, bgcolor, def_node_attr)
+        self.cgraph.set_def_style(fgcolor, bgcolor)
         self.assertEqual(
-            self.cgraph.graph_attr['bgcolor'], '#ffffff00'
+            self.cgraph.graph_attr['bgcolor'], bgcolor
         )
         for attr in ['color', 'fontcolor']:
             self.assertEqual(
@@ -124,7 +128,7 @@ class TestGraphParser(unittest.TestCase):
             self.cgraph.node_attr['fontcolor'], fgcolor
         )
         def_node_attr['style'] = 'unfilled'
-        self.cgraph.set_def_style(fgcolor, bgcolor, def_node_attr)
+        self.cgraph.set_def_style(fgcolor, bgcolor)
         self.assertEqual(
             self.cgraph.node_attr['fontcolor'], fgcolor
         )


### PR DESCRIPTION
Address #2965 
... (may or may not close the issue, depending)

1) consistent use of desktop theme foreground and background colors:
- always use desktop theme foreground for default node boundary, edge, and font color
- always use desktop theme background for default node fill color
- (if users set non-default colors for some attributes, it is up to them to manage contrast with any remaining default colors still being used). 

2) fix `default node attributes`
- now it has exactly the same effect as styling root (and can be overridden by styling root).