### PR TITLE
shellcheck: lint shell script files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,7 @@ unittest: &unittest
   script:
     - export PYTHONPATH=$(pwd -P)/lib/
     - pycodestyle
+    - .travis/shellchecker
     - pytest --cov-append --cov=lib/cylc --cov=lib/parsec
   after_success:
     # Report metrics, such as coverage

--- a/.travis/after_failure.sh
+++ b/.travis/after_failure.sh
@@ -22,5 +22,7 @@
 
 cylc scan -f --color=never
 
-find $HOME/cylc-run -name '*.err' -type f -exec echo '==== {} ====' \; -exec cat '{}' \;
-find /tmp/${USER}/cylctb-* -type f -exec echo '==== {} ====' \; -exec cat '{}' \;
+find "$HOME/cylc-run" -name '*.err' -type f \
+    -exec echo '==== {} ====' \; -exec cat '{}' \;
+find "/tmp/${USER}/cylctb-"* -type f \
+    -exec echo '==== {} ====' \; -exec cat '{}' \;

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -33,6 +33,7 @@ if grep -E '(unit-tests|functional-tests)' <<< "${args[@]}"; then
 fi
 
 if grep 'unit-tests' <<< "${args[@]}"; then
+    sudo apt-get install shellcheck
     pip install pycodestyle pytest testfixtures empy
 fi
 

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -38,7 +38,7 @@ if grep 'unit-tests' <<< "${args[@]}"; then
 fi
 
 # install dependencies required for building documentation
-if grep 'docs' <<< "${args[@]}$"; then
+if grep 'docs' <<< "${args[@]}"; then
     pip install sphinx
     # for PDF output via LaTeX builder
     sudo apt-get install texlive-latex-base

--- a/.travis/shellchecker
+++ b/.travis/shellchecker
@@ -1,0 +1,94 @@
+#!/bin/bash
+#
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Wrapper for running `shellcheck` over projects.
+
+shopt -s extglob
+cd "$(dirname "$0")/../" || exit 1
+
+# find shell files under the specified directory
+find_files () {
+    FPATH="$1"
+    grep --color=never -rl '^#\!.*bash' "${FPATH}" | sed 's/^\.\///' &
+    find "${FPATH}" -name '*.sh' | sed 's/^\.\///'
+}
+
+main () {
+    # parse CLI
+    includes=()
+    excludes=()
+    args=()
+    while [[ "$#" -gt 0 ]]; do
+        if [[ ${1} == '--' ]]; then
+            shift
+            break
+        elif [[ ${1} == "--exclude" ]]; then
+            shift
+            excludes+=("$1")
+        elif [[ ${1} == "-*" ]]; then
+            args+=("$1")
+        else
+            mapfile -t files < <(find_files "${1}")
+            includes=("${includes[@]}" "${files[@]}")
+        fi
+        shift
+    done
+
+    # extract files list
+    files=()
+    for include in "${includes[@]}"; do
+        skip=0
+        for exclude in "${excludes[@]}"; do
+            if [[ "${include}" == "${exclude}"* ]]; then
+                skip=1
+                break
+            fi
+        done
+        if [[ $skip == 0 ]]; then
+            files+=("${include}")
+        fi
+    done
+
+    # sort $files removing duplicates
+    readarray -t files < <(for x in "${files[@]}"; do echo "$x"; done | sort -u)
+
+    # run shellcheck
+    shellcheck "$@" "${files[@]}"
+}
+
+# default configuration for linting cylc
+default () {
+    # run a strict check on all "functional" scripts
+    main '.' \
+        --exclude 'tests/' \
+        --exclude 'lib/parsec/tests' \
+        --exclude 'lib/cylc/job.sh' \
+        --exclude 'etc/dev-bin/live-graph-movie.sh' \
+        -- -e SC1090
+    main 'lib/cylc/job.sh' -- -e SC1090 -s bash
+    main 'lib/cylc/job.sh' -- -e SC1090 -s ksh
+
+    # run a lenient check on all test scripts
+    main 'tests' 'lib/parsec/tests' -- -S error -e SC1090
+}
+
+if [[ $# -gt 0 ]]; then
+    main "$@"
+else
+    default
+fi

--- a/.travis/shellchecker
+++ b/.travis/shellchecker
@@ -18,14 +18,14 @@
 
 # Wrapper for running `shellcheck` over projects.
 
-shopt -s extglob
-cd "$(dirname "$0")/../" || exit 1
+set -e
+cd "$(dirname "$0")/../"
 
 # find shell files under the specified directory
 find_files () {
-    FPATH="$1"
-    grep --color=never -rl '^#\!.*bash' "${FPATH}" | sed 's/^\.\///' &
-    find "${FPATH}" -name '*.sh' | sed 's/^\.\///'
+    SEARCH_PATH="$1"
+    grep --color=never -Rl '^#\!.*bash' "${SEARCH_PATH}" | sed 's/^\.\///'
+    find "${SEARCH_PATH}" -name '*.sh' | sed 's/^\.\///'
 }
 
 main () {

--- a/bin/cylc
+++ b/bin/cylc
@@ -95,15 +95,15 @@ __HELP__
         fi
     fi
     # If category name is used as arg, call the help func with the category
+    local COMMAND
     if [[ $# -gt 1  &&  ( "${CATEGORIES[*]} " == *" $1 "* 
             || " ${HELP_OPTS[*]} " == *" $1 "* ) ]]; then
-        local COMMAND="${CYLC_HOME_BIN}/cylc-help"
+        COMMAND="${CYLC_HOME_BIN}/cylc-help"
         exec "${COMMAND}" "$@"
     fi
     # Deal with cases like 'cylc --help [COMMAND/CATEGORY]'
     if [[ $# -gt 1 && -f "$(ls "cylc-$2"* 2>'/dev/null')" ]]; then
         COMMAND="${CYLC_HOME_BIN}/$(ls "cylc-$2"*)"
-        local COMMAND
         exec "${COMMAND}" "--help"
     fi
     # If not a category or not an actual command in the bin dir, exit
@@ -152,8 +152,8 @@ path_lead() {
 }
 
 get_command_from_abbr() {
-    COMMAND="$(cd "${CYLC_HOME_BIN}" && ls "cylc-$1"* 2>'/dev/null')"
     local COMMAND
+    COMMAND="$(cd "${CYLC_HOME_BIN}" && ls "cylc-$1"* 2>'/dev/null')"
     if [[ -z "${COMMAND}" ]]; then
         # Abbreviation has no match, bad
         echo "cylc $1: unknown utility. Abort." >&2

--- a/bin/cylc
+++ b/bin/cylc
@@ -102,7 +102,8 @@ __HELP__
     fi
     # Deal with cases like 'cylc --help [COMMAND/CATEGORY]'
     if [[ $# -gt 1 && -f "$(ls "cylc-$2"* 2>'/dev/null')" ]]; then
-        local COMMAND="${CYLC_HOME_BIN}/$(ls "cylc-$2"*)"
+        COMMAND="${CYLC_HOME_BIN}/$(ls "cylc-$2"*)"
+        local COMMAND
         exec "${COMMAND}" "--help"
     fi
     # If not a category or not an actual command in the bin dir, exit
@@ -151,7 +152,8 @@ path_lead() {
 }
 
 get_command_from_abbr() {
-    local COMMAND="$(cd "${CYLC_HOME_BIN}" && ls "cylc-$1"* 2>'/dev/null')"
+    COMMAND="$(cd "${CYLC_HOME_BIN}" && ls "cylc-$1"* 2>'/dev/null')"
+    local COMMAND
     if [[ -z "${COMMAND}" ]]; then
         # Abbreviation has no match, bad
         echo "cylc $1: unknown utility. Abort." >&2

--- a/bin/cylc
+++ b/bin/cylc
@@ -31,7 +31,7 @@ print_version() {
     if [[ "$#" -eq 0 ]]; then
         echo "$CYLC_VERSION"
     fi
-    if [[ "$@" == 'long' || "$@" == '--long' ]]; then
+    if [[ "$*" == 'long' || "$*" == '--long' ]]; then
     echo "Cylc ${CYLC_VERSION} (${CYLC_DIR})"    
     fi
 }
@@ -52,11 +52,6 @@ init_cylc() {
 help_util() {
     # Deals with form 'cylc [COMMAND] --help'
     cd "${CYLC_HOME_BIN}"
-    # deal with graph which is a weird edge case...
-    if [[ "$@" == "graph" ]]; then
-        local COMMAND="${CYLC_HOME_BIN}/cylc-graph"
-        exec "${COMMAND}" "--help"
-    fi
     # For help command/option with no args
     if [[ $# == 0 && "${HELP_OPTS[*]} " == *"$UTIL"* ]]; then
         exec "${CYLC_HOME_BIN}/cylc-help"

--- a/bin/cylc-conditions
+++ b/bin/cylc-conditions
@@ -38,5 +38,5 @@ fi
 echo
 echo "The GNU General Public License v3.0"
 echo
-cat $CYLC_DIR/COPYING
+cat "$CYLC_DIR/COPYING"
 echo

--- a/bin/cylc-graph-diff
+++ b/bin/cylc-graph-diff
@@ -19,7 +19,7 @@ set -eu
 
 _clean() {
     if [[ -n "${DIFF_FILES:-}" ]]; then
-        rm -f ${DIFF_FILES:-}
+        rm -f "${DIFF_FILES[@]:-}"
     fi
 }
 
@@ -55,7 +55,7 @@ for ARG in "$@"; do
     else
         # A suite - check it's registered.
         if ! cylc print --fail "$ARG$" >/dev/null 2>&1; then
-            echo "Suite not found: "$ARG >&2
+            echo "Suite not found: $ARG" >&2
             exit 1
         fi
         SUITES="$SUITES $ARG"
@@ -69,17 +69,17 @@ fi
 
 trap _clean EXIT
 trap _clean ERR
-DIFF_FILES=""
+DIFF_FILES=()
 for SUITE in $SUITES; do
     FILE=$(mktemp -t "$(tr '/' '.' <<<"${SUITE}").graph.ref.XXXX")
-    cylc graph --reference "${SUITE}" "$@" >$FILE
-    DIFF_FILES="$DIFF_FILES $FILE"
+    cylc graph --reference "${SUITE}" "$@" >"$FILE"
+    DIFF_FILES+=("$FILE")
 done
 
 if $GRAPHICAL_DIFF; then
     for DIFFTOOL in xxdiff diffuse kdiff3 kompare gvimdiff2 meld tkdiff; do
         if type -P $DIFFTOOL >/dev/null; then
-            "$DIFFTOOL" $DIFF_FILES
+            "$DIFFTOOL" "${DIFF_FILES[@]}"
             exit 0
         fi
     done
@@ -87,4 +87,4 @@ if $GRAPHICAL_DIFF; then
     exit 1
 fi
 
-$DIFF_CMD $DIFF_FILES
+$DIFF_CMD "${DIFF_FILES[@]}"

--- a/bin/cylc-import-examples
+++ b/bin/cylc-import-examples
@@ -55,16 +55,16 @@ if [[ -d $DESTINATION ]]; then
 fi
 
 echo " + Copying example suites"
-mkdir -p $DESTINATION
-cp -r $CYLC_DIR/etc/examples/* $DESTINATION
+mkdir -p "$DESTINATION"
+cp -r "$CYLC_DIR/etc/examples/*" "$DESTINATION"
 
 echo " + Registering example suites"
-cd $DESTINATION
+cd "$DESTINATION"
 SUITE_RCS=$(find . -name suite.rc | sed -e 's@./@@')
 for SUITE_RC in $SUITE_RCS; do
-    SUITE_DEF_DIR=$(dirname $SUITE_RC)
+    SUITE_DEF_DIR="$(dirname "$SUITE_RC")"
     SUITE_REG_NAME=$BASE_DIR/$SUITE_DEF_DIR
-    cylc register $SUITE_REG_NAME $SUITE_DEF_DIR
+    cylc register "$SUITE_REG_NAME" "$SUITE_DEF_DIR"
 done
 
 echo "DONE"

--- a/bin/cylc-jobscript
+++ b/bin/cylc-jobscript
@@ -54,7 +54,7 @@ if sys.argv[1] in ['-g', '--gedit']:
     print glbl_cfg().get(['editors', 'gui'])
 elif sys.argv[1] in ['-e', '--edit']:
     print glbl_cfg().get(['editors', 'terminal'])
-" $1
+" "$1"
 }
 
 PLAIN=false
@@ -66,7 +66,7 @@ for arg in "${@}"; do
         exit 0
     elif [[ "${arg}" == '--edit' ]] || [[ "${arg}" == '--gedit' ]] || \
          [[ "${arg}" == '-e' ]] || [[ "${arg}" == '-g' ]]; then
-        EDITOR_CMD="$(editor ${arg})"
+        EDITOR_CMD="$(editor "${arg}")"
     elif [[ "${arg}" == '--plain' ]]; then
         PLAIN=true
     else
@@ -74,12 +74,13 @@ for arg in "${@}"; do
     fi
 done
 
-if CYLC_SUBMIT_OUT="$(cylc submit --dry-run ${SUBMIT_ARGS})"; then
+if CYLC_SUBMIT_OUT="$(cylc submit --dry-run "${SUBMIT_ARGS}")"; then
     JOBSCRIPT="$(sed -n 's/^JOB SCRIPT=//p' <<<"${CYLC_SUBMIT_OUT}")"
     if ! "${PLAIN}"; then
         echo "Task Job Script Generated: ${JOBSCRIPT}" >&2
     fi
     if [[ -n ${EDITOR_CMD} ]]; then
+        # shellcheck disable=2086
         exec $EDITOR_CMD "${JOBSCRIPT}"
     else
         exec less "${JOBSCRIPT}"

--- a/bin/cylc-make-docs
+++ b/bin/cylc-make-docs
@@ -36,7 +36,7 @@ fi
 echo >&2
 echo "Building the HTML Cylc Documentation with Sphinx:"
 echo >&2
-cd "$CYLC_DIR"/doc/
+cd "$CYLC_DIR/doc/" || exit 1
 echo "... Generating the command reference ..."
 ./src/custom/make-commands.sh
 echo >&2

--- a/bin/cylc-make-docs
+++ b/bin/cylc-make-docs
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+set -eu
+
 usage() {
     echo "Usage: cylc [admin] make-docs [--help]"
     echo "Build the HTML User Guide, with Sphinx."
@@ -36,7 +38,7 @@ fi
 echo >&2
 echo "Building the HTML Cylc Documentation with Sphinx:"
 echo >&2
-cd "$CYLC_DIR/doc/" || exit 1
+cd "$CYLC_DIR/doc/"
 echo "... Generating the command reference ..."
 ./src/custom/make-commands.sh
 echo >&2

--- a/bin/cylc-scp-transfer
+++ b/bin/cylc-scp-transfer
@@ -69,18 +69,18 @@ for T in $SRCE; do
         RMACH=${D%:*}
         RPATH=${D#*:}
 
-        RDIR=$( dirname $RPATH )
+        RDIR="$( dirname "$RPATH" )"
 
         cylc task message "Creating remote destination directory, $RDIR"
-        ssh $RMACH mkdir -p $RDIR
+        ssh "$RMACH" mkdir -p "$RDIR"
     else
-        DIR=$( dirname $D )
+        DIR="$( dirname "$D" )"
         cylc task message "Creating destination directory, $DIR"
-        mkdir -p $DIR
+        mkdir -p "$DIR"
     fi
 
     COMMAND="scp -B -r $T $D"
-    echo $COMMAND
+    echo "$COMMAND"
     if $VERBOSE; then
         $COMMAND
     else

--- a/bin/cylc-test-battery
+++ b/bin/cylc-test-battery
@@ -134,7 +134,7 @@ for ARG in "$@"; do
         --chunk)
             # Replace "--chunk a/b" with the appropriate tests.
             set -- "${@:1:$(( ARG_COUNT - 1 ))}" \
-                $(chunk ${@:$(( ARG_COUNT + 1 )):1}) \
+                $(chunk "${@:$(( ARG_COUNT + 1 )):1}") \
                 "${@:$(( ARG_COUNT + 2 ))}"
             ;;
         *)

--- a/bin/cylc-test-battery
+++ b/bin/cylc-test-battery
@@ -99,12 +99,12 @@ eof
 
 chunk () {
     # argument in the format chunk_no/no_chunks
-    IFS=$'/' read CHUNK_NO CHUNKS <<< "$1"
+    IFS=$'/' read -r CHUNK_NO CHUNKS <<< "$1"
     # create lists of tests in a temp file
     TEST_FILE="$(mktemp)"
     cylc test-battery --dry | sort > "$TEST_FILE"
     LINES_PER_FILE=$(( ( $(wc -l "$TEST_FILE" | cut -d ' ' -f 1) \
-        + $CHUNKS - 1 ) / CHUNKS ))
+        + CHUNKS - 1 ) / CHUNKS ))
     # chunk tests
     split -d -l "$LINES_PER_FILE" "$TEST_FILE" "$TEST_FILE"
     # select chunk
@@ -117,11 +117,12 @@ export CYLC_TEST_RUN_GENERIC=${CYLC_TEST_RUN_GENERIC:-true}
 export CYLC_TEST_RUN_PLATFORM=${CYLC_TEST_RUN_PLATFORM:-true}
 export CYLC_TEST_SKIP=${CYLC_TEST_SKIP:-}
 export CYLC_TEST_IS_GENERIC=true
-export CYLC_TEST_TIME_INIT="$(date -u +'%Y%m%dT%H%M%SZ')"
+CYLC_TEST_TIME_INIT="$(date -u +'%Y%m%dT%H%M%SZ')"
+export CYLC_TEST_TIME_INIT
 
 if [[ "$PWD" != "$CYLC_DIR" ]]; then
     echo "cd \"$CYLC_DIR\""
-    cd "$CYLC_DIR"
+    cd "$CYLC_DIR" || exit 1
 fi
 
 ARG_COUNT=1
@@ -134,7 +135,7 @@ for ARG in "$@"; do
         --chunk)
             # Replace "--chunk a/b" with the appropriate tests.
             set -- "${@:1:$(( ARG_COUNT - 1 ))}" \
-                $(chunk "${@:$(( ARG_COUNT + 1 )):1}") \
+                "$(chunk "${@:$(( ARG_COUNT + 1 )):1}")" \
                 "${@:$(( ARG_COUNT + 2 ))}"
             ;;
         *)

--- a/doc/src/custom/make-commands.sh
+++ b/doc/src/custom/make-commands.sh
@@ -19,10 +19,10 @@
 # Create appendices/command-ref.rst for inclusion in HTML doc.
 
 # All paths relative to 'doc/src/custom/' directory:
-COMMAND_REF_FILE="$(dirname $0)/../appendices/command-ref.rst"
-CYLC=$(dirname $0)/../../../bin/cylc
+COMMAND_REF_FILE="$(dirname "$0")/../appendices/command-ref.rst"
+CYLC="$(dirname "$0")/../../../bin/cylc"
 
-$(cat > "$COMMAND_REF_FILE" <<END
+cat > "$COMMAND_REF_FILE" <<END
 .. _CommandReference:
 
 Command Reference
@@ -41,10 +41,9 @@ Command Categories
 ------------------
 
 END
-)
 
 for CAT in $($CYLC categories); do
-	$(cat >> "$COMMAND_REF_FILE" <<END
+	cat >> "$COMMAND_REF_FILE" <<END
 
 ${CAT}
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -53,23 +52,21 @@ ${CAT}
 
 .. code-block:: none
 
-   $($CYLC $CAT --help | awk '{print "   " $0}')
+   $("$CYLC" "$CAT" --help | awk '{print "   " $0}')
 
 END
-)
 
 done
 
-$(cat >> "$COMMAND_REF_FILE" <<END
+cat >> "$COMMAND_REF_FILE" <<END
 
 Commands
 --------
 
 END
-)
 
 for COM in $($CYLC commands); do
-	$(cat >> "$COMMAND_REF_FILE" <<END
+	cat >> "$COMMAND_REF_FILE" <<END
 
 ${COM}
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -78,9 +75,8 @@ ${COM}
 
 .. code-block:: none
 
-   $($CYLC $COM --help  | awk '{print "   " $0}')
+   $("$CYLC" "$COM" --help  | awk '{print "   " $0}')
 
 END
-)
 
 done

--- a/doc/src/graphics/scale-images.sh
+++ b/doc/src/graphics/scale-images.sh
@@ -32,8 +32,7 @@ set -e
 mkdir -p png/scaled
 for PNG in "png/orig/"*; do
     if [[ ! -f png/scaled/$PNG ]]; then
-    echo "scaling $PNG"
-    convert -resize '600>' "png/orig/$PNG" "png/scaled/$PNG"
+        echo "scaling $PNG"
+        convert -resize '600>' "png/orig/$PNG" "png/scaled/$PNG"
     fi
 done
-

--- a/doc/src/graphics/scale-images.sh
+++ b/doc/src/graphics/scale-images.sh
@@ -30,10 +30,10 @@ set -e
 # for the online documentation, and re-creating them seems to result in 
 # "different" binary files each time.
 mkdir -p png/scaled
-for PNG in $( ls png/orig/ ); do
+for PNG in "png/orig/"*; do
     if [[ ! -f png/scaled/$PNG ]]; then
     echo "scaling $PNG"
-    convert -resize '600>' png/orig/$PNG png/scaled/$PNG
+    convert -resize '600>' "png/orig/$PNG" "png/scaled/$PNG"
     fi
 done
 

--- a/etc/conda-environment.yaml
+++ b/etc/conda-environment.yaml
@@ -1,0 +1,17 @@
+name: cylc8
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.7
+  - pyzmq
+  - python-jose
+  - colorama
+  - jinja2
+  - sphinx
+  - pytest
+  - pycodestyle
+  - coverage
+  - pytest-cov
+  - pip:
+    - empy

--- a/etc/cylc-bash-completion
+++ b/etc/cylc-bash-completion
@@ -33,7 +33,7 @@
 
 _cylc() {
 
-    local cur sec opts base
+    local cur sec opts
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     sec="${COMP_WORDS[1]}"
@@ -43,10 +43,10 @@ _cylc() {
 
     if [[ ${COMP_CWORD} -eq 1 ]]; then
         CYLC_DIR=$(__cylc_get_cylc_dir)
-        cylc_cmds=$(cd $CYLC_DIR/bin && ls cylc-* | sed "s/^cylc-//g")
-        COMPREPLY=($(compgen -W "${cylc_cmds}" -- ${cur}))
+        cylc_cmds="$(cd "$CYLC_DIR/bin" && echo cylc-* | sed "s/^cylc-//g")"
+        COMPREPLY=("$(compgen -W "${cylc_cmds}" -- "${cur}")")
     elif [[ ${sec} =~ ^($suite_cmds)$ ]]; then
-        COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+        COMPREPLY=( "$(compgen -W "${opts}" -- "${cur}")" )
     fi
     return 0
 }

--- a/etc/dev-bin/make-tarball
+++ b/etc/dev-bin/make-tarball
@@ -42,5 +42,5 @@ RELEASE="cylc-${CYLC_VERSION}"
 TARBALL=${RELEASE}.tar.gz
 BRANCH=$( git rev-parse --abbrev-ref HEAD )
 
-git archive $BRANCH --prefix=$RELEASE/ | gzip > $TARBALL
-ls -lh $TARBALL
+git archive "$BRANCH" --prefix="$RELEASE/" | gzip > "$TARBALL"
+ls -lh "$TARBALL"

--- a/etc/dev-bin/start-group-demo.sh
+++ b/etc/dev-bin/start-group-demo.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd $(mktemp -d)
+cd "$(mktemp -d)" || exit 1
 
 cat > suite.rc <<__EOF__
 title = "gcylc task state color theme demo"

--- a/etc/dev-bin/stop-group-demo.sh
+++ b/etc/dev-bin/stop-group-demo.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 for S in $(cylc scan -n groups | awk '{print $1}'); do
-  echo $S
-  cylc stop $S
+  echo "$S"
+  cylc stop "$S"
 done

--- a/etc/dev-bin/updatecopyright.sh
+++ b/etc/dev-bin/updatecopyright.sh
@@ -15,12 +15,11 @@ YY=$(date +%y)
 OLD="Copyright \(C\) 2008-20\d\d NIWA & British Crown \(Met Office\) & Contributors."
 NEW="Copyright (C) 2008-20$YY NIWA & British Crown (Met Office) & Contributors."
 
-FILES=$@
-for FILE in $FILES; do
-    echo $FILE
+for FILE in "$@"; do
+    echo "$FILE"
     if [[ ! -f $FILE ]]; then
         echo "ERROR: no such file: $FILE"
         continue
     fi
-    perl -pi -e "s/$OLD/$NEW/" $FILE
+    perl -pi -e "s/$OLD/$NEW/" "$FILE"
 done

--- a/etc/examples/AutoRecover/CleanupTask/bin/fam_cleanup.sh
+++ b/etc/examples/AutoRecover/CleanupTask/bin/fam_cleanup.sh
@@ -10,14 +10,16 @@ set -e
 sleep 10 # (time to observe the failed tasks in the suite monitor).
 
 # Determine which family member(s) failed, if any
-FAILED_TASKS=$(cylc dump $CYLC_SUITE_NAME | grep $CYLC_TASK_CYCLE_TIME | grep failed | sed -e 's/,.*$//')
+FAILED_TASKS="$(cylc dump "$CYLC_SUITE_NAME" \
+    | grep "$CYLC_TASK_CYCLE_TIME" | grep failed | sed -e 's/,.*$//')"
 
 echo "FAILED TASKS:"
 for T in $FAILED_TASKS; do
     echo -n "   $T ..."
     if [[ $T == m_* ]]; then
         echo "REMOVING family member"
-        cylc control remove --force $CYLC_SUITE_NAME ${T}.$CYLC_TASK_CYCLE_TIME
+        cylc control remove \
+            --force "$CYLC_SUITE_NAME" "${T}.$CYLC_TASK_CYCLE_TIME"
     else
         echo "NOT REMOVING (not family member)"
     fi

--- a/etc/examples/AutoRecover/EventHook/bin/failhook.sh
+++ b/etc/examples/AutoRecover/EventHook/bin/failhook.sh
@@ -17,8 +17,8 @@ sleep 10 # (time to observe failed task in the suite monitor).
 # check that the task has in fact failed
 TASK_NAME=${TASK%.*}
 CYCLE_POINT=${TASK#*.}
-RES=$( cylc dump $SUITE | grep $TASK_NAME | grep $CYCLE_POINT )
-STATE=$( echo $RES | awk '{print $3}' | sed -e 's/,//' )
+RES="$( cylc dump "$SUITE" | grep "$TASK_NAME" | grep "$CYCLE_POINT" )"
+STATE="$( echo "$RES" | awk '{print $3}' | sed -e 's/,//' )"
 if [[ $STATE != failed ]]; then
     echo "HOOK SCRIPT: ERROR: $TASK is not failed: $STATE"
     exit 1
@@ -27,4 +27,4 @@ else
 fi
 
 echo "REMOVING FAILED TASK: $TASK"
-cylc control remove --force $CYLC_SUITE_NAME $TASK
+cylc control remove --force "$CYLC_SUITE_NAME" "$TASK"

--- a/etc/examples/task-states/bin/change-my-job-sub-method.sh
+++ b/etc/examples/task-states/bin/change-my-job-sub-method.sh
@@ -9,5 +9,5 @@ echo "${0}:resetting job batch system with cylc broadcast"
 
 NAME=${TASKID%.*}
 CYCLE=${TASKID#*.}
-cylc broadcast -n $NAME -p $CYCLE --set '[job]batch system=background' $SUITE
-
+cylc broadcast \
+    -n "$NAME" -p "$CYCLE" --set '[job]batch system=background' "$SUITE"

--- a/etc/examples/tutorial/oneoff/retry/bin/HelloWorld.sh
+++ b/etc/examples/tutorial/oneoff/retry/bin/HelloWorld.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 GREETING=${GREETING:-"Goodbye World!"}
-echo $GREETING
+echo "$GREETING"

--- a/lib/cylc/job.sh
+++ b/lib/cylc/job.sh
@@ -54,7 +54,7 @@ cylc__job__main() {
     done
     # Ensure that the "cylc" command is in PATH. It may not be set up correctly
     # in Prelude above, and also not inherited from the job submit environment.
-    if ! which cylc 1>'/dev/null' 2>&1; then
+    if ! command -v cylc 1>'/dev/null' 2>&1; then
         PATH="${CYLC_DIR}/bin:${PATH}"
     fi
     # Init-Script
@@ -147,7 +147,7 @@ cylc__job__main() {
     # Send task succeeded message
     wait "${CYLC_TASK_MESSAGE_STARTED_PID}" 2>'/dev/null' || true
     cylc message -- "${CYLC_SUITE_NAME}" "${CYLC_TASK_JOB}" 'succeeded' || true
-    trap '' ${CYLC_VACATION_SIGNALS:-} ${CYLC_FAIL_SIGNALS}
+    trap '' "${CYLC_VACATION_SIGNALS:-}" "${CYLC_FAIL_SIGNALS}"
     # Execute success exit script
     cylc__job__run_inst_func 'exit_script'
     exit 0

--- a/lib/cylc/job.sh
+++ b/lib/cylc/job.sh
@@ -63,9 +63,11 @@ cylc__job__main() {
     # Start error and vacation traps
     typeset signal_name=
     for signal_name in ${CYLC_FAIL_SIGNALS}; do
+        # shellcheck disable=SC2064
         trap "cylc__job_err ${signal_name}" "${signal_name}"
     done
     for signal_name in ${CYLC_VACATION_SIGNALS:-}; do
+        # shellcheck disable=SC2064
         trap "cylc__job_vacation ${signal_name}" "${signal_name}"
     done
     set -euo pipefail
@@ -92,8 +94,9 @@ cylc__job__main() {
     CYLC_SUITE_WORK_DIR_ROOT="${CYLC_SUITE_WORK_DIR_ROOT:-${CYLC_SUITE_RUN_DIR}}"
     export CYLC_SUITE_SHARE_DIR="${CYLC_SUITE_WORK_DIR_ROOT}/share"
     export CYLC_SUITE_WORK_DIR="${CYLC_SUITE_WORK_DIR_ROOT}/work"
-    export CYLC_TASK_CYCLE_POINT="$(cut -d '/' -f 1 <<<"${CYLC_TASK_JOB}")"
-    export CYLC_TASK_NAME="$(cut -d '/' -f 2 <<<"${CYLC_TASK_JOB}")"
+    CYLC_TASK_CYCLE_POINT="$(cut -d '/' -f 1 <<<"${CYLC_TASK_JOB}")"
+    CYLC_TASK_NAME="$(cut -d '/' -f 2 <<<"${CYLC_TASK_JOB}")"
+    export CYLC_TASK_NAME CYLC_TASK_CYCLE_POINT
     # The "10#" part ensures that the submit number is interpreted in base 10.
     # Otherwise, a zero padded number will be interpreted as an octal.
     export CYLC_TASK_SUBMIT_NUMBER=$((10#$(cut -d '/' -f 3 <<<"${CYLC_TASK_JOB}")))
@@ -111,8 +114,9 @@ cylc__job__main() {
     export CYLC_TASK_WORK_DIR="${CYLC_SUITE_WORK_DIR}/${CYLC_TASK_WORK_DIR_BASE}"
     typeset contact="${CYLC_SUITE_RUN_DIR}/.service/contact"
     if [[ -f "${contact}" ]]; then
-        export CYLC_SUITE_HOST="$(sed -n 's/^CYLC_SUITE_HOST=//p' "${contact}")"
-        export CYLC_SUITE_OWNER="$(sed -n 's/^CYLC_SUITE_OWNER=//p' "${contact}")"
+        CYLC_SUITE_HOST="$(sed -n 's/^CYLC_SUITE_HOST=//p' "${contact}")"
+        CYLC_SUITE_OWNER="$(sed -n 's/^CYLC_SUITE_OWNER=//p' "${contact}")"
+        export CYLC_SUITE_HOST CYLC_SUITE_OWNER
     fi
     # DEPRECATED environment variables
     export CYLC_SUITE_SHARE_PATH="${CYLC_SUITE_SHARE_DIR}"
@@ -182,7 +186,7 @@ cylc__job_finish_err() {
     typeset run_err_script="$2"
     shift 2
     typeset signal_name=
-    trap '' ${CYLC_VACATION_SIGNALS:-} ${CYLC_FAIL_SIGNALS}
+    trap '' "${CYLC_VACATION_SIGNALS:-}" "${CYLC_FAIL_SIGNALS}"
     if [[ -n "${CYLC_TASK_MESSAGE_STARTED_PID:-}" ]]; then
         wait "${CYLC_TASK_MESSAGE_STARTED_PID}" 2>'/dev/null' || true
     fi
@@ -227,7 +231,7 @@ cylc__job_err() {
 #   1 - dummy job fail
 cylc__job__dummy_result() {
     typeset fail_try_1_only="$1"; shift
-    typeset fail_cycle_points="$@"
+    typeset fail_cycle_points="$*"
     typeset fail_this_point=false
     if [[ "${fail_cycle_points}" == *all* ]]; then
         # Fail all points.
@@ -243,7 +247,7 @@ cylc__job__dummy_result() {
             done
         else
             for POINT in ${fail_cycle_points}; do
-                if $(cylc cyclepoint --equal="$POINT"); then
+                if cylc cyclepoint --equal="$POINT"; then
                     fail_this_point=true
                     break
                 fi

--- a/lib/cylc/tests/test_task_outputs.py
+++ b/lib/cylc/tests/test_task_outputs.py
@@ -1,5 +1,3 @@
-#!/bin/bash
-#
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
 # Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
 #

--- a/lib/parsec/tests/lib/bash/test_header
+++ b/lib/parsec/tests/lib/bash/test_header
@@ -81,12 +81,12 @@ function set_test_number() {
 }
 
 function ok() {
-    echo "ok $((++TEST_NUMBER)) - $@"
+    echo "ok $((++TEST_NUMBER)) - $*"
 }
 
 function fail() {
     ((++FAILURES))
-    echo "not ok $((++TEST_NUMBER)) - $@"
+    echo "not ok $((++TEST_NUMBER)) - $*"
 }
 
 function run_ok() {
@@ -166,7 +166,7 @@ function skip() {
     shift 1
     local COUNT=0
     while ((COUNT++ < N_TO_SKIP)); do
-        echo "ok $((++TEST_NUMBER)) # skip $@"
+        echo "ok $((++TEST_NUMBER)) # skip $*"
     done
 }
 

--- a/tests/lib/bash/test_header
+++ b/tests/lib/bash/test_header
@@ -148,12 +148,12 @@ set_test_number() {
 }
 
 ok() {
-    echo "ok $((++TEST_NUMBER)) - $@"
+    echo "ok $((++TEST_NUMBER)) - $*"
 }
 
 fail() {
     ((++FAILURES))
-    echo "not ok $((++TEST_NUMBER)) - $@"
+    echo "not ok $((++TEST_NUMBER)) - $*"
     if [[ -n "${CYLC_TEST_DEBUG:-}" ]]; then
         echo >'/dev/tty'
         echo "${TEST_NAME_BASE} ${TEST_NAME}" >'/dev/tty'
@@ -455,12 +455,12 @@ skip() {
     shift 1
     local COUNT=0
     while ((COUNT++ < N_TO_SKIP)); do
-        echo "ok $((++TEST_NUMBER)) # skip $@"
+        echo "ok $((++TEST_NUMBER)) # skip $*"
     done
 }
 
 skip_all() {
-    echo "1..0 # SKIP $@"
+    echo "1..0 # SKIP $*"
     exit
 }
 

--- a/tests/lib/python/diffr.py
+++ b/tests/lib/python/diffr.py
@@ -1,5 +1,3 @@
-#!/bin/bash
-#
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
 # Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
 #

--- a/tests/lib/python/test_diffr.py
+++ b/tests/lib/python/test_diffr.py
@@ -1,5 +1,3 @@
-#!/bin/bash
-#
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
 # Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
 #

--- a/tests/validate/04-builtin-suites.t
+++ b/tests/validate/04-builtin-suites.t
@@ -46,7 +46,7 @@ NO_EMPY=true
 if cylc check-software 2>'/dev/null' | grep -q '^Python:EmPy.*([^-]*)$'; then
     NO_EMPY=false
 fi
-for suite in ${SUITES[@]}; do
+for suite in "${SUITES[@]}"; do
     suite_name=$(sed 's/\//-/g' <<<"${suite:$ABS_PATH_LENGTH}")
     TEST_NAME="${TEST_NAME_BASE}${suite_name}"
     if "${NO_EMPY}" && grep -qi '^#!empy' < <(head -1 "${suite}"); then

--- a/usr/bin/cylc
+++ b/usr/bin/cylc
@@ -66,4 +66,4 @@ if [[ -z ${CYLC_HOME:-} ]]; then
         CYLC_HOME=$CYLC_HOME_ROOT/cylc
     fi
 fi
-exec $CYLC_HOME/bin/$(basename $0) "$@"
+exec "$CYLC_HOME/bin/$(basename "$0")" "$@"


### PR DESCRIPTION
Run the brilliantly named `shellcheck` over all shell scripts to improve code quality and cut down on review overheads.

* Sadly `shellcheck` runs over files rather than projects unlike many other linters (e.g. pycodestyle) so I've implemented a minimal script for including / excluding files in the check. I did look at borrowing the tox interface from pycodestyle but it would probably be more effort than it's worth for this simple linter.
* The test-battery scripts have a somewhat larger volume of warnings than I'm prepared to address in this PR so I've run them separately in a more lenient manner for the moment.