### PR TITLE
Add kill all to functional tests.

### DIFF
--- a/tests/job-kill/00-local.t
+++ b/tests/job-kill/00-local.t
@@ -18,7 +18,7 @@
 # Test kill local jobs.
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
-set_test_number 6
+set_test_number 10
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-validate

--- a/tests/job-kill/00-local/reference.log
+++ b/tests/job-kill/00-local/reference.log
@@ -1,5 +1,9 @@
-2013/12/18 09:33:35 INFO - Initial point: 1
-2013/12/18 09:33:35 INFO - Final point: 1
-2013/12/18 09:33:35 INFO - [t2.1] -triggered off []
-2013/12/18 09:33:35 INFO - [t1.1] -triggered off []
-2013/12/18 09:33:39 INFO - [stop.1] -triggered off ['t1.1', 't2.1']
+2019-04-10T16:15:32+12:00 INFO - Initial point: 1
+2019-04-10T16:15:32+12:00 INFO - Final point: 1
+2019-04-10T16:15:32+12:00 INFO - [t2.1] -triggered off []
+2019-04-10T16:15:32+12:00 INFO - [t1.1] -triggered off []
+2019-04-10T16:15:36+12:00 INFO - [stop1.1] -triggered off ['t1.1', 't2.1']
+2019-04-10T16:15:39+12:00 INFO - [t4.1] -triggered off ['stop1.1']
+2019-04-10T16:15:39+12:00 INFO - [t3.1] -triggered off ['stop1.1']
+2019-04-10T16:15:43+12:00 INFO - [stop2.1] -triggered off ['t3.1', 't4.1']
+2019-04-10T16:15:46+12:00 INFO - [shutdown.1] -triggered off ['stop2.1']

--- a/tests/job-kill/00-local/suite.rc
+++ b/tests/job-kill/00-local/suite.rc
@@ -2,14 +2,14 @@
 [cylc]
    [[reference test]]
        required run mode=live
-       expected task failures = t1.1, t2.1
-       live mode suite timeout = PT2M
+       expected task failures = t1.1, t2.1, t3.1, t4.1, stop2.1
+       live mode suite timeout = PT1M
 [scheduling]
     [[dependencies]]
         graph="""
-t1:start=>stop
-t2:start=>stop
-"""
+           t1:start & t2:start => stop1 =>
+              t3:start & t4:start => stop2
+           stop2:fail => shutdown"""
 [runtime]
     [[T]]
         script=sleep 120 & echo $! >file; wait
@@ -17,14 +17,16 @@ t2:start=>stop
         [[[remote]]]
             host={{environ["CYLC_TEST_HOST"]}}
 {% endif %}
-    [[t1]]
+    [[t1, t2, t3, t4]]
         inherit=T
-        [[[job]]]
-            batch system=at
-    [[t2]]
-        inherit=T
-    [[stop]]
+    [[stop1]]
         script="""
-cylc kill "$CYLC_SUITE_NAME" 't1.1' 't2.1' || true
-cylc stop "$CYLC_SUITE_NAME"
-"""
+# Kill t1.1 and t2.1 explicitly.
+cylc kill $CYLC_SUITE_NAME t1.1 t2.1 || true"""
+    [[stop2]]
+        script="""
+# Kill t3.1, t4.1, and myself! implicitly (kill all active tasks).
+cylc kill $CYLC_SUITE_NAME || true
+sleep 30"""
+    [[shutdown]]
+        script = "cylc stop $CYLC_SUITE_NAME"


### PR DESCRIPTION
Extend an existing `cylc kill`functional test to cover the "kill all active tasks" use case.

cylc-8 counterpart of #3100 (on master, the functionality already works, but the test coverage was lacking).
