### PR TITLE
Remove globalcfg add_bin_dir and use_ssh, codacy issue about unused code

### DIFF
--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -235,9 +235,6 @@ SPEC = {
 
 def upg(cfg, descr):
     """Upgrader."""
-    add_bin_dir = converter(lambda x: x + '/bin', "Added + '/bin' to path")
-    use_ssh = converter(lambda x: "ssh", "set to 'ssh'")
-
     u = upgrader(cfg, descr)
 
     u.obsolete('6.4.1', ['test battery', 'directives'])


### PR DESCRIPTION
While looking at an issue in Codacy for #3060 , I noted that there was another issue about these two unused functions/lambdas in `globalcfg`. Not sure if they are used anywhere. IDE pointing as not used, and `grep` found only `use_ssh` for `optparse`, which I think is unrelated.

Sending PR with low priority, to see if Travis and Codacy are happy with the change, and so others can review and perhaps chime in in case this is some code that needs to be kept in Cylc 8. Not sure if it needs to be backported to Cylc 7.8?