### PR TITLE
Fix cylc-search for directories without suite.rc

### DIFF
--- a/bin/cylc-search
+++ b/bin/cylc-search
@@ -61,7 +61,8 @@ def print_heading(heading):
     print('>>>' + '->'.join(heading))
 
 
-def parse_args():
+@cli_function
+def main():
     parser = COP(
         __doc__, prep=True,
         argdoc=[('SUITE', 'Suite name or path'),
@@ -72,12 +73,7 @@ def parse_args():
         "-x", help="Do not search in the suite bin directory",
         action="store_false", default=True, dest="search_bin")
 
-    return parser.parse_args()
-
-
-@cli_function
-def main():
-    options, args = parse_args()
+    options, args = parser.parse_args()
     suite, suiterc = SuiteSrvFilesManager().parse_suite_arg(options, args[0])
 
     # cylc search SUITE PATTERN


### PR DESCRIPTION
```
cylc search /home/kinow/cylc-run/five/share foo*
```

Works fine. But using another directory, the previous version would print usage and exit with a non zero exit code. Current version in `master` is broken.

```
$ cylc search /home/kinow/cylc-run/five/share foo*
Traceback (most recent call last):
  File "/home/kinow/Development/python/workspace/cylc/venv/bin/cylc-search", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/home/kinow/Development/python/workspace/cylc/bin/cylc-search", line 196, in <module>
    main()
  File "/home/kinow/Development/python/workspace/cylc/lib/cylc/terminal.py", line 65, in wrapper
    function(*args, **kwargs)
  File "/home/kinow/Development/python/workspace/cylc/bin/cylc-search", line 94, in main
    parser.error("File not found: " + suiterc)
NameError: name 'parser' is not defined
```

This small fix unfortunately removes the function to parse args (which is good to encapsulate that part...) in order to keep the exact previous behaviour without having to copy or mimic the calls to print usage and exit status.