### PR TITLE
Run prove with --timer

### DIFF
--- a/bin/cylc-test-battery
+++ b/bin/cylc-test-battery
@@ -158,8 +158,8 @@ if perl -e 'use Test::Harness 3.00' 2>/dev/null; then
         NPROC=$(python3 -c \
             'import multiprocessing as mp; print(mp.cpu_count())')
     fi
-    exec prove -j "$NPROC" -s -r "${@:-tests}"
+    exec prove --timer -j "$NPROC" -s -r "${@:-tests}"
 else
     echo "WARNING: cannot run tests in parallel (Test::Harness < 3.00)" >&2
-    exec prove -s -r "${@:-tests}"
+    exec prove --timer -s -r "${@:-tests}"
 fi


### PR DESCRIPTION
Part of #3046.

To run `prove` with the `--timer` option. From their help page:

```
          --timer           Print elapsed time after each test.
```

That should give us an idea of how long the tests are taking to run. Should increase a bit the total execution time, but it shouldn't be a considerable increase.