### PR TITLE
Remove unused imports (mainly cylc.flags)

### DIFF
--- a/bin/cylc-broadcast
+++ b/bin/cylc-broadcast
@@ -87,7 +87,6 @@ from cylc.broadcast_report import (
     get_broadcast_change_report, get_broadcast_bad_options_report)
 from cylc.cfgspec.suite import SPEC, upg
 from cylc.cfgvalidate import cylc_config_validate
-import cylc.flags
 from cylc.network.client import SuiteRuntimeClient
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.print_tree import print_tree

--- a/bin/cylc-checkpoint
+++ b/bin/cylc-checkpoint
@@ -28,7 +28,6 @@ if "--use-ssh" in sys.argv[1:]:
     if remrun():
         sys.exit(0)
 
-import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
 from cylc.terminal import cli_function

--- a/bin/cylc-diff
+++ b/bin/cylc-diff
@@ -33,7 +33,6 @@ from cylc.remote import remrun
 if remrun():
     sys.exit(0)
 
-import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.config import SuiteConfig
 from cylc.suite_srv_files_mgr import SuiteSrvFilesManager

--- a/bin/cylc-dump
+++ b/bin/cylc-dump
@@ -39,7 +39,6 @@ if '--use-ssh' in sys.argv[1:]:
     if remrun():
         sys.exit(0)
 
-import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
 from cylc.dump import dump_to_stdout

--- a/bin/cylc-edit
+++ b/bin/cylc-edit
@@ -71,7 +71,6 @@ from parsec.include import inline, \
     split_file, backup, backups, newfiles, cleanup, modtimes
 
 
-import cylc.flags
 from cylc.cfgspec.glbl_cfg import glbl_cfg
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.suite_srv_files_mgr import SuiteSrvFilesManager

--- a/bin/cylc-ext-trigger
+++ b/bin/cylc-ext-trigger
@@ -35,12 +35,10 @@ The suite passphrase must be installed in $HOME/.cylc/<SUITE>/.
 
 Note: to manually trigger a task use 'cylc trigger', not this command."""
 
-import sys
 from time import sleep
 
 from cylc import LOG
 from cylc.exceptions import CylcError, ClientError
-import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
 from cylc.terminal import cli_function

--- a/bin/cylc-get-suite-config
+++ b/bin/cylc-get-suite-config
@@ -57,7 +57,6 @@ if remrun():
     sys.exit(0)
 
 from cylc.config import SuiteConfig
-import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.suite_srv_files_mgr import SuiteSrvFilesManager
 from cylc.templatevars import load_template_vars

--- a/bin/cylc-get-suite-version
+++ b/bin/cylc-get-suite-version
@@ -29,10 +29,8 @@ if '--use-ssh' in sys.argv[1:]:
     if remrun():
         sys.exit(0)
 
-import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
-from cylc.terminal import cli_function
 
 
 def main():

--- a/bin/cylc-graph
+++ b/bin/cylc-graph
@@ -22,7 +22,6 @@ Implement the old ``cylc graph --reference command`` for producing a textural
 graph of a suite.
 
 """
-import sys
 
 from cylc.config import SuiteConfig
 from cylc.cycling.loader import get_point

--- a/bin/cylc-hold
+++ b/bin/cylc-hold
@@ -33,7 +33,6 @@ if '--use-ssh' in sys.argv[1:]:
     if remrun():
         sys.exit(0)
 
-import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
 from cylc.terminal import prompt, cli_function

--- a/bin/cylc-insert
+++ b/bin/cylc-insert
@@ -41,7 +41,6 @@ if '--use-ssh' in sys.argv[1:]:
         sys.exit(0)
 
 from cylc.exceptions import UserInputError
-import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
 from cylc.task_id import TaskID

--- a/bin/cylc-kill
+++ b/bin/cylc-kill
@@ -31,7 +31,6 @@ if '--use-ssh' in sys.argv[1:]:
     if remrun():
         sys.exit(0)
 
-import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
 from cylc.terminal import prompt, cli_function

--- a/bin/cylc-list
+++ b/bin/cylc-list
@@ -34,7 +34,6 @@ if remrun():
     sys.exit(0)
 
 from cylc.config import SuiteConfig
-import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.suite_srv_files_mgr import SuiteSrvFilesManager
 from cylc.templatevars import load_template_vars

--- a/bin/cylc-nudge
+++ b/bin/cylc-nudge
@@ -35,7 +35,6 @@ if '--use-ssh' in sys.argv[1:]:
     if remrun():
         sys.exit(0)
 
-import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
 from cylc.terminal import cli_function

--- a/bin/cylc-poll
+++ b/bin/cylc-poll
@@ -31,7 +31,6 @@ if '--use-ssh' in sys.argv[1:]:
     if remrun():
         sys.exit(0)
 
-import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
 from cylc.terminal import prompt, cli_function

--- a/bin/cylc-print
+++ b/bin/cylc-print
@@ -35,7 +35,6 @@ if remrun():
 import os
 import re
 
-import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.suite_srv_files_mgr import SuiteSrvFilesManager
 from cylc.print_tree import print_tree

--- a/bin/cylc-register
+++ b/bin/cylc-register
@@ -55,7 +55,6 @@ from cylc.remote import remrun
 if remrun():
     sys.exit(0)
 
-import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.suite_srv_files_mgr import SuiteSrvFilesManager
 from cylc.terminal import cli_function

--- a/bin/cylc-release
+++ b/bin/cylc-release
@@ -32,7 +32,6 @@ if '--use-ssh' in sys.argv[1:]:
     if remrun():
         sys.exit(0)
 
-import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
 from cylc.terminal import prompt, cli_function

--- a/bin/cylc-reload
+++ b/bin/cylc-reload
@@ -46,7 +46,6 @@ if '--use-ssh' in sys.argv[1:]:
     if remrun():
         sys.exit(0)
 
-import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
 from cylc.terminal import prompt, cli_function

--- a/bin/cylc-remove
+++ b/bin/cylc-remove
@@ -31,7 +31,6 @@ if '--use-ssh' in sys.argv[1:]:
     if remrun():
         sys.exit(0)
 
-import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
 from cylc.terminal import prompt, cli_function

--- a/bin/cylc-report-timings
+++ b/bin/cylc-report-timings
@@ -58,7 +58,6 @@ import contextlib
 import os
 
 from cylc.exceptions import CylcError
-import cylc.flags
 from cylc.cfgspec.glbl_cfg import glbl_cfg
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.rundb import CylcSuiteDAO

--- a/bin/cylc-reset
+++ b/bin/cylc-reset
@@ -40,7 +40,6 @@ if '--use-ssh' in sys.argv[1:]:
     if remrun():
         sys.exit(0)
 
-import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
 from cylc.task_state import TASK_STATUSES_CAN_RESET_TO

--- a/bin/cylc-set-verbosity
+++ b/bin/cylc-set-verbosity
@@ -31,7 +31,6 @@ if '--use-ssh' in sys.argv[1:]:
     if remrun():
         sys.exit(0)
 
-import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
 from cylc.terminal import prompt, cli_function

--- a/bin/cylc-show
+++ b/bin/cylc-show
@@ -31,7 +31,6 @@ if '--use-ssh' in sys.argv[1:]:
 
 import json
 
-import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
 from cylc.task_id import TaskID

--- a/bin/cylc-spawn
+++ b/bin/cylc-spawn
@@ -30,7 +30,6 @@ if '--use-ssh' in sys.argv[1:]:
     if remrun():
         sys.exit(0)
 
-import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
 from cylc.terminal import prompt, cli_function

--- a/bin/cylc-stop
+++ b/bin/cylc-stop
@@ -47,7 +47,6 @@ if '--use-ssh' in sys.argv[1:]:
 
 from cylc.command_polling import Poller
 from cylc.exceptions import ClientError, ClientTimeout
-import cylc.flags
 from cylc.network.client import SuiteRuntimeClient
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.task_id import TaskID

--- a/bin/cylc-trigger
+++ b/bin/cylc-trigger
@@ -49,7 +49,6 @@ import difflib
 from subprocess import call
 
 from cylc.exceptions import CylcError, UserInputError
-import cylc.flags
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.network.client import SuiteRuntimeClient
 from cylc.cfgspec.glbl_cfg import glbl_cfg

--- a/bin/cylc-view
+++ b/bin/cylc-view
@@ -40,7 +40,6 @@ from tempfile import NamedTemporaryFile
 import shlex
 from subprocess import call
 
-import cylc.flags
 from cylc.cfgspec.glbl_cfg import glbl_cfg
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.suite_srv_files_mgr import SuiteSrvFilesManager

--- a/bin/cylc-warranty
+++ b/bin/cylc-warranty
@@ -23,7 +23,6 @@ Options:
   --help   Print this usage message."""
 
 import sys
-import cylc.flags
 from cylc.terminal import cli_function
 
 

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -25,7 +25,7 @@ from tempfile import mkdtemp
 
 from parsec.config import ParsecConfig
 from parsec.exceptions import ParsecError
-from parsec.upgrade import upgrader, converter
+from parsec.upgrade import upgrader
 
 from cylc import LOG
 from cylc.cfgvalidate import (

--- a/lib/cylc/cycling/__init__.py
+++ b/lib/cylc/cycling/__init__.py
@@ -20,9 +20,7 @@
 
 from abc import ABCMeta, abstractmethod
 
-from cylc.exceptions import (
-    CyclerTypeError, PointParsingError, IntervalParsingError,
-    SequenceDegenerateError)
+from cylc.exceptions import CyclerTypeError
 
 
 def parse_exclusion(expr):

--- a/lib/cylc/cycling/integer.py
+++ b/lib/cylc/cycling/integer.py
@@ -22,10 +22,11 @@ Integer cycling by point, interval, and sequence classes.
 import re
 
 from cylc.cycling import (
-    PointBase, IntervalBase, SequenceBase, ExclusionBase, PointParsingError,
-    IntervalParsingError, parse_exclusion, cmp
+    PointBase, IntervalBase, SequenceBase, ExclusionBase, parse_exclusion, cmp
 )
-from cylc.exceptions import CylcMissingContextPointError
+from cylc.exceptions import (
+    CylcMissingContextPointError, PointParsingError, IntervalParsingError
+)
 
 CYCLER_TYPE_INTEGER = "integer"
 CYCLER_TYPE_SORT_KEY_INTEGER = "a"

--- a/lib/cylc/cycling/iso8601.py
+++ b/lib/cylc/cycling/iso8601.py
@@ -26,8 +26,11 @@ from isodatetime.timezone import (
     get_local_time_zone, get_local_time_zone_format, TimeZoneFormatMode)
 from cylc.time_parser import CylcTimeParser
 from cylc.cycling import (
-    PointBase, IntervalBase, SequenceBase, ExclusionBase, PointParsingError,
-    IntervalParsingError, SequenceDegenerateError, cmp_to_rich, cmp)
+    PointBase, IntervalBase, SequenceBase, ExclusionBase, cmp_to_rich, cmp
+)
+from cylc.exceptions import (
+    SequenceDegenerateError, PointParsingError, IntervalParsingError
+)
 from cylc.wallclock import get_current_time_string
 from parsec.validate import IllegalValueError
 

--- a/lib/parsec/tests/test_include.py
+++ b/lib/parsec/tests/test_include.py
@@ -24,7 +24,6 @@ tests. So this suite of unit tests should not cover all the module features.
 import tempfile
 import unittest
 
-from parsec.exceptions import ParsecError
 from parsec.include import *
 
 


### PR DESCRIPTION
Mainly `cylc.flags`, that is probably not required any longer due to some refactoring/improvement for Cylc 8 :+1: 

Hoping Travis-CI will confirm these imports are not used.