### PR TITLE
Fix work loc assumption in a test.

### DIFF
--- a/tests/cyclers/00-daily.t
+++ b/tests/cyclers/00-daily.t
@@ -39,8 +39,11 @@ suite_run_ok $TEST_NAME cylc run --reference-test --debug --no-detach $SUITE_NAM
 #-------------------------------------------------------------------------------
 if [[ -f "$TEST_SOURCE_DIR/$TEST_NAME_BASE-find.out" ]]; then
     TEST_NAME="$TEST_NAME_BASE-find"
-    SUITE_DIR="$(cylc get-global-config --print-run-dir)/$SUITE_NAME"
-    (cd "$SUITE_DIR"; find log/job work -type f | sort -V) >"$TEST_NAME"
+    SUITE_RUN_DIR="$(cylc get-global-config --print-run-dir)/$SUITE_NAME"
+    SUITE_WRK_DIR="$(cylc get-global-config -i '[hosts][localhost]work directory')/$SUITE_NAME"
+    (cd "$SUITE_RUN_DIR"; find log/job -type f) >"${TEST_NAME}.tmp"
+    (cd "$SUITE_WRK_DIR"; find work -type f) >>"${TEST_NAME}.tmp"
+    cat ${TEST_NAME}.tmp | sort -V >"$TEST_NAME"
     cmp_ok "$TEST_NAME" "$TEST_SOURCE_DIR/$TEST_NAME_BASE-find.out"
 fi
 #-------------------------------------------------------------------------------

--- a/tests/cyclers/00-daily.t
+++ b/tests/cyclers/00-daily.t
@@ -41,10 +41,11 @@ if [[ -f "$TEST_SOURCE_DIR/$TEST_NAME_BASE-find.out" ]]; then
     TEST_NAME="$TEST_NAME_BASE-find"
     SUITE_RUN_DIR="$(cylc get-global-config --print-run-dir)/$SUITE_NAME"
     SUITE_WRK_DIR="$(cylc get-global-config -i '[hosts][localhost]work directory')/$SUITE_NAME"
-    (cd "$SUITE_RUN_DIR"; find log/job -type f) >"${TEST_NAME}.tmp"
-    (cd "$SUITE_WRK_DIR"; find work -type f) >>"${TEST_NAME}.tmp"
-    cat ${TEST_NAME}.tmp | sort -V >"$TEST_NAME"
-    cmp_ok "$TEST_NAME" "$TEST_SOURCE_DIR/$TEST_NAME_BASE-find.out"
+    {
+        (cd "${SUITE_RUN_DIR}" && find log/job -type f)
+        (cd "${SUITE_WRK_DIR}" && find work -type f)
+    } | sort -V >"${TEST_NAME}"
+    cmp_ok "${TEST_NAME}" "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}-find.out"
 fi
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME


### PR DESCRIPTION
This fixes the bug noted here: https://github.com/cylc/cylc/issues/3098#issuecomment-481505878

(A test fails if `global-tests.rc` configures a non-standard run directory but leaves `work directory` in the default location).

Posting a PR since I looked at the problem and fixed this test. (And same on master next).

NOTE: there are almost certainly other tests that have a similar problem (assuming standard location of run or work directory instead of querying the relevant config, or assuming that the work directory is under the run directory.  However, IMO we shouldn't blow any time on this now ... it is unlikely that anyone needs to run the test battery with different run and work locations, and we have "bigger fish to fry".