### PR TITLE
Prepend custom Jinja2 paths.

### DIFF
--- a/lib/parsec/jinja2support.py
+++ b/lib/parsec/jinja2support.py
@@ -117,7 +117,7 @@ def jinja2environment(dir_=None):
                 os.path.join(dir_, nspdir),
                 os.path.join(os.environ['HOME'], '.cylc', nspdir)]:
             if os.path.isdir(fdir):
-                sys.path.append(os.path.abspath(fdir))
+                sys.path.insert(1, os.path.abspath(fdir))
                 for name in glob(os.path.join(fdir, '*.py')):
                     fname = os.path.splitext(os.path.basename(name))[0]
                     # TODO - EXCEPTION HANDLING FOR LOADING CUSTOM FILTERS


### PR DESCRIPTION
Close #3109 

(Apparently the right thing to do is insert new `sys.path` elements at the 2nd position, not the 1st - because the 1st element is supposed to contain the location of the current script).
