### PR TITLE
Fix import issues in cylc get-directory

### DIFF
--- a/bin/cylc-get-directory
+++ b/bin/cylc-get-directory
@@ -24,12 +24,11 @@ Here's an easy way to move to a suite source directory:
 
 from cylc.remote import remrun
 if remrun():
+    import sys
     sys.exit(0)
 
-import sys
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.suite_srv_files_mgr import SuiteSrvFilesManager
-import cylc.flags
 from cylc.terminal import cli_function
 
 


### PR DESCRIPTION
Never used this command (also not sure if will be kept in Cylc 8, e.g. #2972), and it works in my local environment. But I suspect if `remrun` returns true, it will probably raise `ImportError` or `ModuleNotFoundError`, as the `import sys` is after the call to `sys.exit`.