### PR TITLE
patch metomi/isodatetime#127

### DIFF
--- a/lib/isodatetime/data.py
+++ b/lib/isodatetime/data.py
@@ -1425,8 +1425,20 @@ class TimePoint(object):
         if was_week_date:
             self.to_week_date()
 
-    def tick_over(self):
-        """Correct all the units going from smallest to largest."""
+    def tick_over(self, check_changes=False):
+        """Correct all the units going from smallest to largest.
+
+        Args:
+            check_changes (bool, optional):
+                If True tick_over will return a dict of any changed fields.
+
+        Returns:
+            dict: Dictionary of changed fields with before and after values
+            if check_changes is True else None.
+
+        """
+        if check_changes:
+            before = {key: getattr(self, key) for key in self.DATA_ATTRIBUTES}
         if (self.hour_of_day is not None and
                 self.minute_of_hour is not None):
             hours_remainder = self.hour_of_day - int(self.hour_of_day)
@@ -1491,6 +1503,12 @@ class TimePoint(object):
             while self.month_of_year > CALENDAR.MONTHS_IN_YEAR:
                 self.month_of_year -= CALENDAR.MONTHS_IN_YEAR
                 self.year += 1
+        if check_changes:
+            return {
+                key: (value, getattr(self, key))
+                for key, value in before.items()
+                if getattr(self, key) != value
+            }
 
     def _tick_over_day_of_month(self):
         if self.day_of_month < 1:

--- a/lib/isodatetime/tests/test_parser.py
+++ b/lib/isodatetime/tests/test_parser.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------------
+# Copyright (C) 2013-2019 British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# ----------------------------------------------------------------------------
+"""Test isodatetime.parsers."""
+
+import pytest
+
+from isodatetime.parsers import TimePointParser
+
+
+def test_invalid_components():
+    parser = TimePointParser()
+    for date, invalid in {
+        '2000-01-01T00:00:60': ['second_of_minute=60'],
+        '2000-01-01T00:60:00': ['minute_of_hour=60'],
+        '2000-01-01T60:00:00': ['hour_of_day=60'],
+        '2000-01-32T00:00:00': ['day_of_month=32'],
+        '2000-13-00T00:00:00': ['month_of_year=13'],
+        '2000-13-32T60:60:60': ['month_of_year=13',
+                                'day_of_month=32',
+                                'hour_of_day=60',
+                                'minute_of_hour=60',
+                                'second_of_minute=60']
+    }.items():
+        with pytest.raises(ValueError) as exc:
+            parser.parse(date)
+        for item in invalid:
+            assert item in str(exc)


### PR DESCRIPTION
closes #3074 
*(for 7.8.x, master will be fixed with next release of isodatetime)*

Patch bundled isodatetime to include a fix which prevents invalid datetimes causing an infinite loop in the `tick_over` function which affects the new ICP `next()`, `previous()` functionality.