### PR TITLE
7.8.x backport pr 3060

### DIFF
--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -2104,13 +2104,14 @@ class SuiteConfig(object):
                     try:
                         if not callable(get_func(xtrig.func_name, self.fdir)):
                             raise SuiteConfigError(
-                                f"ERROR, "
-                                f"xtrigger function not callable: "
-                                f"{xtrig.func_name}")
+                                "ERROR, "
+                                "xtrigger function not callable: %s" %
+                                xtrig.func_name)
                     except (ImportError, AttributeError):
                         raise SuiteConfigError(
-                            f"ERROR, "
-                            f"xtrigger function not found: {xtrig.func_name}")
+                            "ERROR, "
+                            "xtrigger function not found: %s" %
+                            xtrig.func_name)
                     self.xtrigger_mgr.add_trig(label, xtrig)
                     self.taskdefs[task_name].xtrig_labels.add(label)
 

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -2103,13 +2103,14 @@ class SuiteConfig(object):
                 else:
                     try:
                         if not callable(get_func(xtrig.func_name, self.fdir)):
-                            raise SuiteConfigError("ERROR, xtrigger function "
-                                                   "not callable: "
-                                                   "%s" % xtrig.func_name)
-                    except ImportError:
-                        raise SuiteConfigError("ERROR, xtrigger function "
-                                               "not found: "
-                                               "%s" % xtrig.func_name)
+                            raise SuiteConfigError(
+                                f"ERROR, "
+                                f"xtrigger function not callable: "
+                                f"{xtrig.func_name}")
+                    except (ImportError, AttributeError):
+                        raise SuiteConfigError(
+                            f"ERROR, "
+                            f"xtrigger function not found: {xtrig.func_name}")
                     self.xtrigger_mgr.add_trig(label, xtrig)
                     self.taskdefs[task_name].xtrig_labels.add(label)
 

--- a/lib/cylc/tests/test_config.py
+++ b/lib/cylc/tests/test_config.py
@@ -15,115 +15,128 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import pytest
-from tempfile import TemporaryDirectory
-from pathlib import Path
+import shutil
+import unittest
+from tempfile import mkdtemp
+
 from cylc.config import SuiteConfig, SuiteConfigError
 
 
-class TestSuiteConfig(object):
+class TestSuiteConfig(unittest.TestCase):
     """Test class for the Cylc SuiteConfig object."""
 
     def test_xfunction_imports(self):
         """Test for a suite configuration with valid xtriggers"""
-        with TemporaryDirectory() as temp_dir:
-            python_dir = Path(os.path.join(temp_dir, "lib", "python"))
-            python_dir.mkdir(parents=True)
-            name_a_tree_file = python_dir / "name_a_tree.py"
-            with name_a_tree_file.open(mode="w") as f:
-                # NB: we are not returning a lambda, instead we have a scalar
-                f.write("""name_a_tree = lambda: 'jacaranda'""")
-                f.flush()
-            suite_rc = Path(temp_dir, "suite.rc")
-            with suite_rc.open(mode="w") as f:
-                f.write("""
-    [scheduling]
-        initial cycle point = 2018-01-01
-        [[xtriggers]]
-            tree = name_a_tree()
-        [[dependencies]]
-            [[[R1]]]
-                graph = '@tree => qux'
-                """)
-                f.flush()
-                suite_config = SuiteConfig(suite="name_a_tree", fpath=f.name)
-                config = suite_config
-                assert 'tree' in config.xtriggers['qux']
+        temp_dir = mkdtemp()
+        python_dir = os.path.join(temp_dir, "lib", "python")
+        if not os.path.exists(python_dir):
+            os.makedirs(python_dir)
+        name_a_tree_file = os.path.join(python_dir, "name_a_tree.py")
+        with open(name_a_tree_file, mode="w") as f:
+            # NB: we are not returning a lambda, instead we have a scalar
+            f.write("""name_a_tree = lambda: 'jacaranda'""")
+            f.flush()
+        suite_rc = os.path.join(temp_dir, "suite.rc")
+        with open(suite_rc, mode="w") as f:
+            f.write("""
+[scheduling]
+    initial cycle point = 2018-01-01
+    [[xtriggers]]
+        tree = name_a_tree()
+    [[dependencies]]
+        [[[R1]]]
+            graph = '@tree => qux'
+            """)
+            f.flush()
+            suite_config = SuiteConfig(suite="name_a_tree", fpath=f.name)
+            config = suite_config
+            self.assertTrue('tree' in config.xtriggers['qux'])
+        shutil.rmtree(temp_dir)
 
     def test_xfunction_import_error(self):
         """Test for error when a xtrigger function cannot be imported."""
-        with TemporaryDirectory() as temp_dir:
-            python_dir = Path(os.path.join(temp_dir, "lib", "python"))
-            python_dir.mkdir(parents=True)
-            caiman_file = python_dir / "caiman.py"
-            with caiman_file.open(mode="w") as f:
-                # NB: we are not returning a lambda, instead we have a scalar
-                f.write("""caiman = lambda: True""")
-                f.flush()
-            suite_rc = Path(temp_dir, "suite.rc")
-            with suite_rc.open(mode="w") as f:
-                f.write("""
-    [scheduling]
-        initial cycle point = 2018-01-01
-        [[xtriggers]]
-            oopsie = piranha()
-        [[dependencies]]
-            [[[R1]]]
-                graph = '@oopsie => qux'
-                """)
-                f.flush()
-                with pytest.raises(SuiteConfigError) as excinfo:
-                    SuiteConfig(suite="caiman_suite", fpath=f.name)
-                assert "not found" in str(excinfo.value)
+        temp_dir = mkdtemp()
+        python_dir = os.path.join(temp_dir, "lib", "python")
+        if not os.path.exists(python_dir):
+            os.makedirs(python_dir)
+        caiman_file = os.path.join(python_dir, "caiman.py")
+        with open(caiman_file, mode="w") as f:
+            # NB: we are not returning a lambda, instead we have a scalar
+            f.write("""caiman = lambda: True""")
+            f.flush()
+        suite_rc = os.path.join(temp_dir, "suite.rc")
+        with open(suite_rc, mode="w") as f:
+            f.write("""
+[scheduling]
+    initial cycle point = 2018-01-01
+    [[xtriggers]]
+        oopsie = piranha()
+    [[dependencies]]
+        [[[R1]]]
+            graph = '@oopsie => qux'
+            """)
+            f.flush()
+            with self.assertRaises(SuiteConfigError) as ex:
+                SuiteConfig(suite="caiman_suite", fpath=f.name)
+                self.assertTrue("not found" in str(ex))
+        shutil.rmtree(temp_dir)
 
     def test_xfunction_attribute_error(self):
         """Test for error when a xtrigger function cannot be imported."""
-        with TemporaryDirectory() as temp_dir:
-            python_dir = Path(os.path.join(temp_dir, "lib", "python"))
-            python_dir.mkdir(parents=True)
-            capybara_file = python_dir / "capybara.py"
-            with capybara_file.open(mode="w") as f:
-                # NB: we are not returning a lambda, instead we have a scalar
-                f.write("""toucan = lambda: True""")
-                f.flush()
-            suite_rc = Path(temp_dir, "suite.rc")
-            with suite_rc.open(mode="w") as f:
-                f.write("""
-    [scheduling]
-        initial cycle point = 2018-01-01
-        [[xtriggers]]
-            oopsie = capybara()
-        [[dependencies]]
-            [[[R1]]]
-                graph = '@oopsie => qux'
-                """)
-                f.flush()
-                with pytest.raises(SuiteConfigError) as excinfo:
-                    SuiteConfig(suite="capybara_suite", fpath=f.name)
-                assert "not found" in str(excinfo.value)
+        temp_dir = mkdtemp()
+        python_dir = os.path.join(temp_dir, "lib", "python")
+        if not os.path.exists(python_dir):
+            os.makedirs(python_dir)
+        capybara_file = os.path.join(python_dir, "capybara.py")
+        with open(capybara_file, mode="w") as f:
+            # NB: we are not returning a lambda, instead we have a scalar
+            f.write("""toucan = lambda: True""")
+            f.flush()
+        suite_rc = os.path.join(temp_dir, "suite.rc")
+        with open(suite_rc, mode="w") as f:
+            f.write("""
+[scheduling]
+    initial cycle point = 2018-01-01
+    [[xtriggers]]
+        oopsie = capybara()
+    [[dependencies]]
+        [[[R1]]]
+            graph = '@oopsie => qux'
+            """)
+            f.flush()
+            with self.assertRaises(SuiteConfigError) as ex:
+                SuiteConfig(suite="capybara_suite", fpath=f.name)
+                self.assertTrue("not found" in str(ex))
+        shutil.rmtree(temp_dir)
 
     def test_xfunction_not_callable(self):
         """Test for error when a xtrigger function is not callable."""
-        with TemporaryDirectory() as temp_dir:
-            python_dir = Path(os.path.join(temp_dir, "lib", "python"))
-            python_dir.mkdir(parents=True)
-            not_callable_file = python_dir / "not_callable.py"
-            with not_callable_file.open(mode="w") as f:
-                # NB: we are not returning a lambda, instead we have a scalar
-                f.write("""not_callable = 42""")
-                f.flush()
-            suite_rc = Path(temp_dir, "suite.rc")
-            with suite_rc.open(mode="w") as f:
-                f.write("""
-    [scheduling]
-        initial cycle point = 2018-01-01
-        [[xtriggers]]
-            oopsie = not_callable()
-        [[dependencies]]
-            [[[R1]]]
-                graph = '@oopsie => qux'
-                """)
-                f.flush()
-                with pytest.raises(SuiteConfigError) as excinfo:
-                    SuiteConfig(suite="suite_with_not_callable", fpath=f.name)
-                assert "callable" in str(excinfo.value)
+        temp_dir = mkdtemp()
+        python_dir = os.path.join(temp_dir, "lib", "python")
+        if not os.path.exists(python_dir):
+            os.makedirs(python_dir)
+        not_callable_file = os.path.join(python_dir, "not_callable.py")
+        with open(not_callable_file, mode="w") as f:
+            # NB: we are not returning a lambda, instead we have a scalar
+            f.write("""not_callable = 42""")
+            f.flush()
+        suite_rc = os.path.join(temp_dir, "suite.rc")
+        with open(suite_rc, mode="w") as f:
+            f.write("""
+[scheduling]
+    initial cycle point = 2018-01-01
+    [[xtriggers]]
+        oopsie = not_callable()
+    [[dependencies]]
+        [[[R1]]]
+            graph = '@oopsie => qux'
+            """)
+            f.flush()
+            with self.assertRaises(SuiteConfigError) as ex:
+                SuiteConfig(suite="suite_with_not_callable", fpath=f.name)
+                self.assertTrue("callable" in str(ex))
+        shutil.rmtree(temp_dir)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/cylc/tests/test_config.py
+++ b/lib/cylc/tests/test_config.py
@@ -1,0 +1,103 @@
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import pytest
+from tempfile import TemporaryDirectory
+from pathlib import Path
+from cylc.config import SuiteConfig, SuiteConfigError
+
+
+class TestSuiteConfig(object):
+    """Test class for the Cylc SuiteConfig object."""
+
+    def test_xfunction_imports(self):
+        """Test for a suite configuration with valid xtriggers"""
+        with TemporaryDirectory() as temp_dir:
+            python_dir = Path(os.path.join(temp_dir, "lib", "python"))
+            python_dir.mkdir(parents=True)
+            name_a_tree_file = python_dir / "name_a_tree.py"
+            with name_a_tree_file.open(mode="w") as f:
+                # NB: we are not returning a lambda, instead we have a scalar
+                f.write("""name_a_tree = lambda: 'jacaranda'""")
+                f.flush()
+            suite_rc = Path(temp_dir, "suite.rc")
+            with suite_rc.open(mode="w") as f:
+                f.write("""
+    [scheduling]
+        initial cycle point = 2018-01-01
+        [[xtriggers]]
+            tree = name_a_tree()
+        [[dependencies]]
+            [[[R1]]]
+                graph = '@tree => qux'
+                """)
+                f.flush()
+                suite_config = SuiteConfig(suite="name_a_tree", fpath=f.name)
+                config = suite_config
+                assert 'tree' in config.xtriggers['qux']
+
+    def test_xfunction_import_error(self):
+        """Test for error when a xtrigger function cannot be imported."""
+        with TemporaryDirectory() as temp_dir:
+            python_dir = Path(os.path.join(temp_dir, "lib", "python"))
+            python_dir.mkdir(parents=True)
+            caiman_file = python_dir / "caiman.py"
+            with caiman_file.open(mode="w") as f:
+                # NB: we are not returning a lambda, instead we have a scalar
+                f.write("""caiman = lambda: True""")
+                f.flush()
+            suite_rc = Path(temp_dir, "suite.rc")
+            with suite_rc.open(mode="w") as f:
+                f.write("""
+    [scheduling]
+        initial cycle point = 2018-01-01
+        [[xtriggers]]
+            oopsie = piranha()
+        [[dependencies]]
+            [[[R1]]]
+                graph = '@oopsie => qux'
+                """)
+                f.flush()
+                with pytest.raises(SuiteConfigError) as excinfo:
+                    SuiteConfig(suite="caiman_suite", fpath=f.name)
+                assert "not found" in str(excinfo.value)
+
+    def test_xfunction_not_callable(self):
+        """Test for error when a xtrigger function is not callable."""
+        with TemporaryDirectory() as temp_dir:
+            python_dir = Path(os.path.join(temp_dir, "lib", "python"))
+            python_dir.mkdir(parents=True)
+            not_callable_file = python_dir / "not_callable.py"
+            with not_callable_file.open(mode="w") as f:
+                # NB: we are not returning a lambda, instead we have a scalar
+                f.write("""not_callable = 42""")
+                f.flush()
+            suite_rc = Path(temp_dir, "suite.rc")
+            with suite_rc.open(mode="w") as f:
+                f.write("""
+    [scheduling]
+        initial cycle point = 2018-01-01
+        [[xtriggers]]
+            oopsie = not_callable()
+        [[dependencies]]
+            [[[R1]]]
+                graph = '@oopsie => qux'
+                """)
+                f.flush()
+                with pytest.raises(SuiteConfigError) as excinfo:
+                    SuiteConfig(suite="suite_with_not_callable", fpath=f.name)
+                assert "callable" in str(excinfo.value)

--- a/lib/cylc/tests/test_subprocpool.py
+++ b/lib/cylc/tests/test_subprocpool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
 # Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
@@ -16,11 +16,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from tempfile import NamedTemporaryFile, SpooledTemporaryFile, TemporaryFile
+from tempfile import NamedTemporaryFile, SpooledTemporaryFile, TemporaryFile,\
+    TemporaryDirectory
 import unittest
 
+from pathlib import Path
+
 from cylc.subprocctx import SubProcContext
-from cylc.subprocpool import SubProcPool
+from cylc.subprocpool import SubProcPool, _XTRIG_FUNCS, get_func
 
 
 class TestSubProcPool(unittest.TestCase):
@@ -127,6 +130,63 @@ class TestSubProcPool(unittest.TestCase):
         self.assertEqual(ctx.ret_code, 0)
         for handle in handles:
             handle.close()
+
+    def test_xfunction(self):
+        """Test xtrigger function import."""
+        with TemporaryDirectory() as temp_dir:
+            python_dir = Path(temp_dir, "lib", "python")
+            python_dir.mkdir(parents=True)
+            the_answer_file = python_dir / "the_answer.py"
+            with the_answer_file.open(mode="w") as f:
+                f.write("""the_answer = lambda: 42""")
+                f.flush()
+            fn = get_func("the_answer", temp_dir)
+            result = fn()
+            self.assertEqual(42, result)
+
+    def test_xfunction_cache(self):
+        """Test xtrigger function import cache."""
+        with TemporaryDirectory() as temp_dir:
+            python_dir = Path(temp_dir, "lib", "python")
+            python_dir.mkdir(parents=True)
+            amandita_file = python_dir / "amandita.py"
+            with amandita_file.open(mode="w") as f:
+                f.write("""amandita = lambda: 'chocolate'""")
+                f.flush()
+            fn = get_func("amandita", temp_dir)
+            result = fn()
+            self.assertEqual('chocolate', result)
+
+            # is in the cache
+            self.assertTrue('amandita' in _XTRIG_FUNCS)
+            # returned from cache
+            self.assertEqual(fn, get_func("amandita", temp_dir))
+            del _XTRIG_FUNCS['amandita']
+            # is not in the cache
+            self.assertFalse('amandita' in _XTRIG_FUNCS)
+
+    def test_xfunction_import_error(self):
+        """Test for error on importing a xtrigger function.
+
+        To prevent the test eventually failing if the test function is added
+        and successfully imported, we use an invalid module name as per Python
+        spec.
+        """
+        with TemporaryDirectory() as temp_dir:
+            with self.assertRaises(ModuleNotFoundError):
+                get_func("invalid-module-name", temp_dir)
+
+    def test_xfunction_attribute_error(self):
+        """Test for error on looking for an attribute in a xtrigger script."""
+        with TemporaryDirectory() as temp_dir:
+            python_dir = Path(temp_dir, "lib", "python")
+            python_dir.mkdir(parents=True)
+            the_answer_file = python_dir / "the_sword.py"
+            with the_answer_file.open(mode="w") as f:
+                f.write("""the_droid = lambda: 'excalibur'""")
+                f.flush()
+            with self.assertRaises(AttributeError):
+                get_func("the_sword", temp_dir)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Backport for pr #3060 

NB: this is slightly different than #3060 in the tests, as I used Python 3.6 features, and pytest, which are not supported in our 7.8.x branch with Python 2.

The number of commits is the same as #3060, because I dropped the `codacy.yml` commit, as that file is not required, and added one commit to adjust the test code. So better to wait for Travis!