### PR TITLE
job.sh: run as bash only

### DIFF
--- a/.travis/shellchecker
+++ b/.travis/shellchecker
@@ -77,10 +77,8 @@ default () {
     main '.' \
         --exclude 'tests/' \
         --exclude 'lib/parsec/tests' \
-        --exclude 'lib/cylc/job.sh' \
         --exclude 'etc/dev-bin/live-graph-movie.sh' \
         -- -e SC1090
-    main 'lib/cylc/job.sh' -- -e SC1090 -s bash
 
     # run a lenient check on all test scripts
     main 'tests' 'lib/parsec/tests' -- -S error -e SC1090

--- a/lib/cylc/job.sh
+++ b/lib/cylc/job.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
 # Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.


### PR DESCRIPTION
Follow-up to #3088, use `bash` shebang for the `job.sh` file.