### PR TITLE
Simplify regexes

### DIFF
--- a/bin/cylc-get-host-metrics
+++ b/bin/cylc-get-host-metrics
@@ -79,7 +79,7 @@ DISK_TEMPLATES, e.g. for mount directory path option '--disk-space=/boot':
     /dev/md0                    96978     33904   *57856*      37% /boot.
 """
 LOAD_TEMPLATES = ['uptime', (1, 5, 15), re.compile(
-                  r'load average:\s([\d\.]+),\s([\d\.]+),\s([\d\.]+)')]
+                  r'load average:\s([\d.]+),\s([\d.]+),\s([\d.]+)')]
 MEMORY_TEMPLATES = ['cat /proc/meminfo', re.compile(
                     (r'MemFree:\s*(\d+)\skB\n.*\n*Buffers:\s*(\d+)\skB'
                      r'\n.*\n*Cached:\s*(\d+)\skB'))]

--- a/bin/cylc-search
+++ b/bin/cylc-search
@@ -97,7 +97,7 @@ prev_file = None
 
 for line in lines:
 
-    m = re.match(r'^#\+\+\+\+ START INLINED INCLUDE FILE ([\w/\.\-]+)', line)
+    m = re.match(r'^#\+\+\+\+ START INLINED INCLUDE FILE ([\w/.\-]+)', line)
     if m:
         inc_file = m.groups()[0]
         in_include_file = True

--- a/lib/cylc/cfgvalidate.py
+++ b/lib/cylc/cfgvalidate.py
@@ -46,7 +46,7 @@ class CylcConfigValidator(ParsecValidator):
     """
     # Parameterized names containing at least one comma.
     _REC_NAME_SUFFIX = re.compile(r'\A[\w\-+%@]+\Z')
-    _REC_TRIG_FUNC = re.compile(r'(\w+)\((.*)\)(?:\:(\w+))?')
+    _REC_TRIG_FUNC = re.compile(r'(\w+)\((.*)\)(?::(\w+))?')
 
     # Value type constants
     V_CYCLE_POINT = 'V_CYCLE_POINT'

--- a/lib/cylc/cycling/iso8601.py
+++ b/lib/cylc/cycling/iso8601.py
@@ -684,12 +684,12 @@ def ingest_time(value, my_now=None):
 
     # correct for year in 'now' if year only,
     # or year and time, specified in input
-    if re.search(r"\(-\d{2}[\);T]", value):
+    if re.search(r"\(-\d{2}[);T]", value):
         my_now.year = my_now.year + 1
 
     # correct for month in 'now' if year and month only,
     # or year, month and time, specified in input
-    elif re.search(r"\(-\d{4}[\);T]", value):
+    elif re.search(r"\(-\d{4}[);T]", value):
         my_now.month_of_year = my_now.month_of_year + 1
 
     if "next" in value or "previous" in value:
@@ -751,11 +751,11 @@ def ingest_time(value, my_now=None):
         # for time point is reversed!!!
         # https://github.com/metomi/isodatetime/pull/101
         # case 1 - year only
-        if re.search(r"\(-\d{2}[\);T]", value):
+        if re.search(r"\(-\d{2}[);T]", value):
             my_cp.month_of_year = 1
             my_cp.day_of_month = 1
         # case 2 - month only or year and month
-        elif re.search(r"\(-(-\d{2}|\d{4})[;T\)]", value):
+        elif re.search(r"\(-(-\d{2}|\d{4})[;T)]", value):
             my_cp.day_of_month = 1
 
     elif value.startswith("P") or value.startswith("-P"):

--- a/lib/cylc/graph_parser.py
+++ b/lib/cylc/graph_parser.py
@@ -147,7 +147,7 @@ class GraphParser(object):
 
     # Detect and extract suite state polling task info.
     REC_SUITE_STATE = re.compile(
-        r'(' + TaskID.NAME_RE + r')(<([\w\.\-/]+)::(' +
+        r'(' + TaskID.NAME_RE + r')(<([\w.\-/]+)::(' +
         TaskID.NAME_RE + r')(' + _RE_TRIG + r')?>)')
 
     def __init__(self, family_map=None, parameters=None):

--- a/lib/cylc/param_expand.py
+++ b/lib/cylc/param_expand.py
@@ -64,7 +64,7 @@ from cylc.task_id import TaskID
 from parsec.OrderedDict import OrderedDictWithDefaults
 
 # To split runtime heading name lists.
-REC_NAMES = re.compile(r'(?:[^,<]|\<[^>]*\>)+')
+REC_NAMES = re.compile(r'(?:[^,<]|<[^>]*>)+')
 # To extract (e.g.) 'name', 'the, quick, brown', and 'other' from
 #   'name<the, quick, brown>other' (other is used for clock-offsets).
 REC_P_ALL = re.compile(r"(%s)?(?:<(.*?)>)?(.+)?" % TaskID.NAME_RE)
@@ -72,7 +72,7 @@ REC_P_ALL = re.compile(r"(%s)?(?:<(.*?)>)?(.+)?" % TaskID.NAME_RE)
 REC_P_GROUP = re.compile(r"<(.*?)>")
 # To extract parameter name and optional offset or value e.g. 'm-1'.
 REC_P_OFFS = re.compile(
-    r'(\w+)\s*([\-\+]\s*\d+|=\s*%s)?' % TaskID.NAME_SUFFIX_RE)
+    r'(\w+)\s*([\-+]\s*\d+|=\s*%s)?' % TaskID.NAME_SUFFIX_RE)
 
 
 def item_in_iterable(item, itt):

--- a/lib/cylc/task_remote_mgr.py
+++ b/lib/cylc/task_remote_mgr.py
@@ -40,7 +40,7 @@ from cylc.task_remote_cmd import (
     FILE_BASE_UUID, REMOTE_INIT_DONE, REMOTE_INIT_NOT_REQUIRED)
 
 
-REC_COMMAND = re.compile(r'(`|\$\()\s*(.*)\s*(`|\))$')
+REC_COMMAND = re.compile(r'(`|\$\()\s*(.*)\s*([`)])$')
 REMOTE_INIT_FAILED = 'REMOTE INIT FAILED'
 
 

--- a/lib/cylc/time_parser.py
+++ b/lib/cylc/time_parser.py
@@ -99,7 +99,7 @@ class CylcTimeParser(object):
 
     CHAIN_REGEX = re.compile(r'((?:[+-P]|[\dT])[\d\w]*)')
 
-    MIN_REGEX = re.compile(r'min\(([^\)]+)\)')
+    MIN_REGEX = re.compile(r'min\(([^)]+)\)')
 
     OFFSET_REGEX = re.compile(r"(?P<sign>[+-])(?P<intv>P.+)$")
 

--- a/lib/parsec/fileparse.py
+++ b/lib/parsec/fileparse.py
@@ -62,7 +62,7 @@ _HEADING = re.compile(
 _KEY_VALUE = re.compile(
     r'''^
     (\s*)                   # indentation
-    ([\.\-\w \,]+?(\s*<.*?>)?)  # key with optional parameters, e.g. foo<m,n>
+    ([.\-\w ,]+?(\s*<.*?>)?)  # key with optional parameters, e.g. foo<m,n>
     \s*=\s*                 # =
     (.*)                    # value (quoted any style + comment)
     $   # line end

--- a/lib/parsec/include.py
+++ b/lib/parsec/include.py
@@ -194,7 +194,7 @@ def split_file(dir_, lines, filename, recovery=False, level=None):
         if not match_on:
             m = re.match(
                 r'^#\+\+\+\+ START INLINED INCLUDE FILE ' +
-                r'([\w\/\.\-]+) \(DO NOT MODIFY THIS LINE!\)', line)
+                r'([\w/.\-]+) \(DO NOT MODIFY THIS LINE!\)', line)
             if m:
                 match_on = True
                 inc_filename = m.groups()[0]

--- a/lib/parsec/validate.py
+++ b/lib/parsec/validate.py
@@ -83,8 +83,8 @@ class ParsecValidator(object):
     _REC_SQ_L_VALUE = re.compile(r"'([^'\\]*(?:\\.[^'\\]*)*)'")
     _REC_DQ_L_VALUE = re.compile(r'"([^"\\]*(?:\\.[^"\\]*)*)"')
     # quoted values with ignored trailing comments
-    _REC_SQ_VALUE = re.compile(r"'([^'\\]*(?:\\.[^'\\]*)*)'(?:\s*(?:\#.*)?)?$")
-    _REC_DQ_VALUE = re.compile(r'"([^"\\]*(?:\\.[^"\\]*)*)"(?:\s*(?:\#.*)?)?$')
+    _REC_SQ_VALUE = re.compile(r"'([^'\\]*(?:\\.[^'\\]*)*)'(?:\s*(?:#.*)?)?$")
+    _REC_DQ_VALUE = re.compile(r'"([^"\\]*(?:\\.[^"\\]*)*)"(?:\s*(?:#.*)?)?$')
 
     _REC_UQLP = re.compile(r"""(['"]?)(.*?)\1(,|$)""")
     _REC_SQV = re.compile(r"((?:^[^']*(?:'[^']*')*[^']*)*)(#.*)$")
@@ -96,7 +96,7 @@ class ParsecValidator(object):
         r'\A"""(.*?)"""\s*(?:#.*)?\Z', re.MULTILINE | re.DOTALL)
     # integer range syntax START..END[..STEP]
     _REC_INT_RANGE = re.compile(
-        r'\A([\+\-]?\d+)\s*\.\.\s*([\+\-]?\d+)(?:\s*\.\.\s*(\d+))?\Z')
+        r'\A([+\-]?\d+)\s*\.\.\s*([+\-]?\d+)(?:\s*\.\.\s*(\d+))?\Z')
     # Parameterized names containing at least one comma.
     _REC_MULTI_PARAM = re.compile(r'<[\w]+,.*?>')
 


### PR DESCRIPTION
When using `[...]` in regexes, I believe we do not need to escape `.`, `:`, `)`, `<`, `>`, etc. As far as I know, we need to escape only the closing `]`, and the normal sequences like `\n`, `\r`, `\t`.

Python regex engine does the job of escaping these character anyway, but being regexes not always the fastest option, perhaps removing unnecessary escapes is a good idea?

Also included one more change (second commit) to use ```([`\])``` instead of ```(`|\)```. For two characters it makes no difference performance-wise. With more characters ```[`\]``` would probably be faster. But it's still easier to read I think?

Low priority, for Cylc 8 or later, without backport to Cylc 7 (I do not think it's necessary for the 7.8.x release series).

Cheers
Bruno