### PR TITLE
Fix recent shellcheck-inspired quoting errors.

### DIFF
--- a/bin/cylc-jobscript
+++ b/bin/cylc-jobscript
@@ -51,9 +51,9 @@ editor () {
 import sys
 from cylc.cfgspec.glbl_cfg import glbl_cfg
 if sys.argv[1] in ['-g', '--gedit']:
-    print glbl_cfg().get(['editors', 'gui'])
+    print(glbl_cfg().get(['editors', 'gui']))
 elif sys.argv[1] in ['-e', '--edit']:
-    print glbl_cfg().get(['editors', 'terminal'])
+    print(glbl_cfg().get(['editors', 'terminal']))
 " "$1"
 }
 
@@ -74,7 +74,8 @@ for arg in "${@}"; do
     fi
 done
 
-if CYLC_SUBMIT_OUT="$(cylc submit --dry-run "${SUBMIT_ARGS}")"; then
+# shellcheck disable=2086
+if CYLC_SUBMIT_OUT="$(cylc submit --dry-run ${SUBMIT_ARGS})"; then
     JOBSCRIPT="$(sed -n 's/^JOB SCRIPT=//p' <<<"${CYLC_SUBMIT_OUT}")"
     if ! "${PLAIN}"; then
         echo "Task Job Script Generated: ${JOBSCRIPT}" >&2

--- a/bin/cylc-test-battery
+++ b/bin/cylc-test-battery
@@ -135,7 +135,7 @@ for ARG in "$@"; do
         --chunk)
             # Replace "--chunk a/b" with the appropriate tests.
             set -- "${@:1:$(( ARG_COUNT - 1 ))}" \
-                "$(chunk "${@:$(( ARG_COUNT + 1 )):1}")" \
+                $(chunk "${@:$(( ARG_COUNT + 1 )):1}") \
                 "${@:$(( ARG_COUNT + 2 ))}"
             ;;
         *)

--- a/bin/cylc-test-battery
+++ b/bin/cylc-test-battery
@@ -134,6 +134,8 @@ for ARG in "$@"; do
             ;;
         --chunk)
             # Replace "--chunk a/b" with the appropriate tests.
+	    # (Ignore shellcheck "word splitting" warning here).
+	    # shellcheck disable=SC2046 
             set -- "${@:1:$(( ARG_COUNT - 1 ))}" \
                 $(chunk "${@:$(( ARG_COUNT + 1 )):1}") \
                 "${@:$(( ARG_COUNT + 2 ))}"

--- a/lib/cylc/job.sh
+++ b/lib/cylc/job.sh
@@ -147,7 +147,9 @@ cylc__job__main() {
     # Send task succeeded message
     wait "${CYLC_TASK_MESSAGE_STARTED_PID}" 2>'/dev/null' || true
     cylc message -- "${CYLC_SUITE_NAME}" "${CYLC_TASK_JOB}" 'succeeded' || true
-    trap '' "${CYLC_VACATION_SIGNALS:-}" "${CYLC_FAIL_SIGNALS}"
+    # (Ignore shellcheck "globbing and word splitting" warning here).
+    # shellcheck disable=SC2086
+    trap '' ${CYLC_VACATION_SIGNALS:-} ${CYLC_FAIL_SIGNALS}
     # Execute success exit script
     cylc__job__run_inst_func 'exit_script'
     exit 0
@@ -186,7 +188,9 @@ cylc__job_finish_err() {
     typeset run_err_script="$2"
     shift 2
     typeset signal_name=
-    trap '' "${CYLC_VACATION_SIGNALS:-}" "${CYLC_FAIL_SIGNALS}"
+    # (Ignore shellcheck "globbing and word splitting" warning here).
+    # shellcheck disable=SC2086
+    trap '' ${CYLC_VACATION_SIGNALS:-} ${CYLC_FAIL_SIGNALS}
     if [[ -n "${CYLC_TASK_MESSAGE_STARTED_PID:-}" ]]; then
         wait "${CYLC_TASK_MESSAGE_STARTED_PID}" 2>'/dev/null' || true
     fi


### PR DESCRIPTION
Revert a few lines of #3068

In several places: remove outer quotes that incorrectly turn a whole bunch of args into a single arg containing spaces.

@kinow - one review will do, since functional tests currently broken by the bug

@oliver-sanders can take a look afterwards to check that I've done the right thing...